### PR TITLE
Small update to Related Projects static page

### DIFF
--- a/templates/static/related-projects.html
+++ b/templates/static/related-projects.html
@@ -18,7 +18,7 @@
 		<li><a href="http://psookim.com/default.aspx">Psookim</a> - Multimedia presentations of Jewish texts.</li>
 		<li><a href="http://www.mechon-mamre.org/">Mechon Mamre</a> - A great, free collection of texts online, but under copyright.</li>
 		<li><a href="http://www.responsa.co.il">The Responsa Project</a> - The biggest collection of digitized Jewish texts, available for a price.</li>
-		<li><a href="http://www.responsa.co.il">JHacker.org</a> - Great blog and hub for Judaism and technology.</li>
+		<li><a href="http://jhacker.org">JHacker.org</a> - Great blog and hub for Judaism and technology.</li>
 	</ul>
 </div>
 


### PR DESCRIPTION
While investigating open source projects in the Jewish world, I noticed the link to jhacker.org was set incorrectly to the same site as the previous bullet (responsa.co.il).

This would be my first open source contribution, and at one line of code it's a humble beginning, but it's still good to be getting started.
