### PR TITLE
Update link to exported data

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -2,7 +2,7 @@
 
 Sefaria is creating interfaces, apps (like a source sheet builder) and infrastructure (like an API and a structured dataset) for Jewish texts and textual learning. Our demo is up at www.sefaria.org.
 
-You can find outputs of our entire database in [Sefaria-Export](https://github.com/blockspeiser/Sefaria-Export).
+You can find outputs of our entire database in [Sefaria-Export](https://github.com/Sefaria/Sefaria-Export).
 
 Interested developers should join the [sefara-dev mailing list](https://groups.google.com/forum/#!forum/sefaria-dev).
 


### PR DESCRIPTION
The link on the current README to the exported data set points to a repo that's no longer there. Updating that link to point to `Sefaria/Sefaria-Project` instead.