### PR TITLE
remove temp code for backend migration from subsources

### DIFF
--- a/sheets/views.py
+++ b/sheets/views.py
@@ -560,13 +560,6 @@ def sheet_list_api(request):
 			return jsonResponse({"error": "No JSON given in post data."})
 		sheet = json.loads(j)
 
-
-		#Temp code to throw error in case someone has old sourcesheet code running in browser when backend migration from subsources to indent occurs
-		#Todo remove me by 3/21/16
-		if "sources" in sheet:
-			if "subsources" in sheet["sources"]:
-				return jsonResponse({"error": "There's been an error. Please refresh the page."})
-
 		if "id" in sheet:
 			existing = get_sheet(sheet["id"])
 			if "error" not in existing  and \


### PR DESCRIPTION
Noticed this as I was working on sheets/views.py. Not sure what the exact implications of removing this snippet of code would be, but I noticed it is long past the removal date stated in the comment regarding it. Should the code be removed? Should the comment be updated to reflect its more permanent nature now? I believe @rneiss was the person who added it, so maybe it would be good for him to weigh-in on this.