### PR TITLE
Fix typos of font names in /static/css/base.css.

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -7,7 +7,7 @@
 html, body {
 	height: 100%;
 	width: 100%;
-  font-family: "Montserrat", "Alef", "Helvetica Neue", Helvetica, Ariel, san-serif;
+  font-family: "Montserrat", "Alef", "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
 
 p {


### PR DESCRIPTION
Fix typos of font names in /static/css/base.css. `Ariel` --> `Arial` and `san-serif` --> `sans-serif`.