### PR TITLE
Closes #233. Upload locally stored photos to Source Sheet

### DIFF
--- a/static/css/sheets.css
+++ b/static/css/sheets.css
@@ -1688,7 +1688,7 @@ img {
 	display:none;
 }
 
-#inlineAdd {
+.inlineAddTextInput {
 	width: 320px;
 	height: 32px;
 	margin: 0;
@@ -1696,10 +1696,9 @@ img {
 	font-size:14px;
 	padding-left: 12px;
 	padding-right: 12px;
-
 }
 
-#inlineAddOr {
+.inlineAddOr {
 	display:inline-block;
 	color: #999;
     margin: 6px;
@@ -1785,10 +1784,7 @@ img {
 	text-align: right;
 }
 #inlineAddMediaInput{
-	width:100%;
-	margin-bottom:40px;
-	height:32px;
-	font-size:14px;
+	width: 290px;
 }
 
 .s2AddedBy {

--- a/static/css/sheets.css
+++ b/static/css/sheets.css
@@ -1784,7 +1784,7 @@ img {
 	text-align: right;
 }
 #inlineAddMediaInput{
-	width: 290px;
+	width: 280px;
 }
 
 .s2AddedBy {

--- a/static/js/sheets.js
+++ b/static/js/sheets.js
@@ -3353,3 +3353,56 @@ var afterAction = function() {
 		$("#fileControlMsg").hide();
 	}
 };
+
+// ------------------ Upload locally stored images to Imgur ------------------
+
+var imgurClientId = "f409a1105c5e8af";
+
+var addmediaChooseFile = function() {
+  var file = this.files[0];
+
+  if (file == null)
+    return;
+
+  if (/\.(jpe?g|png|gif)$/i.test(file.name)) {
+    var reader = new FileReader();
+
+    reader.addEventListener("load", function() {
+      addmediaUploadImageToImgur(reader.result);
+    }, false);
+
+    reader.addEventListener("onerror", function() {
+      sjs.alert.message(reader.error);
+    }, false);
+
+    reader.readAsDataURL(file);
+  } else {
+      sjs.alert.message("Could not add image. Please make sure that the file you attempted to upload is a JPEG, PNG, or GIF");
+  }
+};
+
+var addmediaUploadImageToImgur = function(imageData) {
+  $.ajax({
+    url: "https://api.imgur.com/3/image",
+    type: "POST",
+    headers: {
+      Authorization: "Client-ID " + imgurClientId,
+      Accept: "application/json"
+    },
+    data: {
+      image: imageData.replace(/data:image\/(jpe?g|png|gif);base64,/, ""),
+      type: "base64"
+    },
+    success: function(result) {
+			var imageUrl = "https://i.imgur.com/" + result.data.id + ".png";
+      $("#inlineAddMediaInput").val(imageUrl);
+      $("#addmediaDiv").find(".button").first().trigger("click");
+			$("#inlineAddMediaInput").val("");
+    },
+    error: function(result) {
+      sjs.alert.message(result.responseJSON.data.error);
+    }
+  });
+};
+
+$("#addmediaFileSelector").change(addmediaChooseFile);

--- a/templates/s2_sheets.html
+++ b/templates/s2_sheets.html
@@ -376,7 +376,11 @@
                 </div>
                 <div class="pull-right">
                     <div class="inlineAddDesc">Upload an Image</div>
-                    <input id="addmediaFileSelector" type="file">
+                    <label for="addmediaFileSelector" class="button">
+                      <i class="fa fa-upload" aria-hidden="true"></i>
+                      Choose a file...
+                    </label>
+                    <input id="addmediaFileSelector" type="file" style="display:none">
                 </div>
             </div>
 

--- a/templates/s2_sheets.html
+++ b/templates/s2_sheets.html
@@ -340,12 +340,12 @@
             <div id="addsourceDiv">
                 <div id="inlineAddDialogTitle" class="inlineAddDesc">Select a text</div>
                 <div class="blockContainer">
-                    <input id="inlineAdd" placeholder="Search for a Text or Commentator"/>
+                    <input id="inlineAdd" class="inlineAddTextInput" placeholder="Search for a Text or Commentator"/>
                     <div class="buttonContainer">
                         <div id="inlineAddBrowseBox" class="inlineAddSourceByttons">
                             <div id="inlineAddSourceOK" class='button disabled'>Add Source</div>
                         </div>
-                        <div id="inlineAddOr"> or </div>
+                        <div class="inlineAddOr"> or </div>
                         <div id="inlineAddBrowseBox" class="inlineAddSourceByttons">
                             <div id="inlineAddBrowse" class='button'>Browse Sources</div>
                         </div>
@@ -368,19 +368,23 @@
                 </div>
                 <div class="button">Add to Sheet</div>
             </div>
-            <div id="addmediaDiv" class="clearfix">
-                <div class="pull-left" style="width:60%">
-                    <div class="inlineAddDesc">Add Image, Youtube Video, or MP3</div>
-                    <input id="inlineAddMediaInput" placeholder="Paste URL"><br/>
-                    <div class="button">Add to Sheet</div>
-                </div>
-                <div class="pull-right" style="width:40%">
-                    <div class="inlineAddDesc">Upload an Image</div>
-                    <label for="addmediaFileSelector" class="button">
-                      <i class="fa fa-upload" aria-hidden="true"></i>
-                      Choose a file...
-                    </label>
-                    <input id="addmediaFileSelector" type="file" style="display:none">
+            <div id="addmediaDiv">
+                <div class="inlineAddDesc">Add Image, Youtube Video, or MP3</div>
+                <div class="blockContainer">
+                    <input id="inlineAddMediaInput" class="inlineAddTextInput" placeholder="Paste URL">
+                    <div class="buttonContainer">
+                        <div class="inlineAddSourceByttons">
+                            <div class="button">Add to Sheet</div>
+                        </div>
+                        <div class="inlineAddOr"> or </div>
+                        <div class="inlineAddSourceByttons">
+                            <label for="addmediaFileSelector" class="button">
+                                <i class="fa fa-upload" aria-hidden="true"></i>
+                                Choose a file...
+                            </label>
+                            <input id="addmediaFileSelector" type="file" style="display:none">
+                        </div>
+                    </div>
                 </div>
             </div>
 

--- a/templates/s2_sheets.html
+++ b/templates/s2_sheets.html
@@ -28,21 +28,6 @@
         background-color:#f8f8f8;
     }
 
-    .clearfix:before,
-    .clearfix:after {
-      content: " ";
-      display: table;
-    }
-    .clearfix:after {
-      clear: both;
-    }
-    .pull-right {
-      float: right !important;
-    }
-    .pull-left {
-      float: left !important;
-    }
-
 {% endblock %}
 
 {% block content %}

--- a/templates/s2_sheets.html
+++ b/templates/s2_sheets.html
@@ -28,6 +28,21 @@
         background-color:#f8f8f8;
     }
 
+    .clearfix:before,
+    .clearfix:after {
+      content: " ";
+      display: table;
+    }
+    .clearfix:after {
+      clear: both;
+    }
+    .pull-right {
+      float: right !important;
+    }
+    .pull-left {
+      float: left !important;
+    }
+
 {% endblock %}
 
 {% block content %}
@@ -353,10 +368,16 @@
                 </div>
                 <div class="button">Add to Sheet</div>
             </div>
-            <div id="addmediaDiv">
-                <div class="inlineAddDesc">Add Image, Youtube Video, or MP3</div>
-                <input id="inlineAddMediaInput" placeholder="Paste URL"><br/>
-                <div class="button">Add to Sheet</div>
+            <div id="addmediaDiv" class="clearfix">
+                <div class="pull-left">
+                    <div class="inlineAddDesc">Add Image, Youtube Video, or MP3</div>
+                    <input id="inlineAddMediaInput" placeholder="Paste URL"><br/>
+                    <div class="button">Add to Sheet</div>
+                </div>
+                <div class="pull-right">
+                    <div class="inlineAddDesc">Upload an Image</div>
+                    <input id="addmediaFileSelector" type="file">
+                </div>
             </div>
 
 

--- a/templates/s2_sheets.html
+++ b/templates/s2_sheets.html
@@ -365,7 +365,7 @@
                         <div class="inlineAddSourceByttons">
                             <label for="addmediaFileSelector" class="button">
                                 <i class="fa fa-upload" aria-hidden="true"></i>
-                                Choose a file...
+                                Upload an Image
                             </label>
                             <input id="addmediaFileSelector" type="file" style="display:none">
                         </div>

--- a/templates/s2_sheets.html
+++ b/templates/s2_sheets.html
@@ -369,12 +369,12 @@
                 <div class="button">Add to Sheet</div>
             </div>
             <div id="addmediaDiv" class="clearfix">
-                <div class="pull-left">
+                <div class="pull-left" style="width:60%">
                     <div class="inlineAddDesc">Add Image, Youtube Video, or MP3</div>
                     <input id="inlineAddMediaInput" placeholder="Paste URL"><br/>
                     <div class="button">Add to Sheet</div>
                 </div>
-                <div class="pull-right">
+                <div class="pull-right" style="width:40%">
                     <div class="inlineAddDesc">Upload an Image</div>
                     <label for="addmediaFileSelector" class="button">
                       <i class="fa fa-upload" aria-hidden="true"></i>


### PR DESCRIPTION
I decided to take a stab at this issue tonight. My solution was to upload the image to Imgur using the [Imgur API](https://api.imgur.com/) and then, insert the direct link to the image that the API returns into [`inlineAddMediaInput`](https://github.com/Sefaria/Sefaria-Project/blob/master/templates/s2_sheets.html#L358) and trigger a click event on its respective `.button` using jQuery. I'll admit, it's a little bit hacky, but it was working great on JPGs, PNGs, and GIFs when I manually tested it. I would recommend cleaning up the CSS a little bit though. I was having some difficulty styling the `input[type=file]`.