### PR TITLE
bug fiexes in Ref.all_subrefs and migrate_to_complex_structure

### DIFF
--- a/sefaria/model/text.py
+++ b/sefaria/model/text.py
@@ -2805,6 +2805,8 @@ class Ref(object):
         assert not self.is_range(), "Ref.all_subrefs() is not intended for use on Ranges"
 
         size = self.get_state_ja(lang).sub_array_length([i - 1 for i in self.sections])
+        if size is None:
+            size = 0
         return self.subrefs(size)
 
     def context_ref(self, level=1):


### PR DESCRIPTION
Ref.all_subrefs returns empty list if passed a reference to a location beyond the end of the text

migrate_to_complex_structure: gracefull fail if Ref can't instantiate; prevent loss of data when creating the new index
