### PR TITLE
makes lang parameter more resilient

### DIFF
--- a/reader/views.py
+++ b/reader/views.py
@@ -60,6 +60,12 @@ logger = logging.getLogger(__name__)
 
 @ensure_csrf_cookie
 def reader(request, tref, lang=None, version=None):
+
+    # if lang parameter has not been set
+    # then pull it off of the request query parameters
+    if lang is None:
+        lang =  request.GET.get('lang', None)
+
     # Redirect to standard URLs
     def reader_redirect(uref, lang, version):
         url = "/" + uref


### PR DESCRIPTION
I had pulled down the repo to make a different pull request, and I noticed that the `lang` parameter being passed into `reader` was `None`, instead of what I think would be theoretically `'he'` or `'en'`. 
I don't know the code base that well, just dove into it today. Maybe this is what is supposed to be happening.