### PR TITLE
Updated Fedora instructions

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -48,7 +48,7 @@ On Debian systems:
 
 On Fedora systems:
 
-    sudo yum install python-devel
+    sudo dnf install python2-devel
 
 After installing the Python development libraries, run `pip install -r requirements.txt` again.
 


### PR DESCRIPTION
1. Fedora now uses `dnf` instead of `yum`.
2. The relevant package is now called `python2-devel`.