### PR TITLE
all_subrefs() now returns only existent refs

### DIFF
--- a/sefaria/model/tests/ref_test.py
+++ b/sefaria/model/tests/ref_test.py
@@ -389,6 +389,8 @@ class Test_Ref(object):
     def test_all_subrefs(self):
         assert Ref("Genesis").all_subrefs()[49] == Ref("Genesis 50")
         assert Ref("Genesis 40").all_subrefs()[22] == Ref("Genesis 40:23")
+        assert Ref("Tamid").all_subrefs()[0] == Ref("Tamid 25b")
+        assert Ref("Berakhot").all_subrefs()[0] == Ref("Berakhot 2a")
 
     def test_ref_regex(self):
         assert Ref("Exodus 15").regex() == u'^Exodus( 15$| 15:| 15 \\d)'

--- a/sefaria/model/text.py
+++ b/sefaria/model/text.py
@@ -2940,10 +2940,17 @@ class Ref(object):
         # TODO this function should take Version as optional parameter to limit the refs it returns to ones existing in that Version
         assert not self.is_range(), "Ref.all_subrefs() is not intended for use on Ranges"
 
-        size = self.get_state_ja(lang).sub_array_length([i - 1 for i in self.sections])
+        ja = self.get_state_ja(lang)
+        size = ja.sub_array_length([i - 1 for i in self.sections])
         if size is None:
             size = 0
-        return self.subrefs(size)
+        subrefs = self.subrefs(size)
+
+        # at this point, subrefs can include non-existent refs, so now filter those out using ja.array()
+        subrefs = [poss_subref for poss_subref, actual_subref in zip(subrefs, ja.array()) if actual_subref != []]
+
+        return subrefs
+
 
     def context_ref(self, level=1):
         """


### PR DESCRIPTION
A trello card mentions that Ref("Tamid").all_subrefs() didn't work as expected.
As of this commit, all_subrefs() still passes the old test in test_all_subrefs() and now passes two new tests I based on the bug mentioned in the trello card.