### PR TITLE
Added parashot sharedTitle checker to validate()

### DIFF
--- a/sefaria/model/schema.py
+++ b/sefaria/model/schema.py
@@ -781,6 +781,18 @@ class TitledTreeNode(TreeNode, AbstractTitledOrTermedObject):
         if self.sharedTitle and Term().load({"name": self.sharedTitle}).titles != self.get_titles_object():
             raise IndexSchemaError(u"Schema node {} with sharedTitle can not have explicit titles".format(self))
 
+        special_book_cases = ["Genesis", "Exodus", "Leviticus", "Numbers", "Deuteronomy"]
+        for title in self.title_group.titles:
+            title = title["text"]
+            if title in special_book_cases:
+                continue
+            term = Term().load_by_title(title)
+            if term:
+                if "scheme" in vars(term).keys():
+                    if vars(term)["scheme"] == "Parasha":
+                        raise InputError(
+                            "Nodes that represent Parashot must contain the corresponding sharedTitles.")
+
         #if not self.default and not self.primary_title("he"):
         #    raise IndexSchemaError("Schema node {} missing primary Hebrew title".format(self.key))
 


### PR DESCRIPTION
To prevent people from trying to add new indices to the Sefaria library that contain titles of Parashot not using sharedTitles in the future, I added a checker to the validate function that iterates through the indices' nodes' titles and raises an error if any of the titles are Parashot that aren't using sharedTitles. 