### PR TITLE
Update README with reCAPTCHA keys instructions

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -110,6 +110,12 @@ This will create (or overwrite) a mongo database called `sefaria`.
 If you have used `dump_small.tar.gz`, use the mongo client shell, or a GUI you have installed to create an empty collection inside the `sefaria` database called `history`.
 
 #### Set up Django's local server
+
+Sefaria is using Google's reCAPTCHA to verify the user is not a bot. For a deployment you should register and use your own reCAPTCHA keys (https://pypi.org/project/django-recaptcha/#installation).
+For local development the default test keys would suffice. The warning can be suprassed by adding the following to the settings file:
+
+    SILENCED_SYSTEM_CHECKS = ['captcha.recaptcha_test_key_error']
+
 `manage.py` is used to run and to manage the local server.  It is located in the root directory of the `Sefaria-Project` code base. 
 
 Django auth features run on a separate database. To init this database and set up Django's auth system, switch to the root directory of the `Sefaria-Project` code base, and run (from the project root):


### PR DESCRIPTION
Motivation:
  Leaving the default reCAPTCHA test keys produces an error. This commit
  explains the cause of the error and suggests solutions.

Signed-off-by: Dimid Duchovny <dimidd@gmail.com>