### PR TITLE
Setting #inlineTextPreview z-index to auto

### DIFF
--- a/static/css/sheets.css
+++ b/static/css/sheets.css
@@ -432,7 +432,7 @@ body:not(.user-is-tabbing) #sheet .cke_editable:focus {
 	background: white;
 	border: 1px solid #ddd;
 	border-radius: 3px;
-	z-index: 101;
+	z-index: auto;
 	width: 600px;
 	display: none;
 }

--- a/static/css/sheets.css
+++ b/static/css/sheets.css
@@ -432,7 +432,7 @@ body:not(.user-is-tabbing) #sheet .cke_editable:focus {
 	background: white;
 	border: 1px solid #ddd;
 	border-radius: 3px;
-	z-index: auto;
+	z-index: 19;
 	width: 600px;
 	display: none;
 }


### PR DESCRIPTION
Fixes #487 

This branch updates the z-index of `#inlineTextPreview` to auto so that the stacking level is the same as its parent and `#textBrowser` renders correctly over it.

Note: I only tested this fix with firefox dev tools

All feedback welcome, especially whether this approach makes sense or whether another approach would be appropriate.

