### PR TITLE
Setting #inlineTextPreview z-index to be one less than #textBrowser

### DIFF
--- a/static/css/sheets.css
+++ b/static/css/sheets.css
@@ -432,7 +432,7 @@ body:not(.user-is-tabbing) #sheet .cke_editable:focus {
 	background: white;
 	border: 1px solid #ddd;
 	border-radius: 3px;
-	z-index: 101;
+	z-index: auto;
 	width: 600px;
 	display: none;
 }

--- a/static/css/sheets.css
+++ b/static/css/sheets.css
@@ -432,7 +432,7 @@ body:not(.user-is-tabbing) #sheet .cke_editable:focus {
 	background: white;
 	border: 1px solid #ddd;
 	border-radius: 3px;
-	z-index: auto;
+	z-index: 19;
 	width: 600px;
 	display: none;
 }


### PR DESCRIPTION
Fixes #487, using recommended fix from @blockspeiser in #490.

This branch updates the `z-index` of `#inlineTextPreview` to be 19, one less than the `z-index` of the `#textBrowser`.

All comments welcome.