### PR TITLE
Use `/usr/bin/env bash` to locate Bash

### DIFF
--- a/cli
+++ b/cli
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 export PYTHONPATH=$(pwd)
 export DJANGO_SETTINGS_MODULE=sefaria.settings

--- a/run
+++ b/run
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Run a python script with necessary setup
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"

--- a/scripts/generate_test_monitor_image.sh
+++ b/scripts/generate_test_monitor_image.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd "${0%/*}"  # cd to directory of script
 TMP_DIR="./tmp_monitor_build"
 

--- a/scripts/test_scripts
+++ b/scripts/test_scripts
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Test runner for scripts
 # Currently just runs listed scripts and show any error messages.
 

--- a/test
+++ b/test
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #py.test tests
 py.test -v -m 'not deep and not failing'


### PR DESCRIPTION
Some number of Unix variants include the Posix shell
in /bin while bash is not included in the base system.
FreeBSSD is an example.

macos does include `/bin/bash`, but it's a very old version:
3.2.57 as of Catalinar/10.15

Using `/usr/bin/env` will use the first `bash` instance in your
PATH without assuming a hardcoded location.