### PR TITLE
Add an optional timezone parameter to /api/calendars

### DIFF
--- a/reader/views.py
+++ b/reader/views.py
@@ -11,6 +11,7 @@ from bson.json_util import dumps
 import socket
 import bleach
 from collections import OrderedDict
+import pytz
 
 from rest_framework.decorators import api_view
 from django.template.loader import render_to_string, get_template
@@ -2199,13 +2200,23 @@ def calendars_api(request):
         import datetime
         diaspora = request.GET.get("diaspora", "1")
         custom = request.GET.get("custom", None)
+
+        zone = request.GET.get("timezone", None)
+        if zone:
+            try:
+                zone = pytz.timezone(zone)
+            except pytz.exceptions.UnknownTimeZoneError as e:
+                return jsonResponse({"error": "Unknown 'timezone' value: '%s'." % zone})\
+        else:
+            zone = timezone.now()
+
         try:
             year = int(request.GET.get("year", None))
             month = int(request.GET.get("month", None))
             day = int(request.GET.get("day", None))
-            datetimeobj = datetime.datetime(year, month, day)
+            datetimeobj = datetime.datetime(year, month, day, tzinfo=zone)
         except Exception as e:
-            datetimeobj = timezone.localtime(timezone.now())
+            datetimeobj = timezone.localtime(zone)
 
         if diaspora not in ["0", "1"]:
             return jsonResponse({"error": "'Diaspora' parameter must be 1 or 0."})

--- a/reader/views.py
+++ b/reader/views.py
@@ -2201,15 +2201,11 @@ def calendars_api(request):
         diaspora = request.GET.get("diaspora", "1")
         custom = request.GET.get("custom", None)
 
-        zone_name = request.GET.get("timezone", None)
-        if zone_name:
-            try:
-                zone = pytz.timezone(zone_name)
-            except pytz.exceptions.UnknownTimeZoneError as e:
-                return jsonResponse({"error": "Unknown 'timezone' value: '%s'." % zone})\
-        else:
-            zone = None
-            zone_name = timezone.get_current_timezone_name()
+        zone_name = request.GET.get("timezone", timezone.get_current_timezone_name())
+        try:
+            zone = pytz.timezone(zone_name)
+        except pytz.exceptions.UnknownTimeZoneError as e:
+            return jsonResponse({"error": "Unknown 'timezone' value: '%s'." % zone})\
 
         try:
             year = int(request.GET.get("year", None))


### PR DESCRIPTION
Discussions:
  - https://groups.google.com/forum/?fromgroups#!topic/sefaria-dev/r-MjlKAr8z8
  - https://groups.google.com/forum/?fromgroups#!topic/sefaria-dev/P31bOJ0LIcc\

I don't have a local dev environment set up, so I wasn't able to test things, but I tried within a repl to make sure that this was correct. If someone that does have a dev setup could validate, that would be great.