### PR TITLE
Cleanup: Inline conditional that is always true

### DIFF
--- a/sefaria/model/text.py
+++ b/sefaria/model/text.py
@@ -3603,53 +3603,51 @@ class Ref(object, metaclass=RefCacheType):
             [Ref('Shabbat 13b:3-50'), Ref('Shabbat 14a'), Ref('Shabbat 14b:1-3')]
 
         """
-        if not self._spanned_refs or True:
+        if self.index_node.depth == 1 or not self.is_spanning():
+            self._spanned_refs = [self]
 
-            if self.index_node.depth == 1 or not self.is_spanning():
-                self._spanned_refs = [self]
+        else:
+            start, end = self.sections[self.range_index()], self.toSections[self.range_index()]
+            ref_depth = len(self.sections)
+            to_ref_depth = len(self.toSections)
 
-            else:
-                start, end = self.sections[self.range_index()], self.toSections[self.range_index()]
-                ref_depth = len(self.sections)
-                to_ref_depth = len(self.toSections)
+            refs = []
+            for n in range(start, end + 1):
+                d = self._core_dict()
+                if n == start:
+                    d["toSections"] = self.sections[0:self.range_index() + 1]
 
-                refs = []
-                for n in range(start, end + 1):
-                    d = self._core_dict()
-                    if n == start:
-                        d["toSections"] = self.sections[0:self.range_index() + 1]
+                    for i in range(self.range_index() + 1, ref_depth):
+                        d["toSections"] += [self.get_state_ja().sub_array_length([s - 1 for s in d["toSections"][0:i]],until_lnonempty=True)]
+                elif n == end:
+                    d["sections"] = self.toSections[0:self.range_index() + 1]
+                    for _ in range(self.range_index() + 1, to_ref_depth):
+                        d["sections"] += [1]
+                else:
+                    d["sections"] = self.sections[0:self.range_index()] + [n]
+                    d["toSections"] = self.sections[0:self.range_index()] + [n]
 
+                    '''  If we find that we need to expand inner refs, add this arg.
+                    # It will require handling on cached ref and passing on the recursive call below.
+                    if expand_middle:
                         for i in range(self.range_index() + 1, ref_depth):
-                            d["toSections"] += [self.get_state_ja().sub_array_length([s - 1 for s in d["toSections"][0:i]],until_last_nonempty=True)]
-                    elif n == end:
-                        d["sections"] = self.toSections[0:self.range_index() + 1]
-                        for _ in range(self.range_index() + 1, to_ref_depth):
                             d["sections"] += [1]
-                    else:
-                        d["sections"] = self.sections[0:self.range_index()] + [n]
-                        d["toSections"] = self.sections[0:self.range_index()] + [n]
+                            d["toSections"] += [self.get_state_ja().sub_array_length([s - 1 for s in d["toSections"][0:i]])]
+                    '''
 
-                        '''  If we find that we need to expand inner refs, add this arg.
-                        # It will require handling on cached ref and passing on the recursive call below.
-                        if expand_middle:
-                            for i in range(self.range_index() + 1, ref_depth):
-                                d["sections"] += [1]
-                                d["toSections"] += [self.get_state_ja().sub_array_length([s - 1 for s in d["toSections"][0:i]])]
-                        '''
+                if d["toSections"][-1]:  # to filter out, e.g. non-existant Rashi's, where the last index is 0
+                    try:
+                        refs.append(Ref(_obj=d))
+                    except InputError:
+                        pass
 
-                    if d["toSections"][-1]:  # to filter out, e.g. non-existant Rashi's, where the last index is 0
-                        try:
-                            refs.append(Ref(_obj=d))
-                        except InputError:
-                            pass
-
-                if self.range_depth() == 2:
-                    self._spanned_refs = refs
-                if self.range_depth() > 2: #recurse
-                    expanded_refs = []
-                    for ref in refs:
-                        expanded_refs.extend(ref.split_spanning_ref())
-                    self._spanned_refs = expanded_refs
+            if self.range_depth() == 2:
+                self._spanned_refs = refs
+            if self.range_depth() > 2: #recurse
+                expanded_refs = []
+                for ref in refs:
+                    expanded_refs.extend(ref.split_spanning_ref())
+                self._spanned_refs = expanded_refs
 
         return self._spanned_refs
 


### PR DESCRIPTION
This change removes an `if` statement that is always `True` (the `or True` clause causes the result to always be true, even if `not self._spanned_refs` is false.

The rest of the change is simply outdenting the code that was previously nested inside the `if`.