### PR TITLE
Propose that the gettext path is added to .bashrc

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -105,12 +105,11 @@ After installing the Python development libraries, run `pip install -r requireme
     brew install gettext
     
     
-On some macOS systems `gettext` will atill not run after installation and `django manage.py makemessages` will fail. In such a case, one easy solution is to run (replace x's with your gettext version number) before running functions that invoke gettext:
+On some macOS systems `gettext` will still not run after installation and `django manage.py makemessages` will fail. In such a case, one easy solution is to add (replace x's with your gettext version number) to your .bashrc(or its equivalent on your system):
     
     export TEMP_PATH=$PATH
     export PATH=$PATH:/usr/local/Cellar/gettext/0.xx.x/bin
     
-> If you work on such systems, you may want to add this to your .bashrc(or its equivalent on your system) so that you don't have to write it manually every time you want to manage localizations.
 
 ###### On Debian systems
 

--- a/README.mkd
+++ b/README.mkd
@@ -109,6 +109,8 @@ On some macOS systems `gettext` will atill not run after installation and `djang
     
     export TEMP_PATH=$PATH
     export PATH=$PATH:/usr/local/Cellar/gettext/0.xx.x/bin
+    
+> If you work on such systems, you may want to add this to your .bashrc(or its equivalent on your system) so that you don't have to write it manually every time you want to manage localizations.
 
 ###### On Debian systems
 


### PR DESCRIPTION
In my opinion it is a good idea to propose to this contributors that work on macOS systems on which gettext won't run, to add the needed exports to their .bashrc.