### PR TITLE
Offer consistent size to virtual keyboard :onhover

### DIFF
--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -6178,7 +6178,7 @@ body #keyboardInputMaster tbody tr td table tbody tr td{
 body #keyboardInputMaster tbody tr td table tbody tr td:hover,
 body #keyboardInputMaster tbody tr td table tbody tr td:active,
 body #keyboardInputMaster tbody tr td table tbody tr td.pressed{
-    border: 1px solid #eee;
+    border: 0.5px solid #eee;
     background: #eee;
 }
 #editGroupPageContainerInner {


### PR DESCRIPTION
If the size difference was intentional, perhaps reducing it from 1px to 0.6px could both retain the effect and not move around the keyboard when switching between rows.