### PR TITLE
removed unnecessary statement internal_do_delete causing bug

### DIFF
--- a/reader/views.py
+++ b/reader/views.py
@@ -1830,8 +1830,6 @@ def links_api(request, link_id_or_ref=None):
         if not user.is_staff:
             return jsonResponse({"error": "Only Sefaria Moderators can delete links."})
         
-        retval = _internal_do_delete(request, link_id_or_ref, uid)
-
         try:
             ref = Ref(link_id_or_ref)
         except InputError as e:


### PR DESCRIPTION
the line "retval = _internal_do_delete" may have been retained in the previous merge.
this line causes the API to fail if a Ref was passed as opposed to an ID which would succeed