### PR TITLE
fix footer_html when USE_NODE is False

### DIFF
--- a/sefaria/system/context_processors.py
+++ b/sefaria/system/context_processors.py
@@ -167,8 +167,8 @@ def footer_html(request):
     if request.path == "/data.js":
         return {}
     global FOOTER
+    lang = request.interfaceLang
     if USE_NODE:
-        lang = request.interfaceLang
         FOOTER[lang] = FOOTER[lang] or render_react_component("Footer", {"interfaceLang": request.interfaceLang, "_siteSettings": SITE_SETTINGS})
         FOOTER[lang] = "" if "appLoading" in FOOTER[lang] else FOOTER[lang]
     else:


### PR DESCRIPTION
This PR fixes the following error when `USE_NODE` is `False` in settings:

```
UnboundLocalError at /
local variable 'lang' referenced before assignment
/www/sefaria/system/context_processors.py in footer_html, line 175
```
