### PR TITLE
`npm run setup` now works on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "watch-explore": "webpack --config ./node/webpack.explore.js --progress -w --stdin",
     "watch-sefaria": "webpack --config ./node/webpack.sefaria.js --progress -w --stdin",
     "watch-timeline": "webpack --config ./node/webpack.timeline.js --progress -w --stdin",
-    "setup": "npm install -g nodemon; npm install -g babel-cli; npm install -g forever",
+    "setup": "npm install -g nodemon babel-cli forever",
     "b": "npm run build",
     "w": "npm run watch-client-server",
     "wc": "npm run watch-client",


### PR DESCRIPTION
When attempting to set up Sefaria on Windows 10, I encountered the following problem when running `npm run setup`:

C:\Users\LENOVO\Documents\Sefaria-Project>npm run setup

```
> sefaria-web@1.0.0 setup C:\Users\LENOVO\Documents\Sefaria-Project
> npm install -g nodemon; npm install -g babel-cli; npm install -g forever

  npm ERR! code EINVALIDTAGNAME
  npm ERR! Invalid tag name "nodemon;": Tags may not have any characters that encodeURIComponent encodes.
  
  npm ERR! A complete log of this run can be found in:
  npm ERR!     C:\Users\LENOVO\AppData\Roaming\npm-cache\_logs\2021-04-22T18_51_24_131Z-debug.log
  npm ERR! code ELIFECYCLE
  npm ERR! errno 1
  npm ERR! sefaria-web@1.0.0 setup: `npm install -g nodemon; npm install -g babel-cli; npm install -g forever`
  npm ERR! Exit status 1
  npm ERR!
  npm ERR! Failed at the sefaria-web@1.0.0 setup script.
  npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
```

After replacing the multiple commands with a single npm install command, it completed successfully.

[A quick googling](https://github.com/npm/npm/issues/4040) revealed that this is a known problem and many people have inventive ways of getting around it, but for our case just joining the multiple commands into a single command is enough to make it multiplatform.