### PR TITLE
Added 'download MongoDB Database tools' to readme

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -149,6 +149,8 @@ The recommended dump (which is of a manageable size) is available [here](https:/
 
 A complete dump is also available [here](https://storage.googleapis.com/sefaria-mongo-backup/dump.tar.gz). The complete dump includes the `history` collections which contains a complete revision history of every text our library. For many applications this data is not relevant. We recommend using the smaller dump unless you're specifically interested in texts revision history within Sefaria.
 
+From MongoDB version 4.4, mongorestore comes separately from the MongoDB server, you'll also need to download the [Database Tools](https://www.mongodb.com/try/download/database-tools?tck=docs_databasetools)
+
 Once you've download and unzipped this content, from the parent directory which contains `dump` run:
 
     mongorestore --drop


### PR DESCRIPTION
As documented [here](https://docs.mongodb.com/database-tools/mongorestore/), from MongoDB 4.4 the database tools (including mongorestore) are versioned and installed separately from the MongoDB server, making their installation a necessary step for the import.

Also, since the import is slightly lengthier on Windows (download file - unzip *twice* - go to folder above dump/sefaria, run mongorestore there by adding the folder to path OR specifying the exact exe file location) I think it could be helpful to future Windows devs to state that. I feel that there are a lot of steps here that are assumed or glossed over, which can make it difficult for more junior devs to get started with it.