### PR TITLE
'python manage.py runserver' now working again

### DIFF
--- a/sefaria/model/user_profile.py
+++ b/sefaria/model/user_profile.py
@@ -27,7 +27,6 @@ from sefaria.model.text import Ref
 from sefaria.system.database import db
 from sefaria.utils.util import epoch_time
 from django.utils import translation
-from sefaria.settings import PARTNER_GROUP_EMAIL_PATTERN_LOOKUP_FILE
 
 import structlog
 logger = structlog.get_logger(__name__)

--- a/sefaria/views.py
+++ b/sefaria/views.py
@@ -38,7 +38,7 @@ import sefaria.model as model
 import sefaria.system.cache as scache
 from sefaria.client.util import jsonResponse, subscribe_to_list, send_email
 from sefaria.forms import SefariaNewUserForm, SefariaNewUserFormAPI
-from sefaria.settings import MAINTENANCE_MESSAGE, USE_VARNISH, MULTISERVER_ENABLED, relative_to_abs_path, PARTNER_GROUP_EMAIL_PATTERN_LOOKUP_FILE, RTC_SERVER
+from sefaria.settings import MAINTENANCE_MESSAGE, USE_VARNISH, MULTISERVER_ENABLED, relative_to_abs_path, RTC_SERVER
 from sefaria.model.user_profile import UserProfile, user_link
 from sefaria.model.collection import CollectionSet
 from sefaria.export import export_all as start_export_all


### PR DESCRIPTION
Removed references to missing (and unused) PARTNER_GROUP_EMAIL_PATTERN_LOOKUP_FILE which were causing failures when running 'python manage.py runserver'

When running `python manage.py runserver` I encountered the following errors:

```
Unhandled exception in thread started by <function check_errors.<locals>.wrapper at 0x00000253496F29D8>
Traceback (most recent call last):
  File "C:\Users\LENOVO\AppData\Local\Programs\Python\Python37\lib\site-packages\django\utils\autoreload.py", line 228, in wrapper
    fn(*args, **kwargs)
  File "C:\Users\LENOVO\AppData\Local\Programs\Python\Python37\lib\site-packages\django\core\management\commands\runserver.py", line 124, in inner_run
    self.check(display_num_errors=True)
  File "C:\Users\LENOVO\AppData\Local\Programs\Python\Python37\lib\site-packages\django\core\management\base.py", line 359, in check
    include_deployment_checks=include_deployment_checks,
  File "C:\Users\LENOVO\AppData\Local\Programs\Python\Python37\lib\site-packages\django\core\management\base.py", line 346, in _run_checks
    return checks.run_checks(**kwargs)
  File "C:\Users\LENOVO\AppData\Local\Programs\Python\Python37\lib\site-packages\django\core\checks\registry.py", line 81, in run_checks
    new_errors = check(app_configs=app_configs)
  File "C:\Users\LENOVO\AppData\Local\Programs\Python\Python37\lib\site-packages\django\core\checks\urls.py", line 16, in check_url_config
    return check_resolver(resolver)
  File "C:\Users\LENOVO\AppData\Local\Programs\Python\Python37\lib\site-packages\django\core\checks\urls.py", line 26, in check_resolver
    return check_method()
  File "C:\Users\LENOVO\AppData\Local\Programs\Python\Python37\lib\site-packages\django\urls\resolvers.py", line 256, in check
    for pattern in self.url_patterns:
  File "C:\Users\LENOVO\AppData\Local\Programs\Python\Python37\lib\site-packages\django\utils\functional.py", line 35, in __get__
    res = instance.__dict__[self.name] = self.func(instance)
  File "C:\Users\LENOVO\AppData\Local\Programs\Python\Python37\lib\site-packages\django\urls\resolvers.py", line 407, in url_patterns
    patterns = getattr(self.urlconf_module, "urlpatterns", self.urlconf_module)
  File "C:\Users\LENOVO\AppData\Local\Programs\Python\Python37\lib\site-packages\django\utils\functional.py", line 35, in __get__
    res = instance.__dict__[self.name] = self.func(instance)
  File "C:\Users\LENOVO\AppData\Local\Programs\Python\Python37\lib\site-packages\django\urls\resolvers.py", line 400, in urlconf_module
    return import_module(self.urlconf_name)
  File "C:\Users\LENOVO\AppData\Local\Programs\Python\Python37\lib\importlib\__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 728, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "C:\Users\LENOVO\Documents\Sefaria-Project\sefaria\urls.py", line 11, in <module>
    import reader.views as reader_views
  File "C:\Users\LENOVO\Documents\Sefaria-Project\reader\views.py", line 34, in <module>
    from sefaria.model import *
  File "C:\Users\LENOVO\Documents\Sefaria-Project\sefaria\model\__init__.py", line 15, in <module>
    from . import history, schema, text, link, note, layer, notification, queue, lock, following, user_profile, version_state, \
  File "C:\Users\LENOVO\Documents\Sefaria-Project\sefaria\model\notification.py", line 16, in <module>
    from . import user_profile
  File "C:\Users\LENOVO\Documents\Sefaria-Project\sefaria\model\user_profile.py", line 30, in <module>
    from sefaria.settings import PARTNER_GROUP_EMAIL_PATTERN_LOOKUP_FILE
ImportError: cannot import name 'PARTNER_GROUP_EMAIL_PATTERN_LOOKUP_FILE' from 'sefaria.settings' (C:\Users\LENOVO\Documents\Sefaria-Project\sefaria\settings.py)





Unhandled exception in thread started by <function check_errors.<locals>.wrapper at 0x00000262FCCB29D8>
Traceback (most recent call last):
  File "C:\Users\LENOVO\AppData\Local\Programs\Python\Python37\lib\site-packages\django\utils\autoreload.py", line 228, in wrapper
    fn(*args, **kwargs)
  File "C:\Users\LENOVO\AppData\Local\Programs\Python\Python37\lib\site-packages\django\core\management\commands\runserver.py", line 124, in inner_run
    self.check(display_num_errors=True)
  File "C:\Users\LENOVO\AppData\Local\Programs\Python\Python37\lib\site-packages\django\core\management\base.py", line 359, in check
    include_deployment_checks=include_deployment_checks,
  File "C:\Users\LENOVO\AppData\Local\Programs\Python\Python37\lib\site-packages\django\core\management\base.py", line 346, in _run_checks
    return checks.run_checks(**kwargs)
  File "C:\Users\LENOVO\AppData\Local\Programs\Python\Python37\lib\site-packages\django\core\checks\registry.py", line 81, in run_checks
    new_errors = check(app_configs=app_configs)
  File "C:\Users\LENOVO\AppData\Local\Programs\Python\Python37\lib\site-packages\django\core\checks\urls.py", line 16, in check_url_config
    return check_resolver(resolver)
  File "C:\Users\LENOVO\AppData\Local\Programs\Python\Python37\lib\site-packages\django\core\checks\urls.py", line 26, in check_resolver
    return check_method()
  File "C:\Users\LENOVO\AppData\Local\Programs\Python\Python37\lib\site-packages\django\urls\resolvers.py", line 256, in check
    for pattern in self.url_patterns:
  File "C:\Users\LENOVO\AppData\Local\Programs\Python\Python37\lib\site-packages\django\utils\functional.py", line 35, in __get__
    res = instance.__dict__[self.name] = self.func(instance)
  File "C:\Users\LENOVO\AppData\Local\Programs\Python\Python37\lib\site-packages\django\urls\resolvers.py", line 407, in url_patterns
    patterns = getattr(self.urlconf_module, "urlpatterns", self.urlconf_module)
  File "C:\Users\LENOVO\AppData\Local\Programs\Python\Python37\lib\site-packages\django\utils\functional.py", line 35, in __get__
    res = instance.__dict__[self.name] = self.func(instance)
  File "C:\Users\LENOVO\AppData\Local\Programs\Python\Python37\lib\site-packages\django\urls\resolvers.py", line 400, in urlconf_module
    return import_module(self.urlconf_name)
  File "C:\Users\LENOVO\AppData\Local\Programs\Python\Python37\lib\importlib\__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 728, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "C:\Users\LENOVO\Documents\Sefaria-Project\sefaria\urls.py", line 12, in <module>
    import sefaria.views as sefaria_views
  File "C:\Users\LENOVO\Documents\Sefaria-Project\sefaria\views.py", line 41, in <module>
    from sefaria.settings import MAINTENANCE_MESSAGE, USE_VARNISH, MULTISERVER_ENABLED, relative_to_abs_path, PARTNER_GROUP_EMAIL_PATTERN_LOOKUP_FILE, RTC_SERVER
ImportError: cannot import name 'PARTNER_GROUP_EMAIL_PATTERN_LOOKUP_FILE' from 'sefaria.settings' (C:\Users\LENOVO\Documents\Sefaria-Project\sefaria\settings.py)
```

Checking the settings file, I saw that it was indeed missing. And checking the two files that referenced it, I saw that the PARTNER_GROUP_EMAIL_PATTERN_LOOKUP_FILE did not appear anywhere else in the file, and therefore was probably a holdout from previous versions.

What I can't understand is how this was working for y'all up till now? This is a cross-platform problem, and should have affected everyone - am I missing something?