### PR TITLE
Resolved #541 - multi-page commentary references no longer split into individual letters at /api/texts

### DIFF
--- a/sefaria/client/wrapper.py
+++ b/sefaria/client/wrapper.py
@@ -250,7 +250,9 @@ def get_links(tref, with_text=True, with_sheet_links=False):
                             }
                     com_sections = [i - 1 for i in com_oref.sections]
                     com_toSections = [i - 1 for i in com_oref.toSections]
-                    for lang, (attr, versionAttr, licenseAttr, vtitleInHeAttr) in (("he", ("he","heVersionTitle","heLicense","heVersionTitleInHebrew")), ("en", ("text", "versionTitle","license","versionTitleInHebrew"))):
+                    for lang, (attr, versionAttr, licenseAttr, vtitleInHeAttr) in (
+                            ("he", ("he","heVersionTitle","heLicense","heVersionTitleInHebrew")),
+                            ("en", ("text", "versionTitle","license","versionTitleInHebrew"))):
                         temp_nref_data = texts[top_nref][lang]
                         res = temp_nref_data['ja'].subarray(com_sections[1:], com_toSections[1:]).array()
                         if attr not in com:
@@ -258,6 +260,8 @@ def get_links(tref, with_text=True, with_sheet_links=False):
                         else:
                             if isinstance(com[attr], str):
                                 com[attr] = [com[attr]]
+                            if isinstance(res, str):
+                                res = [res]
                             com[attr] += res
                         temp_version = temp_nref_data['version']
                         if isinstance(temp_version, str) or temp_version is None:

--- a/sefaria/client/wrapper.py
+++ b/sefaria/client/wrapper.py
@@ -254,15 +254,17 @@ def get_links(tref, with_text=True, with_sheet_links=False):
                             ("he", ("he","heVersionTitle","heLicense","heVersionTitleInHebrew")),
                             ("en", ("text", "versionTitle","license","versionTitleInHebrew"))):
                         temp_nref_data = texts[top_nref][lang]
+                        # Because of how the jagged arrays work, res may be either a single line or a list of lines
                         res = temp_nref_data['ja'].subarray(com_sections[1:], com_toSections[1:]).array()
-                        if attr not in com:
-                            com[attr] = res
-                        else:
+                        if attr not in com: # If this is the first com_oref, and so the object doesn't contain any data in this field,
+                            com[attr] = res  # Set the text directly in the object
+                        else:  # This is not the first oref (this was a spanning ref, e.g. "Ketubot 110b:25-111a:1".
+                            # We'll want to connect the texts from all pages together. As mentioned, each can be either a string or a list.
                             if isinstance(com[attr], str):
                                 com[attr] = [com[attr]]
                             if isinstance(res, str):
                                 res = [res]
-                            com[attr] += res
+                            com[attr] += res  # Once they're both definitely lists, merge the lists together.
                         temp_version = temp_nref_data['version']
                         if isinstance(temp_version, str) or temp_version is None:
                             com[versionAttr] = temp_version


### PR DESCRIPTION
When you have references that span multiple pages, Sefaria attempts to connect the text in the pages together to a single list.
It goes over each page (wrapper.py:215, `for com_oref in con_orefs`) and for each tries to add it to a list.

For the first item in the list (which is usually all you have) it just uses that string (wrapper.py:259, `com[attr] = res`)

However on the SECOND one, it attempts to make a list that will include both.
:262, `com[attr] = [com[attr]]` works fine. However :263, `com[attr] += res` treats the res (which can be a single line of text) AS A LIST, and therefore adds all the elements of the list to the other list... since it's a string, that means the individual chars...

The solution is to check if it's a string or not.

However, I think the real source of the problem is the ambiguity in the JaggedArray.array() function.

:257 has `res = temp_nref_data['ja'].subarray(com_sections[1:], com_toSections[1:]).array()`. As a casual reader, I would expect that res is therefore an array (it has .array() at the end, after all). THIS IS A TRAP.

Would typing the .array() function to indicate it can return either an array or a string have helped? I don't know. But it might have avoided this edge case.