### PR TITLE
Tosefta Kifshutah view in TOC

### DIFF
--- a/static/js/ReaderNavigationCategoryMenu.jsx
+++ b/static/js/ReaderNavigationCategoryMenu.jsx
@@ -300,8 +300,8 @@ const getRenderedTextTitleString = (title, heTitle, categories) => {
     }
 
     const replaceTitles = {
-        "en": ['Jerusalem Talmud'].concat(categories),
-        "he": ['תלמוד ירושלמי'].concat(categories.map(Sefaria.hebrewTerm))
+        "en": ['Jerusalem Talmud', 'Tosefta Kifshutah'].concat(categories),
+        "he": ['תלמוד ירושלמי', 'תוספתא כפשוטה'].concat(categories.map(Sefaria.hebrewTerm))
     };
     const replaceOther = {
         "en" : [", ", "; ", " on ", " to ", " of "],


### PR DESCRIPTION
Indexes appea as 'Kifshutah on {masechet}'.
This is a patch for it, so it will appear just with the masechet like other commentaries.