### PR TITLE
fix a doc build indentation issue

### DIFF
--- a/sefaria/model/text.py
+++ b/sefaria/model/text.py
@@ -2932,7 +2932,9 @@ class Ref(object, metaclass=RefCacheType):
     def is_segment_level(self):
         """
         Is this Ref segment (e.g. Verse) level?
+
         ::
+
             >>> Ref("Leviticus 15:3").is_segment_level()
             True
             >>> Ref("Leviticus 15").is_segment_level()


### PR DESCRIPTION
Fix this issue. when `make`-ing `doc`
```
/home/uri/git/Sefaria-Project/sefaria/model/text.py:docstring of sefaria.model.text.Ref.is_segment_level:3: WARNING: Unexpected indentation.
```
See #646.