### PR TITLE
Fix 'copy link' button in share menu

### DIFF
--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -6195,8 +6195,6 @@ body .ui-autocomplete.dictionary-toc-autocomplete .ui-menu-item a.ui-state-focus
 
 .shareInputBox .shareInputButton:active {
   background-color: var(--light-grey);
-  border: 0;
-  margin-inline-start: 20px;
 }
 
 .shareSettingsBox {


### PR DESCRIPTION
The 'copy link' button in the 'share' menu was jumping around when clicked, which then meant that the link wasn't actually getting copied because the mouse wasn't on the button when it was released.

To get to the button I'm referring to: Open Genesis, click a verse, scroll down in the sidebar to "share," click the copy link button next to the text box.