### PR TITLE
Learning schedules autocompleter

### DIFF
--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -9223,6 +9223,7 @@ background-color: white;
   pointer-events: none;
   display: inline-block;
   position: relative;
+  width: 100%;
 }
 
 .addInterfaceInput .textPreview {

--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -7658,6 +7658,7 @@ body.interface-english .publishBox .react-tags__suggestions ul {
 }
 .scheduleForm .label {
   font-weight: bold;
+  white-space: nowrap;
 }
 .scheduleForm div.scheduleDescription {
   color: var(--dark-grey);

--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -9222,6 +9222,7 @@ background-color: white;
 .addInterfaceInput {
   pointer-events: none;
   display: inline-block;
+  position: relative;
 }
 
 .addInterfaceInput .textPreview {

--- a/static/js/Editor.jsx
+++ b/static/js/Editor.jsx
@@ -2774,4 +2774,4 @@ const SefariaEditor = (props) => {
     )
 };
 
-export default SefariaEditor;
+export {SefariaEditor, Autocompleter};

--- a/static/js/Editor.jsx
+++ b/static/js/Editor.jsx
@@ -824,16 +824,28 @@ const AddInterfaceInput = ({ inputType, resetInterface }) => {
     }
 
     else if (inputType == "source") {
+        const isSectionOrSegment = (res) => {
+            if (res.is_section || res.is_segment) {
+                return true;
+            } else {
+                return false
+            }
+        }
         return (
-            <Autocompleter
+            <Autocompleter 
                 selectedRefCallback={selectedRefCallback}
-            />
-        )
+                refsOnly={true}
+                showSuggestionsFx={(d) => !isSectionOrSegment(d)} 
+                showPreviewFx={isSectionOrSegment}
+                showAddressCompletionsFx={(d) => d.is_book}
+                showAddButtonFx={isSectionOrSegment}
+                />)
     }
 
-        else {return(null)}
-
+    else { return (null) }
 }
+
+
 
 const AddInterface = ({ attributes, children, element }) => {
     const editor = useSlate();

--- a/static/js/Editor.jsx
+++ b/static/js/Editor.jsx
@@ -2774,4 +2774,4 @@ const SefariaEditor = (props) => {
     )
 };
 
-export {SefariaEditor, Autocompleter};
+export default SefariaEditor;

--- a/static/js/Misc.jsx
+++ b/static/js/Misc.jsx
@@ -2402,7 +2402,7 @@ const SheetMetaDataBox = (props) => (
   </div>
 );
 
-const Autocompleter = ({selectedRefCallback}) => {
+const Autocompleter = ({selectedRefCallback, refsOnly, showSuggestionsFx, showAddressCompletionsFx, showPreviewFx, showAddButtonFx }) => {
   const [inputValue, setInputValue] = useState("");
   const [currentSuggestions, setCurrentSuggestions] = useState(null);
   const [previewText, setPreviewText] = useState(null);
@@ -2447,9 +2447,6 @@ const Autocompleter = ({selectedRefCallback}) => {
     }, [previewText]
   )
 
-
-
-
   const getSuggestions = (input) => {
     setInputValue(input)
     if (input == "") {
@@ -2458,37 +2455,40 @@ const Autocompleter = ({selectedRefCallback}) => {
       setCurrentSuggestions(null)
       return
     }
-    Sefaria.getName(input, true, 5).then(d => {
+    Sefaria.getName(input, refsOnly, 5).then(d => {
 
-      if (d.is_section || d.is_segment) {
-        setCurrentSuggestions(null)
-        generatePreviewText(input);
-        setHelperPromptText(null)
-        setShowAddButton(true)
-        return
-      }
-      else {
-        setShowAddButton(false)
-        setPreviewText(null)
-      }
-
-      //We want to show address completions when book exists but not once we start typing further
-      if (d.is_book && isNaN(input.trim().slice(-1))) {
-        setHelperPromptText(<InterfaceText text={{en: d.addressExamples[0], he: d.heAddressExamples[0]}} />)
-        document.querySelector('.addInterfaceInput input+span.helperCompletionText').style.insetInlineStart = `${getWidthOfInput()}px`;
-      }
-      else {
-        setHelperPromptText(null)
-      }
-
-      const suggestions = d.completion_objects
+      if (showSuggestionsFx(d)) {
+        const suggestions = d.completion_objects
           .map((suggestion, index) => ({
             name: suggestion.title,
             key: suggestion.key,
             border_color: Sefaria.palette.refColor(suggestion.key)
-          })
-      )
-      setCurrentSuggestions(suggestions);
+          }))
+
+        setCurrentSuggestions(suggestions);
+      } else {
+        setCurrentSuggestions(null);
+      }
+
+      //We want to show address completions when book exists but not once we start typing further
+      if (showAddressCompletionsFx(d) && isNaN(input.trim().slice(-1))) {
+        setHelperPromptText(<InterfaceText text={{ en: d.addressExamples[0], he: d.heAddressExamples[0] }} />)
+        document.querySelector('.addInterfaceInput input+span.helperCompletionText').style.insetInlineStart = `${getWidthOfInput()}px`;
+      } else {
+        setHelperPromptText(null)
+      }
+
+      if (showPreviewFx(d)) {
+        generatePreviewText(input);
+      } else {
+        setPreviewText(null)
+      }
+
+      if (showAddButtonFx(d)) {
+        setShowAddButton(true);
+      } else {
+        setShowAddButton(false);
+      }
     })
   }
 

--- a/static/js/Misc.jsx
+++ b/static/js/Misc.jsx
@@ -2475,14 +2475,14 @@ const Autocompleter = ({selectedRefCallback, refsOnly, showSuggestionsFx, showAd
       }
 
       //We want to show address completions when book exists but not once we start typing further
-      if (showAddressCompletionsFx(d) && isNaN(input.trim().slice(-1))) {
+      if (showAddressCompletionsFx && showAddressCompletionsFx(d) && isNaN(input.trim().slice(-1))) {
         setHelperPromptText(<InterfaceText text={{ en: d.addressExamples[0], he: d.heAddressExamples[0] }} />)
         document.querySelector('.addInterfaceInput input+span.helperCompletionText').style.insetInlineStart = `${getWidthOfInput()}px`;
       } else {
         setHelperPromptText(null)
       }
 
-      if (showPreviewFx(d)) {
+      if (showPreviewFx && showPreviewFx(d)) {
         generatePreviewText(input);
       } else {
         setPreviewText(null)

--- a/static/js/Misc.jsx
+++ b/static/js/Misc.jsx
@@ -2402,7 +2402,7 @@ const SheetMetaDataBox = (props) => (
   </div>
 );
 
-const Autocompleter = ({selectedRefCallback, refsOnly, showSuggestionsFx, showAddressCompletionsFx, showPreviewFx, showAddButtonFx }) => {
+const Autocompleter = ({selectedRefCallback, refsOnly, showSuggestionsFx, showAddressCompletionsFx, showPreviewFx, showAddButtonFx, filterResultsFx }) => {
   const [inputValue, setInputValue] = useState("");
   const [currentSuggestions, setCurrentSuggestions] = useState(null);
   const [previewText, setPreviewText] = useState(null);
@@ -2457,7 +2457,7 @@ const Autocompleter = ({selectedRefCallback, refsOnly, showSuggestionsFx, showAd
     }
     Sefaria.getName(input, refsOnly, 5).then(d => {
 
-      if (showSuggestionsFx(d)) {
+      if (showSuggestionsFx(d, input)) {
         const suggestions = d.completion_objects
           .map((suggestion, index) => ({
             name: suggestion.title,

--- a/static/js/Misc.jsx
+++ b/static/js/Misc.jsx
@@ -2402,7 +2402,7 @@ const SheetMetaDataBox = (props) => (
   </div>
 );
 
-const Autocompleter = ({selectedRefCallback}) => {
+const Autocompleter = ({selectedRefCallback, selectionType, additionalValues}) => {
   const [inputValue, setInputValue] = useState("");
   const [currentSuggestions, setCurrentSuggestions] = useState(null);
   const [previewText, setPreviewText] = useState(null);
@@ -2447,49 +2447,61 @@ const Autocompleter = ({selectedRefCallback}) => {
     }, [previewText]
   )
 
-
-
-
   const getSuggestions = (input) => {
-    setInputValue(input)
+    setInputValue(input);
     if (input == "") {
-      setPreviewText(null)
-      setHelperPromptText(null)
-      setCurrentSuggestions(null)
-      return
+      setPreviewText(null);
+      setHelperPromptText(null);
+      setCurrentSuggestions(null);
+      return;
     }
     Sefaria.getName(input, true, 5).then(d => {
+    switch (selectionType ? selectionType : "") {
+      case "bookOnly":
+        if (d.is_book) {
+          setCurrentSuggestions(null)
+          generatePreviewText(input);
+          setHelperPromptText(null)
+          setShowAddButton(true)
+          return
+        }
+        else {
+          setShowAddButton(false)
+          setPreviewText(null)
+        }
+        break;
+      default:
 
-      if (d.is_section || d.is_segment) {
-        setCurrentSuggestions(null)
-        generatePreviewText(input);
-        setHelperPromptText(null)
-        setShowAddButton(true)
-        return
-      }
-      else {
-        setShowAddButton(false)
-        setPreviewText(null)
-      }
+          if (d.is_section || d.is_segment) {
+            setCurrentSuggestions(null)
+            generatePreviewText(input);
+            setHelperPromptText(null)
+            setShowAddButton(true)
+            return
+          }
+          else {
+            setShowAddButton(false)
+            setPreviewText(null)
+          }
 
-      //We want to show address completions when book exists but not once we start typing further
-      if (d.is_book && isNaN(input.trim().slice(-1))) {
-        setHelperPromptText(<InterfaceText text={{en: d.addressExamples[0], he: d.heAddressExamples[0]}} />)
-        document.querySelector('.addInterfaceInput input+span.helperCompletionText').style.insetInlineStart = `${getWidthOfInput()}px`;
-      }
-      else {
-        setHelperPromptText(null)
-      }
-
-      const suggestions = d.completion_objects
-          .map((suggestion, index) => ({
-            name: suggestion.title,
-            key: suggestion.key,
-            border_color: Sefaria.palette.refColor(suggestion.key)
-          })
-      )
-      setCurrentSuggestions(suggestions);
-    })
+          //We want to show address completions when book exists but not once we start typing further
+          if (d.is_book && isNaN(input.trim().slice(-1))) {
+            setHelperPromptText(<InterfaceText text={{ en: d.addressExamples[0], he: d.heAddressExamples[0] }} />)
+            document.querySelector('.addInterfaceInput input+span.helperCompletionText').style.insetInlineStart = `${getWidthOfInput()}px`;
+          }
+          else {
+            setHelperPromptText(null)
+          }
+          }
+          const suggestions = d.completion_objects
+            .map((suggestion, index) => ({
+              name: suggestion.title,
+              key: suggestion.key,
+              border_color: Sefaria.palette.refColor(suggestion.key)
+            })
+            )
+          setCurrentSuggestions(suggestions);
+        });
   }
 
   const resizeInputIfNeeded = () => {

--- a/static/js/Misc.jsx
+++ b/static/js/Misc.jsx
@@ -2402,7 +2402,7 @@ const SheetMetaDataBox = (props) => (
   </div>
 );
 
-const Autocompleter = ({selectedRefCallback, selectionType, additionalValues}) => {
+const Autocompleter = ({selectedRefCallback}) => {
   const [inputValue, setInputValue] = useState("");
   const [currentSuggestions, setCurrentSuggestions] = useState(null);
   const [previewText, setPreviewText] = useState(null);
@@ -2447,61 +2447,49 @@ const Autocompleter = ({selectedRefCallback, selectionType, additionalValues}) =
     }, [previewText]
   )
 
+
+
+
   const getSuggestions = (input) => {
-    setInputValue(input);
+    setInputValue(input)
     if (input == "") {
-      setPreviewText(null);
-      setHelperPromptText(null);
-      setCurrentSuggestions(null);
-      return;
+      setPreviewText(null)
+      setHelperPromptText(null)
+      setCurrentSuggestions(null)
+      return
     }
     Sefaria.getName(input, true, 5).then(d => {
-    switch (selectionType ? selectionType : "") {
-      case "bookOnly":
-        if (d.is_book) {
-          setCurrentSuggestions(null)
-          generatePreviewText(input);
-          setHelperPromptText(null)
-          setShowAddButton(true)
-          return
-        }
-        else {
-          setShowAddButton(false)
-          setPreviewText(null)
-        }
-        break;
-      default:
 
-          if (d.is_section || d.is_segment) {
-            setCurrentSuggestions(null)
-            generatePreviewText(input);
-            setHelperPromptText(null)
-            setShowAddButton(true)
-            return
-          }
-          else {
-            setShowAddButton(false)
-            setPreviewText(null)
-          }
+      if (d.is_section || d.is_segment) {
+        setCurrentSuggestions(null)
+        generatePreviewText(input);
+        setHelperPromptText(null)
+        setShowAddButton(true)
+        return
+      }
+      else {
+        setShowAddButton(false)
+        setPreviewText(null)
+      }
 
-          //We want to show address completions when book exists but not once we start typing further
-          if (d.is_book && isNaN(input.trim().slice(-1))) {
-            setHelperPromptText(<InterfaceText text={{ en: d.addressExamples[0], he: d.heAddressExamples[0] }} />)
-            document.querySelector('.addInterfaceInput input+span.helperCompletionText').style.insetInlineStart = `${getWidthOfInput()}px`;
-          }
-          else {
-            setHelperPromptText(null)
-          }
-          }
-          const suggestions = d.completion_objects
-            .map((suggestion, index) => ({
-              name: suggestion.title,
-              key: suggestion.key,
-              border_color: Sefaria.palette.refColor(suggestion.key)
-            })
-            )
-          setCurrentSuggestions(suggestions);
-        });
+      //We want to show address completions when book exists but not once we start typing further
+      if (d.is_book && isNaN(input.trim().slice(-1))) {
+        setHelperPromptText(<InterfaceText text={{en: d.addressExamples[0], he: d.heAddressExamples[0]}} />)
+        document.querySelector('.addInterfaceInput input+span.helperCompletionText').style.insetInlineStart = `${getWidthOfInput()}px`;
+      }
+      else {
+        setHelperPromptText(null)
+      }
+
+      const suggestions = d.completion_objects
+          .map((suggestion, index) => ({
+            name: suggestion.title,
+            key: suggestion.key,
+            border_color: Sefaria.palette.refColor(suggestion.key)
+          })
+      )
+      setCurrentSuggestions(suggestions);
+    })
   }
 
   const resizeInputIfNeeded = () => {

--- a/static/js/Misc.jsx
+++ b/static/js/Misc.jsx
@@ -2455,19 +2455,23 @@ const Autocompleter = ({selectedRefCallback, refsOnly, showSuggestionsFx, showAd
       setCurrentSuggestions(null)
       return
     }
-    Sefaria.getName(input, refsOnly, 5).then(d => {
+    Sefaria.getName(input, refsOnly, 20).then(d => {
 
       if (showSuggestionsFx(d, input)) {
         const suggestions = d.completion_objects
+          .filter(completion_obj => {
+            if (filterResultsFx) {
+              return filterResultsFx(completion_obj);
+            } else {
+              return true;
+            }
+          })
           .map((suggestion, index) => ({
             name: suggestion.title,
             key: suggestion.key,
+            type: suggestion.type,
             border_color: Sefaria.palette.refColor(suggestion.key)
-          }))
-
-        if (filterResultsFx) {
-          suggestions = suggestions.filter(filterResultsFx);
-        }
+          }));
 
         setCurrentSuggestions(suggestions);
       } else {
@@ -2488,7 +2492,7 @@ const Autocompleter = ({selectedRefCallback, refsOnly, showSuggestionsFx, showAd
         setPreviewText(null)
       }
 
-      if (showAddButtonFx(d)) {
+      if (showAddButtonFx(d, input)) {
         setShowAddButton(true);
       } else {
         setShowAddButton(false);

--- a/static/js/Misc.jsx
+++ b/static/js/Misc.jsx
@@ -2402,7 +2402,7 @@ const SheetMetaDataBox = (props) => (
   </div>
 );
 
-const Autocompleter = ({selectedRefCallback, refsOnly, showSuggestionsFx, showAddressCompletionsFx, showPreviewFx, showAddButtonFx, filterResultsFx }) => {
+const Autocompleter = ({selectedRefCallback, refsOnly, showSuggestionsFx, showAddressCompletionsFx, showPreviewFx, showAddButtonFx, filterResultsFx, limit }) => {
   const [inputValue, setInputValue] = useState("");
   const [currentSuggestions, setCurrentSuggestions] = useState(null);
   const [previewText, setPreviewText] = useState(null);
@@ -2411,6 +2411,7 @@ const Autocompleter = ({selectedRefCallback, refsOnly, showSuggestionsFx, showAd
 
   const suggestionEl = useRef(null);
   const inputEl = useRef(null);
+  const defaultAutocompleteLimit = 5;
 
 
   const getWidthOfInput = () => {
@@ -2471,7 +2472,8 @@ const Autocompleter = ({selectedRefCallback, refsOnly, showSuggestionsFx, showAd
             key: suggestion.key,
             type: suggestion.type,
             border_color: Sefaria.palette.refColor(suggestion.key)
-          }));
+          }))
+          .slice(0, limit ? limit : defaultAutocompleteLimit);
 
         setCurrentSuggestions(suggestions);
       } else {

--- a/static/js/Misc.jsx
+++ b/static/js/Misc.jsx
@@ -2465,6 +2465,10 @@ const Autocompleter = ({selectedRefCallback, refsOnly, showSuggestionsFx, showAd
             border_color: Sefaria.palette.refColor(suggestion.key)
           }))
 
+        if (filterResultsFx) {
+          suggestions = suggestions.filter(filterResultsFx);
+        }
+
         setCurrentSuggestions(suggestions);
       } else {
         setCurrentSuggestions(null);

--- a/static/js/Sheet.jsx
+++ b/static/js/Sheet.jsx
@@ -6,7 +6,7 @@ import sanitizeHtml  from 'sanitize-html';
 import Component from 'react-class'
 import $  from './sefaria/sefariaJquery';
 import Sefaria  from './sefaria/sefaria';
-import { SefariaEditor } from './Editor';
+import SefariaEditor from './Editor';
 import {
   InterfaceText,
   LoadingMessage,

--- a/static/js/Sheet.jsx
+++ b/static/js/Sheet.jsx
@@ -6,7 +6,7 @@ import sanitizeHtml  from 'sanitize-html';
 import Component from 'react-class'
 import $  from './sefaria/sefariaJquery';
 import Sefaria  from './sefaria/sefaria';
-import SefariaEditor from './Editor';
+import { SefariaEditor } from './Editor';
 import {
   InterfaceText,
   LoadingMessage,

--- a/static/js/UserProfile.jsx
+++ b/static/js/UserProfile.jsx
@@ -5,6 +5,7 @@ import Sefaria  from './sefaria/sefaria';
 import NoteListing  from './NoteListing';
 import Footer  from './Footer';
 import {
+  Autocompleter,
   CollectionListing,
   FilterableList,
   LoadingMessage,
@@ -19,7 +20,6 @@ import {
   InterfaceOption
 } from './Misc';
 import { CalendarsPage, reformatCalendars } from './CalendarsPage';
-import { Autocompleter } from './Editor'
 
 class UserProfile extends Component {
   constructor(props) {

--- a/static/js/UserProfile.jsx
+++ b/static/js/UserProfile.jsx
@@ -562,8 +562,6 @@ const BookCorpusAutocompleter = ({updateSelectedItem}) => {
   return (showAutocompleter ? <Autocompleter selectedRefCallback={onSelect}
     refsOnly={false}
     showSuggestionsFx={(d,inp) => !d.is_book || !d.is_ref || d.completion_objects.map(x => x.title).filter(x => x.toLowerCase().startsWith(inp.toLowerCase()) & x.length > inp.length)}
-    showAddressCompletionsFx={() => false}
-    showPreviewFx={() => false}
     showAddButtonFx={d => d.is_book || d.is_ref}
   /> : <button onClick={() => setShowAutocompleter(true)}>{selectedItem ? selectedItem.toString() : null}</button>)
 }

--- a/static/js/UserProfile.jsx
+++ b/static/js/UserProfile.jsx
@@ -559,7 +559,7 @@ const BookCorpusAutocompleter = ({updateSelectedItem}) => {
     setSelectedItem(value);
     setShowAutocompleter(false);
   }
-  return (showAutocompleter ? <Autocompleter selectedRefCallback={onSelect}/> : <button onClick={() => setShowAutocompleter(true)}>{selectedItem ? selectedItem.toString() : null}</button>)
+  return (showAutocompleter ? <Autocompleter selectedRefCallback={onSelect} selectionType="bookOnly"/> : <button onClick={() => setShowAutocompleter(true)}>{selectedItem ? selectedItem.toString() : null}</button>)
 }
 
 

--- a/static/js/UserProfile.jsx
+++ b/static/js/UserProfile.jsx
@@ -547,6 +547,22 @@ UserProfile.propTypes = {
   profile: PropTypes.object.isRequired,
 };
 
+
+const BookCorpusAutocompleter = ({updateSelectedItem}) => {
+  const [selectedItem, setSelectedItem] = useState("");
+  const [showAutocompleter, setShowAutocompleter] = useState(true);
+  useEffect(() => {
+    console.log(selectedItem);
+    updateSelectedItem(selectedItem);
+  }, [selectedItem])
+  const onSelect = (value) => {
+    setSelectedItem(value);
+    setShowAutocompleter(false);
+  }
+  return (showAutocompleter ? <Autocompleter selectedRefCallback={onSelect}/> : <button onClick={() => setShowAutocompleter(true)}>{selectedItem ? selectedItem.toString() : null}</button>)
+}
+
+
 const CustomLearningSchedulePicker = ({currentValues, onUpdate}) => {
 
   const [startRef, setStartRef] = currentValues ? useState(currentValues.startRef) : useState("");
@@ -593,12 +609,13 @@ const CustomLearningSchedulePicker = ({currentValues, onUpdate}) => {
     <>
       <div className="scheduleFormHorizontal" id="alertsContainer">
         <span className="label">Text to learn: </span>
-        <select onChange={$event => setStartRef($event.target.value)} value={startRef || ""}>
+        {/* <select onChange={$event => setStartRef($event.target.value)} value={startRef || ""}>
           <InterfaceOption key="none" text="None" value=""></InterfaceOption>
           {dropdownTexts.map(text => {
             return <InterfaceOption key={text.en} text={text} value={text.en}></InterfaceOption>
           })}
-        </select>
+        </select> */}
+        <BookCorpusAutocompleter updateSelectedItem={setStartRef} />
       </div>
       <div className="scheduleDescription">
         {unitCount ? <>It will take you {unitCount.toString()} days to finish learning this text.</> : null}

--- a/static/js/UserProfile.jsx
+++ b/static/js/UserProfile.jsx
@@ -559,7 +559,13 @@ const BookCorpusAutocompleter = ({updateSelectedItem}) => {
     setSelectedItem(value);
     setShowAutocompleter(false);
   }
-  return (showAutocompleter ? <Autocompleter selectedRefCallback={onSelect}/> : <button onClick={() => setShowAutocompleter(true)}>{selectedItem ? selectedItem.toString() : null}</button>)
+  return (showAutocompleter ? <Autocompleter selectedRefCallback={onSelect}
+    refsOnly={false}
+    showSuggestionsFx={(d,inp) => !d.is_book || !d.is_ref || d.completion_objects.map(x => x.title).filter(x => x.toLowerCase().startsWith(inp.toLowerCase()) & x.length > inp.length)}
+    showAddressCompletionsFx={() => false}
+    showPreviewFx={() => false}
+    showAddButtonFx={d => d.is_book || d.is_ref}
+  /> : <button onClick={() => setShowAutocompleter(true)}>{selectedItem ? selectedItem.toString() : null}</button>)
 }
 
 

--- a/static/js/UserProfile.jsx
+++ b/static/js/UserProfile.jsx
@@ -559,7 +559,7 @@ const BookCorpusAutocompleter = ({updateSelectedItem}) => {
     setSelectedItem(value);
     setShowAutocompleter(false);
   }
-  return (showAutocompleter ? <Autocompleter selectedRefCallback={onSelect} selectionType="bookOnly"/> : <button onClick={() => setShowAutocompleter(true)}>{selectedItem ? selectedItem.toString() : null}</button>)
+  return (showAutocompleter ? <Autocompleter selectedRefCallback={onSelect}/> : <button onClick={() => setShowAutocompleter(true)}>{selectedItem ? selectedItem.toString() : null}</button>)
 }
 
 


### PR DESCRIPTION
https://trello.com/c/4TcpUVJm/12-refactor-autocompleter-to-be-generic-enough-to-be-used-here


Major changes
- Refactor Autocompleter to take functions for determining when to show various components of autocompleter (autocomplete results, helper/address completion text, add source button, etc).
- Pull extra results from API then filter/pare down (as opposed to only pulling 5 results)
- Update Editor.jsx to use refactored autocompleter
- Now sending book/corpus to schedules API as separate key/value

Concerns:
- Is this accessible? 
- Too many inline functions in BookCorpusAutocompleter to be readable (lines 563-569)
- Are there edge case bugs I did not catch?
- Original design had startRef/endRef, are we going to use these ever or should I just get rid of them for good?