### PR TITLE
Mobileftnotes

### DIFF
--- a/sefaria/model/text.py
+++ b/sefaria/model/text.py
@@ -1211,7 +1211,8 @@ class AbstractTextRecord(object):
         if isinstance(tag, Tag):
             is_inline_commentator = tag.name == "i" and len(tag.get('data-commentator', '')) > 0
             is_page_marker = tag.name == "i" and len(tag.get('data-overlay','')) > 0
-            is_tanakh_end_sup = tag.name == "sup" and re.search("^-[a-zA-Z0-9]{1,2}", tag.text) is not None  # footnotes like this occur in JPS english
+            is_tanakh_end_sup = tag.name == "sup" and tag.get('class') == ['endFootnotes'] \
+                                and re.search("^-[a-zA-Z0-9]{1,2}", tag.text) is not None  # footnotes like this occur in JPS english
             return AbstractTextRecord._itag_is_footnote(tag) or is_inline_commentator or is_page_marker or is_tanakh_end_sup
         return False
 

--- a/sefaria/model/text.py
+++ b/sefaria/model/text.py
@@ -1211,8 +1211,7 @@ class AbstractTextRecord(object):
         if isinstance(tag, Tag):
             is_inline_commentator = tag.name == "i" and len(tag.get('data-commentator', '')) > 0
             is_page_marker = tag.name == "i" and len(tag.get('data-overlay','')) > 0
-            is_tanakh_end_sup = tag.name == "sup" and tag.get('class') == ['endFootnote'] \
-                                and re.search("^-[a-zA-Z0-9]{1,2}", tag.text) is not None  # footnotes like this occur in JPS english
+            is_tanakh_end_sup = tag.name == "sup" and tag.get('class') == ['endFootnote']  # footnotes like this occur in JPS english
             return AbstractTextRecord._itag_is_footnote(tag) or is_inline_commentator or is_page_marker or is_tanakh_end_sup
         return False
 

--- a/sefaria/model/text.py
+++ b/sefaria/model/text.py
@@ -1211,7 +1211,7 @@ class AbstractTextRecord(object):
         if isinstance(tag, Tag):
             is_inline_commentator = tag.name == "i" and len(tag.get('data-commentator', '')) > 0
             is_page_marker = tag.name == "i" and len(tag.get('data-overlay','')) > 0
-            is_tanakh_end_sup = tag.name == "sup" and tag.get('class') == ['endFootnotes'] \
+            is_tanakh_end_sup = tag.name == "sup" and tag.get('class') == ['endFootnote'] \
                                 and re.search("^-[a-zA-Z0-9]{1,2}", tag.text) is not None  # footnotes like this occur in JPS english
             return AbstractTextRecord._itag_is_footnote(tag) or is_inline_commentator or is_page_marker or is_tanakh_end_sup
         return False

--- a/sefaria/model/text.py
+++ b/sefaria/model/text.py
@@ -1211,7 +1211,8 @@ class AbstractTextRecord(object):
         if isinstance(tag, Tag):
             is_inline_commentator = tag.name == "i" and len(tag.get('data-commentator', '')) > 0
             is_page_marker = tag.name == "i" and len(tag.get('data-overlay','')) > 0
-            return AbstractTextRecord._itag_is_footnote(tag) or is_inline_commentator or is_page_marker
+            is_tanakh_end_sup = tag.name == "sup" and re.search("^-[a-zA-Z0-9]{1,2}", tag.text) is not None  # footnotes like this occur in JPS english
+            return AbstractTextRecord._itag_is_footnote(tag) or is_inline_commentator or is_page_marker or is_tanakh_end_sup
         return False
 
     @staticmethod


### PR DESCRIPTION
`<sup class='endFootnote'>-b</sup>` will now get stripped but 
`<sup>-b</sup>` will not get stripped
Therefore, we will need a Content Quality card that converts the data's sup tags