### PR TITLE
Version links

### DIFF
--- a/sefaria/model/text.py
+++ b/sefaria/model/text.py
@@ -1031,7 +1031,7 @@ class AbstractTextRecord(object):
         # structure placement (e.g. page transitions): uses 'data-overlay', 'data-value'
         'i': ['data-overlay', 'data-value', 'data-commentator', 'data-order', 'class', 'data-label', 'dir'],
         'img': lambda name, value: name == 'src' and value.startswith("data:image/"),
-        'a': ['dir', 'class', 'href', 'data-ref'],
+        'a': ['dir', 'class', 'href', 'data-ref', "data-ven", "data-vhe"],
     }
 
     def word_count(self):

--- a/static/js/ReaderPanel.jsx
+++ b/static/js/ReaderPanel.jsx
@@ -166,7 +166,7 @@ class ReaderPanel extends Component {
     if (this.props.multiPanel) {
       this.props.onCitationClick(citationRef, textRef, replace, currVersions);
     } else {
-      this.showBaseText(citationRef, currVersions);
+      this.showBaseText(citationRef, replace, currVersions);
     }
   }
   handleTextListClick(ref, replaceHistory, currVersions) {

--- a/static/js/TextRange.jsx
+++ b/static/js/TextRange.jsx
@@ -124,7 +124,7 @@ class TextRange extends Component {
       // Replace ReaderPanel contents with split refs if ref is spanning
       // Pass parameter to showBaseText to replaceHistory - normalization should't add a step to history
       // console.log("Re-rewriting spanning ref")
-      this.props.showBaseText(data.spanningRefs, true, this.props.version, this.props.versionLanguage);
+      this.props.showBaseText(data.spanningRefs, true, this.props.currVersions, this.props.versionLanguage);
       return;
     }
 

--- a/static/js/TextRange.jsx
+++ b/static/js/TextRange.jsx
@@ -495,10 +495,9 @@ class TextSegment extends Component {
       //Click of citation
       event.preventDefault();
       let ref = Sefaria.humanRef(refLink.attr("data-ref"));
-      const vtitle = refLink.attr("vtitle");
-      const vlang = refLink.attr("vlang");
-      let currVersions = {"en": null, "he": null};
-      currVersions[vlang] = vtitle;
+      const ven = refLink.attr("data-ven") ? refLink.attr("data-ven") : null;
+      const vhe = refLink.attr("data-vhe") ? refLink.attr("data-vhe") : null;
+      let currVersions = {"en": ven, "he": vhe};
       this.props.onCitationClick(ref, this.props.sref, true, currVersions);
       event.stopPropagation();
       Sefaria.track.event("Reader", "Citation Link Click", ref);


### PR DESCRIPTION
Version links now behave as expected, although a script on prod needs to be run.  One thing though: I'm not sure about the change I made to ReaderPanel, where I passed `replace` to showBaseText.  It seems like it should be passed but perhaps there was a reason why we didn't want to pass it?