### PR TITLE
fix: bump helm-chart version for backup logic

### DIFF
--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: sefaria
-version: v0.0.5
+version: v0.0.6
 description: Chart to deploy complete Sefaria environment
 icon: https://raw.githubusercontent.com/Sefaria/Sefaria-Project/e757b59968adbc0d6845eaa1b420f934ad864d32/static/img/logo/icon.svg
 home: https://sefaria.org


### PR DESCRIPTION
should have been part of #819 