### PR TITLE
feat: allow restore to be disabled in helm chart

### DIFF
--- a/helm-chart/templates/jobs/mongo-restore.yaml
+++ b/helm-chart/templates/jobs/mongo-restore.yaml
@@ -5,7 +5,7 @@
 # SANDBOX_NAME: The name of the table created by this job
 # ENVIRONMENT: Deployment environment {prod, preprod, stage}
 ---
-{{- if eq .Values.sandbox "true" }}
+{{- if and (eq .Values.sandbox "true") .Values.restore.enabled }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -28,6 +28,7 @@ previousServicesCount: "3"
 # write the full path to the back up if you want to start the environment from
 # a specific backup else leave blank.
 restore:
+  enabled: true
   bucket: sefaria-mongo-backup
   # tarball:
   serviceAccount: database-backup-read


### PR DESCRIPTION
I'm leaving out the selective destroy for now - I think the idea we discussed where cauldrons who's data should persist should rather be backed up and then that can be used as the base for a new restore at a later point.  This will still help with mongo-in-a-can setups, which would not need to restore, as well as migrating old cauldrons to reuse their existing DBs.  For the latter cauldron creation would probably need to be manual, unless there's a feeling disabling restore would be something that should be added to the cauldron creation process?