### PR TITLE
Reformat Hebrew refs

### DIFF
--- a/static/js/sefaria/search.js
+++ b/static/js/sefaria/search.js
@@ -72,12 +72,12 @@ class Search {
 
     }
     reformatDictaRef(ref) {
-        let hebrewRef = ref.match(/תנ"ך\/.*\/ספר (.*)\/פרק (.*)\/פסוק (.*)/);
+        const hebrewRef = ref.match(/תנ"ך\/.*\/ספר (.*)\/פרק (.*)\/פסוק (.*)/);
         const sefer = hebrewRef[1];
         const perek = hebrewRef[2].length === 1 ? `${hebrewRef[2]}'` : hebrewRef[2].split('').join('"');
         const pasuk = hebrewRef[3].length === 1 ? `${hebrewRef[3]}'`: hebrewRef[3].split('').join('"');
-        hebrewRef = `${sefer} ${perek}:${pasuk}`;
-        return hebrewRef;
+        const cleanedHebrewRef = `${sefer} ${perek}:${pasuk}`;
+        return cleanedHebrewRef;
     }
     dictaQuery(args, isQueryStart, wrapper) {
         function ammendArgsForDicta(standardArgs, lastSeen) {

--- a/static/js/sefaria/search.js
+++ b/static/js/sefaria/search.js
@@ -130,6 +130,7 @@ class Search {
                 const bookTitle = bookData[2].replace(/_/g, ' ');
                 const bookLoc = bookData.slice(3, 5).join(':');
                 const version = "Tanach with Ta'amei Hamikra";
+                const hebrewPathNoSlash = hit.hebrewPath.replace(/\//g,' ');
                 adaptedHits.push({
                     _source: {
                         type: 'text',
@@ -137,7 +138,7 @@ class Search {
                         version: version,
                         path: categories,
                         ref: `${bookTitle} ${bookLoc}`,
-                        heRef: hit.hebrewPath,
+                        heRef: hebrewPathNoSlash,
                         pagesheetrank: (hit.pagerank) ? hit.pagerank : 0,
                     },
                     highlight: {naive_lemmatizer: [hit.highlight[0].text]},

--- a/static/js/sefaria/search.js
+++ b/static/js/sefaria/search.js
@@ -72,13 +72,13 @@ class Search {
 
     }
     reformatDictaRef(ref) {
-        let hebrewRef = ref.match(/תנ"ך\/נביאים\/ספר (.*)\/פרק (.*)\/פסוק (.*)/);
-        const perek = hebrewRef && hebrewRef[2].length === 1 ? `${hebrewRef[2]}'` : hebrewRef[2].split('').join('"');
-        const pasuk = hebrewRef && hebrewRef[3].length === 1 ? `${hebrewRef[3]}'`: hebrewRef[3].split('').join('"');
-        const sefer = hebrewRef && hebrewRef[1]
+        let hebrewRef = ref.match(/תנ"ך\/.*\/ספר (.*)\/פרק (.*)\/פסוק (.*)/);
+        const sefer = hebrewRef[1];
+        const perek = hebrewRef[2].length === 1 ? `${hebrewRef[2]}'` : hebrewRef[2].split('').join('"');
+        const pasuk = hebrewRef[3].length === 1 ? `${hebrewRef[3]}'`: hebrewRef[3].split('').join('"');
         hebrewRef = `${sefer} ${perek}:${pasuk}`;
         console.log('Hebrew ref', hebrewRef);
-        return hebrewRef
+        return hebrewRef;
     }
     dictaQuery(args, isQueryStart, wrapper) {
         function ammendArgsForDicta(standardArgs, lastSeen) {

--- a/static/js/sefaria/search.js
+++ b/static/js/sefaria/search.js
@@ -77,7 +77,6 @@ class Search {
         const perek = hebrewRef[2].length === 1 ? `${hebrewRef[2]}'` : hebrewRef[2].split('').join('"');
         const pasuk = hebrewRef[3].length === 1 ? `${hebrewRef[3]}'`: hebrewRef[3].split('').join('"');
         hebrewRef = `${sefer} ${perek}:${pasuk}`;
-        console.log('Hebrew ref', hebrewRef);
         return hebrewRef;
     }
     dictaQuery(args, isQueryStart, wrapper) {

--- a/static/js/sefaria/search.js
+++ b/static/js/sefaria/search.js
@@ -71,6 +71,15 @@ class Search {
         });
 
     }
+    reformatDictaRef(ref) {
+        let hebrewRef = ref.match(/תנ"ך\/נביאים\/ספר (.*)\/פרק (.*)\/פסוק (.*)/);
+        const perek = hebrewRef && hebrewRef[2].length === 1 ? `${hebrewRef[2]}'` : hebrewRef[2].split('').join('"');
+        const pasuk = hebrewRef && hebrewRef[3].length === 1 ? `${hebrewRef[3]}'`: hebrewRef[3].split('').join('"');
+        const sefer = hebrewRef && hebrewRef[1]
+        hebrewRef = `${sefer} ${perek}:${pasuk}`;
+        console.log('Hebrew ref', hebrewRef);
+        return hebrewRef
+    }
     dictaQuery(args, isQueryStart, wrapper) {
         function ammendArgsForDicta(standardArgs, lastSeen) {
             let filters = (standardArgs.applied_filters) ? standardArgs.applied_filters.map(book => {
@@ -130,7 +139,6 @@ class Search {
                 const bookTitle = bookData[2].replace(/_/g, ' ');
                 const bookLoc = bookData.slice(3, 5).join(':');
                 const version = "Tanach with Ta'amei Hamikra";
-                const hebrewPathNoSlash = hit.hebrewPath.replace(/\//g,' ');
                 adaptedHits.push({
                     _source: {
                         type: 'text',
@@ -138,7 +146,7 @@ class Search {
                         version: version,
                         path: categories,
                         ref: `${bookTitle} ${bookLoc}`,
-                        heRef: hebrewPathNoSlash,
+                        heRef: this.reformatDictaRef(hit.hebrewPath),
                         pagesheetrank: (hit.pagerank) ? hit.pagerank : 0,
                     },
                     highlight: {naive_lemmatizer: [hit.highlight[0].text]},

--- a/static/js/sefaria/search.js
+++ b/static/js/sefaria/search.js
@@ -71,6 +71,12 @@ class Search {
         });
 
     }
+    /**
+     * Function to reformat the Hebrew Ref from the Dicta convention - תנ״ר/נביאים/ספר זכריה/פרק א/פסוק א
+     * to the Sefaria Hebrew Ref convention (the results of Ref('Zechariah 1.1').he_normal())
+     * @param {*} ref - the incoming Dicta Ref
+     * @returns cleanedHebrewRef - according to Sefaria conventions
+     */
     reformatDictaRef(ref) {
         const hebrewRef = ref.match(/תנ"ך\/.*\/ספר (.*)\/פרק (.*)\/פסוק (.*)/);
         const sefer = hebrewRef[1];


### PR DESCRIPTION
Added a line to remove slashes from Hebrew refs from Dicta, and to reformat in Sefaria Ref style. Returned search results now look like this:

<img width="728" alt="Screen Shot 2022-05-26 at 14 53 16" src="https://user-images.githubusercontent.com/36717225/170483266-f3ea2472-8596-465e-ab1b-647f8dff14d5.png">

