### PR TITLE
Double click bug

### DIFF
--- a/static/js/TextRange.jsx
+++ b/static/js/TextRange.jsx
@@ -469,6 +469,10 @@ TextRange.defaultProps = {
 
 
 class TextSegment extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {lastClickXY: false}
+  }
   shouldComponentUpdate(nextProps) {
     if (this.props.highlight !== nextProps.highlight)           { return true; }
     if (this.props.showHighlight !== nextProps.showHighlight)   { return true; }
@@ -517,6 +521,22 @@ class TextSegment extends Component {
     } else if (this.props.onSegmentClick) {
       this.props.onSegmentClick(this.props.sref);
       Sefaria.track.event("Reader", "Text Segment Click", this.props.sref);
+    }
+    const rect = event.target.getBoundingClientRect();
+    const x = event.clientX - rect.left; //x position within the element.
+    const y = event.clientY - rect.top;  //y position within the element.
+    this.setState({lastClickXY:[x,y]})
+  }
+  handleDoubleClick(event) {
+    if (event.detail > 1) {
+      const rect = event.target.getBoundingClientRect();
+      const x = event.clientX - rect.left; //x position within the element.
+      const y = event.clientY - rect.top;  //y position within the element.
+      console.log(x, y);
+      console.log(this.state.lastClickXY)
+      if (!(this.state.lastClickXY[0] == x && this.state.lastClickXY[1] == y)) {
+        event.preventDefault();
+      }
     }
   }
   handleKeyPress(event) {
@@ -627,7 +647,7 @@ class TextSegment extends Component {
     }
     return (
       <div tabIndex="0"
-           className={classes} onClick={this.handleClick} onKeyPress={this.handleKeyPress}
+           className={classes} onClick={this.handleClick} onKeyPress={this.handleKeyPress} onMouseDown={this.handleDoubleClick}
            data-ref={this.props.sref} aria-controls={"panel-"+(this.props.panelPosition+1)}
            aria-label={"Click to see links to "+this.props.sref}>
         {segmentNumber}

--- a/static/js/TextRange.jsx
+++ b/static/js/TextRange.jsx
@@ -469,10 +469,10 @@ TextRange.defaultProps = {
 
 
 class TextSegment extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {lastClickXY: false}
-  }
+  // constructor(props) {
+  //   super(props);
+  //   this.state = {lastClickXY: false}
+  // }
   shouldComponentUpdate(nextProps) {
     if (this.props.highlight !== nextProps.highlight)           { return true; }
     if (this.props.showHighlight !== nextProps.showHighlight)   { return true; }
@@ -491,6 +491,14 @@ class TextSegment extends Component {
       this.props.unsetTextHighlight();
     }
   }
+
+  calculatePositionWithinElement(event){
+    const rect = event.target.getBoundingClientRect();
+    const x = event.clientX - rect.left; //x position within the element.
+    const y = event.clientY - rect.top;  //y position within the element.
+    return [x,y]
+  }
+
   handleClick(event) {
     // grab refLink from target or parent (sometimes there is an <i> within refLink forcing us to look for the parent)
     const refLink = $(event.target).hasClass("refLink") ? $(event.target) : ($(event.target.parentElement).hasClass("refLink") ? $(event.target.parentElement) : null);
@@ -522,19 +530,13 @@ class TextSegment extends Component {
       this.props.onSegmentClick(this.props.sref);
       Sefaria.track.event("Reader", "Text Segment Click", this.props.sref);
     }
-    const rect = event.target.getBoundingClientRect();
-    const x = event.clientX - rect.left; //x position within the element.
-    const y = event.clientY - rect.top;  //y position within the element.
-    this.setState({lastClickXY:[x,y]})
+    const pos = this.calculatePositionWithinElement(event)
+    this.setState({lastClickXY:pos})
   }
   handleDoubleClick(event) {
     if (event.detail > 1) {
-      const rect = event.target.getBoundingClientRect();
-      const x = event.clientX - rect.left; //x position within the element.
-      const y = event.clientY - rect.top;  //y position within the element.
-      console.log(x, y);
-      console.log(this.state.lastClickXY)
-      if (!(this.state.lastClickXY[0] == x && this.state.lastClickXY[1] == y)) {
+    const pos = this.calculatePositionWithinElement(event)
+      if (this.state.lastClickXY != pos){
         event.preventDefault();
       }
     }

--- a/static/js/TextRange.jsx
+++ b/static/js/TextRange.jsx
@@ -469,10 +469,6 @@ TextRange.defaultProps = {
 
 
 class TextSegment extends Component {
-  // constructor(props) {
-  //   super(props);
-  //   this.state = {lastClickXY: false}
-  // }
   shouldComponentUpdate(nextProps) {
     if (this.props.highlight !== nextProps.highlight)           { return true; }
     if (this.props.showHighlight !== nextProps.showHighlight)   { return true; }
@@ -491,14 +487,12 @@ class TextSegment extends Component {
       this.props.unsetTextHighlight();
     }
   }
-
   calculatePositionWithinElement(event){
     const rect = event.target.getBoundingClientRect();
     const x = event.clientX - rect.left; //x position within the element.
     const y = event.clientY - rect.top;  //y position within the element.
     return [x,y]
   }
-
   handleClick(event) {
     // grab refLink from target or parent (sometimes there is an <i> within refLink forcing us to look for the parent)
     const refLink = $(event.target).hasClass("refLink") ? $(event.target) : ($(event.target.parentElement).hasClass("refLink") ? $(event.target.parentElement) : null);
@@ -536,6 +530,7 @@ class TextSegment extends Component {
   handleDoubleClick(event) {
     if (event.detail > 1) {
     const pos = this.calculatePositionWithinElement(event)
+      // might be problimatic if there is a slight move in the double-click shaky hands. can be fixed with an error of a few px on both axes.
       if (this.state.lastClickXY != pos){
         event.preventDefault();
       }


### PR DESCRIPTION
A fix for the bug where on double click for dictionary search with sidebar closed the first click opened the sidebar and changed the place of the curser so the chosen word for search is not the intended one. The fix deletes this behavior. and essentially the user will need to double click again after the sidebar is opened.  