### PR TITLE
stub for redirecting find-refs api to linker

### DIFF
--- a/helm-chart/sefaria-project/templates/configmap/nginx.yaml
+++ b/helm-chart/sefaria-project/templates/configmap/nginx.yaml
@@ -122,6 +122,11 @@ data:
           access_log off;
           proxy_pass https://storage.googleapis.com/sefaria-sitemaps$request_uri;
         }
+
+        location /api/find-refs {
+          access_log off;
+          proxy_pass <LINKER_URL_HERE>;
+        }
       } # server
 
       types {


### PR DESCRIPTION
@BrendanGalloway here's a stub for the redirect to the linker pod for the relevant API call. We need to define an environment variable for the location of the linker pod. I left that as a placeholder for now.