### PR TITLE
Fix for doubleclick on TextRange.

### DIFF
--- a/static/js/TextColumn.jsx
+++ b/static/js/TextColumn.jsx
@@ -95,6 +95,26 @@ class TextColumn extends Component {
     this.debouncedAdjustHighlightedAndVisible();
     this.adjustInfiniteScroll();
   }
+  calculatePositionWithinElement(event){
+    const rect = event.target.getBoundingClientRect();
+    const x = event.clientX - rect.left; //x position within the element.
+    const y = event.clientY - rect.top;  //y position within the element.
+    return [x,y]
+  }
+  handleClick(event) {
+    const pos = this.calculatePositionWithinElement(event)
+    this.setState({lastClickXY:pos})
+  }
+  handleDoubleClick(event) {
+    if (event.detail > 1) {
+    const pos = this.calculatePositionWithinElement(event)
+      // might be problematic if there is a slight move in the double-click shaky hands. can be fixed with an error of a few px on both axes.
+      if (this.state.lastClickXY[0] != pos[0] || this.state.lastClickXY[1] != pos[1]){
+        event.preventDefault();
+      }
+    }
+  }
+
   handleTextSelection() {
     const selection = window.getSelection();
     let refs = [];
@@ -388,7 +408,7 @@ class TextColumn extends Component {
         <LoadingMessage message={" "} className="base next final" key={"next"}/>;
     }
 
-    return (<div className={classes} onMouseUp={this.handleTextSelection}>
+    return (<div className={classes} onMouseUp={this.handleTextSelection} onClick={this.handleClick} onMouseDown={this.handleDoubleClick}>
       {pre}
       {content}
       {post}

--- a/static/js/TextRange.jsx
+++ b/static/js/TextRange.jsx
@@ -488,12 +488,6 @@ class TextSegment extends Component {
       this.props.unsetTextHighlight();
     }
   }
-  calculatePositionWithinElement(event){
-    const rect = event.target.getBoundingClientRect();
-    const x = event.clientX - rect.left; //x position within the element.
-    const y = event.clientY - rect.top;  //y position within the element.
-    return [x,y]
-  }
   handleClick(event) {
     // grab refLink from target or parent (sometimes there is an <i> within refLink forcing us to look for the parent)
     const refLink = $(event.target).hasClass("refLink") ? $(event.target) : ($(event.target.parentElement).hasClass("refLink") ? $(event.target.parentElement) : null);
@@ -525,17 +519,6 @@ class TextSegment extends Component {
     } else if (this.props.onSegmentClick) {
       this.props.onSegmentClick(this.props.sref);
       Sefaria.track.event("Reader", "Text Segment Click", this.props.sref);
-    }
-    const pos = this.calculatePositionWithinElement(event)
-    this.setState({lastClickXY:pos})
-  }
-  handleDoubleClick(event) {
-    if (event.detail > 1) {
-    const pos = this.calculatePositionWithinElement(event)
-      // might be problimatic if there is a slight move in the double-click shaky hands. can be fixed with an error of a few px on both axes.
-      if (this.state.lastClickXY != pos){
-        event.preventDefault();
-      }
     }
   }
   handleKeyPress(event) {
@@ -646,7 +629,7 @@ class TextSegment extends Component {
     }
     return (
       <div tabIndex="0"
-           className={classes} onClick={this.handleClick} onKeyPress={this.handleKeyPress} onMouseDown={this.handleDoubleClick}
+           className={classes} onClick={this.handleClick} onKeyPress={this.handleKeyPress}
            data-ref={this.props.sref} aria-controls={"panel-"+(this.props.panelPosition+1)}
            aria-label={"Click to see links to "+this.props.sref}>
         {segmentNumber}


### PR DESCRIPTION
Moved the logic from TextRange to TextColumn for onclick and doubleclick to avoid second click firing in the empty space on the margins.  