### PR TITLE
fix bug where double mongo profiles were being created on production …

### DIFF
--- a/sefaria/views.py
+++ b/sefaria/views.py
@@ -83,7 +83,7 @@ def process_register_form(request, auth_method='session'):
             new_user = form.save()
             user = authenticate(email=form.cleaned_data['email'],
                                 password=form.cleaned_data['password1'])
-            p = UserProfile(id=user.id)
+            p = UserProfile(id=user.id, user_registration=True)
             p.assign_slug()
             p.join_invited_collections()
             if hasattr(request, "interfaceLang"):


### PR DESCRIPTION
…during user registration; note that on local and cauldrons / where postgres is not up to date, new users can be assigned to existing users in profiles collection