### PR TITLE
feat (python-dependencies): Update ipython and jedi to newer versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,8 @@ google-cloud-storage==1.32.0
 gunicorn==20.0.4
 html5lib==0.9999999
 httplib2==0.18.1
-ipython==7.18.1
+ipython==7.34.*
+jedi==0.18.1 # Ipython was previosuly pinned at 7.18 because Jedi 0.18 broke it. This is currently the latest version. 
 jsonpickle==1.4.1
 lxml==4.6.1
 mailchimp==2.0.9


### PR DESCRIPTION
This fixes an issue with ipython autocompletion in the command line, after a version of ipython became incompatible with one of its dependencies, jedi.

Ipython is still not at latest because of python changes required