### PR TITLE
chore(linker): preemptively add linker paths without enabling it

### DIFF
--- a/helm-chart/sefaria-project/values.yaml
+++ b/helm-chart/sefaria-project/values.yaml
@@ -91,11 +91,11 @@ linker:
   enabled: false
   # key-pair values to load into web pod environment.  Takes precedence over global localsettings
   model_paths:
-    en: foo
-    he: foo
+    # en: future_path
+    he: "gs://sefaria-ml-models/ref_model.tar.gz"
   part_model_paths:
-    en: foo
-    he: foo
+    # en: future_path
+    he: "gs://sefaria-ml-models/subref_model.tar.gz"
   localsettings:
   # APP: web
   containerImage:


### PR DESCRIPTION
- Added paths of Hebrew models that are currently somewhat stable.
- Removed "en" key so that it doesn't break model loading