### PR TITLE
fix: correctly encap json string output

### DIFF
--- a/helm-chart/sefaria-project/templates/rollout/linker.yaml
+++ b/helm-chart/sefaria-project/templates/rollout/linker.yaml
@@ -90,9 +90,9 @@ spec:
           - name: DISABLE_AUTOCOMPLETER
             value: "True"
           - name: RAW_REF_MODEL_BY_LANG_FILEPATH
-            value: "{{ .Values.linker.model_paths | toJson }}"
+            value: '{{ toJson .Values.linker.model_paths }}'
           - name: RAW_REF_PART_MODEL_BY_LANG_FILEPATH 
-            value: "{{ .Values.linker.part_model_paths | toJson }}"
+            value: '{{ toJson .Values.linker.part_model_paths }}'
         envFrom:
           - secretRef:
               name: {{ .Values.secrets.localSettings.ref }}


### PR DESCRIPTION
`value: '{"he":"gs://sefaria-ml-models/ref_model.tar.gz"}'`
vs
`value: "{"he":"gs://sefaria-ml-models/ref_model.tar.gz"}"`