### PR TITLE
chore: change all service types to clusterip

### DIFF
--- a/helm-chart/sefaria-project/templates/service/nginx-preview.yaml
+++ b/helm-chart/sefaria-project/templates/service/nginx-preview.yaml
@@ -11,7 +11,7 @@ metadata:
     argoPreview: "true"
     {{- end }}
 spec:
-  type: {{ if eq .Values.sandbox "true" }}ClusterIP{{ else }}NodePort{{ end }}
+  type: ClusterIP
   ports:
   - name: http
     port: 80

--- a/helm-chart/sefaria-project/templates/service/nginx-previous.yaml
+++ b/helm-chart/sefaria-project/templates/service/nginx-previous.yaml
@@ -14,7 +14,7 @@ metadata:
     sandbox-name: "{{ $.Values.deployEnv }}"
     {{- end }}
 spec:
-  type: {{ if eq $.Values.sandbox "true" }}ClusterIP{{ else }}NodePort{{ end }}
+  type: ClusterIP
   ports:
   - name: http
     port: 80

--- a/helm-chart/sefaria-project/templates/service/nginx.yaml
+++ b/helm-chart/sefaria-project/templates/service/nginx.yaml
@@ -10,7 +10,7 @@ metadata:
     sandbox-name: "{{ .Values.deployEnv }}"
     {{- end }}
 spec:
-  type: {{ if eq .Values.sandbox "true" }}ClusterIP{{ else }}NodePort{{ end }}
+  type: ClusterIP
   ports:
   - name: http
     port: 80


### PR DESCRIPTION
Now that we are no longer using the GKE ingress, there is no need for the nginx service to bind to nodeports