### PR TITLE
fix: 404 pages no longer fail due to missing attrs on request object

### DIFF
--- a/sefaria/system/middleware.py
+++ b/sefaria/system/middleware.py
@@ -51,6 +51,9 @@ class LanguageSettingsMiddleware(MiddlewareMixin):
         if any([request.path.startswith(start) for start in excluded]):
             request.interfaceLang = "english"
             request.contentLang = "bilingual"
+            request.translation_language_preference = None
+            request.version_preferences_by_corpus = {}
+            request.translation_language_preference_suggestion = None
             return # Save looking up a UserProfile, or redirecting when not needed
 
         profile = UserProfile(id=request.user.id) if request.user.is_authenticated else None


### PR DESCRIPTION
I spent a while trying to trace down a seemingly unrelated error on a new API I was working on. After a while, I figured out that the error was actually a red herring and the real error was that the URL was hitting a 404. This PR fixes that red herring error.