### PR TITLE
updated to correct command

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -167,7 +167,7 @@ The recommended dump (which is a more manageable size) is available [here](https
 
 A complete dump is also available [here](https://storage.googleapis.com/sefaria-mongo-backup/dump.tar.gz). The complete dump includes the `history` collections, which contains a complete revision history of every text in our library. For many applications, this data is not relevant. We recommend using the smaller dump unless you're specifically interested in texts revision history within Sefaria.
 
-Unzip the file and extract the `dump` folder. If you don't have an app for unzipping, this can be done from Command Prompt by navigating to the folder containing the download and using `tar -x dump.tar.gz` or `tar -x dump_small.tar.gz` (depending on which dump you downloaded).
+Unzip the file and extract the `dump` folder. If you don't have an app for unzipping, this can be done from Command Prompt by navigating to the folder containing the download and using `tar -xf dump.tar.gz` or `tar -xf dump_small.tar.gz` (depending on which dump you downloaded).
 
 This `dump` must be restored as a MongoDB database. 
 


### PR DESCRIPTION
tar -x dump_small.tar.gz
give this error in windows:
tar: Error opening archive: Failed to open '\\.\tape0'
and this error in ubuntu:
tar: Refusing to read archive contents from terminal (missing -f option?)
tar: Error is not recoverable: exiting now

the correct command is 
tar -xf dump_small.tar.gz
with an f after the x