### PR TITLE
Translations ux updates

### DIFF
--- a/reader/views.py
+++ b/reader/views.py
@@ -4258,7 +4258,7 @@ def translations_api(request, lang=None):
                             continue
                 else:
                     to_add["title"] = my_index_info["title"]
-                    to_add["url"] = f'/{my_index["vstate"][0]["first_section_ref"].replace(":", ".")}?{"ven=" + my_index["versionTitle"] if my_index["language"] == "en" else "vhe=" + my_index["versionTitle"]}'
+                    to_add["url"] = f'/{my_index["vstate"][0]["first_section_ref"].replace(":", ".")}?{"ven=" + my_index["versionTitle"] if my_index["language"] == "en" else "vhe=" + my_index["versionTitle"]}&lang=bi'
 
                 if "order" in my_index["index"][0]:
                     to_add["order"] = my_index["index"][0]["order"]

--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -2153,18 +2153,21 @@ div.interfaceLinks-row a {
   text-transform: none;
   color: #000;
 }
-.translationsPage details > ul {
+.translationsPage details > ul,
+.translationsPage > ul {
   padding: 0;
   margin: 20px 0;
   display: flex;
   flex-wrap: wrap;
 }
-.translationsPage details > ul > li:after {
+.translationsPage details > ul > li:after,
+.translationsPage > ul > li:after {
   content: "\2022";
   white-space:pre;
   margin: 0 5px;
 }
-.translationsPage details > ul > li:last-child:after {
+.translationsPage details > ul > li:last-child:after,
+.translationsPage > ul > li:last-child:after{
   content: none;
 }
 .readerPanel .translationsPage details > summary::-webkit-details-marker {

--- a/static/js/ReaderApp.jsx
+++ b/static/js/ReaderApp.jsx
@@ -1043,12 +1043,13 @@ class ReaderApp extends Component {
     //All links within sheet content should open in a new panel
     const isSheet = !!(linkTarget.closest(".sheetItem"))
     const replacePanel = !(isSheet)
-    const handled = this.openURL(href,replacePanel);
+    const isTranslationsPage = !!(linkTarget.closest(".translationsPage"));
+    const handled = this.openURL(href,replacePanel, isTranslationsPage);
     if (handled) {
       e.preventDefault();
     }
   }
-  openURL(href, replace=true) {
+  openURL(href, replace=true, overrideContentLang=false) {
     // Attempts to open `href` in app, return true if successful.
     href = href.startsWith("/") ? "https://www.sefaria.org" + href : href;
     let url;
@@ -1065,6 +1066,11 @@ class ReaderApp extends Component {
     }
     const path = decodeURI(url.pathname);
     const params = url.searchParams;
+    if(overrideContentLang && params.get('lang')) {
+      let lang = params.get("lang")
+      lang = lang === "bi" ? "bilingual" : lang === "en" ? "english" : "hebrew";
+      this.setDefaultOption("language", lang)
+    }
     const openPanel = replace ? this.openPanel : this.openPanelAtEnd;
     if (path === "/") {
       this.showLibrary();


### PR DESCRIPTION
Hi Russel! This PR adds the following ux improvements to language pages (details here: https://trello.com/c/GuzEI5pl/2786-language-page-improvements)
- When users click a text from a language list, their content language is switched to bilingual for that session only
- Prioritized texts should show up at the top of category, not under uncategorized