### PR TITLE
Maintain scroll position in sidebar

### DIFF
--- a/static/js/ConnectionFilters.jsx
+++ b/static/js/ConnectionFilters.jsx
@@ -20,7 +20,7 @@ class CategoryFilter extends Component {
     }
   }
   render() {
-    const filterSuffix = this.props.category  == "Quoting Commentary" ? "Quoting" : null;
+    const filterSuffix = this.props.category  === "Quoting Commentary" ? "Quoting" : null;
     const textMissingDescription = null; //"missing description"
     const textFilters = this.props.showBooks ? this.props.books.map(function(book, i) {
       return (<TextFilter
@@ -45,7 +45,7 @@ class CategoryFilter extends Component {
     let innerClasses = classNames({categoryFilter: 1, withBooks: this.props.showBooks, on: this.props.on});
     let handleClick  = this.handleClick;
     const url = (this.props.srefs && this.props.srefs.length > 0)?"/" + Sefaria.normRef(this.props.srefs[0]) + "?with=" + this.props.category:"";
-    const classesDesc = classNames({ sidebarDescription: 1, lowlight: this.props.count == 0, title:1});
+    const classesDesc = classNames({ sidebarDescription: 1, lowlight: this.props.count === 0, title:1});
     let outerClasses = classNames({categoryFilterGroup: 1, withBooks: this.props.showBooks});
     const catDesc = Sefaria.getDescriptionDict(this.props.category, []);
     const catEnDesc = catDesc[0];

--- a/static/js/ConnectionsPanel.jsx
+++ b/static/js/ConnectionsPanel.jsx
@@ -96,7 +96,6 @@ class ConnectionsPanel extends Component {
     if (prevProps.mode !== this.props.mode || prevProps.connectionsCategory !== this.props.connectionsCategory) {
       this.removeScrollListener();
 
-      debugger;
       if (this.props.scrollPosition) {
         $(".content").scrollTop(this.props.scrollPosition)
             .trigger("scroll");
@@ -122,7 +121,6 @@ class ConnectionsPanel extends Component {
       this.props.setScrollPosition(this.props.connectionsCategory, $(event.target).scrollTop());
     }
     else if (this.props.mode === "WebPages") {
-      debugger;
       this.props.setScrollPosition(this.props.mode, $(event.target).scrollTop());
     }
     else if (this.props.mode === "TextList") {

--- a/static/js/ConnectionsPanel.jsx
+++ b/static/js/ConnectionsPanel.jsx
@@ -63,6 +63,7 @@ class ConnectionsPanel extends Component {
     this.debouncedCheckVisibleSegments = Sefaria.util.debounce(this.checkVisibleSegments, 100);
     this.addScrollListener();
   }
+
   componentWillUnmount() {
     this._isMounted = false;
     this.removeScrollListener();
@@ -92,11 +93,19 @@ class ConnectionsPanel extends Component {
       this.getCurrentVersions();
     }
 
-    if (prevProps.mode !== 'TextList' && this.props.mode === 'TextList') {
+    if (prevProps.mode !== this.props.mode || prevProps.connectionsCategory !== this.props.connectionsCategory) {
       this.removeScrollListener();
+
+      debugger;
+      if (this.props.scrollPosition) {
+        $(".content").scrollTop(this.props.scrollPosition)
+            .trigger("scroll");
+      }
+
       this.addScrollListener();
     }
   }
+
   addScrollListener() {
     this.$scrollView = $(".connectionsPanel .texts");
     if (this.$scrollView[0]) {
@@ -109,7 +118,16 @@ class ConnectionsPanel extends Component {
     }
   }
   handleScroll(event) {
-    this.debouncedCheckVisibleSegments();
+    if (this.props.mode === "ConnectionsList") {
+      this.props.setScrollPosition(this.props.connectionsCategory, $(event.target).scrollTop());
+    }
+    else if (this.props.mode === "WebPages") {
+      debugger;
+      this.props.setScrollPosition(this.props.mode, $(event.target).scrollTop());
+    }
+    else if (this.props.mode === "TextList") {
+      this.debouncedCheckVisibleSegments();
+    }
   }
   checkVisibleSegments() {
     if (!this._isMounted || !this.props.filter || !this.props.filter.length) { return; }
@@ -759,6 +777,8 @@ ConnectionsPanel.propTypes = {
   clearSelectedWords: PropTypes.func.isRequired,
   clearNamedEntity: PropTypes.func.isRequired,
   translationLanguagePreference: PropTypes.string,
+  scrollPosition: PropTypes.number,
+  setScrollPosition: PropTypes.func.isRequired,
 };
 
 

--- a/static/js/ConnectionsPanel.jsx
+++ b/static/js/ConnectionsPanel.jsx
@@ -215,19 +215,19 @@ class ConnectionsPanel extends Component {
     //d - data received from this.getData()
     //language - the language of the version
     //console.log(d);
-    const currentVersionTitle = (lang == "he") ? d.heVersionTitle : d.versionTitle;
+    const currentVersionTitle = (lang === "he") ? d.heVersionTitle : d.versionTitle;
     return {
-      ...d.versions.find(v => v.versionTitle == currentVersionTitle && v.language == lang),
+      ...d.versions.find(v => v.versionTitle === currentVersionTitle && v.language === lang),
       title: d.indexTitle,
       heTitle: d.heIndexTitle,
-      sources: lang == "he" ? d.heSources : d.sources,
-      merged: lang == "he" ? !!d.heSources : !!d.sources,
+      sources: lang === "he" ? d.heSources : d.sources,
+      merged: lang === "he" ? !!d.heSources : !!d.sources,
     }
   }
   getCurrentVersions() {
     const data = this.getData((data) => {
       let currentLanguage = this.props.masterPanelLanguage;
-      if (currentLanguage == "bilingual") {
+      if (currentLanguage === "bilingual") {
         currentLanguage = "hebrew"
       }
       if (!data || data.error) {
@@ -237,16 +237,16 @@ class ConnectionsPanel extends Component {
         });
         return
       }
-      if (currentLanguage == "hebrew" && !data.he.length) {
+      if (currentLanguage === "hebrew" && !data.he.length) {
         currentLanguage = "english"
       }
-      if (currentLanguage == "english" && !data.text.length) {
+      if (currentLanguage === "english" && !data.text.length) {
         currentLanguage = "hebrew"
       }
       this.setState({
         currObjectVersions: {
-          en: ((this.props.masterPanelLanguage != "hebrew" && !!data.text.length) || (this.props.masterPanelLanguage == "hebrew" && !data.he.length)) ? this.getVersionFromData(data, "en") : null,
-          he: ((this.props.masterPanelLanguage != "english" && !!data.he.length) || (this.props.masterPanelLanguage == "english" && !data.text.length)) ? this.getVersionFromData(data, "he") : null,
+          en: ((this.props.masterPanelLanguage !== "hebrew" && !!data.text.length) || (this.props.masterPanelLanguage === "hebrew" && !data.he.length)) ? this.getVersionFromData(data, "en") : null,
+          he: ((this.props.masterPanelLanguage !== "english" && !!data.he.length) || (this.props.masterPanelLanguage === "english" && !data.text.length)) ? this.getVersionFromData(data, "he") : null,
         },
         mainVersionLanguage: currentLanguage,
         sectionRef: data.sectionRef,
@@ -255,10 +255,10 @@ class ConnectionsPanel extends Component {
   }
   checkSrefs(srefs) {
     // Mostly exists for properly displaying Ranging refs in TextList on page loads and on sheets
-    if (typeof (srefs) == "object" && srefs.length == 1) {
+    if (typeof (srefs) == "object" && srefs.length === 1) {
       srefs = Sefaria.splitRangingRef(srefs[0]);
     }
-    if (srefs.length == 1 && (Sefaria.sectionRef(srefs[0]) == srefs[0])) {
+    if (srefs.length === 1 && (Sefaria.sectionRef(srefs[0]) === srefs[0])) {
       const oref = Sefaria.ref(srefs[0]);
       srefs = Sefaria.makeSegments(oref).map(segment => segment.ref)
     }

--- a/static/js/ConnectionsPanel.jsx
+++ b/static/js/ConnectionsPanel.jsx
@@ -120,7 +120,7 @@ class ConnectionsPanel extends Component {
     if (this.props.mode === "ConnectionsList") {
       this.props.setScrollPosition(this.props.connectionsCategory, $(event.target).scrollTop());
     }
-    else if (this.props.mode === "WebPages") {
+    else if (this.props.mode === "WebPages" || this.props.mode === "Sheets") {
       this.props.setScrollPosition(this.props.mode, $(event.target).scrollTop());
     }
     else if (this.props.mode === "TextList") {

--- a/static/js/ConnectionsPanelHeader.jsx
+++ b/static/js/ConnectionsPanelHeader.jsx
@@ -30,7 +30,7 @@ class ConnectionsPanelHeader extends Component {
     // compared to the header. This functions sets appropriate margin to compensate.
     const width      = Sefaria.util.getScrollbarWidth();
     const $container = $(ReactDOM.findDOMNode(this));
-    if (this.props.interfaceLang == "hebrew") {
+    if (this.props.interfaceLang === "hebrew") {
       $container.css({marginRight: 0, marginLeft: width});
     } else {
       $container.css({marginRight: width, marginLeft: 0});
@@ -49,13 +49,13 @@ class ConnectionsPanelHeader extends Component {
       /** TODO: fix for interfacetext */
     const previousMode = this.getPreviousMode();
     let title;
-    if (this.props.connectionsMode == "Resources") {
+    if (this.props.connectionsMode === "Resources") {
       // Top Level Menu
       title = <div className="connectionsHeaderTitle sans-serif">
                     <InterfaceText text={{en: "Resources" , he:"קישורים וכלים" }} />
                   </div>;
 
-    } else if ((this.props.previousCategory && this.props.connectionsMode == "TextList") || previousMode) {
+    } else if ((this.props.previousCategory && this.props.connectionsMode === "TextList") || previousMode) {
       // In a text list, back to Previous Category
       const prev = previousMode ? previousMode.splitCamelCase() : this.props.previousCategory;
       const prevHe = previousMode ? Sefaria._(prev) : Sefaria._(this.props.previousCategory);
@@ -93,7 +93,7 @@ class ConnectionsPanelHeader extends Component {
                   </a>;
     }
     if (this.props.multiPanel) {
-      const toggleLang = Sefaria.util.getUrlVars()["lang2"] == "en" ? "he" : "en";
+      const toggleLang = Sefaria.util.getUrlVars()["lang2"] === "en" ? "he" : "en";
       const langUrl = Sefaria.util.replaceUrlParam("lang2", toggleLang);
       const closeUrl = Sefaria.util.removeUrlParam("with");
       return (<div className="connectionsPanelHeader">
@@ -106,8 +106,8 @@ class ConnectionsPanelHeader extends Component {
                 </div>
               </div>);
     } else {
-      const style = !this.props.multiPanel && this.props.connectionsMode == "TextList" ? {"borderTopColor": Sefaria.palette.categoryColor(this.props.previousCategory)} : {}
-      const cStyle = !this.props.multiPanel && this.props.connectionsMode == "Resources" ? {"justifyContent": "center"} : style;
+      const style = !this.props.multiPanel && this.props.connectionsMode === "TextList" ? {"borderTopColor": Sefaria.palette.categoryColor(this.props.previousCategory)} : {}
+      const cStyle = !this.props.multiPanel && this.props.connectionsMode === "Resources" ? {"justifyContent": "center"} : style;
       // Modeling the class structure when ConnectionsPanelHeader is created inside ReaderControls in the multiPanel case
       let classes = classNames({readerControls: 1, connectionsHeader: 1, fullPanel: this.props.multiPanel});
       return (<div className={classes} style={style}>
@@ -115,7 +115,7 @@ class ConnectionsPanelHeader extends Component {
                   <div className="readerTextToc">
                     <div className="connectionsPanelHeader" style={cStyle}>
                       {title}
-                      {!this.props.multiPanel && this.props.previousCategory && this.props.connectionsMode == "TextList" ?
+                      {!this.props.multiPanel && this.props.previousCategory && this.props.connectionsMode === "TextList" ?
                       <RecentFilterSet
                         srefs={this.props.baseRefs}
                         asHeader={true}

--- a/static/js/ReaderApp.jsx
+++ b/static/js/ReaderApp.jsx
@@ -171,7 +171,7 @@ class ReaderApp extends Component {
     if (this.state && panel.refs.length && ((panel.settings.language === "hebrew" && !panel.currVersions.he) || (panel.settings.language !== "hebrew" && !panel.currVersions.en ))) {
       var oRef = Sefaria.ref(panel.refs[0]);
       if (oRef) {
-        const lang = panel.settings.language == "hebrew"?"he":"en";
+        const lang = panel.settings.language === "hebrew"?"he":"en";
         panel.currVersions[lang] = this.getCachedVersion(oRef.indexTitle, lang);
       }
     }
@@ -247,7 +247,7 @@ class ReaderApp extends Component {
 
 
   handlePopState(event) {
-    var state = event.state;
+    const state = event.state;
     // console.log("Pop - " + window.location.pathname);
     // console.log(event.state);
     if (state) {
@@ -408,7 +408,7 @@ class ReaderApp extends Component {
     var histories = [];
     var states = this.state.panels;
     var siteName = Sefaria._siteSettings["SITE_NAME"]["en"]; // e.g. "Sefaria"
-    const shortLang = Sefaria.interfaceLang == 'hebrew' ? 'he' : 'en';
+    const shortLang = Sefaria.interfaceLang === 'hebrew' ? 'he' : 'en';
 
     // List of modes that the ConnectionsPanel may have which can be represented in a URL.
     const sidebarModes = new Set(["Sheets", "Notes", "Translations", "Translation Open",
@@ -835,7 +835,7 @@ class ReaderApp extends Component {
     this.scrollPositionTimer = this.checkIntentTimer(this.scrollPositionTimer, () => {
       const scrollTop = $scrollContainer.scrollTop();
       const state = history.state;
-      if (scrollTop == state.scrollPosition) { return; }
+      if (scrollTop === state.scrollPosition) { return; }
       state.scrollPosition = scrollTop;
       history.replaceState(state, window.location.href);
     }, 300);
@@ -1901,21 +1901,21 @@ class ReaderApp extends Component {
       wrapBoxScroll = true;
     }
 
-    if (panelStates.length == 2 &&
-        (panelStates[0].mode == "Text" || panelStates[0].mode == "Sheet") &&
-        (panelStates[1].mode == "Connections" || panelStates[1].menuOpen === "search" || panelStates[1].compare)) {
+    if (panelStates.length === 2 &&
+        (panelStates[0].mode === "Text" || panelStates[0].mode === "Sheet") &&
+        (panelStates[1].mode === "Connections" || panelStates[1].menuOpen === "search" || panelStates[1].compare)) {
       widths = [68.0, 32.0];
       unit = "%";
-    } else if (panelStates.length == 3 &&
-        (panelStates[0].mode == "Text" || panelStates[0].mode == "Sheet") &&
-        panelStates[1].mode == "Connections" &&
-        (panelStates[2].mode == "Text" || panelStates[2].mode == "Sheet")) {
+    } else if (panelStates.length === 3 &&
+        (panelStates[0].mode === "Text" || panelStates[0].mode === "Sheet") &&
+        panelStates[1].mode === "Connections" &&
+        (panelStates[2].mode === "Text" || panelStates[2].mode === "Sheet")) {
       widths = [37.0, 26.0, 37.0];
       unit = "%";
-    } else if (panelStates.length == 3 &&
-        (panelStates[0].mode == "Text"|| panelStates[0].mode == "Sheet") &&
-        (panelStates[1].mode == "Text"|| panelStates[1].mode == "Sheet") &&
-        panelStates[2].mode == "Connections") {
+    } else if (panelStates.length === 3 &&
+        (panelStates[0].mode === "Text"|| panelStates[0].mode === "Sheet") &&
+        (panelStates[1].mode === "Text"|| panelStates[1].mode === "Sheet") &&
+        panelStates[2].mode === "Connections") {
       widths = [37.0, 37.0, 26.0];
       unit = "%";
     } else {

--- a/static/js/ReaderApp.jsx
+++ b/static/js/ReaderApp.jsx
@@ -166,6 +166,7 @@ class ReaderApp extends Component {
       profile:                 state.profile                 || null,
       tab:                     state.tab                     || null,
       beitMidrashId:           state.beitMidrashId           || null,
+      scrollPositions:         state.scrollPositions  || {},
     };
     // if version is not set for the language you're in, see if you can retrieve it from cache
     if (this.state && panel.refs.length && ((panel.settings.language === "hebrew" && !panel.currVersions.he) || (panel.settings.language !== "hebrew" && !panel.currVersions.en ))) {
@@ -1514,8 +1515,8 @@ class ReaderApp extends Component {
   }
   setConnectionsFilter(n, filter, updateRecent) {
     // Set the filter for connections panel at `n`, carry data onto the panel's basetext as well.
-    var connectionsPanel = this.state.panels[n];
-    var basePanel        = this.state.panels[n-1];
+    const connectionsPanel = this.state.panels[n];
+    const basePanel        = this.state.panels[n-1];
     if (filter) {
       if (updateRecent) {
         if (Sefaria.util.inArray(filter, connectionsPanel.recentFilters) !== -1) {
@@ -1535,6 +1536,13 @@ class ReaderApp extends Component {
       basePanel.recentFilters = connectionsPanel.recentFilters;
     }
     this.setState({panels: this.state.panels});
+  }
+  setScrollPosition(n, filter, pos) {
+    const connectionsPanel = this.state.panels[n];
+    if (filter && pos) {
+      connectionsPanel.scrollPositions[filter] = pos;
+      this.setState({panels: this.state.panels});
+    }
   }
   setVersionFilter(n, filter) {
     var connectionsPanel = this.state.panels[n];
@@ -1981,6 +1989,7 @@ class ReaderApp extends Component {
       var closePanel                     = panel.compare ? this.convertToTextList.bind(null, i) : this.closePanel.bind(null, i);
       var setPanelState                  = this.setPanelState.bind(null, i);
       var setConnectionsFilter           = this.setConnectionsFilter.bind(this, i);
+      var setScrollPosition              = this.setScrollPosition.bind(this, i);
       var setVersionFilter               = this.setVersionFilter.bind(this, i);
       var selectVersion                  = this.selectVersion.bind(null, i);
       var viewExtendedNotes              = this.viewExtendedNotes.bind(this, i);
@@ -2013,6 +2022,7 @@ class ReaderApp extends Component {
                       openComparePanel={openComparePanel}
                       setTextListHighlight={setTextListHighlight}
                       setConnectionsFilter={setConnectionsFilter}
+                      setScrollPosition={setScrollPosition}
                       setVersionFilter={setVersionFilter}
                       setSelectedWords={setSelectedWords}
                       selectVersion={selectVersion}

--- a/static/js/ReaderPanel.jsx
+++ b/static/js/ReaderPanel.jsx
@@ -719,7 +719,7 @@ class ReaderPanel extends Component {
           allOpenRefs={this.props.allOpenRefs}
           canEditText={canEditText}
           setFilter={this.setFilter}
-          scrollPosition={this.state.scrollPositions[this.state.filter[0]] || 0}
+          scrollPosition={this.state.scrollPositions[this.state.filter[0] || this.state.connectionsMode] || 0}
           setScrollPosition={this.props.setScrollPosition}
           toggleSignUpModal={this.props.toggleSignUpModal}
           setConnectionsMode={this.setConnectionsMode}

--- a/static/js/ReaderPanel.jsx
+++ b/static/js/ReaderPanel.jsx
@@ -719,6 +719,8 @@ class ReaderPanel extends Component {
           allOpenRefs={this.props.allOpenRefs}
           canEditText={canEditText}
           setFilter={this.setFilter}
+          scrollPosition={this.state.scrollPositions[this.state.filter[0]] || 0}
+          setScrollPosition={this.props.setScrollPosition}
           toggleSignUpModal={this.props.toggleSignUpModal}
           setConnectionsMode={this.setConnectionsMode}
           setConnectionsCategory={this.setConnectionsCategory}
@@ -1153,6 +1155,7 @@ ReaderPanel.propTypes = {
   closePanel:                  PropTypes.func,
   closeMenus:                  PropTypes.func,
   setConnectionsFilter:        PropTypes.func,
+  setScrollPosition:           PropTypes.func,
   setDefaultOption:            PropTypes.func,
   selectVersion:               PropTypes.func,
   viewExtendedNotes:           PropTypes.func,

--- a/static/js/ReaderPanel.jsx
+++ b/static/js/ReaderPanel.jsx
@@ -53,8 +53,6 @@ class ReaderPanel extends Component {
     this.state = state;
     this.sheetRef = React.createRef();
     this.readerContentRef = React.createRef();
-
-    return;
   }
   componentDidMount() {
     window.addEventListener("resize", this.setWidth);
@@ -231,13 +229,13 @@ class ReaderPanel extends Component {
     if (!ref) { return; }
     this.replaceHistory = Boolean(replaceHistory);
     // console.log("showBaseText", ref, replaceHistory);
-    if (this.state.mode == "Connections" && this.props.masterPanelLanguage == "bilingual") {
+    if (this.state.mode === "Connections" && this.props.masterPanelLanguage === "bilingual") {
       // Connections panels are forced to be mono-lingual. When opening a text from a connections panel,
       // allow it to return to bilingual.
       this.state.settings.language = "bilingual";
     }
     let refs, currentlyVisibleRef, highlightedRefs;
-    if (ref.constructor == Array) {
+    if (ref.constructor === Array) {
       // When called with an array, set highlight for the whole spanning range
       refs = ref;
       currentlyVisibleRef = Sefaria.humanRef(ref);

--- a/static/js/SearchResultList.jsx
+++ b/static/js/SearchResultList.jsx
@@ -125,7 +125,7 @@ class SearchResultList extends Component {
         $(ReactDOM.findDOMNode(this)).closest(".content").off("scroll.infiniteScroll", this.handleScroll);
     }
     componentWillReceiveProps(newProps) {
-      if(this.props.query != newProps.query) {
+      if(this.props.query !== newProps.query) {
         this.setState({
           totals: this._typeObjDefault(0),
           hits: this._typeObjDefault([]),


### PR DESCRIPTION
This feature aims to maintain the user's scroll position in lists of commentators.  The user will scroll down to e.g. Rashbam, click into Rashbam, and then click back.  The position in the list of commentators will be retained. 

Similarly the position in the list of Websites will be maintained as the user clicks into the webpage list and then back. 

The scroll position in sheets is maintained as well, but the use case is more limited.  Clicking on a sheet closes the sidebar, and the scroll state is lost.  But if a user scrolls through sheets then navigates up to resources and back to sheets, the position is maintained. 

Review of this feature should pay attention to any impact on user history collection.  There was a pre-existing scroll event on the connections panel that was used to see what texts were in the viewport for the sake of collecting history.  

There is also a top level scroll event in effect on the .content div, which is a generic function for handling <back> actions.  That shouldn't be impacted by this.  