### PR TITLE
ci: add workflow to deploy to prod via semantic release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,11 @@
+name: Deploy to Production
+on:
+  workflow_dispatch: {}
+jobs:
+  semantic-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: codfish/semantic-release-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Once this merges, there will be a manually triggerable github action that will automatically create a new release (and corresponding version tag) based on the contents of conventional commit messages.