### PR TITLE
helm: allow forks to publish charts

### DIFF
--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -35,8 +35,6 @@ jobs:
       contents: write # needed to write releases
     needs:
       - lint
-    if: |
-      (github.repository == 'sefaria/sefaria-project')
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
@EliezerIsrael You might need to enable github-pages on Contextus project once this syncs over, I can't remember whate we needed to do in this repo to get the charts publishing correct