### PR TITLE
Sort imports in ./reader

### DIFF
--- a/reader/browsertest/basic_tests.py
+++ b/reader/browsertest/basic_tests.py
@@ -1,18 +1,19 @@
 # -*- coding: utf-8 -*-
-from urllib.parse import urlparse, quote_plus
-
-from selenium.webdriver.common.by import By
-from selenium.common.exceptions import TimeoutException
-from selenium.webdriver.support.ui import WebDriverWait, Select
-from selenium.webdriver.support.expected_conditions import title_contains, staleness_of, element_to_be_clickable, visibility_of_element_located, invisibility_of_element_located, text_to_be_present_in_element
-from selenium.common.exceptions import WebDriverException
+import time  # import stand library below name collision in sefaria.model
+from urllib.parse import quote_plus, urlparse
 
 from sefaria.model import *
-from sefaria.utils.hebrew import strip_cantillation, strip_nikkud
-from sefaria.utils.hebrew import has_cantillation
-from .framework import SefariaTest, one_of_these_texts_present_in_element
+from sefaria.utils.hebrew import (has_cantillation, strip_cantillation,
+                                  strip_nikkud)
+from selenium.common.exceptions import TimeoutException, WebDriverException
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.expected_conditions import (
+    element_to_be_clickable, invisibility_of_element_located, staleness_of,
+    text_to_be_present_in_element, title_contains,
+    visibility_of_element_located)
+from selenium.webdriver.support.ui import Select, WebDriverWait
 
-import time  # import stand library below name collision in sefaria.model
+from .framework import SefariaTest, one_of_these_texts_present_in_element
 
 TEMPER = 30
 

--- a/reader/browsertest/framework/__init__.py
+++ b/reader/browsertest/framework/__init__.py
@@ -1,1 +1,2 @@
-from .elements import SefariaTest, SingleTestResult, Trial, one_of_these_texts_present_in_element
+from .elements import (SefariaTest, SingleTestResult, Trial,
+                       one_of_these_texts_present_in_element)

--- a/reader/browsertest/framework/elements.py
+++ b/reader/browsertest/framework/elements.py
@@ -1,30 +1,37 @@
 
 # -*- coding: utf-8 -*-
 
-from .config import TEMPER, SAUCE_CORE_CAPS, SAUCE_MAX_THREADS, LOCAL_URL, LOCAL_SELENIUM_CAPS
-from sefaria.model import *
-from pathos.multiprocessing import ProcessingPool as Pool
-import os
 import inspect
-import traceback
+import os
 import sys
-
+import time  # import stand library below name collision in sefaria.model
+import traceback
 import urllib.parse
+
+from appium import webdriver as appium_webdriver
+from pathos.multiprocessing import ProcessingPool as Pool
+from sefaria.model import *
+from selenium import webdriver
+from selenium.common.exceptions import (ElementClickInterceptedException,
+                                        NoAlertPresentException,
+                                        NoSuchElementException,
+                                        StaleElementReferenceException,
+                                        TimeoutException, WebDriverException)
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.support.expected_conditions import (
+    _find_element, element_to_be_clickable, presence_of_element_located,
+    title_contains, visibility_of_any_elements_located,
+    visibility_of_element_located)
+from selenium.webdriver.support.ui import WebDriverWait
 from urllib3.exceptions import MaxRetryError
 
-from selenium import webdriver
-from appium import webdriver as appium_webdriver
-from selenium.webdriver.common.by import By
-from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.support.expected_conditions import title_contains, presence_of_element_located, \
-    element_to_be_clickable, _find_element, visibility_of_element_located, visibility_of_any_elements_located
-from selenium.webdriver.common.keys import Keys
-from selenium.common.exceptions import NoSuchElementException, NoAlertPresentException, TimeoutException, WebDriverException, \
-    ElementClickInterceptedException, StaleElementReferenceException
+from .config import (LOCAL_SELENIUM_CAPS, LOCAL_URL, SAUCE_CORE_CAPS,
+                     SAUCE_MAX_THREADS, TEMPER)
+
 # http://selenium-python.readthedocs.io/waits.html
 # http://selenium-python.readthedocs.io/api.html#module-selenium.webdriver.support.expected_conditions
 
-import time # import stand library below name collision in sefaria.model
 
 
 class AbstractTest(object):

--- a/reader/browsertest/run_local.py
+++ b/reader/browsertest/run_local.py
@@ -2,13 +2,15 @@
 __package__ = "reader.browsertest"
 
 import sys
-from selenium import webdriver
-from appium import webdriver as appiumWebdriver
 from optparse import OptionParser
+
 import django
+from appium import webdriver as appiumWebdriver
+from selenium import webdriver
+
 django.setup()
-from .framework import Trial
 from . import basic_tests
+from .framework import Trial
 
 
 def _get_appium_webdriver(caps):

--- a/reader/browsertest/run_local_sel.py
+++ b/reader/browsertest/run_local_sel.py
@@ -2,13 +2,14 @@
 __package__ = "reader.browsertest"
 
 import sys
-from selenium import webdriver
 from optparse import OptionParser
-import django
-django.setup()
-from .framework import Trial
-from . import basic_tests
 
+import django
+from selenium import webdriver
+
+django.setup()
+from . import basic_tests
+from .framework import Trial
 from .framework.config import LOCAL_SELENIUM_CAPS
 
 if __name__ == '__main__':

--- a/reader/browsertest/run_one_local.py
+++ b/reader/browsertest/run_one_local.py
@@ -3,11 +3,14 @@
 # For instance: python run_one_local.py ClickVersionedSearchResultDesktop
 __package__ = "reader.browsertest"
 
-import django
-django.setup()
-from .framework import Trial
-from . import basic_tests
 import sys
+
+import django
+
+from . import basic_tests
+from .framework import Trial
+
+django.setup()
 
 test = sys.argv[1]
 klass = getattr(basic_tests, test)

--- a/reader/browsertest/run_one_local_sel.py
+++ b/reader/browsertest/run_one_local_sel.py
@@ -3,13 +3,15 @@
 # For instance: python3 ./run_one_local.py ClickVersionedSearchResultDesktop
 __package__ = "reader.browsertest"
 
-import django
-django.setup()
-
-from .framework import Trial
-from . import basic_tests
 import sys
 from time import gmtime, strftime
+
+import django
+
+from . import basic_tests
+from .framework import Trial
+
+django.setup()
 
 test = sys.argv[1]
 klass = getattr(basic_tests, test)

--- a/reader/browsertest/run_one_remote.py
+++ b/reader/browsertest/run_one_remote.py
@@ -3,13 +3,15 @@
 # For instance: python3 ./run_one_local.py ClickVersionedSearchResultDesktop
 __package__ = "reader.browsertest"
 
-import django
-django.setup()
-
-from .framework import Trial
-from . import basic_tests
 import sys
 from time import gmtime, strftime
+
+import django
+
+from . import basic_tests
+from .framework import Trial
+
+django.setup()
 
 test = sys.argv[1]
 klass = getattr(basic_tests, test)

--- a/reader/browsertest/run_remote_new.py
+++ b/reader/browsertest/run_remote_new.py
@@ -1,15 +1,17 @@
 # This script runs all available tests on the remote service, and displays a report
 # It takes the build name as its only command line argument
 __package__ = "reader.browsertest"
-import django
-django.setup()
-from .framework import Trial
-from . import basic_tests    # This is in fact needed - to register subclasses Trial, etc.
-import sys
 import os
+import sys
 
+import django
+
+from . import \
+    basic_tests  # This is in fact needed - to register subclasses Trial, etc.
+from .framework import Trial
 from .framework.seleniumManager import SeleniumDriverManager as sdm
 
+django.setup()
 
 # Get environment variables
 seleniumServerUrl = os.environ['SELENIUM_SERVER_URL']

--- a/reader/browsertest/run_tests.py
+++ b/reader/browsertest/run_tests.py
@@ -1,11 +1,15 @@
 # This script runs all available tests on the remote service, and displays a report
 # It takes the build name as its only command line argument
 __package__ = "reader.browsertest"
-import django
-django.setup()
-from .framework import Trial
-from . import basic_tests    # This is in fact needed - to register subclasses Trial, etc.
 import sys
+
+import django
+
+from . import \
+    basic_tests  # This is in fact needed - to register subclasses Trial, etc.
+from .framework import Trial
+
+django.setup()
 
 build = sys.argv[1]
 

--- a/reader/browsertest/run_tests_on_github.py
+++ b/reader/browsertest/run_tests_on_github.py
@@ -3,17 +3,18 @@
 __package__ = "reader.browsertest"
 
 
+import os
 import sys
-from selenium import webdriver
 from optparse import OptionParser
 
 import django
-django.setup()
+from selenium import webdriver
 
+from . import \
+    basic_tests  # This is in fact needed - to register subclasses Trial, etc.
 from .framework import Trial
-from . import basic_tests    # This is in fact needed - to register subclasses Trial, etc.
-import sys
-import os
+
+django.setup()
 
 build = os.getenv("GITHUB_SHA_SHORT", "deadbeef")
 

--- a/reader/browsertest/run_tests_on_travis.py
+++ b/reader/browsertest/run_tests_on_travis.py
@@ -2,12 +2,15 @@
 # It takes the build name as its only command line argument
 __package__ = "reader.browsertest"
 
-import django
-django.setup()
-
-from .framework import Trial
-from . import basic_tests    # This is in fact needed - to register subclasses Trial, etc.
 import sys
+
+import django
+
+from . import \
+    basic_tests  # This is in fact needed - to register subclasses Trial, etc.
+from .framework import Trial
+
+django.setup()
 
 build = sys.argv[1]
 

--- a/reader/templatetags/sefaria_tags.py
+++ b/reader/templatetags/sefaria_tags.py
@@ -3,31 +3,34 @@
 Custom Sefaria Tags for Django Templates
 """
 import json
-import re
-import dateutil.parser
-import urllib.request, urllib.parse, urllib.error
 import math
-from urllib.parse import urlparse
+import re
+import urllib.error
+import urllib.parse
+import urllib.request
 from datetime import datetime
+from urllib.parse import urlparse
+
+import dateutil.parser
+import sefaria.model as m
+import sefaria.model.text
 from django import template
-from django.template.defaultfilters import stringfilter
-from django.utils.safestring import mark_safe
+from django.contrib.sites.models import Site
 from django.core.serializers import serialize
 from django.db.models.query import QuerySet
-from django.contrib.sites.models import Site
+from django.template.defaultfilters import stringfilter
+from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
-
-from sefaria.sheets import get_sheet
-from sefaria.model.user_profile import user_link as ulink, user_name as uname, public_user_data
-from sefaria.model.text import Version
 from sefaria.model.collection import Collection
-from sefaria.utils.util import strip_tags as strip_tags_func
-from sefaria.utils.hebrew import hebrew_plural, hebrew_term, hebrew_parasha_name
+from sefaria.model.text import Version
+from sefaria.model.user_profile import public_user_data
+from sefaria.model.user_profile import user_link as ulink
+from sefaria.model.user_profile import user_name as uname
+from sefaria.sheets import get_sheet
+from sefaria.utils.hebrew import hebrew_parasha_name, hebrew_plural
+from sefaria.utils.hebrew import hebrew_term
 from sefaria.utils.hebrew import hebrew_term as translate_hebrew_term
-
-import sefaria.model.text
-import sefaria.model as m
-
+from sefaria.utils.util import strip_tags as strip_tags_func
 
 register = template.Library()
 
@@ -137,7 +140,7 @@ def text_toc_link(indx):
 	"""
 	Return an <a> tag linking to the text TOC for the Index
 	"""
-	from sefaria.model.text import library, AbstractIndex
+	from sefaria.model.text import AbstractIndex, library
 	if not isinstance(indx, AbstractIndex):
 		indx = library.get_index(indx)
 

--- a/reader/tests.py
+++ b/reader/tests.py
@@ -3,26 +3,27 @@
 Run me with:
 python manage.py test reader
 """
+import json
 import sys
-
-# Tells sefaria.system.database to use a test db
-sys._called_from_test = True
-
 from copy import deepcopy
 from pprint import pprint
-import json
 
+import sefaria.system.cache as scache
+import sefaria.utils.testing_utils as tutils
+from django.contrib.auth.models import User
 from django.test import TestCase
 from django.test.client import Client
-from django.contrib.auth.models import User
-# import selenium
-
-import sefaria.utils.testing_utils as tutils
-
-from sefaria.model import library, Index, IndexSet, VersionSet, LinkSet, NoteSet, HistorySet, Ref, VersionState, \
-    VersionStateSet, TextChunk, Category, UserHistory, UserHistorySet
+from sefaria.model import (Category, HistorySet, Index, IndexSet, LinkSet,
+                           NoteSet, Ref, TextChunk, UserHistory,
+                           UserHistorySet, VersionSet, VersionState,
+                           VersionStateSet, library)
 from sefaria.system.database import db
-import sefaria.system.cache as scache
+
+# Tells sefaria.system.database to use a test db
+
+sys._called_from_test = True
+
+# import selenium
 
 c = Client()
 

--- a/reader/views.py
+++ b/reader/views.py
@@ -1,74 +1,95 @@
 # -*- coding: utf-8 -*-
-from datetime import datetime, timedelta
-from elasticsearch_dsl import Search
-from elasticsearch import Elasticsearch
-from random import choice
 import json
-import urllib.request, urllib.parse, urllib.error
-from bson.json_util import dumps
-import socket
-import bleach
-from collections import OrderedDict
-import pytz
-from html import unescape
-import redis
 import os
 import re
+import socket
+import urllib.error
+import urllib.parse
+import urllib.request
 import uuid
+from collections import OrderedDict
+from datetime import datetime, timedelta
+from html import unescape
+from random import choice
 
+import bleach
+import pytz
+import redis
+import sefaria.tracker as tracker
+from bson.json_util import dumps
+from bson.objectid import ObjectId
+from django import http
+from django.contrib.admin.views.decorators import staff_member_required
+from django.contrib.auth.decorators import login_required
+from django.contrib.auth.models import User
+from django.http import Http404, QueryDict
+from django.shortcuts import redirect, render
+from django.template.loader import render_to_string
+from django.utils import timezone
+from django.utils.encoding import iri_to_uri
+from django.utils.html import strip_tags
+from django.utils.translation import ugettext as _
+from django.views.decorators.csrf import (csrf_exempt, csrf_protect,
+                                          ensure_csrf_cookie,
+                                          requires_csrf_token)
+from elasticsearch import Elasticsearch
+from elasticsearch_dsl import Search
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import IsAuthenticated
-from django.template.loader import render_to_string
-from django.shortcuts import render, redirect
-from django.http import Http404, QueryDict
-from django.contrib.auth.decorators import login_required
-from django.contrib.admin.views.decorators import staff_member_required
-from django.utils.encoding import iri_to_uri
-from django.utils.translation import ugettext as _
-from django.views.decorators.csrf import ensure_csrf_cookie, csrf_exempt, csrf_protect, requires_csrf_token
-from django.contrib.auth.models import User
-from django import http
-from django.utils import timezone
-from django.utils.html import strip_tags
-from bson.objectid import ObjectId
-
-from sefaria.model import *
-from sefaria.google_storage_manager import GoogleStorageManager
-from sefaria.model.user_profile import UserProfile, user_link, user_started_text, public_user_data
-from sefaria.model.collection import CollectionSet
-from sefaria.model.webpage import get_webpages_for_ref
-from sefaria.model.media import get_media_for_ref
-from sefaria.model.schema import SheetLibraryNode
-from sefaria.model.following import general_follow_recommendations
-from sefaria.model.trend import user_stats_data, site_stats_data
-from sefaria.client.wrapper import format_object_for_client, format_note_object_for_client, get_notes, get_links
 from sefaria.client.util import jsonResponse
-from sefaria.history import text_history, get_maximal_collapsed_activity, top_contributors, text_at_revision, record_version_deletion, record_index_deletion
-from sefaria.sheets import get_sheets_for_ref, get_sheet_for_panel, annotate_user_links, trending_topics
-from sefaria.utils.util import text_preview
-from sefaria.utils.hebrew import hebrew_term, is_hebrew
-from sefaria.utils.calendars import get_all_calendar_items, get_todays_calendar_items, get_keyed_calendar_items, get_parasha, get_todays_parasha
-from sefaria.utils.util import short_to_long_lang_code
-from sefaria.settings import STATIC_URL, USE_VARNISH, USE_NODE, NODE_HOST, DOMAIN_LANGUAGES, MULTISERVER_ENABLED, SEARCH_ADMIN, RTC_SERVER, MULTISERVER_REDIS_SERVER, \
-    MULTISERVER_REDIS_PORT, MULTISERVER_REDIS_DB, DISABLE_AUTOCOMPLETER, ENABLE_LINKER
-from sefaria.site.site_settings import SITE_SETTINGS
-from sefaria.system.multiserver.coordinator import server_coordinator
-from sefaria.system.decorators import catch_error_as_json, sanitize_get_params, json_response_decorator
-from sefaria.system.exceptions import InputError, PartialRefInputError, BookNameError, NoVersionFoundError, DictionaryEntryNotFoundError
-from sefaria.system.cache import django_cache
-from sefaria.system.database import db
-from sefaria.helper.search import get_query_obj
-from sefaria.search import get_search_categories
-from sefaria.helper.topic import get_topic, get_all_topics, get_topics_for_ref, get_topics_for_book
+from sefaria.client.wrapper import (format_note_object_for_client,
+                                    format_object_for_client, get_links,
+                                    get_notes)
+from sefaria.google_storage_manager import GoogleStorageManager
 from sefaria.helper.community_page import get_community_page_items
 from sefaria.helper.file import get_resized_file
+from sefaria.helper.search import get_query_obj
+from sefaria.helper.topic import (get_all_topics, get_topic,
+                                  get_topics_for_book, get_topics_for_ref)
+from sefaria.history import (get_maximal_collapsed_activity,
+                             record_index_deletion, record_version_deletion,
+                             text_at_revision, text_history, top_contributors)
 from sefaria.image_generator import make_img_http_response
-import sefaria.tracker as tracker
+from sefaria.model import *
+from sefaria.model.collection import CollectionSet
+from sefaria.model.following import general_follow_recommendations
+from sefaria.model.media import get_media_for_ref
+from sefaria.model.schema import SheetLibraryNode
+from sefaria.model.trend import site_stats_data, user_stats_data
+from sefaria.model.user_profile import (UserProfile, public_user_data,
+                                        user_link, user_started_text)
+from sefaria.model.webpage import get_webpages_for_ref
+from sefaria.search import get_search_categories
+from sefaria.settings import (DISABLE_AUTOCOMPLETER, DOMAIN_LANGUAGES,
+                              ENABLE_LINKER, MULTISERVER_ENABLED,
+                              MULTISERVER_REDIS_DB, MULTISERVER_REDIS_PORT,
+                              MULTISERVER_REDIS_SERVER, NODE_HOST, RTC_SERVER,
+                              SEARCH_ADMIN, STATIC_URL, USE_NODE, USE_VARNISH)
+from sefaria.sheets import (annotate_user_links, get_sheet_for_panel,
+                            get_sheets_for_ref, trending_topics)
+from sefaria.site.site_settings import SITE_SETTINGS
+from sefaria.system.cache import django_cache
+from sefaria.system.database import db
+from sefaria.system.decorators import (catch_error_as_json,
+                                       json_response_decorator,
+                                       sanitize_get_params)
+from sefaria.system.exceptions import (BookNameError,
+                                       DictionaryEntryNotFoundError,
+                                       InputError, NoVersionFoundError,
+                                       PartialRefInputError)
+from sefaria.system.multiserver.coordinator import server_coordinator
+from sefaria.utils.calendars import (get_all_calendar_items,
+                                     get_keyed_calendar_items, get_parasha,
+                                     get_todays_calendar_items,
+                                     get_todays_parasha)
+from sefaria.utils.hebrew import hebrew_term, is_hebrew
+from sefaria.utils.util import short_to_long_lang_code, text_preview
 
 if USE_VARNISH:
     from sefaria.system.varnish.wrapper import invalidate_ref, invalidate_linked
 
 import structlog
+
 logger = structlog.get_logger(__name__)
 
 #    #    #
@@ -175,8 +196,8 @@ def base_props(request):
     AND are able to be sent over the wire to the Node SSR server.
     """
     from sefaria.model.user_profile import UserProfile, UserWrapper
-    from sefaria.site.site_settings import SITE_SETTINGS
     from sefaria.settings import DEBUG, GLOBAL_INTERRUPTING_MESSAGE, RTC_SERVER
+    from sefaria.site.site_settings import SITE_SETTINGS
 
     if hasattr(request, "init_shared_cache"):
         logger.warning("Shared cache disappeared while application was running")
@@ -3707,8 +3728,9 @@ def profile_upload_photo(request):
     if not request.user.is_authenticated:
         return jsonResponse({"error": _("You must be logged in to update your profile photo.")})
     if request.method == "POST":
-        from PIL import Image
         from io import BytesIO
+
+        from PIL import Image
         from sefaria.utils.util import epoch_time
         now = epoch_time()
 
@@ -3823,8 +3845,8 @@ def profile_sync_api(request):
 @permission_classes([IsAuthenticated])
 def delete_user_account_api(request):
     # Deletes the user and emails sefaria staff for followup
-    from sefaria.utils.user import delete_user_account
     from django.core.mail import EmailMultiAlternatives
+    from sefaria.utils.user import delete_user_account
 
     if not request.user.is_authenticated:
         return jsonResponse({"error": _("You must be logged in to delete your account.")})


### PR DESCRIPTION
Sort all import in reader module.
This reduces code repetition and Reimport of some modules.
also cleans-up the earlier PR of moving imports to top.

Adderesses PEP8 C0411-13, W0404