### PR TITLE
fix(search): lastSeen off by one error on first query

### DIFF
--- a/static/js/sefaria/search.js
+++ b/static/js/sefaria/search.js
@@ -167,7 +167,7 @@ class Search {
                     total: x.total,
                     hits: adaptedHits
                 },
-                lastSeen: ('start' in args) ? this.dictaQueryQueue.lastSeen + adaptedHits.length : adaptedHits.length
+                lastSeen: ('start' in args) ? this.dictaQueryQueue.lastSeen + adaptedHits.length : adaptedHits.length - 1
 
             }
         }).catch(x => {


### PR DESCRIPTION
Whereas lastSeen is supposed to correspond to the index of the last item, it was assigned to the length instead, producing an off-by-one error. lastSeen became 50 instead of being 49, and Isaiah 5:21, the 51st ref, fell through the cracks.