### PR TITLE
Bugweek hebrew language issues in search

### DIFF
--- a/static/js/NavSidebar.jsx
+++ b/static/js/NavSidebar.jsx
@@ -464,7 +464,15 @@ const AboutTopics = ({hideTitle}) => (
   <Module>
     {hideTitle ? null :
     <ModuleTitle>About Topics</ModuleTitle> }
-    <InterfaceText>Topics bring you straight to selections of texts and user created source sheets about thousands of subjects. Sources that appear are drawn from existing indices of Jewish texts (like Aspaklaria) and from the sources our users include on their public source sheets.</InterfaceText>
+    <InterfaceText>
+        <HebrewText>
+"בדפי הנושא מלוקטים מקורות נבחרים ודפי מקורות של משתמשים על נושא מסוים. המקורות המופיעים בדפי הנושא נאספים ממאגרים קיימים של ספרות יהודית (דוגמת 'אספקלריא') ומתוך דפי מקורות פומביים של משתמשי ספריא.
+        </HebrewText>
+        <EnglishText>
+            Topics bring you straight to selections of texts and user created source sheets about thousands of subjects. Sources that appear are drawn from existing indices of Jewish texts (like Aspaklaria) and from the sources our users include on their public source sheets.
+        </EnglishText>
+
+    </InterfaceText>
   </Module>
 );
 

--- a/static/js/SearchSheetResult.jsx
+++ b/static/js/SearchSheetResult.jsx
@@ -42,9 +42,13 @@ class SearchSheetResult extends Component {
         return (
             <div className='result sheetResult'>
                 <a href={href} onClick={this.handleSheetClick}>
-                    <div className={classNames({'result-title': 1, 'in-en': !titleIsHe, 'in-he': titleIsHe})}>{clean_title}</div>
+                    <div className={classNames({'result-title': 1, 'in-en': !titleIsHe, 'in-he': titleIsHe})}>
+                        <span dir={titleIsHe ? "rtl" : "ltr"}>{clean_title}</span>
+                    </div>
                     <ColorBarBox tref={"Sheet 1"}>
-                      <div className={snippetClasses} dangerouslySetInnerHTML={snippetMarkup.markup}></div>
+                      <div className={snippetClasses}>
+                          <span dir={snippetMarkup.lang === 'he' ? "rtl" : "ltr"} dangerouslySetInnerHTML={snippetMarkup.markup} ></span>
+                      </div>
                     </ColorBarBox>
                 </a>
                 <div className="sheetData sans-serif">

--- a/static/js/TopicsPage.jsx
+++ b/static/js/TopicsPage.jsx
@@ -62,7 +62,7 @@ const TopicsPage = ({setNavTopic, multiPanel, initialWidth}) => {
       topicStatus = <TopicEditor close={toggleAddingTopics}/>;
   }
   else if (Sefaria.is_moderator) {
-      topicStatus = <TopicEditorButton text="Create a Topic" toggleAddingTopics={toggleAddingTopics}/>;
+      topicStatus = <TopicEditorButton text={<InterfaceText>Create a Topic</InterfaceText>} toggleAddingTopics={toggleAddingTopics}/>;
   }
   return (
     <div className="readerNavMenu noLangToggleInHebrew" key="0">

--- a/static/js/TopicsPage.jsx
+++ b/static/js/TopicsPage.jsx
@@ -62,7 +62,7 @@ const TopicsPage = ({setNavTopic, multiPanel, initialWidth}) => {
       topicStatus = <TopicEditor close={toggleAddingTopics}/>;
   }
   else if (Sefaria.is_moderator) {
-      topicStatus = <TopicEditorButton text={<InterfaceText>Create a Topic</InterfaceText>} toggleAddingTopics={toggleAddingTopics}/>;
+      topicStatus = <TopicEditorButton text="Create a Topic" toggleAddingTopics={toggleAddingTopics}/>;
   }
   return (
     <div className="readerNavMenu noLangToggleInHebrew" key="0">

--- a/static/js/sefaria/strings.js
+++ b/static/js/sefaria/strings.js
@@ -60,7 +60,7 @@ const Strings = {
     "Explore Jewish Texts by Topic": "עיון בארון הספרים היהודי לפי נושא",
     "Explore by Topic": "לימוד לפי נושאים",
     "About Topics": "אודות \"נושאים\"",
-    "Topic pages bring you straight to selections of texts and user created source sheets about thousands of subjects. Sources that appear are drawn from existing indices of Jewish texts (like Aspaklaria) and from the sources our users include on their public source sheets.": "בדפי הנושא מלוקטים מקורות נבחרים ודפי מקורות של משתמשים על נושא מסוים. המקורות המופיעים בדפי הנושא נאספים ממאגרים קיימים של ספרות יהודית (דוגמת 'אספקלריא') ומתוך דפי מקורות פומביים של משתמשי ספריא.",
+    "Topics bring you straight to selections of texts and user created source sheets about thousands of subjects. Sources that appear are drawn from existing indices of Jewish texts (like Aspaklaria) and from the sources our users include on their public source sheets.": "בדפי הנושא מלוקטים מקורות נבחרים ודפי מקורות של משתמשים על נושא מסוים. המקורות המופיעים בדפי הנושא נאספים ממאגרים קיימים של ספרות יהודית (דוגמת 'אספקלריא') ומתוך דפי מקורות פומביים של משתמשי ספריא.",
     "Trending Topics": "נושאים נפוצים",
     "More": "עוד",
     "Less": "פחות",

--- a/static/js/sefaria/strings.js
+++ b/static/js/sefaria/strings.js
@@ -66,6 +66,7 @@ const Strings = {
     "Less": "פחות",
     "All Topics A-Z": "כל הנושאים א-ת",
     "Browse or search our complete list of topics.": "חיפוש ברשימת הנושאים.",
+    "Create a Topic": "ליצירת נושא חדש",
 
     // All Topics
     "All Topics": "כל הנושאים",

--- a/static/js/sefaria/strings.js
+++ b/static/js/sefaria/strings.js
@@ -66,6 +66,7 @@ const Strings = {
     "All Topics A-Z": "כל הנושאים א-ת",
     "Browse or search our complete list of topics.": "חיפוש ברשימת הנושאים.",
     "Create a Topic": "ליצירת נושא חדש",
+    "Edit Topic": "עריכת נושא",
 
     // All Topics
     "All Topics": "כל הנושאים",

--- a/static/js/sefaria/strings.js
+++ b/static/js/sefaria/strings.js
@@ -60,7 +60,6 @@ const Strings = {
     "Explore Jewish Texts by Topic": "עיון בארון הספרים היהודי לפי נושא",
     "Explore by Topic": "לימוד לפי נושאים",
     "About Topics": "אודות \"נושאים\"",
-    "Topics bring you straight to selections of texts and user created source sheets about thousands of subjects. Sources that appear are drawn from existing indices of Jewish texts (like Aspaklaria) and from the sources our users include on their public source sheets.": "בדפי הנושא מלוקטים מקורות נבחרים ודפי מקורות של משתמשים על נושא מסוים. המקורות המופיעים בדפי הנושא נאספים ממאגרים קיימים של ספרות יהודית (דוגמת 'אספקלריא') ומתוך דפי מקורות פומביים של משתמשי ספריא.",
     "Trending Topics": "נושאים נפוצים",
     "More": "עוד",
     "Less": "פחות",


### PR DESCRIPTION
Addressing the issues on [this](https://trello.com/c/0HHNe8P0/2629-hebrew-language-issues-in-search) card. 

1. Topics "about" description appears in English, not Hebrew on the Hebrew side of the site
2. "Create a New Topic" button appears in English, not Hebrew, when logged in on the site. "Edit a Topic" button appears in English, not Hebrew, when logged in on the site. 
3. Ending punctuation on English language sheet titles is mixed up LTR/RTL