### PR TITLE
Bugweek connections panel flashes

### DIFF
--- a/static/js/ReaderApp.jsx
+++ b/static/js/ReaderApp.jsx
@@ -782,7 +782,7 @@ class ReaderApp extends Component {
 
     if (replace) {
       history.replaceState(hist.state, hist.title, hist.url);
-      console.log("Replace History - " + hist.url + " | " + currentUrl);
+      // console.log("Replace History - " + hist.url + " | " + currentUrl);
       if (currentUrl !== hist.url) { this.checkScrollIntentAndTrack(); }
       //console.log(hist);
     } else {

--- a/static/js/ReaderApp.jsx
+++ b/static/js/ReaderApp.jsx
@@ -765,7 +765,7 @@ class ReaderApp extends Component {
       }
     }
     // Replace the first only & with a ?
-    hist.url = hist.url.replace(/&/, "?");
+    hist.url = encodeURI(hist.url.replace(/&/, "?"));
 
     return hist;
   }
@@ -782,11 +782,11 @@ class ReaderApp extends Component {
 
     if (replace) {
       history.replaceState(hist.state, hist.title, hist.url);
-      // console.log("Replace History - " + hist.url);
-      if (currentUrl != hist.url) { this.checkScrollIntentAndTrack(); }
+      console.log("Replace History - " + hist.url + " | " + currentUrl);
+      if (currentUrl !== hist.url) { this.checkScrollIntentAndTrack(); }
       //console.log(hist);
     } else {
-      if (currentUrl == hist.url) { return; } // Never push history with the same URL
+      if (currentUrl === hist.url) { return; } // Never push history with the same URL
       history.pushState(hist.state, hist.title, hist.url);
       // console.log("Push History - " + hist.url);
       this.trackPageview();

--- a/static/js/TextList.jsx
+++ b/static/js/TextList.jsx
@@ -31,7 +31,9 @@ class TextList extends Component {
     this._isMounted = false;
   }
   componentWillReceiveProps(nextProps) {
-    this.preloadText(nextProps.filter);
+    if (!Sefaria.util.object_equals(this.props.filter, nextProps.filter)) {
+      this.preloadText(nextProps.filter);
+    }
   }
   componentWillUpdate(nextProps) {
   }


### PR DESCRIPTION
Fixes two issues

1. Encodes URI in history so that ReaderApp can properly compare old URL to new URL (one was not URL encoded before so they were considered different)
2. Only preload text for TextList when filter changes

Fixes this card: https://trello.com/c/RMjyHww2/2820-connections-panel-flashes-reload-on-minor-scrolling-not-past-segment