### PR TITLE
ToC Back Button

### DIFF
--- a/static/js/ReaderPanel.jsx
+++ b/static/js/ReaderPanel.jsx
@@ -515,8 +515,9 @@ class ReaderPanel extends Component {
       currentlyVisibleRef: ref,
     });
   }
-  setTab(tab, replaceHistory=false) {
-    this.replaceHistory = replaceHistory;
+  setTab(tab, replaceHistoryIfReaderAppUpdated=false) {
+    // race condition so only replace history if ReaderApp ComponentDidUpdate has already been called
+    this.replaceHistory = replaceHistoryIfReaderAppUpdated ? !history.state.panels[0].mode : false
     this.conditionalSetState({tab: tab})
   }
   currentMode() {


### PR DESCRIPTION
fix(TabView): Prevent replacing previous history object if TabView mounts before ReaderApp ComponentDidUpdate gets called.
This commit addresses the ToC Back button bug: https://trello.com/c/HMHtwUWq
This bug was caused by a race condition where if TabView had not ever been loaded, ReaderApp's ComponentDidUpdate was getting called first, but if it had, TabView's componentDidMount was getting called first. Both of these functions attempted to modify the history object, but we only wanted to replace state if componentDidMount has already been called for that update cycle.
Russel, this fix feels a little "hacky" and I'm wondering if you can think of a better way to deal with this. I think if you think of someone who cares more about not having a bunch of hacky fixes you can tag them to review instead 😂😂