### PR TITLE
fix(linker): fix AddressPerek regex so it only catches Peh followed i…

### DIFF
--- a/sefaria/model/schema.py
+++ b/sefaria/model/schema.py
@@ -2607,7 +2607,7 @@ class AddressPerek(AddressInteger):
     }
     section_patterns = {
         "en": r"""(?:(?:[Cc]h(apters?|\.)|[Pp]erek|s\.)?\s*)""",  # the internal ? is a hack to allow a non match, even if 'strict'
-        "he": fr"""(?:\u05d1?{AddressType.reish_samekh_reg}\u05e4(?:"|\u05f4|''|'\s)?                  # Peh (for 'perek') maybe followed by a quote of some sort
+        "he": fr"""(?:\u05d1?{AddressType.reish_samekh_reg}\u05e4((?:"|\u05f4|''|'\s)|(?=[\u05d0-\u05ea]+(?:"|\u05f4|''|'\s)))   # Peh (for 'perek') maybe followed by a quote of some sort OR lookahead for some letters followed by a quote (e.g. פי״א for chapter 11)
         |\u05e4\u05bc?\u05b6?\u05e8\u05b6?\u05e7(?:\u05d9\u05b4?\u05dd)?\s*                  # or 'perek(ym)' spelled out, followed by space
         )"""
     }

--- a/sefaria/model/tests/he_ref_test.py
+++ b/sefaria/model/tests/he_ref_test.py
@@ -188,6 +188,9 @@ class Test_parse_he_ref(object):
         assert r.sections[0] == 4
         assert len(r.sections) == 1
 
+        assert m.Ref('תהלים פד:ג') == m.Ref("Psalms 84:3")  # dont strip peh when no quotation
+
+
     def test_volume_address(self):
         assert m.Ref("זוהר, ח״א, נד, ב") == m.Ref("Zohar 1:54b")
         assert m.Ref("זוהר, א, נד, ב") == m.Ref("Zohar 1:54b")


### PR DESCRIPTION
…mmediately by quotes OR Peh with lookahead for Hebrew letters followed by quotes (for פי״א)