### PR TITLE
feat: create Dockerfile for standalone development database container

### DIFF
--- a/.github/workflows/weekly.yaml
+++ b/.github/workflows/weekly.yaml
@@ -5,5 +5,43 @@ on:
     - cron: '0 0 * 6 *'
 
 jobs:
-
+  build-mongo:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to GCR
+        uses: docker/login-action@v1
+        with:
+          registry: gcr.io
+          username: _json_key
+          password: ${{ secrets.DEV_CLOUDBUILD_SA_KEY }}
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y%m%d%H%M')"
+      - name: Generate image metadata
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: |
+            gcr.io/${{ secrets.DEV_PROJECT }}/sefaria-mongo
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=sha,enable=true,priority=100,prefix=sha-,suffix=-${{ steps.date.outputs.date }},format=short
+            type=sha
+          flavor: |
+            latest=true
+      - name: build and push
+        uses: docker/build-push-action@v2
+        with:
+          cache-from: type=registry, ref=sefaria-mongo/cache
+          cache-to: type=registry, ref=sefaria-mongo/cache, mode=max
+          context: .
+          push: true
+          file: ./build/standalone-db/Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
 ...

--- a/build/standalone-db/Dockerfile
+++ b/build/standalone-db/Dockerfile
@@ -1,0 +1,16 @@
+FROM mongo:4.4
+
+# Move mongo data path out of VOLUME to force persistence
+RUN mkdir -p /data/persist \
+    && chown -R mongodb:mongodb /data/persist
+
+ENV HOME=/data/persist
+
+RUN mkdir /temp
+# For faster iteration, download by hand and swap commented lines
+ADD https://storage.googleapis.com/sefaria-mongo-backup/dump_small.tar.gz /temp/
+#COPY dump_small.tar.gz /temp/
+
+RUN tar xzvf /temp/dump_small.tar.gz -C /temp && docker-entrypoint.sh mongod --fork --logpath /dev/null --dbpath /data/persist && mongorestore --drop --host=127.0.0.1:27017 -v -d sefaria --dir=/temp/dump/sefaria && mongod --shutdown --dbpath /data/persist && rm -rf /temp
+
+CMD [ "mongod", "--dbpath", "/data/persist" ] 


### PR DESCRIPTION
This ended up being a bit more difficult that I originally thought because of some fine grained stuff about how docker build works and what the mongo image does upstream.  Essentially docker is told to ignore anything that ends up in /data/db because it's expected that the container will be connected to some form of persistent volume at that location, because generally DB contents are explicitly not supposed to be in an image.  I worked around this by shifting the whole DB to a new location.  There's a couple caveats now though:

If a dev wants to run this image with any funny commandline overrides to mongo (eg hosting it  on a different port), they'll also need to know to point mongo at the new database location.
Devs would need to know they need to take snapshots of the image if they want to keep db changes between restarts of the container ( note these can increase in size pretty rapidly)

As an alternative, the solution to this out the box dev experience would be a script that starts the upstream mongo container with a persistent local volume configured and does a restore into it from the latest dump?  Maybe not as 'in a can' convenient, but might make for a more amenable  workflow for development actions?

In the meantime can you build the dockerfile and run the resultant image with -p 27017, then connect to it and check it has all the content youexpect?