### PR TITLE
Clarification for setup documentation

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -140,7 +140,7 @@ On some macOS systems `gettext` will still not run after installation and `djang
     
 Replace the placeholder values with those matching your environment. For the most part, you should only have to specify values in the top part of the file where it directs you to change the given values.
 
-Note: The placeholder for the database `NAME` can simply be a path where Django can create a sqlite database for you. If you choose to make the path `Your/unique/path/to/Sefaria-Project/`, that is sufficient. You do not need to be concerned about a database accidentally being committed, as our `.gitignore` file will not track any files ending with `.sqlite`.
+Note: You can set the database `NAME` to a path where Django can create a sqlite database. Using `Your/unique/path/to/Sefaria-Project/` is sufficient, as we git-ignore all `.sqlite` files.
 
 You can name your local database (`sefaria` will be the default created by `mongorestore` below). You can leave `SEFARIA_DB_USER` ad `SEFARIA_DB_PASSWORD` blank if you don't need to run authentication on Mongo.
 

--- a/README.mkd
+++ b/README.mkd
@@ -140,6 +140,8 @@ On some macOS systems `gettext` will still not run after installation and `djang
     
 Replace the placeholder values with those matching your environment. For the most part, you should only have to specify values in the top part of the file where it directs you to change the given values.
 
+Note: The placeholder for the database `NAME` can simply be a path where Django can create a sqlite database for you. If you choose to make the path `Your/unique/path/to/Sefaria-Project/`, that is sufficient. You do not need to be concerned about a database accidentally being committed, as our `.gitignore` file will not track any files ending with `.sqlite`.
+
 You can name your local database (`sefaria` will be the default created by `mongorestore` below). You can leave `SEFARIA_DB_USER` ad `SEFARIA_DB_PASSWORD` blank if you don't need to run authentication on Mongo.
 
 #### 6) Create a log directory:

--- a/README.mkd
+++ b/README.mkd
@@ -140,7 +140,7 @@ On some macOS systems `gettext` will still not run after installation and `djang
     
 Replace the placeholder values with those matching your environment. For the most part, you should only have to specify values in the top part of the file where it directs you to change the given values.
 
-Note: You can set the database `NAME` to a path where Django can create a sqlite database. Using `Your/unique/path/to/Sefaria-Project/` is sufficient, as we git-ignore all `.sqlite` files.
+Note: Among the placeholder values that need to be replaced, set the `DATABASES` default `NAME` field to a path (including a file name) where Django can create a sqlite database. Using `/path/to/Sefaria-Project/db.sqlite` is sufficient, as we git-ignore all `.sqlite` files.
 
 You can name your local database (`sefaria` will be the default created by `mongorestore` below). You can leave `SEFARIA_DB_USER` ad `SEFARIA_DB_PASSWORD` blank if you don't need to run authentication on Mongo.
 

--- a/sefaria/local_settings_example.py
+++ b/sefaria/local_settings_example.py
@@ -7,10 +7,11 @@ import sefaria.system.logging as sefaria_logging
 
 # These are things you need to change!
 
-################ YOU ONLY NEED TO CHANGE "NAME" TO THE PATH OF YOUR SQLITE DATA FILE
-# (If the db.sqlite file does not exist, simply create a path to where it can be created.
-# You can just put to the path to your Sefaria-Project, as all sqlite files in our repo are ignored by git,
-# and won't accidentally be committed) ########################################
+################
+# YOU ONLY NEED TO CHANGE "NAME" TO THE PATH OF YOUR SQLITE DATA FILE
+# If the db.sqlite file does not exist, simply list a path where it can be created.
+# You can set the path to your Sefaria-Project, since we git-ignore all sqlite files
+# ########################################
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3', # Add 'postgresql_psycopg2', 'mysql', 'sqlite3' or 'oracle'.

--- a/sefaria/local_settings_example.py
+++ b/sefaria/local_settings_example.py
@@ -7,11 +7,14 @@ import sefaria.system.logging as sefaria_logging
 
 # These are things you need to change!
 
-################ YOU ONLY NEED TO CHANGE "NAME" TO THE PATH OF YOUR SQLITE DATA FILE (If the db.sqlite file does not exist, simply create it) ########################################
+################ YOU ONLY NEED TO CHANGE "NAME" TO THE PATH OF YOUR SQLITE DATA FILE
+# (If the db.sqlite file does not exist, simply create a path to where it can be created.
+# You can just put to the path to your Sefaria-Project, as all sqlite files in our repo are ignored by git,
+# and won't accidentally be committed) ########################################
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3', # Add 'postgresql_psycopg2', 'mysql', 'sqlite3' or 'oracle'.
-        'NAME': '/path/to/your/sefaria/data/db.sqlite', # Or path to database file if using sqlite3.
+        'NAME': '/path/to/your/sefaria/data/', # Path to where you would like the database to be created, or path to database file if using sqlite3.
         'USER': '',                      # Not used with sqlite3.
         'PASSWORD': '',                  # Not used with sqlite3.
         'HOST': '',                      # Set to empty string for localhost. Not used with sqlite3.

--- a/sefaria/local_settings_example.py
+++ b/sefaria/local_settings_example.py
@@ -10,12 +10,13 @@ import sefaria.system.logging as sefaria_logging
 ################
 # YOU ONLY NEED TO CHANGE "NAME" TO THE PATH OF YOUR SQLITE DATA FILE
 # If the db.sqlite file does not exist, simply list a path where it can be created.
-# You can set the path to your Sefaria-Project, since we git-ignore all sqlite files
+# You can set the path to /path/to/Sefaria-Project/db.sqlite, since we git-ignore all sqlite files
+# (you do not need to create the empty db.sqlite file, as Django will handle that later)
 # ########################################
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3', # Add 'postgresql_psycopg2', 'mysql', 'sqlite3' or 'oracle'.
-        'NAME': '/path/to/your/sefaria/data/', # Path to where you would like the database to be created, or path to database file if using sqlite3.
+        'NAME': '/path/to/Sefaria-Project/db.sqlite', # Path to where you would like the database to be created including a file name, or path to an existing database file if using sqlite3.
         'USER': '',                      # Not used with sqlite3.
         'PASSWORD': '',                  # Not used with sqlite3.
         'HOST': '',                      # Set to empty string for localhost. Not used with sqlite3.


### PR DESCRIPTION
It was not clear if one needs to create a sqlite database as part of setup, and how that works with Django for the `manage.py` script. These small changes are an attempt to clarify, both in the language of the comments and in the `README` itself. 