### PR TITLE
fix: Index Editor with 0 authors fails

### DIFF
--- a/static/js/BookPage.jsx
+++ b/static/js/BookPage.jsx
@@ -1152,7 +1152,7 @@ const EditTextInfo = function({initTitle, close}) {
   const [enShortDesc, setEnShortDesc] = useState(index.current?.enShortDesc || "");
   const [heDesc, setHeDesc] = useState(index.current?.heDesc || "");
   const [heShortDesc, setHeShortDesc] = useState(index.current?.heShortDesc || "");
-  const [authors, setAuthors] = useState(index.current.authors.map((item, i) =>({["name"]: item.en, ["slug"]: item.slug, ["id"]: i})));
+  const [authors, setAuthors] = useState(index.current.authors?.map((item, i) =>({["name"]: item.en, ["slug"]: item.slug, ["id"]: i})) || []);
   const [compDate, setCompDate] = useState(index.current?.compDate || "");
   const [errorMargin, setErrorMargin] = useState(index.current?.errorMargin || "");
 


### PR DESCRIPTION
All the texts I tested had an authors value of an empty array.  However, I've just noticed that many texts are missing an authors field entirely.  This line deals with those texts.