### PR TITLE
Infinite load commentary fix

### DIFF
--- a/static/js/ReaderPanel.jsx
+++ b/static/js/ReaderPanel.jsx
@@ -769,7 +769,7 @@ class ReaderPanel extends Component {
       );
     }
 
-    if (this.state.menuOpen == "navigation") {
+    if (this.state.menuOpen === "navigation") {
 
       const openNav     = this.state.compare ? this.props.openComparePanel : this.openMenu.bind(null, "navigation");
       const openTextTOC = this.state.compare ? this.openCompareTextTOC : null;

--- a/static/js/TextRange.jsx
+++ b/static/js/TextRange.jsx
@@ -101,6 +101,7 @@ class TextRange extends Component {
       context: this.props.withContext ? 1 : 0,
       enVersion: this.props.currVersions.en || null,
       heVersion: this.props.currVersions.he || null,
+      firstAvailableRef: 0,
       translationLanguagePreference: this.props.translationLanguagePreference,
       versionPref: Sefaria.versionPreferences.getVersionPref(this.props.sref),
     };

--- a/static/js/TextRange.jsx
+++ b/static/js/TextRange.jsx
@@ -101,7 +101,8 @@ class TextRange extends Component {
       context: this.props.withContext ? 1 : 0,
       enVersion: this.props.currVersions.en || null,
       heVersion: this.props.currVersions.he || null,
-      firstAvailableRef: 0,
+      // Support redirect of basetext for schema node refs.  Don't rewrite refs on sidebar to avoid infinite loop of cache misses.
+      firstAvailableRef: this.props.basetext ? 1 : 0,
       translationLanguagePreference: this.props.translationLanguagePreference,
       versionPref: Sefaria.versionPreferences.getVersionPref(this.props.sref),
     };

--- a/static/js/sefaria/sefaria.js
+++ b/static/js/sefaria/sefaria.js
@@ -411,8 +411,8 @@ Sefaria = extend(Sefaria, {
       wrapNamedEntities: ("wrapNamedEntities" in settings) ? settings.wrapNamedEntities : 1,
       translationLanguagePreference: settings.translationLanguagePreference || null,
       versionPref: settings.versionPref || null,
-      firstAvailableRef: settings.firstAvailableRef || 1,
-      fallbackOnDefaultVersion: settings.fallbackOnDefaultVersion || 1,
+      firstAvailableRef: ("firstAvailableRef" in settings) ? settings.firstAvailableRef : 1,
+      fallbackOnDefaultVersion: ("fallbackOnDefaultVersion" in settings) ? settings.fallbackOnDefaultVersion : 1,
     };
     if (settings.versionPref) {
       // for every lang/vtitle pair in versionPref, update corresponding version url param if it doesn't already exist


### PR DESCRIPTION
For TextRange this is a basetext, allow redirect to first content ref. 
But for links, don't rewrite the refs.  Thus avoiding cache miss and infinite loop.   
