### PR TITLE
fix(linker): default to empty object to allow for no params passed to…

### DIFF
--- a/static/js/linker.v3/main.js
+++ b/static/js/linker.v3/main.js
@@ -381,7 +381,7 @@ import {LinkExcluder} from "./excluder";
         });
     }
 
-    function deprecatedOptionsWarning({ selector, excludeFromTracking, parenthesesOnly, quotationOnly }) {
+    function deprecatedOptionsWarning({ selector, excludeFromTracking, parenthesesOnly, quotationOnly } = {}) {
         if (selector || excludeFromTracking || parenthesesOnly || quotationOnly) {
             console.warn("Deprecation warning: you are currently using at least one of the following deprecated options:" +
                 " `selector`, `excludeFromTracking`, `parenthesesOnly`, `quotationOnly`. These options no longer are" +


### PR DESCRIPTION
… sefaria.link()