### PR TITLE
is_already_following field on notifications api

### DIFF
--- a/sefaria/model/following.py
+++ b/sefaria/model/following.py
@@ -20,7 +20,7 @@ class FollowRelationship(object):
         self.follow_date = datetime.now()
 
     def exists(self):
-        bool(db.following.find_one({"follower": self.follower, "followee": self.followee}))
+        return bool(db.following.find_one({"follower": self.follower, "followee": self.followee}))
 
     def follow(self):
         from sefaria.model.notification import Notification

--- a/static/js/NotificationsPanel.jsx
+++ b/static/js/NotificationsPanel.jsx
@@ -217,13 +217,13 @@ const FollowNotification = ({date, content}) => {
     </>
   );
 
-  const body = Sefaria.following.indexOf(content.follower) === -1 ? (
+  const body = content.is_already_following ? null : (
     <FollowButton
       large={true}
       uid={content.follower}
       followBack={true}
       smallText={false} />
-  ) : null;
+  );
 
   return (
     <Notification


### PR DESCRIPTION
I needed to add `is_already_following` to the notifications api because I need to use this API in mobile and we don't have access to `Sefaria.following` (a global variable of all users following the currently logged in user). Anyway, `Sefaria.following` is bad architecture and it's preferable to get the data from the api directly.