### PR TITLE
Fix copying/pasting poetry translations into Google Docs in Chrome

### DIFF
--- a/static/js/ReaderApp.jsx
+++ b/static/js/ReaderApp.jsx
@@ -1881,6 +1881,12 @@ toggleSignUpModal(modalContentKind = SignUpModalKind.Default) {
         container.setAttribute('dir', 'rtl');
       }
 
+      // Collapse all nodes with poetry classes. This is needed for specifically pasting into Google Docs in Chrome to work.
+      const poetryElsToCollapse = container.querySelectorAll('.poetry');
+      poetryElsToCollapse.forEach(poetryEl => {
+        poetryEl.outerHTML = poetryEl.innerHTML;
+      });
+
       // Remove extra breaks for continuous mode
       if (closestReaderPanel && closestReaderPanel.classList.contains('continuous')) {
         let elsToRemove = container.querySelectorAll("br");


### PR DESCRIPTION
**Resolves** https://trello.com/c/xwL5do14/93-text-copied-from-a-bilingual-torah-presentation-w-fox-translation-and-pasted-into-a-rich-context-is-missing-elements

**Example**
![Google Chrome - Genesis 1 2023-05-05 at 1 49 47 PM](https://user-images.githubusercontent.com/14145322/236531238-fb23d378-d0f0-4bbd-913f-635645139e70.gif)

**Context**
Google Docs in Chrome doesn't process pasted html data in the case of span's with classes within div's. The poetry spans are now collapsed to prevent the missing Hebrew text from happening.