### PR TITLE
ci: Update Dockerfile to remove the deprecated pip command.

### DIFF
--- a/build/web/Dockerfile
+++ b/build/web/Dockerfile
@@ -3,7 +3,7 @@ FROM gcr.io/production-deployment/base-web:v3.7-bullseye
 WORKDIR /app/
 # Copied separately to allow for caching of the `pip install` build step
 COPY requirements.txt /app/requirements.txt
-RUN pip3 install --no-cache-dir -r /app/requirements.txt --use-feature=2020-resolver && opentelemetry-bootstrap -a install 
+RUN pip3 install --no-cache-dir -r /app/requirements.txt && opentelemetry-bootstrap -a install 
 
 COPY package*.json /app/
 RUN npm install --unsafe-perm


### PR DESCRIPTION
We remove the line --use-feature=2020-resolver from the call to pip install since it has become the default dependency resolver and the warning against using it is scheduled to become an error in alter versions of pip.