### PR TITLE
Bug: fix copy past for non html elements

### DIFF
--- a/static/js/ReaderApp.jsx
+++ b/static/js/ReaderApp.jsx
@@ -1856,6 +1856,11 @@ toggleSignUpModal(modalContentKind = SignUpModalKind.Default) {
 
   handleCopyEvent(e) {
     // Custom processing of Copy/Paste
+    if (!Sefaria.util.isHtml(textOnly)) {
+      // If the selection is not HTML, don't do anything special
+      return
+    }
+
     const selection = document.getSelection()
     const closestReaderPanel = this.state.panels.length > 0 && e.target.closest('.readerPanel') || null
     let textOnly = selection.toString();

--- a/static/js/sefaria/util.js
+++ b/static/js/sefaria/util.js
@@ -309,6 +309,11 @@ class Util {
       return (res !== null)
     }
 
+    static isHtml(str) {
+      // returns true if str contains html tags
+      return /<[a-z][\s\S]*>/i.test(str);
+    }
+
     static parseUrl(url) {
       var a =  document.createElement('a');
       a.href = url;


### PR DESCRIPTION
Bug: handleCopyEvent event is only meant to handle copy of HTML elements, when no HTML element is present the copied text is lost.

Fix checks if string is HTML element, and if it isn't we allow the browser to continue as usual