### PR TITLE
Linker specify version

### DIFF
--- a/sefaria/helper/linker.py
+++ b/sefaria/helper/linker.py
@@ -231,6 +231,8 @@ def _make_ref_response_for_linker(oref: text.Ref, options: _FindRefsTextOptions)
 def _get_preferred_vtitle(oref: text.Ref, lang: str, version_preferences_by_corpus: dict) -> Optional[str]:
     vprefs = version_preferences_by_corpus
     corpus = oref.index.get_primary_corpus()
+    # Make sure ref's corpus and current lang are specified in version_preferences_by_corpus.
+    # If not, use default version
     if vprefs is None or corpus not in vprefs or lang not in vprefs[corpus]:
         return
     return vprefs[corpus][lang]

--- a/sefaria/helper/linker.py
+++ b/sefaria/helper/linker.py
@@ -50,8 +50,7 @@ def _create_find_refs_options(request) -> FindRefsTextOptions:
     with_text = bool(int(request.GET.get("with_text", False)))
     debug = bool(int(request.GET.get("debug", False)))
     max_segments = int(request.GET.get("max_segments", 0))
-    version_title_preference = request.GET.get("version_title_preference")
-    return FindRefsTextOptions(with_text, debug, max_segments, version_title_preference)
+    return FindRefsTextOptions(with_text, debug, max_segments)
 
 
 def add_webpage_hit_for_url(url):

--- a/sefaria/helper/linker.py
+++ b/sefaria/helper/linker.py
@@ -62,7 +62,7 @@ def add_webpage_hit_for_url(url):
 
 
 def make_find_refs_response(request):
-    request_text, options, meta_data = unpack_find_refs_request(request)
+    request_text, options, meta_data = _unpack_find_refs_request(request)
     if meta_data:
         add_webpage_hit_for_url(meta_data.get("url", None))
     return _make_find_refs_response_with_cache(request_text, options, meta_data)

--- a/sefaria/helper/linker.py
+++ b/sefaria/helper/linker.py
@@ -80,7 +80,7 @@ def _create_find_refs_text(post_body) -> _FindRefsText:
     return _FindRefsText(title, body)
 
 
-def _create_find_refs_options(get_body, post_body) -> _FindRefsTextOptions:
+def _create_find_refs_options(get_body: dict, post_body: dict) -> _FindRefsTextOptions:
     with_text: bool = bool(int(get_body.get("with_text", False)))
     debug: bool = bool(int(get_body.get("debug", False)))
     max_segments: int = int(get_body.get("max_segments", 0))

--- a/sefaria/helper/linker.py
+++ b/sefaria/helper/linker.py
@@ -96,8 +96,6 @@ def _add_webpage_hit_for_url(url):
     webpage.save()
 
 
-
-
 @django_cache(cache_type="persistent")
 def _make_find_refs_response_with_cache(request_text, options, meta_data):
     if request_text.lang == 'he':

--- a/sefaria/helper/linker.py
+++ b/sefaria/helper/linker.py
@@ -213,7 +213,7 @@ def _get_preferred_vtitle(oref: text.Ref, lang: str, version_preferences_by_corp
 
 def get_ref_text_by_lang_for_linker(oref: text.Ref, lang: str, options: FindRefsTextOptions):
     vtitle = _get_preferred_vtitle(oref, lang, options.version_preferences_by_corpus)
-    chunk = text.TextChunk(oref, lang=lang, vtitle=vtitle)
+    chunk = text.TextChunk(oref, lang=lang, vtitle=vtitle, fallback_on_default_version=True)
     as_array = [chunk.strip_itags(s) for s in chunk.ja().flatten_to_array()]
     was_truncated = 0 < options.max_segments < len(as_array)
     return as_array[:options.max_segments or None], was_truncated

--- a/sefaria/helper/linker.py
+++ b/sefaria/helper/linker.py
@@ -34,7 +34,7 @@ class FindRefsText:
         self.lang = 'he' if is_hebrew(self.body) else 'en'
 
 
-def unpack_find_refs_request(request):
+def _unpack_find_refs_request(request):
     post_body = json.loads(request.body)
     meta_data = post_body.get('metaDataForTracking')
     return _create_find_refs_text(post_body), _create_find_refs_options(request), meta_data

--- a/sefaria/helper/tests/linker_test.py
+++ b/sefaria/helper/tests/linker_test.py
@@ -6,7 +6,6 @@ from unittest.mock import patch, Mock
 from sefaria.google_storage_manager import GoogleStorageManager
 from django.test import RequestFactory
 from django.core.handlers.wsgi import WSGIRequest
-import spacy
 import tarfile
 import io
 from sefaria.model.text import Ref, TextChunk
@@ -19,8 +18,8 @@ def mock_oref() -> Ref:
 
 
 @pytest.fixture
-def spacy_model() -> spacy.Language:
-    return spacy.blank('en')
+def spacy_model():
+    return Mock()
 
 
 class TestLoadSpacyModel:
@@ -36,14 +35,14 @@ class TestLoadSpacyModel:
 
     @staticmethod
     @patch('spacy.load')
-    def test_load_spacy_model_local(spacy_load_mock: Callable, spacy_model: spacy.Language):
+    def test_load_spacy_model_local(spacy_load_mock: Callable, spacy_model):
         spacy_load_mock.return_value = spacy_model
         assert linker.load_spacy_model('local/path') == spacy_model
 
     @staticmethod
     @patch('spacy.load')
     @patch.object(GoogleStorageManager, 'get_filename')
-    def test_load_spacy_model_cloud(get_filename_mock: Callable, spacy_load_mock: Callable, spacy_model: spacy.Language,
+    def test_load_spacy_model_cloud(get_filename_mock: Callable, spacy_load_mock: Callable, spacy_model,
                                     tarfile_buffer: io.BytesIO):
         get_filename_mock.return_value = tarfile_buffer
         spacy_load_mock.return_value = spacy_model
@@ -53,7 +52,7 @@ class TestLoadSpacyModel:
     @patch('spacy.load')
     @patch.object(GoogleStorageManager, 'get_filename')
     def test_load_spacy_model_cloud_invalid_path(get_filename_mock: Callable, spacy_load_mock: Callable,
-                                                 spacy_model: spacy.Language, tarfile_buffer: io.BytesIO):
+                                                 spacy_model, tarfile_buffer: io.BytesIO):
         get_filename_mock.return_value = tarfile_buffer
         spacy_load_mock.side_effect = OSError
         with pytest.raises(OSError):
@@ -120,7 +119,7 @@ def mock_webpage() -> WebPage:
 class TestFindRefsHelperClasses:
 
     @patch('sefaria.utils.hebrew.is_hebrew', return_value=False)
-    def test_find_refs_text(self, mock_is_hebrew: Mock[Callable]):
+    def test_find_refs_text(self, mock_is_hebrew: Mock):
         find_refs_text = linker._FindRefsText('title', 'body')
         mock_is_hebrew.assert_called_once_with('body')
         assert find_refs_text.lang == 'en'
@@ -148,13 +147,13 @@ class TestFindRefsHelperClasses:
 
 
 class TestMakeFindRefsResponse:
-    def test_make_find_refs_response_with_meta_data(self, mock_request: WSGIRequest, mock_webpage: Mock[WebPage]):
+    def test_make_find_refs_response_with_meta_data(self, mock_request: WSGIRequest, mock_webpage: Mock):
         response = linker.make_find_refs_response(mock_request)
         mock_webpage.add_hit.assert_called_once()
         mock_webpage.save.assert_called_once()
 
     def test_make_find_refs_response_without_meta_data(self, mock_request_without_meta_data: dict,
-                                                       mock_webpage: Mock[WebPage]):
+                                                       mock_webpage: Mock):
         response = linker.make_find_refs_response(mock_request_without_meta_data)
         mock_webpage.add_hit.assert_not_called()
         mock_webpage.save.assert_not_called()
@@ -175,12 +174,12 @@ class TestUnpackFindRefsRequest:
 
 
 class TestAddWebpageHitForUrl:
-    def test_add_webpage_hit_for_url(self, mock_webpage: Mock[WebPage]):
+    def test_add_webpage_hit_for_url(self, mock_webpage: Mock):
         linker._add_webpage_hit_for_url('https://test.com')
         mock_webpage.add_hit.assert_called_once()
         mock_webpage.save.assert_called_once()
 
-    def test_add_webpage_hit_for_url_no_url(self, mock_webpage: Mock[WebPage]):
+    def test_add_webpage_hit_for_url_no_url(self, mock_webpage: Mock):
         linker._add_webpage_hit_for_url(None)
         mock_webpage.add_hit.assert_not_called()
         mock_webpage.save.assert_not_called()
@@ -189,7 +188,7 @@ class TestAddWebpageHitForUrl:
 class TestFindRefsResponseLinkerV3:
 
     @pytest.fixture
-    def mock_get_ref_resolver(self, spacy_model: spacy.Language):
+    def mock_get_ref_resolver(self, spacy_model):
         from sefaria.model.text import library
         with patch.object(library, 'get_ref_resolver') as mock_get_ref_resolver:
             mock_ref_resolver = Mock()

--- a/sefaria/helper/tests/linker_test.py
+++ b/sefaria/helper/tests/linker_test.py
@@ -1,17 +1,47 @@
-from pytest import fixture
-from sefaria.helper.linker import _FindRefsText, _create_find_refs_text
+from sefaria.helper.linker import _FindRefsText, _create_find_refs_text, _FindRefsTextOptions, load_spacy_model
+import pytest
+from unittest.mock import patch
+from sefaria.google_storage_manager import GoogleStorageManager
+import spacy
+import tarfile
+import io
 
 
-@fixture
-def post_body():
-    return {"text": {"title": "TITLE", "body": "BODY"}}
+class TestLoadSpacyModel:
 
+    @staticmethod
+    @pytest.fixture
+    def spacy_model():
+        return spacy.blank('en')
 
-@fixture
-def expected_find_refs_text(post_body):
-    return _FindRefsText(post_body['text']['title'], post_body['text']['body'])
+    @staticmethod
+    @pytest.fixture
+    def tarfile_buffer():
+        tar_buffer = io.BytesIO()
+        with tarfile.open(fileobj=tar_buffer, mode='w:gz') as tar:
+            tar.addfile(tarfile.TarInfo('test'))
+        tar_buffer.seek(0)
+        return tar_buffer
 
+    @staticmethod
+    @patch('spacy.load')
+    def test_load_spacy_model_local(spacy_load_mock, spacy_model):
+        spacy_load_mock.return_value = spacy_model
+        assert load_spacy_model('local/path') == spacy_model
 
-def test_create_find_refs_text(post_body: dict, expected_find_refs_text: _FindRefsText):
-    actual_find_refs_text = _create_find_refs_text(post_body)
-    assert expected_find_refs_text == actual_find_refs_text
+    @staticmethod
+    @patch('spacy.load')
+    @patch.object(GoogleStorageManager, 'get_filename')
+    def test_load_spacy_model_cloud(get_filename_mock, spacy_load_mock, spacy_model, tarfile_buffer):
+        get_filename_mock.return_value = tarfile_buffer
+        spacy_load_mock.return_value = spacy_model
+        assert load_spacy_model('gs://bucket_name/blob_name') == spacy_model
+
+    @staticmethod
+    @patch('spacy.load')
+    @patch.object(GoogleStorageManager, 'get_filename')
+    def test_load_spacy_model_cloud_invalid_path(get_filename_mock, spacy_load_mock, spacy_model, tarfile_buffer):
+        get_filename_mock.return_value = tarfile_buffer
+        spacy_load_mock.side_effect = OSError
+        with pytest.raises(OSError):
+            load_spacy_model('invalid_path')

--- a/sefaria/helper/tests/linker_test.py
+++ b/sefaria/helper/tests/linker_test.py
@@ -9,6 +9,7 @@ import tarfile
 import io
 from sefaria.model.text import Ref
 
+
 @pytest.fixture
 def mock_oref():
     return Ref("Job 17")
@@ -247,7 +248,8 @@ class TestRefTextByLangForLinker:
         ({"max_segments": 2}, ['a', 'b'], ['a', 'b'], False),
         ({"max_segments": 2}, ['a', 'b', 'c'], ['a', 'b'], True),
     ])
-    def test_get_ref_text_by_lang_for_linker(self, mock_text_chunk, mock_ja, mock_oref, options, text_array, expected_text_array, expected_was_truncated):
+    def test_get_ref_text_by_lang_for_linker(self, mock_text_chunk, mock_ja, mock_oref, options, text_array,
+                                             expected_text_array, expected_was_truncated):
         mock_ja.flatten_to_array.return_value = text_array
         find_refs_options = linker._FindRefsTextOptions(**options)
         actual_text_array, actual_was_truncated = linker._get_ref_text_by_lang_for_linker(mock_oref, 'en', find_refs_options)

--- a/sefaria/helper/tests/linker_test.py
+++ b/sefaria/helper/tests/linker_test.py
@@ -1,22 +1,25 @@
+from typing import Callable
 from sefaria.helper import linker
 import json
 import pytest
 from unittest.mock import patch, Mock
 from sefaria.google_storage_manager import GoogleStorageManager
 from django.test import RequestFactory
+from django.core.handlers.wsgi import WSGIRequest
 import spacy
 import tarfile
 import io
-from sefaria.model.text import Ref
+from sefaria.model.text import Ref, TextChunk
+from sefaria.model.webpage import WebPage
 
 
 @pytest.fixture
-def mock_oref():
+def mock_oref() -> Ref:
     return Ref("Job 17")
 
 
 @pytest.fixture
-def spacy_model():
+def spacy_model() -> spacy.Language:
     return spacy.blank('en')
 
 
@@ -24,7 +27,7 @@ class TestLoadSpacyModel:
 
     @staticmethod
     @pytest.fixture
-    def tarfile_buffer():
+    def tarfile_buffer() -> io.BytesIO:
         tar_buffer = io.BytesIO()
         with tarfile.open(fileobj=tar_buffer, mode='w:gz') as tar:
             tar.addfile(tarfile.TarInfo('test'))
@@ -33,14 +36,15 @@ class TestLoadSpacyModel:
 
     @staticmethod
     @patch('spacy.load')
-    def test_load_spacy_model_local(spacy_load_mock, spacy_model):
+    def test_load_spacy_model_local(spacy_load_mock: Callable, spacy_model: spacy.Language):
         spacy_load_mock.return_value = spacy_model
         assert linker.load_spacy_model('local/path') == spacy_model
 
     @staticmethod
     @patch('spacy.load')
     @patch.object(GoogleStorageManager, 'get_filename')
-    def test_load_spacy_model_cloud(get_filename_mock, spacy_load_mock, spacy_model, tarfile_buffer):
+    def test_load_spacy_model_cloud(get_filename_mock: Callable, spacy_load_mock: Callable, spacy_model: spacy.Language,
+                                    tarfile_buffer: io.BytesIO):
         get_filename_mock.return_value = tarfile_buffer
         spacy_load_mock.return_value = spacy_model
         assert linker.load_spacy_model('gs://bucket_name/blob_name') == spacy_model
@@ -48,7 +52,8 @@ class TestLoadSpacyModel:
     @staticmethod
     @patch('spacy.load')
     @patch.object(GoogleStorageManager, 'get_filename')
-    def test_load_spacy_model_cloud_invalid_path(get_filename_mock, spacy_load_mock, spacy_model, tarfile_buffer):
+    def test_load_spacy_model_cloud_invalid_path(get_filename_mock: Callable, spacy_load_mock: Callable,
+                                                 spacy_model: spacy.Language, tarfile_buffer: io.BytesIO):
         get_filename_mock.return_value = tarfile_buffer
         spacy_load_mock.side_effect = OSError
         with pytest.raises(OSError):
@@ -56,7 +61,7 @@ class TestLoadSpacyModel:
 
 
 @pytest.fixture
-def mock_request_post_data():
+def mock_request_post_data() -> dict:
     return {
         'text': {'title': 'title', 'body': 'body'},
         'version_preferences_by_corpus': {},
@@ -65,12 +70,12 @@ def mock_request_post_data():
 
 
 @pytest.fixture
-def mock_request_post_data_without_meta_data(mock_request_post_data):
+def mock_request_post_data_without_meta_data(mock_request_post_data: dict) -> dict:
     del mock_request_post_data['metaDataForTracking']
     return mock_request_post_data
 
 
-def make_mock_request(post_data):
+def make_mock_request(post_data: dict) -> WSGIRequest:
     factory = RequestFactory()
     request = factory.post('/api/find-refs', data=json.dumps(post_data), content_type='application/json')
     request.GET = {'with_text': '1', 'debug': '1', 'max_segments': '10'}
@@ -78,29 +83,31 @@ def make_mock_request(post_data):
 
 
 @pytest.fixture
-def mock_request(mock_request_post_data):
+def mock_request(mock_request_post_data: dict) -> WSGIRequest:
     return make_mock_request(mock_request_post_data)
 
 
 @pytest.fixture
-def mock_find_refs_text(mock_request):
+def mock_find_refs_text(mock_request: WSGIRequest) -> linker._FindRefsText:
     post_body = json.loads(mock_request.body)
     return linker._create_find_refs_text(post_body)
 
 
 @pytest.fixture
-def mock_find_refs_options(mock_request):
+def mock_find_refs_options(mock_request: WSGIRequest) -> linker._FindRefsTextOptions:
     post_body = json.loads(mock_request.body)
     return linker._create_find_refs_options(mock_request.GET, post_body)
 
 
 @pytest.fixture
-def mock_request_without_meta_data(mock_request_post_data_without_meta_data):
+def mock_request_without_meta_data(mock_request_post_data_without_meta_data: dict) -> WSGIRequest:
     return make_mock_request(mock_request_post_data_without_meta_data)
 
 
 @pytest.fixture
-def mock_webpage():
+def mock_webpage() -> WebPage:
+    # Note, the path of WebPage matches the path of the import we want to patch
+    # NOT the location of the WebPage class
     with patch('sefaria.helper.linker.WebPage') as MockWebPage:
         mock_webpage = MockWebPage.return_value
         loaded_webpage = Mock()
@@ -113,7 +120,7 @@ def mock_webpage():
 class TestFindRefsHelperClasses:
 
     @patch('sefaria.utils.hebrew.is_hebrew', return_value=False)
-    def test_find_refs_text(self, mock_is_hebrew):
+    def test_find_refs_text(self, mock_is_hebrew: Mock[Callable]):
         find_refs_text = linker._FindRefsText('title', 'body')
         mock_is_hebrew.assert_called_once_with('body')
         assert find_refs_text.lang == 'en'
@@ -125,13 +132,13 @@ class TestFindRefsHelperClasses:
         assert find_refs_text_options.max_segments == 10
         assert find_refs_text_options.version_preferences_by_corpus == {}
 
-    def test_create_find_refs_text(self, mock_request):
+    def test_create_find_refs_text(self, mock_request: WSGIRequest):
         post_body = json.loads(mock_request.body)
         find_refs_text = linker._create_find_refs_text(post_body)
         assert find_refs_text.title == 'title'
         assert find_refs_text.body == 'body'
 
-    def test_create_find_refs_options(self, mock_request):
+    def test_create_find_refs_options(self, mock_request: WSGIRequest):
         post_body = json.loads(mock_request.body)
         find_refs_options = linker._create_find_refs_options(mock_request.GET, post_body)
         assert find_refs_options.with_text
@@ -141,25 +148,26 @@ class TestFindRefsHelperClasses:
 
 
 class TestMakeFindRefsResponse:
-    def test_make_find_refs_response_with_meta_data(self, mock_request, mock_webpage):
+    def test_make_find_refs_response_with_meta_data(self, mock_request: WSGIRequest, mock_webpage: Mock[WebPage]):
         response = linker.make_find_refs_response(mock_request)
         mock_webpage.add_hit.assert_called_once()
         mock_webpage.save.assert_called_once()
 
-    def test_make_find_refs_response_without_meta_data(self, mock_request_without_meta_data, mock_webpage):
+    def test_make_find_refs_response_without_meta_data(self, mock_request_without_meta_data: dict,
+                                                       mock_webpage: Mock[WebPage]):
         response = linker.make_find_refs_response(mock_request_without_meta_data)
         mock_webpage.add_hit.assert_not_called()
         mock_webpage.save.assert_not_called()
 
 
 class TestUnpackFindRefsRequest:
-    def test_unpack_find_refs_request(self, mock_request):
+    def test_unpack_find_refs_request(self, mock_request: WSGIRequest):
         text, options, meta_data = linker._unpack_find_refs_request(mock_request)
         assert isinstance(text, linker._FindRefsText)
         assert isinstance(options, linker._FindRefsTextOptions)
         assert meta_data == {'url': 'https://test.com', 'description': 'description', 'title': 'title'}
 
-    def test_unpack_find_refs_request_without_meta_data(self, mock_request_without_meta_data):
+    def test_unpack_find_refs_request_without_meta_data(self, mock_request_without_meta_data: dict):
         text, options, meta_data = linker._unpack_find_refs_request(mock_request_without_meta_data)
         assert isinstance(text, linker._FindRefsText)
         assert isinstance(options, linker._FindRefsTextOptions)
@@ -167,12 +175,12 @@ class TestUnpackFindRefsRequest:
 
 
 class TestAddWebpageHitForUrl:
-    def test_add_webpage_hit_for_url(self, mock_webpage):
+    def test_add_webpage_hit_for_url(self, mock_webpage: Mock[WebPage]):
         linker._add_webpage_hit_for_url('https://test.com')
         mock_webpage.add_hit.assert_called_once()
         mock_webpage.save.assert_called_once()
 
-    def test_add_webpage_hit_for_url_no_url(self, mock_webpage):
+    def test_add_webpage_hit_for_url_no_url(self, mock_webpage: Mock[WebPage]):
         linker._add_webpage_hit_for_url(None)
         mock_webpage.add_hit.assert_not_called()
         mock_webpage.save.assert_not_called()
@@ -181,7 +189,7 @@ class TestAddWebpageHitForUrl:
 class TestFindRefsResponseLinkerV3:
 
     @pytest.fixture
-    def mock_get_ref_resolver(self, spacy_model):
+    def mock_get_ref_resolver(self, spacy_model: spacy.Language):
         from sefaria.model.text import library
         with patch.object(library, 'get_ref_resolver') as mock_get_ref_resolver:
             mock_ref_resolver = Mock()
@@ -190,7 +198,9 @@ class TestFindRefsResponseLinkerV3:
             mock_ref_resolver.bulk_resolve_refs.return_value = [[]]
             yield mock_get_ref_resolver
 
-    def test_make_find_refs_response_linker_v3(self, mock_get_ref_resolver, mock_find_refs_text, mock_find_refs_options):
+    def test_make_find_refs_response_linker_v3(self, mock_get_ref_resolver: WSGIRequest,
+                                               mock_find_refs_text: linker._FindRefsText,
+                                               mock_find_refs_options: linker._FindRefsTextOptions):
         response = linker._make_find_refs_response_linker_v3(mock_find_refs_text, mock_find_refs_options)
         assert 'title' in response
         assert 'body' in response
@@ -201,7 +211,7 @@ class TestFindRefsResponseInner:
     def mock_resolved(self):
         return [[]]
 
-    def test_make_find_refs_response_inner(self, mock_resolved, mock_find_refs_options):
+    def test_make_find_refs_response_inner(self, mock_resolved: Mock, mock_find_refs_options: linker._FindRefsTextOptions):
         response = linker._make_find_refs_response_inner(mock_resolved, mock_find_refs_options)
         assert 'results' in response
         assert 'refData' in response
@@ -209,7 +219,7 @@ class TestFindRefsResponseInner:
 
 class TestRefResponseForLinker:
 
-    def test_make_ref_response_for_linker(self, mock_oref, mock_find_refs_options):
+    def test_make_ref_response_for_linker(self, mock_oref: Ref, mock_find_refs_options: linker._FindRefsTextOptions):
         response = linker._make_ref_response_for_linker(mock_oref, mock_find_refs_options)
         assert 'heRef' in response
         assert 'url' in response
@@ -224,7 +234,7 @@ class TestPreferredVtitle:
         [Ref("Shabbat 2a"), {"Bavli": {"en": "vtitle1"}}, "vtitle1"],
         [Ref("Shabbat 2a"), {"Bavli": {"he": "vtitle1"}}, None],
     ])
-    def test_get_preferred_vtitle(self, oref, vprefs_by_corpus, expected_vpref):
+    def test_get_preferred_vtitle(self, oref: Ref, vprefs_by_corpus: dict, expected_vpref: str):
         vpref = linker._get_preferred_vtitle(oref, 'en', vprefs_by_corpus)
         assert vpref == expected_vpref
 
@@ -236,7 +246,7 @@ class TestRefTextByLangForLinker:
         return Mock()
 
     @pytest.fixture
-    def mock_text_chunk(self, mock_ja):
+    def mock_text_chunk(self, mock_ja: Mock):
         with patch('sefaria.model.text.TextChunk') as MockTC:
             mock_tc = MockTC.return_value
             mock_tc.ja.return_value = mock_ja
@@ -248,8 +258,8 @@ class TestRefTextByLangForLinker:
         ({"max_segments": 2}, ['a', 'b'], ['a', 'b'], False),
         ({"max_segments": 2}, ['a', 'b', 'c'], ['a', 'b'], True),
     ])
-    def test_get_ref_text_by_lang_for_linker(self, mock_text_chunk, mock_ja, mock_oref, options, text_array,
-                                             expected_text_array, expected_was_truncated):
+    def test_get_ref_text_by_lang_for_linker(self, mock_text_chunk: TextChunk, mock_ja: Mock, mock_oref: Ref, options: dict,
+                                             text_array: list, expected_text_array: list, expected_was_truncated: bool):
         mock_ja.flatten_to_array.return_value = text_array
         find_refs_options = linker._FindRefsTextOptions(**options)
         actual_text_array, actual_was_truncated = linker._get_ref_text_by_lang_for_linker(mock_oref, 'en', find_refs_options)

--- a/sefaria/helper/tests/linker_test.py
+++ b/sefaria/helper/tests/linker_test.py
@@ -1,16 +1,21 @@
 from typing import Callable
-from sefaria.helper import linker
 import json
 import pytest
 from unittest.mock import patch, Mock
 from sefaria.google_storage_manager import GoogleStorageManager
 from django.test import RequestFactory
 from django.core.handlers.wsgi import WSGIRequest
-import spacy
 import tarfile
 import io
 from sefaria.model.text import Ref, TextChunk
 from sefaria.model.webpage import WebPage
+from sefaria.settings import ENABLE_LINKER
+
+if not ENABLE_LINKER:
+    pytest.skip("Linker not enabled", allow_module_level=True)
+
+from sefaria.helper import linker
+import spacy
 
 
 @pytest.fixture

--- a/sefaria/helper/tests/linker_test.py
+++ b/sefaria/helper/tests/linker_test.py
@@ -120,7 +120,7 @@ def mock_webpage() -> WebPage:
 class TestFindRefsHelperClasses:
 
     @patch('sefaria.utils.hebrew.is_hebrew', return_value=False)
-    def test_find_refs_text(self, mock_is_hebrew: Mock[Callable]):
+    def test_find_refs_text(self, mock_is_hebrew: Mock):
         find_refs_text = linker._FindRefsText('title', 'body')
         mock_is_hebrew.assert_called_once_with('body')
         assert find_refs_text.lang == 'en'
@@ -148,13 +148,13 @@ class TestFindRefsHelperClasses:
 
 
 class TestMakeFindRefsResponse:
-    def test_make_find_refs_response_with_meta_data(self, mock_request: WSGIRequest, mock_webpage: Mock[WebPage]):
+    def test_make_find_refs_response_with_meta_data(self, mock_request: WSGIRequest, mock_webpage: Mock):
         response = linker.make_find_refs_response(mock_request)
         mock_webpage.add_hit.assert_called_once()
         mock_webpage.save.assert_called_once()
 
     def test_make_find_refs_response_without_meta_data(self, mock_request_without_meta_data: dict,
-                                                       mock_webpage: Mock[WebPage]):
+                                                       mock_webpage: Mock):
         response = linker.make_find_refs_response(mock_request_without_meta_data)
         mock_webpage.add_hit.assert_not_called()
         mock_webpage.save.assert_not_called()
@@ -175,12 +175,12 @@ class TestUnpackFindRefsRequest:
 
 
 class TestAddWebpageHitForUrl:
-    def test_add_webpage_hit_for_url(self, mock_webpage: Mock[WebPage]):
+    def test_add_webpage_hit_for_url(self, mock_webpage: Mock):
         linker._add_webpage_hit_for_url('https://test.com')
         mock_webpage.add_hit.assert_called_once()
         mock_webpage.save.assert_called_once()
 
-    def test_add_webpage_hit_for_url_no_url(self, mock_webpage: Mock[WebPage]):
+    def test_add_webpage_hit_for_url_no_url(self, mock_webpage: Mock):
         linker._add_webpage_hit_for_url(None)
         mock_webpage.add_hit.assert_not_called()
         mock_webpage.save.assert_not_called()

--- a/sefaria/helper/tests/linker_test.py
+++ b/sefaria/helper/tests/linker_test.py
@@ -1,0 +1,17 @@
+from pytest import fixture
+from sefaria.helper.linker import _FindRefsText, _create_find_refs_text
+
+
+@fixture
+def post_body():
+    return {"text": {"title": "TITLE", "body": "BODY"}}
+
+
+@fixture
+def expected_find_refs_text(post_body):
+    return _FindRefsText(post_body['text']['title'], post_body['text']['body'])
+
+
+def test_create_find_refs_text(post_body: dict, expected_find_refs_text: _FindRefsText):
+    actual_find_refs_text = _create_find_refs_text(post_body)
+    assert expected_find_refs_text == actual_find_refs_text

--- a/sefaria/views.py
+++ b/sefaria/views.py
@@ -298,17 +298,8 @@ def find_refs_report_api(request):
 
 @api_view(["POST"])
 def find_refs_api(request):
-    from sefaria.helper.linker import make_find_refs_response, add_webpage_hit_for_url
-
-    with_text = bool(int(request.GET.get("with_text", False)))
-    debug = bool(int(request.GET.get("debug", False)))
-    max_segments = int(request.GET.get("max_segments", 0))
-    post_body = json.loads(request.body)
-
-    response = make_find_refs_response(post_body, with_text, debug, max_segments)
-    add_webpage_hit_for_url(post_body.get("metaDataForTracking", {}).get("url", None))
-
-    return jsonResponse(response)
+    from sefaria.helper.linker import make_find_refs_response
+    return jsonResponse(make_find_refs_response(request))
 
 
 @api_view(["GET"])

--- a/static/js/linker.v3/main.js
+++ b/static/js/linker.v3/main.js
@@ -325,7 +325,15 @@ import {LinkExcluder} from "./excluder";
     }
 
     function getFindRefsUrl() {
-        return `${ns.sefariaUrl}/api/find-refs?with_text=1&debug=${0+ns.debug}&max_segments=${ns.maxParagraphs}`;
+        const params = {
+            with_text: 1,
+            debug: 0 + ns.debug,
+            max_segments: ns.maxParagraphs,
+        }
+        const queryString = Object.entries(params)
+            .map(([key, value]) => `${key}=${value}`)
+            .join('&')
+        return `${ns.sefariaUrl}/api/find-refs?${queryString}`;
     }
 
     function getWebsiteApiUrl() {
@@ -408,6 +416,7 @@ import {LinkExcluder} from "./excluder";
             dynamic: false,
             hidePopupsOnMobile: true,
             debug: false,
+            versionTitlePreference: null,
 
             // Deprecated options
             selector: null,           // CSS Selector
@@ -427,6 +436,7 @@ import {LinkExcluder} from "./excluder";
         ns.excludeFromLinking = options.excludeFromLinking;
         ns.dynamic = options.dynamic;
         ns.debug = options.debug;
+        ns.versionTitlePreference = options.versionTitlePreference;
         ns.maxParagraphs = 20;
         // useful to remove sefaria links for now but I think when released we only want this to run in debug mode
         if (options.debug || true) { removeExistingSefariaLinks(); }

--- a/static/js/linker.v3/main.js
+++ b/static/js/linker.v3/main.js
@@ -329,6 +329,7 @@ import {LinkExcluder} from "./excluder";
             with_text: 1,
             debug: 0 + ns.debug,
             max_segments: ns.maxParagraphs,
+            ...(ns.versionTitlePreference ? { versionTitlePreference: ns.versionTitlePreference } : {}),
         }
         const queryString = Object.entries(params)
             .map(([key, value]) => `${key}=${value}`)

--- a/static/js/linker.v3/main.js
+++ b/static/js/linker.v3/main.js
@@ -329,7 +329,7 @@ import {LinkExcluder} from "./excluder";
             with_text: 1,
             debug: 0 + ns.debug,
             max_segments: ns.maxParagraphs,
-            ...(ns.versionTitlePreference ? { versionTitlePreference: ns.versionTitlePreference } : {}),
+            ...(ns.versionTitlePreference ? { version_title_preference: ns.versionTitlePreference } : {}),
         }
         const queryString = Object.entries(params)
             .map(([key, value]) => `${key}=${value}`)

--- a/static/js/linker.v3/main.js
+++ b/static/js/linker.v3/main.js
@@ -329,7 +329,6 @@ import {LinkExcluder} from "./excluder";
             with_text: 1,
             debug: 0 + ns.debug,
             max_segments: ns.maxParagraphs,
-            ...(ns.versionTitlePreference ? { version_title_preference: ns.versionTitlePreference } : {}),
         }
         const queryString = Object.entries(params)
             .map(([key, value]) => `${key}=${value}`)
@@ -354,6 +353,7 @@ import {LinkExcluder} from "./excluder";
                 description: getPageDescription(),
                 title: document.title,
             },
+            version_preferences_by_corpus: ns.versionPreferencesByCorpus,
             text: {
                 ...ns.normalizedInputText,
             },
@@ -417,7 +417,7 @@ import {LinkExcluder} from "./excluder";
             dynamic: false,
             hidePopupsOnMobile: true,
             debug: false,
-            versionTitlePreference: null,
+            versionPreferencesByCorpus: null,
 
             // Deprecated options
             selector: null,           // CSS Selector
@@ -437,7 +437,7 @@ import {LinkExcluder} from "./excluder";
         ns.excludeFromLinking = options.excludeFromLinking;
         ns.dynamic = options.dynamic;
         ns.debug = options.debug;
-        ns.versionTitlePreference = options.versionTitlePreference;
+        ns.versionPreferencesByCorpus = options.versionPreferencesByCorpus;
         ns.maxParagraphs = 20;
         // useful to remove sefaria links for now but I think when released we only want this to run in debug mode
         if (options.debug || true) { removeExistingSefariaLinks(); }


### PR DESCRIPTION
Note, since this code changes the signature of `make_find_refs_response` which is cached using django_cache, this will invalidate the entire current linker cache. I don't see a way around this and I don't think it will be a big deal.