### PR TITLE
fix(utils): prevent truncating in the middle of html tags. this time …

### DIFF
--- a/sefaria/constants/model.py
+++ b/sefaria/constants/model.py
@@ -1,0 +1,12 @@
+ALLOWED_TAGS_IN_ABSTRACT_TEXT_RECORD = ("i", "b", "br", "u", "strong", "em", "big", "small", "img", "sup", "sub", "span", "a")
+ALLOWED_ATTRS_IN_ABSTRACT_TEXT_RECORD = {
+    'sup': ['class'],
+    'span': ['class', 'dir'],
+    # There are three uses of i tags.
+    # footnotes: uses content internal to <i> tag.
+    # commentary placement: uses 'data-commentator', 'data-order', 'data-label'
+    # structure placement (e.g. page transitions): uses 'data-overlay', 'data-value'
+    'i': ['data-overlay', 'data-value', 'data-commentator', 'data-order', 'class', 'data-label', 'dir'],
+    'img': lambda name, value: name == 'src' and value.startswith("data:image/"),
+    'a': ['dir', 'class', 'href', 'data-ref', "data-ven", "data-vhe"],
+}

--- a/sefaria/model/text.py
+++ b/sefaria/model/text.py
@@ -37,6 +37,7 @@ from sefaria.utils.util import list_depth, truncate_string
 from sefaria.datatype.jagged_array import JaggedTextArray, JaggedArray
 from sefaria.settings import DISABLE_INDEX_SAVE, USE_VARNISH, MULTISERVER_ENABLED, RAW_REF_MODEL_BY_LANG_FILEPATH, RAW_REF_PART_MODEL_BY_LANG_FILEPATH, DISABLE_AUTOCOMPLETER
 from sefaria.system.multiserver.coordinator import server_coordinator
+from sefaria.constants import model as constants
 
 """
                 ----------------------------------
@@ -1037,18 +1038,8 @@ class AbstractTextRecord(object):
     """
     """
     text_attr = "chapter"
-    ALLOWED_TAGS    = ("i", "b", "br", "u", "strong", "em", "big", "small", "img", "sup", "sub", "span", "a")
-    ALLOWED_ATTRS   = {
-        'sup': ['class'],
-        'span':['class', 'dir'],
-        # There are three uses of i tags.
-        # footnotes: uses content internal to <i> tag.
-        # commentary placement: uses 'data-commentator', 'data-order', 'data-label'
-        # structure placement (e.g. page transitions): uses 'data-overlay', 'data-value'
-        'i': ['data-overlay', 'data-value', 'data-commentator', 'data-order', 'class', 'data-label', 'dir'],
-        'img': lambda name, value: name == 'src' and value.startswith("data:image/"),
-        'a': ['dir', 'class', 'href', 'data-ref', "data-ven", "data-vhe"],
-    }
+    ALLOWED_TAGS    = constants.ALLOWED_TAGS_IN_ABSTRACT_TEXT_RECORD
+    ALLOWED_ATTRS   = constants.ALLOWED_ATTRS_IN_ABSTRACT_TEXT_RECORD
 
     def word_count(self):
         """ Returns the number of words in this text """

--- a/sefaria/utils/tests/util_test.py
+++ b/sefaria/utils/tests/util_test.py
@@ -1,0 +1,61 @@
+from sefaria.utils.util import find_all_html_elements_indices, truncate_string
+
+class TestFindAllHtmlElementsIndices:
+
+    def test_empty_input(self):
+        input_string = ""
+        expected_output = {}
+        assert find_all_html_elements_indices(input_string) == expected_output
+
+    def test_no_html_elements(self):
+        input_string = "This is a test string without any HTML elements."
+        expected_output = {}
+        assert find_all_html_elements_indices(input_string) == expected_output
+
+    def test_single_html_element(self):
+        input_string = "<b>This is a paragraph.</b>"
+        expected_output = {2: 0, 26: 23}
+        assert find_all_html_elements_indices(input_string) == expected_output
+
+    def test_multiple_html_elements(self):
+        input_string = '<a href="sefaria data-ref="sefaria">This is a <b>test</b> string with <i>HTML</i> elements.</a>'
+        expected_output = {35: 0, 48: 46, 56: 53, 72: 70, 80: 77, 94: 91}
+        assert find_all_html_elements_indices(input_string) == expected_output
+
+
+class TestTruncateString:
+
+    def test_short_string(self):
+        string = "This is a short string."
+        min_length = 10
+        max_length = 25
+        expected_output = "This is a short string."
+        assert truncate_string(string, min_length, max_length) == expected_output
+
+    def test_long_string_without_break_chars(self):
+        string = "This is a long string without any break characters."
+        min_length = 10
+        max_length = 20
+        expected_output = "This is a long…"
+        assert truncate_string(string, min_length, max_length) == expected_output
+
+    def test_long_string_with_break_chars(self):
+        string = "This is a long string, which has multiple break characters, like .,;."
+        min_length = 10
+        max_length = 25
+        expected_output = "This is a long string…"
+        assert truncate_string(string, min_length, max_length) == expected_output
+
+    def test_long_string_with_html_elements(self):
+        string = '<b>This is a long string with <sub class="footnote">HTML</sup> attributes.</b>'
+        min_length = 10
+        max_length = 35
+        expected_output = "<b>This is a long string with…"
+        assert truncate_string(string, min_length, max_length) == expected_output
+
+    def test_string_length_equals_max(self):
+        string = 'string with length of 24'
+        min_length = 10
+        max_length = 24
+        expected_output = "string with length of 24"
+        assert truncate_string(string, min_length, max_length) == expected_output

--- a/sefaria/utils/util.py
+++ b/sefaria/utils/util.py
@@ -7,6 +7,7 @@ from html.parser import HTMLParser
 import re
 from functools import wraps
 from itertools import zip_longest
+from sefaria.constants.model import ALLOWED_TAGS_IN_ABSTRACT_TEXT_RECORD
 
 """
 Time utils
@@ -453,15 +454,27 @@ def wrap_chars_with_overlaps(s, chars_to_wrap, get_wrapped_text, return_chars_to
         return s, chars_to_wrap
     return s
 
+def find_all_html_elements_indices(input_string: str) -> dict:
+    tags = ALLOWED_TAGS_IN_ABSTRACT_TEXT_RECORD
+    tags_regex = f'(?:{"|".join(tags)})'
+    html_element_indices = {}
+    for m in re.finditer(f'</?{tags_regex}(?: [^>]*)?>', input_string):
+        html_element_indices[m.end()-1] = m.start()
+    return html_element_indices
+
 def truncate_string(string, min_length, max_length):
-    if len(string) < max_length:
+    if len(string) <= max_length:
         return string
+    html_element_indices = find_all_html_elements_indices(string)
+    next_html_closing_tag_index = string.find('>', max_length)
     for break_char in ".;, ":
-        # enumerate all places where this char is in segment
-        #Note: this code was reverted to because the change that was made to it affected the related api while fetching webpages. 
-        for pos, char in reversed(list(enumerate(string))):
-            if char == break_char and min_length <= pos <= max_length:
+        pos = next_html_closing_tag_index if next_html_closing_tag_index != -1 else max_length
+        while min_length <= pos:
+            while pos in html_element_indices:
+                pos = html_element_indices[pos] - 1
+            if string[pos] == break_char:
                 return string[:pos] + "…"
+            pos -= 1
     return string
 
 '''


### PR DESCRIPTION
…without a bug when the string has the max required length.