### PR TITLE
Bug/sc 551/skipping problem while scrolling on reader

### DIFF
--- a/sefaria/datatype/jagged_array.py
+++ b/sefaria/datatype/jagged_array.py
@@ -601,6 +601,9 @@ class JaggedArray(object):
     def __len__(self):
         return self.sub_array_length()
 
+    def __repr__(self):
+        return f"{self.__class__.__name__}({self._store})"
+
     def length(self):
         return self.__len__()
 

--- a/sefaria/datatype/jagged_array.py
+++ b/sefaria/datatype/jagged_array.py
@@ -714,8 +714,7 @@ class JaggedTextArray(JaggedArray):
         @return: list
         """
         final_index = len(curr_ja) - 1
-        for i in range(final_index, -1, -1):
-            item = curr_ja[i]
+        for item in reversed(curr_ja):
             if isinstance(item, list) or (isinstance(item, str) and len(item.strip()) > 0):
                 break
             final_index -= 1

--- a/sefaria/datatype/jagged_array.py
+++ b/sefaria/datatype/jagged_array.py
@@ -716,7 +716,8 @@ class JaggedTextArray(JaggedArray):
         # base case, trim ending whitespace
         final_index = len(curr_ja)
         for i in range(final_index - 1, -1, -1):
-            if isinstance(curr_ja[i], list) or (isinstance(curr_ja, str) and len(curr_ja[i].strip())) > 0:
+            item = curr_ja[i]
+            if isinstance(item, list) or (isinstance(item, str) and len(item.strip()) > 0):
                 break
             final_index = i
         if final_index != len(curr_ja):

--- a/sefaria/datatype/jagged_array.py
+++ b/sefaria/datatype/jagged_array.py
@@ -12,7 +12,6 @@ jagged_array.py: a sparse array of arrays
 import re
 from functools import reduce
 from itertools import zip_longest
-from typing import Self
 import structlog
 logger = structlog.get_logger(__name__)
 
@@ -688,7 +687,7 @@ class JaggedTextArray(JaggedArray):
         return joiner.join(self.flatten_to_array())
 
     # warning, writes!
-    def trim_ending_whitespace(self) -> Self:
+    def trim_ending_whitespace(self):
         """
         Removes ending whitespace items from _cur.
         These include empty string, None or items that are entirely whitespace.

--- a/sefaria/datatype/jagged_array.py
+++ b/sefaria/datatype/jagged_array.py
@@ -697,31 +697,31 @@ class JaggedTextArray(JaggedArray):
         self._store = self._trim_ending_whitespace_recursive(self._store)
         return self
 
-    def _trim_ending_whitespace_recursive(self, _cur) -> list:
-        if not isinstance(_cur, list):  # shouldn't get here
-            return _cur
+    def _trim_ending_whitespace_recursive(self, curr_ja: list) -> list:
+        if not isinstance(curr_ja, list):  # shouldn't get here
+            return curr_ja
 
         # recursive step
-        _cur = [self._trim_ending_whitespace_recursive(item) if isinstance(item, list) else item for item in _cur]
-        return self._trim_ending_whitespace_list_of_strs(_cur)
+        curr_ja = [self._trim_ending_whitespace_recursive(item) if isinstance(item, list) else item for item in curr_ja]
+        return self._trim_ending_whitespace_list_of_strs(curr_ja)
 
     @staticmethod
-    def _trim_ending_whitespace_list_of_strs(_cur: list) -> list:
+    def _trim_ending_whitespace_list_of_strs(curr_ja: list) -> list:
         """
         Removes ending whitespace items from _cur. See docs for `trim_ending_whitespace()` for details.
         Doesn't recurse on any nested lists.
-        @param _cur: list with items that are either lists, strs or None
+        @param curr_ja: list with items that are either lists, strs or None
         @return: list
         """
         # base case, trim ending whitespace
-        final_index = len(_cur)
+        final_index = len(curr_ja)
         for i in range(final_index - 1, -1, -1):
-            if isinstance(_cur[i], list) or _cur[i] is None or len(_cur[i].strip()) > 0:
+            if isinstance(curr_ja[i], list) or curr_ja[i] is None or len(curr_ja[i].strip()) > 0:
                 break
             final_index = i
-        if final_index != len(_cur):
-            _cur = _cur[:final_index]
-        return _cur
+        if final_index != len(curr_ja):
+            curr_ja = curr_ja[:final_index]
+        return curr_ja
 
     def overlaps(self, other=None, _self_cur=None, _other_cur=None) -> bool:
         """

--- a/sefaria/datatype/jagged_array.py
+++ b/sefaria/datatype/jagged_array.py
@@ -713,14 +713,13 @@ class JaggedTextArray(JaggedArray):
         @param curr_ja: list with items that are either lists, strs or None
         @return: list
         """
-        final_index = len(curr_ja)
-        for i in range(final_index - 1, -1, -1):
+        final_index = len(curr_ja) - 1
+        for i in range(final_index, -1, -1):
             item = curr_ja[i]
             if isinstance(item, list) or (isinstance(item, str) and len(item.strip()) > 0):
                 break
-            final_index = i
-        if final_index != len(curr_ja):
-            curr_ja = curr_ja[:final_index]
+            final_index -= 1
+        del curr_ja[final_index+1:]
         return curr_ja
 
     def overlaps(self, other=None, _self_cur=None, _other_cur=None) -> bool:

--- a/sefaria/datatype/jagged_array.py
+++ b/sefaria/datatype/jagged_array.py
@@ -713,7 +713,6 @@ class JaggedTextArray(JaggedArray):
         @param curr_ja: list with items that are either lists, strs or None
         @return: list
         """
-        # base case, trim ending whitespace
         final_index = len(curr_ja)
         for i in range(final_index - 1, -1, -1):
             item = curr_ja[i]

--- a/sefaria/datatype/jagged_array.py
+++ b/sefaria/datatype/jagged_array.py
@@ -12,6 +12,7 @@ jagged_array.py: a sparse array of arrays
 import re
 from functools import reduce
 from itertools import zip_longest
+from typing import Self
 import structlog
 logger = structlog.get_logger(__name__)
 
@@ -687,7 +688,7 @@ class JaggedTextArray(JaggedArray):
         return joiner.join(self.flatten_to_array())
 
     # warning, writes!
-    def trim_ending_whitespace(self):
+    def trim_ending_whitespace(self) -> Self:
         """
         Removes ending whitespace items from _cur.
         These include empty string, None or items that are entirely whitespace.

--- a/sefaria/datatype/jagged_array.py
+++ b/sefaria/datatype/jagged_array.py
@@ -689,7 +689,7 @@ class JaggedTextArray(JaggedArray):
     # warning, writes!
     def trim_ending_whitespace(self):
         """
-        Removes ending whitespace items from _cur.
+        Removes ending whitespace items from jagged array.
         These include empty string, None or items that are entirely whitespace.
         Performs process recursively on nested lists
         @return: list

--- a/sefaria/datatype/jagged_array.py
+++ b/sefaria/datatype/jagged_array.py
@@ -716,7 +716,7 @@ class JaggedTextArray(JaggedArray):
         # base case, trim ending whitespace
         final_index = len(curr_ja)
         for i in range(final_index - 1, -1, -1):
-            if isinstance(curr_ja[i], list) or curr_ja[i] is None or len(curr_ja[i].strip()) > 0:
+            if isinstance(curr_ja[i], list) or (isinstance(curr_ja, str) and len(curr_ja[i].strip())) > 0:
                 break
             final_index = i
         if final_index != len(curr_ja):

--- a/sefaria/datatype/tests/jagged_array_test.py
+++ b/sefaria/datatype/tests/jagged_array_test.py
@@ -222,40 +222,21 @@ class Test_Jagged_Text_Array(object):
         assert ja.JaggedTextArray(["a","b","c"]).shape() == 3
 
     def test_trim_ending_whitespace(self):
-        # Note - this test can fail when run in the full suite, because earlier test data bleeds through.
-        # See warning at top of jagged_array.py
-        #do no harm
-        assert ja.JaggedTextArray(twoby).trim_ending_whitespace() == ja.JaggedTextArray(twoby)
-        assert ja.JaggedTextArray(threeby).trim_ending_whitespace() == ja.JaggedTextArray(threeby)
+        depth_two = [["a", "b"], ["a"], ["d"]]
+        depth_two_with_space = [["a", "b", ""], ["a", ""], ["d"]]
+        depth_three = [[["a"], []], [["a", "", "b"], ["", "a", "b", "c"]]]
+        depth_three_with_space = [[["a", ""], [""]], [["a", "", "b"], ["", "a", "b", "c"]]]
+        # do no harm
+        assert ja.JaggedTextArray(depth_two).trim_ending_whitespace() == ja.JaggedTextArray(depth_two)
+        assert ja.JaggedTextArray(depth_three).trim_ending_whitespace() == ja.JaggedTextArray(depth_three)
 
-        twoby_with_space = [
-            ["Line 1:1", "This is the first second", "First third","","",""],
-            ["Chapter 2, Verse 1", "2:2", "2:3", ""],
-            ["Third first", "Third second", "Third third"]
-        ]
-        threeby_with_space = [
-            [
-                ["Part 1 Line 1:1", "This is the first second", "First third","","",""],
-                ["Chapter 2, Verse 1", "2:2", "2:3", "", ""],
-                ["Third first", "Third second", "Third third",""]
-            ],
-            [
-                ["Part 2 Line 1:1", "This is the first second", "First third"],
-                ["Chapter 2, Verse 1", "2:2", "2:3","","",""],
-                ["Third first", "Third second", "Third third"]
-            ],
-            [
-                ["Part 3 Line 1:1", "This is the first second", "First third"],
-                ["Chapter 2, Verse 1", "2:2", "2:3"],
-                ["Third first", "Third second", "Third third",""]
-            ],
-        ]
+        # trim
         assert ja.JaggedTextArray(["a","b","c","",""]).trim_ending_whitespace() == ja.JaggedTextArray(["a","b","c"])
         assert ja.JaggedTextArray(["",None,"\t\n ","",""]).trim_ending_whitespace() == ja.JaggedTextArray([])
         assert ja.JaggedTextArray(["", ["a"]]).trim_ending_whitespace() == ja.JaggedTextArray(["", ["a"]])
         assert ja.JaggedTextArray([[""], "a"]).trim_ending_whitespace() == ja.JaggedTextArray([[], "a"])
-        assert ja.JaggedTextArray(twoby_with_space).trim_ending_whitespace() == ja.JaggedTextArray(twoby)
-        assert ja.JaggedTextArray(threeby_with_space).trim_ending_whitespace() == ja.JaggedTextArray(threeby)
+        assert ja.JaggedTextArray(depth_two_with_space).trim_ending_whitespace() == ja.JaggedTextArray(depth_two)
+        assert ja.JaggedTextArray(depth_three_with_space).trim_ending_whitespace() == ja.JaggedTextArray(depth_three)
 
     def test_overlap(self):
         a = ja.JaggedTextArray([["","b",""],["d","","f"],["","h",""]])

--- a/sefaria/datatype/tests/jagged_array_test.py
+++ b/sefaria/datatype/tests/jagged_array_test.py
@@ -251,7 +251,7 @@ class Test_Jagged_Text_Array(object):
             ],
         ]
         assert ja.JaggedTextArray(["a","b","c","",""]).trim_ending_whitespace() == ja.JaggedTextArray(["a","b","c"])
-        assert ja.JaggedTextArray(["","","","",""]).trim_ending_whitespace() == ja.JaggedTextArray([])
+        assert ja.JaggedTextArray(["",None,"\t\n ","",""]).trim_ending_whitespace() == ja.JaggedTextArray([])
         assert ja.JaggedTextArray(["", ["a"]]).trim_ending_whitespace() == ja.JaggedTextArray(["", ["a"]])
         assert ja.JaggedTextArray([[""], "a"]).trim_ending_whitespace() == ja.JaggedTextArray([[], "a"])
         assert ja.JaggedTextArray(twoby_with_space).trim_ending_whitespace() == ja.JaggedTextArray(twoby)

--- a/sefaria/datatype/tests/jagged_array_test.py
+++ b/sefaria/datatype/tests/jagged_array_test.py
@@ -221,7 +221,6 @@ class Test_Jagged_Text_Array(object):
         assert ja.JaggedTextArray(threeby).shape() == [[3, 3, 3],[3, 3, 3],[3, 3, 3]]
         assert ja.JaggedTextArray(["a","b","c"]).shape() == 3
 
-    @pytest.mark.xfail(reason="unknown")
     def test_trim_ending_whitespace(self):
         # Note - this test can fail when run in the full suite, because earlier test data bleeds through.
         # See warning at top of jagged_array.py
@@ -252,6 +251,9 @@ class Test_Jagged_Text_Array(object):
             ],
         ]
         assert ja.JaggedTextArray(["a","b","c","",""]).trim_ending_whitespace() == ja.JaggedTextArray(["a","b","c"])
+        assert ja.JaggedTextArray(["","","","",""]).trim_ending_whitespace() == ja.JaggedTextArray([])
+        assert ja.JaggedTextArray(["", ["a"]]).trim_ending_whitespace() == ja.JaggedTextArray(["", ["a"]])
+        assert ja.JaggedTextArray([[""], "a"]).trim_ending_whitespace() == ja.JaggedTextArray([[], "a"])
         assert ja.JaggedTextArray(twoby_with_space).trim_ending_whitespace() == ja.JaggedTextArray(twoby)
         assert ja.JaggedTextArray(threeby_with_space).trim_ending_whitespace() == ja.JaggedTextArray(threeby)
 


### PR DESCRIPTION
Solves an issue with trim whitespace that was causing bad data to be saved to our DB. See [here](https://app.shortcut.com/sefaria/story/551/skipping-problem-while-scrolling-on-reader). Need to run a script on production to clean out this bad data once this is launched.