### PR TITLE
fix(startup): fail gracefully when loading categories

### DIFF
--- a/sefaria/model/category.py
+++ b/sefaria/model/category.py
@@ -312,10 +312,13 @@ class TocTree(object):
         return TocTextIndex(d, index_object=index)
 
     def _add_category(self, cat):
-        tc = TocCategory(category_object=cat)
-        parent = self._path_hash[tuple(cat.path[:-1])] if len(cat.path[:-1]) else self._root
-        parent.append(tc)
-        self._path_hash[tuple(cat.path)] = tc
+        try:
+            tc = TocCategory(category_object=cat)
+            parent = self._path_hash[tuple(cat.path[:-1])] if len(cat.path[:-1]) else self._root
+            parent.append(tc)
+            self._path_hash[tuple(cat.path)] = tc
+        except KeyError:
+            logger.warning("Failed to find parent category for {}".format("/".join(cat.path)))
 
     def get_root(self):
         return self._root

--- a/sefaria/model/category.py
+++ b/sefaria/model/category.py
@@ -318,7 +318,7 @@ class TocTree(object):
             parent.append(tc)
             self._path_hash[tuple(cat.path)] = tc
         except KeyError:
-            logger.warning("Failed to find parent category for {}".format("/".join(cat.path)))
+            logger.warning(f"Failed to find parent category for {'/'.join(cat.path)}")
 
     def get_root(self):
         return self._root


### PR DESCRIPTION
The error below is cause by categories that are not in the system. This PR should correct that by failing gracefully and giving us a warning
![image](https://github.com/Sefaria/Sefaria-Project/assets/7838477/7a02cea3-783f-4175-958a-665990ab3be7)
