### PR TITLE
fix(sheets): hebrew interface english text to be ltr.

### DIFF
--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -1406,7 +1406,6 @@ div.interfaceLinks-row a {
 .interface-hebrew .readerPanel .columnLayout,
 .interface-hebrew .readerControls,
 .interface-hebrew .readerPanel .textRange,
-.interface-hebrew .readerPanel .sheetContent,
 .interface-hebrew .readerPanel .readerNavMenu .gridBox,
 .interface-hebrew .readerPanel.bilingual .readerNavMenu .gridBox,
 .readerPanel.hebrew .readerNavSection,


### PR DESCRIPTION
removed a css line applies to all the sheet. it seems that hebrew text has their own css for rtl.
https://app.shortcut.com/sefaria/story/19196/rtl-broken-on-sheets-when-in-hebrew