### PR TITLE
ci: Temp manual bump of default chart version.

### DIFF
--- a/.github/workflows/production-deploy.yaml
+++ b/.github/workflows/production-deploy.yaml
@@ -12,7 +12,7 @@ on:
       chart_version:
         type: string
         required: true
-        default: 0.20.0
+        default: 0.28.0
 
 jobs:
   # Note - build occurs again here, even though this image has been built in continuous.


### PR DESCRIPTION
This is only a temporary measure until we get the pieline for updating the chart version sorted. Generally one should not make changes like these directly. 