### PR TITLE
Layout width

### DIFF
--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -1590,9 +1590,9 @@ div.interfaceLinks-row a {
     flex-direction: column;
   }
 }
-@media (min-width: 2000px) {
+@media (min-width: 1485px) {
   .sidebarLayout {
-    max-width: 1905px; /*assuming inner is 665 and sidebar 420*/
+    max-width: 1485px; /*assuming inner is 665 and sidebar 420*/
     margin: 0 auto;
   }
 }

--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -1590,6 +1590,12 @@ div.interfaceLinks-row a {
     flex-direction: column;
   }
 }
+@media (min-width: 2000px) {
+  .sidebarLayout {
+    max-width: 2000px;
+    margin: 0 auto;
+  }
+}
 .sidebarLayout h1 {
   --english-font: var(--english-sans-serif-font-family);
   --hebrew-font: var(--hebrew-sans-serif-font-family);

--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -1592,7 +1592,7 @@ div.interfaceLinks-row a {
 }
 @media (min-width: 2000px) {
   .sidebarLayout {
-    max-width: 2000px;
+    max-width: 1905px; /*assuming inner is 665 and sidebar 420*/
     margin: 0 auto;
   }
 }


### PR DESCRIPTION
https://app.shortcut.com/sefaria/story/587/navigation-page-sidebars-stay-in-center-of-page-on-large-screens#activity-19515