### PR TITLE
fix: fix is_mostly_hebrew so that length comparison is only against l…

### DIFF
--- a/sefaria/utils/hebrew.py
+++ b/sefaria/utils/hebrew.py
@@ -437,7 +437,8 @@ def is_mostly_hebrew(s: str, len_to_check: int = 60):
 	@return: Returns True if text is majority Hebrew
 	"""
 	s = regex.sub(r"[0-9 .,'\"?!;:\-=@\#$%^&*()/<>]", "", s)  # remove punctuation/spaces/numbers
-	he_count = len(any_hebrew.findall(s[:len_to_check]))
+	s = s[:len_to_check]
+	he_count = len(any_hebrew.findall(s))
 	return he_count > len(s)/2
 
 

--- a/sefaria/utils/tests/hebrew_test.py
+++ b/sefaria/utils/tests/hebrew_test.py
@@ -90,6 +90,8 @@ class TestIsHebrewFuncs:
         assert not h.is_mostly_hebrew("שלום world")  # exactly one less than half
         assert not h.is_mostly_hebrew("שלוגם world")  # exactly half
         assert h.is_mostly_hebrew("שלוגם word")  # exactly one more than half
+        assert not h.is_mostly_hebrew("word לשוםג", len_to_check=4)
+        assert h.is_mostly_hebrew("גשגכדגכשדגכדלשוםג", len_to_check=4)
 
 
 class TestGematria():


### PR DESCRIPTION
…en_to_check. This bug is currently breaking the Hebrew linker. It assumes all text most input is English when it's actually Hebrew.