### PR TITLE
Feature/sc 19738/convert newlines in banners modals components

### DIFF
--- a/sefaria/model/__init__.py
+++ b/sefaria/model/__init__.py
@@ -45,7 +45,6 @@ from .topic import Topic, PersonTopic, AuthorTopic, TopicLinkType, IntraTopicLin
 from .manuscript import Manuscript, ManuscriptSet, ManuscriptPage, ManuscriptPageSet
 from .linker.ref_part import RawRef
 from .linker.ref_resolver import RefResolver
-from .chatroom import Chatroom, ChatroomSet, Message, MessageSet
 
 from . import dependencies
 

--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -5766,7 +5766,7 @@ But not to use a display block directive that might break continuous mode for ot
   margin-bottom: 5px;
   color: #999;
 }
-.textList.singlePanel .versionsTextList .topFiltersInner {
+.textList.singlePanel .versionsTextList .topFiltersInner, .line-break {
   white-space: pre-wrap;
 }
 .showMoreFilters {

--- a/static/js/Misc.jsx
+++ b/static/js/Misc.jsx
@@ -8,7 +8,7 @@ import classNames  from 'classnames';
 import PropTypes  from 'prop-types';
 import Component from 'react-class';
 import { usePaginatedDisplay } from './Hooks';
-import {ContentLanguageContext, AdContext, StrapiDataContext} from './context';
+import {ContentLanguageContext, AdContext, StrapiDataContext, replaceNewLinesWithLinebreaks} from './context';
 import ReactCrop from 'react-image-crop';
 import 'react-image-crop/dist/ReactCrop.css';
 import {Editor} from "slate";
@@ -59,7 +59,7 @@ const __filterChildrenByLanguage = (children, language) => {
   return newChildren;
 };
 
-const InterfaceText = ({text, html, markdown, children, context}) => {
+const InterfaceText = ({text, html, markdown, children, context, styleClasses}) => {
   /**
    * Renders a single span for interface string with either class `int-en`` or `int-he` depending on Sefaria.interfaceLang.
    *  If passed explicit text or html objects as props with "en" and/or "he", will only use those to determine correct text or fallback text to display.
@@ -67,11 +67,12 @@ const InterfaceText = ({text, html, markdown, children, context}) => {
    * `children` can be the English string, which will be translated with Sefaria._ if needed.
    * `children` can also take the form of <LangText> components above, so they can be used for longer paragrpahs or paragraphs containing html, if needed.
    * `context` is passed to Sefaria._ for additional translation context
+   * `styleClasses` are CSS classes that you want applied to all the interface languages
    */
   const contentVariable = html ?
                           html : markdown ? markdown : text;  // assumption is `markdown` or `html` are preferred over `text` if they are present
   const isHebrew = Sefaria.interfaceLang === "hebrew";
-  let elemclasses = classNames({"int-en": !isHebrew, "int-he": isHebrew});
+  let elemclasses = classNames(styleClasses, {"int-en": !isHebrew, "int-he": isHebrew});
   let textResponse = null;
   if (contentVariable) {// Prioritize explicit props passed in for text of the element, does not attempt to use Sefaria._() for this case.
     let {he, en} = contentVariable;
@@ -2192,7 +2193,7 @@ const InterruptingMessage = ({
               </div>
               <div id="interruptingMessageContent">
                 <div id="highHolidayDonation">
-                    <InterfaceText markdown={strapi.modal.modalText} />
+                  <InterfaceText markdown={replaceNewLinesWithLinebreaks(strapi.modal.modalText)} styleClasses={['line-break']} />
                   <div className="buttons">
                     <a
                       className="button int-en"
@@ -2333,7 +2334,7 @@ const Banner = ({ onClose }) => {
         <div id="bannerMessage" className={timesUp ? "" : "hidden"}>
           <div id="bannerMessageContent">
             <div id="bannerTextBox">
-              <InterfaceText markdown={strapi.banner.bannerText} />
+              <InterfaceText markdown={replaceNewLinesWithLinebreaks(strapi.banner.bannerText)} styleClasses={['line-break']} />
             </div>
             <div id="bannerButtonBox">
               <a

--- a/static/js/context.js
+++ b/static/js/context.js
@@ -11,6 +11,11 @@ AdContext.displayName = "AdContext";
 const StrapiDataContext = React.createContext({});
 StrapiDataContext.displayName = "StrapiDataContext";
 
+export function replaceNewLinesWithLinebreaks(string)
+{
+  return string.replace(/\n/gi, "&nbsp; \n")
+}
+
 function StrapiDataProvider({ children }) {
   const [dataFromStrapiHasBeenReceived, setDataFromStrapiHasBeenReceived] =
     useState(false);

--- a/static/js/context.js
+++ b/static/js/context.js
@@ -11,9 +11,16 @@ AdContext.displayName = "AdContext";
 const StrapiDataContext = React.createContext({});
 StrapiDataContext.displayName = "StrapiDataContext";
 
-export function replaceNewLinesWithLinebreaks(string)
-{
-  return string.replace(/\n/gi, "&nbsp; \n")
+const transformValues = (obj, callback) => {
+  const newObj = {};
+  for (let key in obj) {
+    newObj[key] = obj[key] !== null ? callback(obj[key]) : null;
+  }
+  return newObj;
+};
+
+export function replaceNewLinesWithLinebreaks(content) {
+  return transformValues(content, s => s.replace(/\n/gi, "&nbsp; \n") + "&nbsp; \n");
 }
 
 function StrapiDataProvider({ children }) {


### PR DESCRIPTION
This makes it so regular returns can be used in the Strapi CMS interface. Users won't have to use the default of adding 2 spaces in Markdown to get linebreaks.