### PR TITLE
fix(reader): Fix bug that hid inline text when there was a base64 image

### DIFF
--- a/static/js/ContentText.jsx
+++ b/static/js/ContentText.jsx
@@ -26,7 +26,7 @@ const VersionContent = (props) => {
   const [languageToFilter, _] = useContentLang(props.defaultToInterfaceOnBilingual, props.overrideLanguage);
   return langAndContentItems.map((item) => {
       const [lang, content] = item;
-      if (Sefaria.isImage(content)){
+      if (Sefaria.isFullSegmentImage(content)){
         return(<VersionImageSpan lang={lang} content={content} languageToFilter={languageToFilter} imageLoadCallback={props.imageLoadCallback}/>);
       }
       return (<ContentSpan lang={lang} content={content} isHTML={true}/>);

--- a/static/js/sefaria/sefaria.js
+++ b/static/js/sefaria/sefaria.js
@@ -1004,9 +1004,14 @@ Sefaria = extend(Sefaria, {
             }, error);
     });
   },
-  isImage: function(textChunk) {
-    const pattern = /<img\b[^>]*>/i;
-    return pattern.test(textChunk);
+  isFullSegmentImage: function(text) {
+    /**
+     * Is `text` a segment with only an image
+     * To distinguish from inline images
+     * Returns `true` if yes.
+     */
+    const pattern = /^\s*<img\b[^>]*>\s*$/i;
+    return pattern.test(text);
   },
   getRefFromCache: function(ref) {
     if (!ref) return null;


### PR DESCRIPTION
The function Sefaria.isImage() would decide if an image takes up the full segment by simply checking if an image tag existed in the text. We now distinguish between the full segment image case and an inline image case by making the regex more specific.