### PR TITLE
fix(editor): check for divine name replacement before replacing

### DIFF
--- a/static/js/Editor.jsx
+++ b/static/js/Editor.jsx
@@ -2563,7 +2563,7 @@ const SefariaEditor = (props) => {
         () => {
             const nodes = (Editor.nodes(editor, {at: [], match: Text.isText}))
             for (const [node, path] of nodes) {
-                if (node.text) {
+                if (node.text && props.divineNameReplacement) {
                     const newStr = replaceDivineNames(node.text, props.divineNameReplacement)
                     if (newStr != node.text) {
                         Transforms.insertText(editor, newStr, { at: path })


### PR DESCRIPTION
<img width="1042" alt="image" src="https://github.com/Sefaria/Sefaria-Project/assets/7838477/7b80e9f5-ad18-4917-85de-4bf686a62112">
When Gods name is used in freetext and fools our Divine name replacer into action, it attempts to replace it with undefined, while it is difficult to truly define God, as only Moses was permitted to say ויציב ונכון וקיים וישר ונאמן ואהוב וחביב ונחמד ונעים - still, this causes an error and white-screens the editor app. I have added a check for the prop changing the Devine name