### PR TITLE
Normalization fixes

### DIFF
--- a/sefaria/helper/normalization.py
+++ b/sefaria/helper/normalization.py
@@ -127,7 +127,9 @@ class AbstractNormalizer:
         sign = -1 if reverse else 1
         for start, end in normalized_indices:
             unnorm_start_index = bisect_right(removal_keys, start) - 1
-            unnorm_end_index = bisect_right(removal_keys, (end - 1 if reverse else end)) - 1  # not sure if end-1 is specific to reverse case, but seems to be working
+            # special case if range is zero-length. treat end as literal and not off-by-one.
+            bisect_end_index = end if end == start else (end - 1)
+            unnorm_end_index = bisect_right(removal_keys, bisect_end_index) - 1
 
             unnorm_start = start if unnorm_start_index < 0 else start + (sign * removal_map[removal_keys[unnorm_start_index]])
             unnorm_end = end if unnorm_end_index < 0 else end + (sign * removal_map[removal_keys[unnorm_end_index]])

--- a/sefaria/helper/normalization.py
+++ b/sefaria/helper/normalization.py
@@ -108,10 +108,10 @@ class AbstractNormalizer:
                 # must be match object
                 start, end = removal.start(), removal.end()
             normalized_text_index = start if reverse else (start + min(len(subst), end-start) - total_removed)
-            temp_removed = end - start - len(subst)
-            if temp_removed == 0:
+            curr_removed = end - start - len(subst)
+            if curr_removed == 0:
                 continue
-            total_removed += temp_removed
+            total_removed += curr_removed
             removal_map[normalized_text_index] = total_removed
         return removal_map
 
@@ -295,9 +295,9 @@ class NormalizerComposer(AbstractNormalizer):
                 merged_removal_inds += [(curr_inds, curr_repl)]
             else:
                 # some sort of overlap
-                temp_merged_inds = (last_inds[0], max(last_inds[1], curr_inds[1]))
-                temp_merged_repl = last_repl[:curr_inds[0]-last_inds[0]] + curr_repl + last_repl[(curr_inds[1]+1)-last_inds[0]:]
-                merged_removal_inds[-1] = (temp_merged_inds, temp_merged_repl)
+                curr_merged_inds = (last_inds[0], max(last_inds[1], curr_inds[1]))
+                curr_merged_repl = last_repl[:curr_inds[0]-last_inds[0]] + curr_repl + last_repl[(curr_inds[1]+1)-last_inds[0]:]
+                merged_removal_inds[-1] = (curr_merged_inds, curr_merged_repl)
 
         return merged_removal_inds
 

--- a/sefaria/helper/normalization.py
+++ b/sefaria/helper/normalization.py
@@ -274,14 +274,14 @@ class NormalizerComposer(AbstractNormalizer):
 
             # merge any overlapping ranges
             # later edits should override earlier ones
-            final_text_to_remove = self.merge_removal_inds_new(final_text_to_remove, temp_text_to_remove)
+            final_text_to_remove = self.merge_removal_inds(final_text_to_remove, temp_text_to_remove)
             mappings += [step.get_mapping_after_normalization(snorm, **kwargs)]
             snorm = step.normalize(snorm, **kwargs)
         final_text_to_remove.sort(key=lambda x: x[0])
         return final_text_to_remove
 
     @staticmethod
-    def merge_removal_inds_new(*all_removal_inds):
+    def merge_removal_inds(*all_removal_inds):
         combined_removal_inds = reduce(lambda a, b: a + b, all_removal_inds, [])
         combined_removal_inds.sort(key=lambda x: x[0][0])
         merged_removal_inds = []

--- a/sefaria/helper/normalization.py
+++ b/sefaria/helper/normalization.py
@@ -109,10 +109,9 @@ class AbstractNormalizer:
                 start, end = removal.start(), removal.end()
             normalized_text_index = start if reverse else (start + min(len(subst), end-start) - total_removed)
             curr_removed = end - start - len(subst)
-            if curr_removed == 0:
-                continue
-            total_removed += curr_removed
-            removal_map[normalized_text_index] = total_removed
+            if curr_removed > 0:
+                total_removed += curr_removed
+                removal_map[normalized_text_index] = total_removed
         return removal_map
 
     @staticmethod

--- a/sefaria/helper/normalization.py
+++ b/sefaria/helper/normalization.py
@@ -262,18 +262,18 @@ class NormalizerComposer(AbstractNormalizer):
         mappings = []
         snorm = s
         for step in self.steps:
-            temp_text_to_remove = step.find_text_to_remove(snorm, **kwargs)
-            if len(temp_text_to_remove) == 0:
+            curr_text_to_remove = step.find_text_to_remove(snorm, **kwargs)
+            if len(curr_text_to_remove) == 0:
                 text_to_remove_inds, text_to_remove_repls = [], []
             else:
-                text_to_remove_inds, text_to_remove_repls = zip(*temp_text_to_remove)
+                text_to_remove_inds, text_to_remove_repls = zip(*curr_text_to_remove)
             for mapping in reversed(mappings):
                 text_to_remove_inds = step.convert_normalized_indices_to_unnormalized_indices(text_to_remove_inds, mapping)
-            temp_text_to_remove = list(zip(text_to_remove_inds, text_to_remove_repls))
+            curr_text_to_remove = list(zip(text_to_remove_inds, text_to_remove_repls))
 
             # merge any overlapping ranges
             # later edits should override earlier ones
-            final_text_to_remove = self.merge_removal_inds(final_text_to_remove, temp_text_to_remove)
+            final_text_to_remove = self.merge_removal_inds(final_text_to_remove, curr_text_to_remove)
             mappings += [step.get_mapping_after_normalization(snorm, **kwargs)]
             snorm = step.normalize(snorm, **kwargs)
         final_text_to_remove.sort(key=lambda x: x[0])

--- a/sefaria/helper/tests/normalization_tests.py
+++ b/sefaria/helper/tests/normalization_tests.py
@@ -49,15 +49,27 @@ def test_br_tag_html_composer():
     assert text[start4:end4] == '</b> '
 
 
-def test_normalizer_composer():
+def test_simpler_normalizer_composer():
+    text = ' [sup'
+    normalized = " sup"
+    nsc = NormalizerComposer(['brackets', 'double-space'])
+    assert nsc.normalize(text) == normalized
+    text_to_remove = nsc.find_text_to_remove(text)
+    assert len(text_to_remove) == 2
+    (start0, end0), repl0 = text_to_remove[0]
+    assert text[start0:end0] == " "
+    assert repl0 == ' '
+
+
+def test_complicated_normalizer_composer():
     text = """(<i>hello</i> other stuff) [sup] <b>(this is) a test</b>"""
     normalized = """ sup a test """
     nsc = NormalizerComposer(['html', "parens-plus-contents", 'brackets', 'double-space'])
     assert nsc.normalize(text) == normalized
     text_to_remove = nsc.find_text_to_remove(text)
-    assert len(text_to_remove) == 5
+    assert len(text_to_remove) == 6
     (start0, end0), repl0 = text_to_remove[0]
-    assert text[start0:end0] == "(<i>hello</i> other stuff) ["
+    assert text[start0:end0] == "(<i>hello</i> other stuff) "
     assert repl0 == ' '
 
 
@@ -96,7 +108,7 @@ def test_word_to_char():
     word_indices = (2, 4)
     result = char_indices_from_word_indices(test_string, [word_indices])[0]
     start, end = result
-    assert test_string[start:end] == 'go here\n\nhello '  # TODO used to not have trailing space. not sure how critical this is.
+    assert test_string[start:end] == 'go here\n\nhello'
     assert test_string[start:end].split() == words
 
 


### PR DESCRIPTION
Fix various off-by-one errors in normalization code. Refactor some of the code to be simpler / faster so that it was easier to reason about while debugging. Modify tests that were incorrectly accounting for off-by-one errors.