### PR TITLE
Bug/sc 20275/chronological filtering isn t sticky on topics

### DIFF
--- a/reader/views.py
+++ b/reader/views.py
@@ -3060,6 +3060,7 @@ def topic_page(request, topic, test_version=None):
         "initialMenu": "topics",
         "initialTopic": topic,
         "initialTab": urllib.parse.unquote(request.GET.get('tab', 'sources')),
+        "initialTopicSort": urllib.parse.unquote(request.GET.get('sort', 'Relevance')),
         "initialTopicTitle": {
             "en": topic_obj.get_primary_title('en'),
             "he": topic_obj.get_primary_title('he')

--- a/static/js/Misc.jsx
+++ b/static/js/Misc.jsx
@@ -360,15 +360,41 @@ ProfilePic.propTypes = {
 };
 
 
+/**
+ * Renders a list of data that can be filtered and sorted
+ * @param filterFunc
+ * @param sortFunc
+ * @param renderItem
+ * @param sortOptions
+ * @param getData
+ * @param data
+ * @param renderEmptyList
+ * @param renderHeader
+ * @param renderFooter
+ * @param showFilterHeader
+ * @param refreshData
+ * @param initialFilter
+ * @param scrollableElement
+ * @param pageSize
+ * @param onDisplayedDataChange
+ * @param initialRenderSize
+ * @param bottomMargin
+ * @param containerClass
+ * @param onSetSort: optional. function that is passed the current sort option when the user changes it. Use this to control sort from outside the component. See `externalSortOption`.
+ * @param externalSortOption: optional. string that is one of the options in `sortOptions`. Use this to control sort from outside the component. See `onSetSort`.
+ * @returns {JSX.Element}
+ * @constructor
+ */
 const FilterableList = ({
   filterFunc, sortFunc, renderItem, sortOptions, getData, data, renderEmptyList,
   renderHeader, renderFooter, showFilterHeader, refreshData, initialFilter,
   scrollableElement, pageSize, onDisplayedDataChange, initialRenderSize,
-  bottomMargin, containerClass, onSetSort, initialSort,
+  bottomMargin, containerClass, onSetSort, externalSortOption,
 }) => {
   const [filter, setFilter] = useState(initialFilter || '');
-  const [sortOption, setSortOption] = useState(initialSort || sortOptions[0]);
+  const [internalSortOption, setSortOption] = useState(sortOptions[0]);
   const [displaySort, setDisplaySort] = useState(false);
+  const sortOption = externalSortOption || internalSortOption;
 
   // Apply filter and sort to the raw data
   const processData = rawData => rawData ? rawData

--- a/static/js/Misc.jsx
+++ b/static/js/Misc.jsx
@@ -364,10 +364,10 @@ const FilterableList = ({
   filterFunc, sortFunc, renderItem, sortOptions, getData, data, renderEmptyList,
   renderHeader, renderFooter, showFilterHeader, refreshData, initialFilter,
   scrollableElement, pageSize, onDisplayedDataChange, initialRenderSize,
-  bottomMargin, containerClass
+  bottomMargin, containerClass, onSetSort, initialSort,
 }) => {
   const [filter, setFilter] = useState(initialFilter || '');
-  const [sortOption, setSortOption] = useState(sortOptions[0]);
+  const [sortOption, setSortOption] = useState(initialSort || sortOptions[0]);
   const [displaySort, setDisplaySort] = useState(false);
 
   // Apply filter and sort to the raw data
@@ -420,10 +420,11 @@ const FilterableList = ({
     }, [dataUpToPage]);
   }
 
-  const onSortChange = newSortOption => {
+  const setSort = newSortOption => {
     if (newSortOption === sortOption) { return; }
     setSortOption(newSortOption);
     setDisplaySort(false);
+    onSetSort?.(newSortOption);
   };
 
   const oldDesign = typeof showFilterHeader == 'undefined';
@@ -453,7 +454,7 @@ const FilterableList = ({
                 isOpen={displaySort}
                 options={sortOptions.map(option => ({type: option, name: option, heName: Sefaria._(option, "FilterableList")}))}
                 currOptionSelected={sortOption}
-                handleClick={onSortChange}
+                handleClick={setSort}
               />
             </DropdownModal>
             : null
@@ -480,7 +481,7 @@ const FilterableList = ({
               <span
                 key={option}
                 className={classNames({'sans-serif': 1, 'sort-option': 1, noselect: 1, active: sortOption === option})}
-                onClick={() => onSortChange(option)}
+                onClick={() => setSort(option)}
               >
                 <InterfaceText context="FilterableList">{option}</InterfaceText>
               </span>

--- a/static/js/ReaderApp.jsx
+++ b/static/js/ReaderApp.jsx
@@ -50,6 +50,7 @@ class ReaderApp extends Component {
         searchQuery:             props.initialQuery,
         searchTab:               props.initialSearchTab,
         tab:                     props.initialTab,
+        topicSort:               props.initialTopicSort,
         textSearchState: new SearchState({
           type: 'text',
           appliedFilters:        props.initialTextSearchFilters,
@@ -166,6 +167,7 @@ class ReaderApp extends Component {
       textHighlights:          state.textHighlights          || null,
       profile:                 state.profile                 || null,
       tab:                     state.tab                     || null,
+      topicSort:               state.topicSort               || null,
       webPagesFilter:          state.webPagesFilter          || null,
       sideScrollPosition:      state.sideScrollPosition      || null,
       topicTestVersion:        state.topicTestVersion        || null
@@ -378,6 +380,7 @@ class ReaderApp extends Component {
           (prev.searchQuery != next.searchQuery) ||
           (prev.searchTab != next.searchTab) ||
           (prev.tab !== next.tab) ||
+          (prev.topicSort !== next.topicSort) ||
           (prev.collectionName !== next.collectionName) ||
           (prev.collectionTag !== next.collectionTag) ||
           (!prevTextSearchState.isEqual({ other: nextTextSearchState, fields: ["appliedFilters", "field", "sortType"]})) ||
@@ -471,6 +474,7 @@ class ReaderApp extends Component {
           case "topics":
             if (state.navigationTopic) {
               hist.url = state.topicTestVersion ? `topics/${state.topicTestVersion}/${state.navigationTopic}` : `topics/${state.navigationTopic}`;
+              hist.url = hist.url + (state.topicSort ? `&sort=${state.topicSort}` : '');
               hist.title = `${state.topicTitle[shortLang]} | ${ Sefaria._("Texts & Source Sheets from Torah, Talmud and Sefaria's library of Jewish sources.")}`;
               hist.mode  = "topic";
             } else if (state.navigationTopicCategory) {

--- a/static/js/ReaderPanel.jsx
+++ b/static/js/ReaderPanel.jsx
@@ -527,6 +527,9 @@ class ReaderPanel extends Component {
         : false
     this.conditionalSetState({tab: tab})
   }
+  onSetTopicSort(topicSort) {
+    this.conditionalSetState({topicSort});
+  }
   currentMode() {
     return this.state.mode;
   }
@@ -918,6 +921,8 @@ class ReaderPanel extends Component {
           <TopicPage
             tab={this.state.tab}
             setTab={this.setTab}
+            onSetTopicSort={this.onSetTopicSort}
+            topicSort={this.state.topicSort}
             topic={this.state.navigationTopic}
             topicTitle={this.state.topicTitle}
             interfaceLang={this.props.interfaceLang}

--- a/static/js/TopicPage.jsx
+++ b/static/js/TopicPage.jsx
@@ -390,7 +390,8 @@ const useTabDisplayData = (translationLanguagePreference) => {
 
 const TopicPage = ({
   tab, topic, topicTitle, setTopic, setNavTopic, openTopics, multiPanel, showBaseText, navHome,
-  toggleSignUpModal, openDisplaySettings, setTab, openSearch, translationLanguagePreference, versionPref, topicTestVersion
+  toggleSignUpModal, openDisplaySettings, setTab, openSearch, translationLanguagePreference, versionPref,
+  topicTestVersion, onSetTopicSort, topicSort
 }) => {
     const defaultTopicData = {primaryTitle: topicTitle, tabs: {}, isLoading: true};
     const [topicData, setTopicData] = useState(Sefaria.getTopicFromCache(topic, {with_html: true}) || defaultTopicData);
@@ -505,6 +506,8 @@ const TopicPage = ({
                                   }}
                                   initialRenderSize={(topicData._refsDisplayedByTab && topicData._refsDisplayedByTab[key]) || 0}
                                   renderItem={renderWrapper(toggleSignUpModal, topicData, topicTestVersion)}
+                                  onSetTopicSort={onSetTopicSort}
+                                  topicSort={topicSort}
                                 />
                               );
                             })
@@ -550,7 +553,7 @@ TopicPage.propTypes = {
 
 const TopicPageTab = ({
   data, renderItem, classes, sortOptions, sortFunc, filterFunc, showFilterHeader,
-  scrollableElement, onDisplayedDataChange, initialRenderSize
+  scrollableElement, onDisplayedDataChange, initialRenderSize, onSetTopicSort, topicSort
 }) => {
   return (
     <div className="topicTabContents">
@@ -568,6 +571,8 @@ const TopicPageTab = ({
             sortOptions={sortOptions}
             onDisplayedDataChange={onDisplayedDataChange}
             initialRenderSize={initialRenderSize}
+            onSetSort={onSetTopicSort}
+            initialSort={topicSort}
             data={data}
           />
         </div> : <LoadingMessage />

--- a/static/js/TopicPage.jsx
+++ b/static/js/TopicPage.jsx
@@ -572,7 +572,7 @@ const TopicPageTab = ({
             onDisplayedDataChange={onDisplayedDataChange}
             initialRenderSize={initialRenderSize}
             onSetSort={onSetTopicSort}
-            initialSort={topicSort}
+            externalSortOption={topicSort}
             data={data}
           />
         </div> : <LoadingMessage />


### PR DESCRIPTION
Add sort URL param to topic pages.

This will track the sort option on topic pages which can be either "Relevance" or "Chronological".