### PR TITLE
Allow the background color of a banner to be customized in Strapi

### DIFF
--- a/static/js/Misc.jsx
+++ b/static/js/Misc.jsx
@@ -2278,7 +2278,8 @@ const InterruptingMessage = ({
 InterruptingMessage.displayName = "InterruptingMessage";
 
 const Banner = ({ onClose }) => {
-  const [bannerShowDelayHasElapsed, setBannerShowDelayHasElapsed] = useState(false);
+  const [bannerShowDelayHasElapsed, setBannerShowDelayHasElapsed] =
+    useState(false);
   const [hasInteractedWithBanner, setHasInteractedWithBanner] = useState(false);
   const strapi = useContext(StrapiDataContext);
 
@@ -2306,7 +2307,11 @@ const Banner = ({ onClose }) => {
 
   const shouldShow = () => {
     if (!strapi.banner) return false;
-    if (Sefaria.interfaceLang === 'hebrew' && !strapi.banner.locales.includes('he')) return false;
+    if (
+      Sefaria.interfaceLang === "hebrew" &&
+      !strapi.banner.locales.includes("he")
+    )
+      return false;
     if (hasBannerBeenInteractedWith(strapi.banner.internalBannerName))
       return false;
 
@@ -2340,15 +2345,11 @@ const Banner = ({ onClose }) => {
     if (onClose) onClose();
     markBannerAsHasBeenInteractedWith(strapi.banner.internalBannerName);
     setHasInteractedWithBanner(true);
-    trackBannerInteraction(
-      strapi.banner.internalBannerName,
-      eventDescription
-    );
+    trackBannerInteraction(strapi.banner.internalBannerName, eventDescription);
   };
 
   useEffect(() => {
     if (shouldShow()) {
-
       const timeoutId = setTimeout(() => {
         // s2 is the div that contains the React root and needs to be manipulated by traditional DOM methods
         if (document.getElementById("s2").classList.contains("headerOnly")) {
@@ -2365,10 +2366,22 @@ const Banner = ({ onClose }) => {
   if (!hasInteractedWithBanner) {
     return (
       <OnInView onVisible={trackBannerImpression}>
-        <div id="bannerMessage" className={bannerShowDelayHasElapsed ? "" : "hidden"}>
+        <div
+          id="bannerMessage"
+          className={bannerShowDelayHasElapsed ? "" : "hidden"}
+          style={
+            strapi.banner.bannerBackgroundColor && {
+              backgroundColor: strapi.banner.bannerBackgroundColor,
+            }
+          }
+        >
           <div id="bannerMessageContent">
             <div id="bannerTextBox">
-              <InterfaceText markdown={replaceNewLinesWithLinebreaks(strapi.banner.bannerText)} />
+              <InterfaceText
+                markdown={replaceNewLinesWithLinebreaks(
+                  strapi.banner.bannerText
+                )}
+              />
             </div>
             <div id="bannerButtonBox">
               <a
@@ -2385,7 +2398,6 @@ const Banner = ({ onClose }) => {
               </a>
             </div>
           </div>
-          <div id="bannerMessageClose">×</div>
           <div id="bannerMessageClose" onClick={closeBanner}>
             ×
           </div>

--- a/static/js/context.js
+++ b/static/js/context.js
@@ -56,6 +56,7 @@ function StrapiDataProvider({ children }) {
                 buttonText
                 buttonURL
                 showDelay
+                bannerBackgroundColor
                 createdAt
                 locale
                 localizations {


### PR DESCRIPTION
* Resolves https://app.shortcut.com/sefaria/story/20508/allow-background-color-as-an-option-for-banners
* Depends on https://github.com/Sefaria/Sefaria-Project/pull/1606 and https://github.com/Sefaria/Sefaria-Strapi/commit/4cd140e7f463941dcb566d26d60d6f6c23770502

### Changes
* bannerBackgroundColor attribute was added to the GraphQL query
* Check if the optional background color is not null and use it. Otherwise, the background color for a banner will default to what's already included in the CSS file
* bannerBackgroundColor was added to the banner content type for the Strapi server

#### Extra Note
A bug was fixed where there was two close buttons on banners...
