### PR TITLE
Banners (and modals) wouldn't go away but now they will

### DIFF
--- a/static/js/context.js
+++ b/static/js/context.js
@@ -194,12 +194,15 @@ function StrapiDataProvider({ children }) {
             let modals = result.data?.modals?.data;
             let banners = result.data?.banners?.data;
 
-            let removeKeysFromLocalStorageWithPrefix = (prefix) => {
+            let removeContentKeysFromLocalStorage = ({ prefix = "", except = "" } = {}) => {
               let keysToRemove = [];
               // Removing keys while iterating affects the length of localStorage
               for (let i = 0; i < localStorage.length; i++) {
                 let key = localStorage.key(i);
-                if (key.startsWith(prefix)) {
+                if (
+                  key.startsWith(prefix) &&
+                  (except === "" || key !== prefix + except)
+                ) {
                   keysToRemove.push(key);
                 }
               }
@@ -217,8 +220,12 @@ function StrapiDataProvider({ children }) {
                   currentDate <= new Date(modal.attributes.modalEndDate)
               );
               if (modal) {
-                // Remove any other previous modals since there is a new modal to replace it
-                removeKeysFromLocalStorageWithPrefix("modal_");
+                // Remove any other previous modals since there is potentially new modal to replace it
+                // However, do not remove the existing modal if the eligible one found is the same as the current one
+                removeContentKeysFromLocalStorage({
+                  prefix: "modal_",
+                  except: modal.attributes.internalModalName,
+                });
 
                 // Check if there is a Hebrew translation for the modal
                 if (modal.attributes.localizations?.data?.length) {
@@ -262,8 +269,12 @@ function StrapiDataProvider({ children }) {
               );
 
               if (banner) {
-                // Remove any other previous banners since there is a new banner to replace it
-                removeKeysFromLocalStorageWithPrefix("banner_");
+                // Remove any other previous banner since there is potentially new modal to replace it
+                // However, do not remove the existing banner if the eligible one found is the same as the current one
+                removeContentKeysFromLocalStorage({
+                  prefix: "banner_",
+                  except: banner.attributes.internalBannerName,
+                });
 
                 // Check if there is a Hebrew translation
                 if (banner.attributes.localizations?.data?.length) {


### PR DESCRIPTION
## Bug Report

A user reported being unable to get rid of the current deployed banner when they closed it out. They continued to see the banner after interacting and making repeated visits to the Sheets Editor page.

## Bug Sleuthing Investigation
The bug occurred in the following scenarios:
* Interacting with a banner (hitting the close button or donate button) and then going to a static page with ReaderApp in header-only mode
* Interacting with a banner and then starting a new session (closing tab or window)

**Discovered problem:** the entry in local storage to mark whether a banner or modal had been interacted with was being cleared on every page load or session even in the usual case where the current banner or modal hadn't changed.

## Solution (Extermination)
If the current modal or banner is found to be the same as the eligible one returned from Strapi, the marked entry in local storage for that modal or banner should not be cleared, so that its interacted status stays across sessions. Only old entries for modals or banners in local storage that are not valid should be removed. A condition to not consider the current modal or banner was added during the clearing process.