### PR TITLE
URLs on buttons in Hebrew Sidebar Ads were missing

### DIFF
--- a/static/js/Promotions.jsx
+++ b/static/js/Promotions.jsx
@@ -59,7 +59,7 @@ const Promotions = () => {
               title: title,
               bodyText: bodyText,
               buttonText: buttonText,
-              buttonUrl: buttonURL,
+              buttonURL: buttonURL,
               buttonIcon: sidebarAd.buttonIcon,
               buttonLocation: sidebarAd.buttonAboveOrBelow,
               hasBlueBackground: sidebarAd.hasBlueBackground,


### PR DESCRIPTION
This fixes a small typo that left the attribute used for URLs to be undefined