### PR TITLE
Redirection to Strapi endpoints for mobile app users

### DIFF
--- a/helm-chart/sefaria-project/templates/configmap/nginx.yaml
+++ b/helm-chart/sefaria-project/templates/configmap/nginx.yaml
@@ -152,6 +152,14 @@ data:
             proxy_pass http://varnish_upstream;
         }
 
+        location /static/mobile/message-en.json {
+          return 301 ${STRAPI_LOCATION}/api/mobile-message;
+        }
+
+        location /static/mobile/message-he.json {
+          return 301 ${STRAPI_LOCATION}/api/mobile-message-he;
+        }
+
         location /static/ {
           access_log off;
           alias /app/static/;

--- a/helm-chart/sefaria-project/templates/rollout/nginx.yaml
+++ b/helm-chart/sefaria-project/templates/rollout/nginx.yaml
@@ -97,7 +97,10 @@ spec:
           - name: SEARCH_HOST
             value: "{{ .Values.nginx.SEARCH_HOST }}"
           - name: STRAPI_LOCATION
-            value: "{{ .Values.localSettings.STRAPI_LOCATION }}"
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.secrets.localSettings.ref }}
+                key: STRAPI_LOCATION
           {{- if .Values.linker.enabled }}
           - name: LINKER_HOST
             value: "linker-{{ .Values.deployEnv }}-{{ .Release.Revision }}"

--- a/helm-chart/sefaria-project/templates/rollout/nginx.yaml
+++ b/helm-chart/sefaria-project/templates/rollout/nginx.yaml
@@ -54,7 +54,7 @@ spec:
         imagePullPolicy: Always
         command: ["bash", "-c"]
         # https://serverfault.com/questions/577370/how-can-i-use-environment-variables-in-nginx-conf
-        args: [ "envsubst '${ENV_NAME},${VARNISH_HOST},${SEARCH_HOST},${RELEASE_TAG}{{- if .Values.linker.enabled }},${LINKER_HOST}{{- end }}{{- if .Values.instrumentation.enabled }},${NGINX_VERSION}{{- end }}' < /conf/nginx.template.conf > /nginx.conf && exec nginx -c /nginx.conf -g 'daemon off;'" ]
+        args: [ "envsubst '${ENV_NAME},${VARNISH_HOST},${SEARCH_HOST},${RELEASE_TAG},${STRAPI_LOCATION}{{- if .Values.linker.enabled }},${LINKER_HOST}{{- end }}{{- if .Values.instrumentation.enabled }},${NGINX_VERSION}{{- end }}' < /conf/nginx.template.conf > /nginx.conf && exec nginx -c /nginx.conf -g 'daemon off;'" ]
         ports:
         - containerPort: 80
         - containerPort: 443
@@ -96,6 +96,8 @@ spec:
             value: "varnish-{{ .Values.deployEnv }}-{{ .Release.Revision }}"
           - name: SEARCH_HOST
             value: "{{ .Values.nginx.SEARCH_HOST }}"
+          - name: STRAPI_LOCATION
+            value: "{{ .Values.localSettings.STRAPI_LOCATION }}"
           {{- if .Values.linker.enabled }}
           - name: LINKER_HOST
             value: "linker-{{ .Values.deployEnv }}-{{ .Release.Revision }}"


### PR DESCRIPTION
Story details: https://app.shortcut.com/sefaria/story/19579

### Forewarning
This is likely wrong lol. I only tested the redirection part in an example Nginx Docker container on my local. I don't know the correct location or way to reference the secret environment variable used to define `STRAPI_LOCATION`. Since it's only for production, the port shouldn't be necessary.

## Background
I integrated Strapi CMS into Sefaria's codebase. It's currently used on the web interface to serve the content for modals, banners, and sidebar ads. The mobile app currently uses static JSON files for that content which the site needs to redeployed every time when a change needs to be made (see [here](https://github.com/Sefaria/Sefaria-Mobile/blob/c05a9566212ba58d1b0ada3b4b1ce2f513fd066b/InterruptingMessage.js#L68)). To remove the last remaining dependency of the old interrupting message code and ensure backwards compatibility with current mobile app users, there needs to be redirects to the new API endpoints. Having these redirects should work, because the fetch call in the mobile app should default to following redirects though it isn't explicitly specified. 

# Requirements (What I was trying to accomplish)
* https://www.sefaria.org/static/mobile/message-en.json needs to redirect to https://credible-basketball-a14e66cd27.strapiapp.com/api/mobile-message
* https://www.sefaria.org/static/mobile/message-he.json needs to redirect to https://credible-basketball-a14e66cd27.strapiapp.com/api/mobile-message-he

## Further considerations
In the future, the mobile app's URLs for the endpoints will be changed to use the new Strapi based ones, but those will be included in a new update.

## Conclusion
I need to have this done soon (likely by the end of this week), so I tried to get the ball rolling for you guys (@edamboritz and @BrendanGalloway) even though I have no idea what I'm doing  :)