### PR TITLE
chore: set years to 3000 ignore compDate

### DIFF
--- a/sefaria/client/wrapper.py
+++ b/sefaria/client/wrapper.py
@@ -57,7 +57,7 @@ def format_link_object_for_client(link, with_text, ref, pos=None):
     compDate = getattr(linkRef.index, "compDate", None)
     if compDate:
         try:
-            com["compDate"] = compDate[0]
+            com["compDate"] = 3000
         except ValueError:
             com["compDate"] = 3000  # default comp date to in the future
         try:

--- a/sefaria/client/wrapper.py
+++ b/sefaria/client/wrapper.py
@@ -57,7 +57,7 @@ def format_link_object_for_client(link, with_text, ref, pos=None):
     compDate = getattr(linkRef.index, "compDate", None)
     if compDate:
         try:
-            com["compDate"] = int(compDate)
+            com["compDate"] = compDate[0]
         except ValueError:
             com["compDate"] = 3000  # default comp date to in the future
         try:

--- a/sefaria/model/garden.py
+++ b/sefaria/model/garden.py
@@ -444,18 +444,18 @@ class GardenStop(abst.AbstractMongoRecord):
             if getattr(i, "compDate", None):
                 errorMargin = int(getattr(i, "errorMargin", 0))
                 self.startIsApprox = self.endIsApprox = errorMargin > 0
-
-                try:
-                    year = int(getattr(i, "compDate"))
-                    self.start = year - errorMargin
-                    self.end = year + errorMargin
-                except ValueError as e:
-                    years = getattr(i, "compDate").split("-")
-                    if years[0] == "" and len(years) == 3:  #Fix for first value being negative
-                        years[0] = -int(years[1])
-                        years[1] = int(years[2])
-                    self.start = int(years[0]) - errorMargin
-                    self.end = int(years[1]) + errorMargin
+                self.start = self.end = 3000
+                # try:
+                #     year = int(getattr(i, "compDate"))
+                #     self.start = year - errorMargin
+                #     self.end = year + errorMargin
+                # except ValueError as e:
+                #     years = getattr(i, "compDate").split("-")
+                #     if years[0] == "" and len(years) == 3:  #Fix for first value being negative
+                #         years[0] = -int(years[1])
+                #         years[1] = int(years[2])
+                #     self.start = int(years[0]) - errorMargin
+                #     self.end = int(years[1]) + errorMargin
 
             elif author and author.mostAccurateTimePeriod():
                 tp = author.mostAccurateTimePeriod()

--- a/sefaria/model/text.py
+++ b/sefaria/model/text.py
@@ -459,21 +459,21 @@ class Index(abst.AbstractMongoRecord, AbstractIndex):
         if getattr(self, "compDate", None):
             errorMargin = int(getattr(self, "errorMargin", 0))
             self.startIsApprox = self.endIsApprox = errorMargin > 0
-
-            try:
-                year = int(getattr(self, "compDate"))
-                start = year - errorMargin
-                end = year + errorMargin
-            except ValueError as e:
-                years = getattr(self, "compDate").split("-")
-                if years[0] == "" and len(years) == 3:  #Fix for first value being negative
-                    years[0] = -int(years[1])
-                    years[1] = int(years[2])
-                try:
-                    start = int(years[0]) - errorMargin
-                    end = int(years[1]) + errorMargin
-                except UnicodeEncodeError as e:
-                    pass
+            start = end = 3000
+            # try:
+            #     year = int(getattr(self, "compDate"))
+            #     start = year - errorMargin
+            #     end = year + errorMargin
+            # except ValueError as e:
+            #     years = getattr(self, "compDate").split("-")
+            #     if years[0] == "" and len(years) == 3:  #Fix for first value being negative
+            #         years[0] = -int(years[1])
+            #         years[1] = int(years[2])
+            #     try:
+            #         start = int(years[0]) - errorMargin
+            #         end = int(years[1]) + errorMargin
+            #     except UnicodeEncodeError as e:
+            #         pass
 
         else:
             author = self.author_objects()[0] if len(self.author_objects()) > 0 else None
@@ -510,21 +510,21 @@ class Index(abst.AbstractMongoRecord, AbstractIndex):
         except ValueError:
             error_margin = 0
         startIsApprox = endIsApprox = error_margin > 0
-
-        try:
-            year = int(getattr(self, date_field))
-            start = year - error_margin
-            end = year + error_margin
-        except ValueError as e:
-            try:
-                years = getattr(self, date_field).split("-")
-                if years[0] == "" and len(years) == 3:  #Fix for first value being negative
-                    years[0] = -int(years[1])
-                    years[1] = int(years[2])
-                start = int(years[0]) - error_margin
-                end = int(years[1]) + error_margin
-            except ValueError as e:
-                return None
+        start = end = 3000
+        # try:
+        #     year = int(getattr(self, date_field))
+        #     start = year - error_margin
+        #     end = year + error_margin
+        # except ValueError as e:
+        #     try:
+        #         years = getattr(self, date_field).split("-")
+        #         if years[0] == "" and len(years) == 3:  #Fix for first value being negative
+        #             years[0] = -int(years[1])
+        #             years[1] = int(years[2])
+        #         start = int(years[0]) - error_margin
+        #         end = int(years[1]) + error_margin
+        #     except ValueError as e:
+        #         return None
         return timeperiod.TimePeriod({
             "start": start,
             "startIsApprox": startIsApprox,


### PR DESCRIPTION
We are temporarily setting compDate to 3000 across the site in preparation for running a script that normalizes dates by converting strings into lists.  We will then deploy a different branch with code that properly handles compDate as a list