### PR TITLE
Fix learning team links

### DIFF
--- a/sefaria/helper/topic.py
+++ b/sefaria/helper/topic.py
@@ -129,10 +129,8 @@ def update_data_source_in_link(curr_link, new_link, data_source):
     return curr_link
 
 def update_refs(curr_link, new_link):
-    # in case the new_link was created by the learning team, we want to use ref of learning team link
-    # in the case when neither link is from the learning team, use whichever ref covers a smaller range
-    if is_learning_team(curr_link['dataSources']) or len(curr_link['expandedRefs']) > len(
-            new_link['expandedRefs']):
+    # use whichever ref covers a smaller range
+    if len(curr_link['expandedRefs']) > len(new_link['expandedRefs']):
         curr_link['ref'] = new_link['ref']
         curr_link['expandedRefs'] = new_link['expandedRefs']
     return curr_link
@@ -172,7 +170,7 @@ def iterate_and_merge(new_ref_links, new_link, subset_ref_map, temp_subset_refs)
         for index in subset_ref_map[seg_ref]:
             new_ref_links[index]['similarRefs'] += [new_link]
             curr_link_learning_team = any([is_learning_team(dataSource) for dataSource in new_ref_links[index]['dataSources']])
-            if not curr_link_learning_team:  # if learning team, ignore overlapping refs
+            if not curr_link_learning_team:  # if learning team, ignore source with overlapping refs
                 new_ref_links[index] = merge_props_for_similar_refs(new_ref_links[index], new_link)
     return new_ref_links
 

--- a/sefaria/helper/topic.py
+++ b/sefaria/helper/topic.py
@@ -1255,12 +1255,12 @@ def delete_ref_topic_link(tref, to_topic, link_type, lang):
     if link is None:
         return {"error": f"Link between {tref} and {to_topic} doesn't exist."}
 
-    if lang in link.order['availableLangs']:
+    if lang in link.order.get('availableLangs', []):
         link.order['availableLangs'].remove(lang)
-    if lang in link.order['curatedPrimacy']:
+    if lang in link.order.get('curatedPrimacy', []):
         link.order['curatedPrimacy'].pop(lang)
 
-    if len(link.order['availableLangs']) > 0:
+    if len(link.order.get('availableLangs', [])) > 0:
         link.save()
         return {"status": "ok"}
     else:   # deleted in both hebrew and english so delete link object

--- a/static/js/CategoryEditor.jsx
+++ b/static/js/CategoryEditor.jsx
@@ -22,7 +22,7 @@ const Reorder = ({subcategoriesAndBooks, updateOrder, displayType, updateParentC
     const clickHandler = (dir, child) => {
         const index = subcategoriesAndBooks.indexOf(child);
         let index_to_swap = -1;
-        if (dir === 'down' && index < subcategoriesAndBooks.length)
+        if (dir === 'down' && index < subcategoriesAndBooks.length - 1)
         {
             index_to_swap = index + 1;
         }


### PR DESCRIPTION
1.  When merging sources to display in a topic page, any source added by the learning team should be treated separately.  I added checks [here](https://github.com/Sefaria/Sefaria-Project/compare/fix_learning_team_links?expand=1#diff-19364da9061bcb429f3f3c5f63aeab5541e461154bd59e61719b2cd68f631356R173) and [here](https://github.com/Sefaria/Sefaria-Project/compare/fix_learning_team_links?expand=1#diff-19364da9061bcb429f3f3c5f63aeab5541e461154bd59e61719b2cd68f631356R185-R186)
2. I removed the decorator function which was interfering in the merging of two sources where the new one isn't a learning team source.  We wanted to use the source with the smaller expandedRefs but that was not possible because of the decorator.  And it's irrelevant now that learning team links are not merged with others.
3. I also fixed a bug when deleting sources if the source had no curatedPrimacy [here](https://github.com/Sefaria/Sefaria-Project/compare/fix_learning_team_links?expand=1#diff-19364da9061bcb429f3f3c5f63aeab5541e461154bd59e61719b2cd68f631356L1253)
4. Finally, I fixed a minor bug [here](https://github.com/Sefaria/Sefaria-Project/compare/fix_learning_team_links?expand=1#diff-475168e098f3c1facb482e69846fc2ec04b59599ed36e103ae73276f2c93def0R25) involving clicking the down arrow on the last item in the list of sources.  