### PR TITLE
Banners were continuing to show up after interaction

### DIFF
--- a/static/js/Misc.jsx
+++ b/static/js/Misc.jsx
@@ -2426,18 +2426,29 @@ const Banner = ({ onClose }) => {
               <a
                 className="button white int-en"
                 href={strapi.banner.buttonURL.en}
+                onClick={() => {
+                  closeBanner("banner_button_clicked");
+                }}
               >
                 <span>{strapi.banner.buttonText.en}</span>
               </a>
               <a
                 className="button white int-he"
                 href={strapi.banner.buttonURL.he}
+                onClick={() => {
+                  closeBanner("banner_button_clicked");
+                }}
               >
                 <span>{strapi.banner.buttonText.he}</span>
               </a>
             </div>
           </div>
-          <div id="bannerMessageClose" onClick={closeBanner}>
+          <div
+            id="bannerMessageClose"
+            onClick={() => {
+              closeBanner("close_clicked");
+            }}
+          >
             ×
           </div>
         </div>

--- a/static/js/Misc.jsx
+++ b/static/js/Misc.jsx
@@ -2217,8 +2217,14 @@ const InterruptingMessage = ({
       shouldShowModal = true;
     else if (noUserKindIsSet) shouldShowModal = true;
     if (!shouldShowModal) return false;
-
+    // Don't show the modal on pages where the button link goes to since you're already there
     const excludedPaths = ["/donate", "/mobile", "/app", "/ways-to-give"];
+    if (strapi.modal.buttonURL) {
+      excludedPaths.push(
+        new URL(strapi.modal.buttonURL.en).pathname,
+        new URL(strapi.modal.buttonURL.he).pathname
+      );
+    }
     return excludedPaths.indexOf(window.location.pathname) === -1;
   };
 
@@ -2377,6 +2383,13 @@ const Banner = ({ onClose }) => {
     if (!shouldShowBanner) return false;
 
     const excludedPaths = ["/donate", "/mobile", "/app", "/ways-to-give"];
+    // Don't show the banner on pages where the button link goes to since you're already there
+    if (strapi.banner.buttonURL) {
+      excludedPaths.push(
+        new URL(strapi.banner.buttonURL.en).pathname,
+        new URL(strapi.banner.buttonURL.he).pathname
+      );
+    }
     return excludedPaths.indexOf(window.location.pathname) === -1;
   };
 


### PR DESCRIPTION
Banners were continuing to show up after the donate/banner button was clicked. Tracking events for banner button clicks and banner closes was also missing. This PR fixes both problems. This assumes that the banner should not be shown again after the button is clicked on a different page load and that it should be closed on the current page when the button is clicked.