### PR TITLE
fix(Index Save): validate compDate and pubDate are lists of integers

### DIFF
--- a/sefaria/model/text.py
+++ b/sefaria/model/text.py
@@ -687,11 +687,11 @@ class Index(abst.AbstractMongoRecord, AbstractIndex):
         if not Category().load({"path": self.categories}):
             raise InputError("You must create category {} before adding texts to it.".format("/".join(self.categories)))
 
-        for dateKey in ['compDate', 'pubDate']:
-            if hasattr(self, dateKey):
-                val = getattr(self, dateKey)
+        for date_key in ['compDate', 'pubDate']:
+            if hasattr(self, date_key):
+                val = getattr(self, date_key)
                 if not isinstance(val, list) or not all([isinstance(x, int) for x in val]):
-                    raise InputError(f"Optional attribute '{dateKey}' must be list of integers.")
+                    raise InputError(f"Optional attribute '{date_key}' must be list of integers.")
 
         '''
         for cat in self.categories:

--- a/sefaria/model/text.py
+++ b/sefaria/model/text.py
@@ -687,6 +687,12 @@ class Index(abst.AbstractMongoRecord, AbstractIndex):
         if not Category().load({"path": self.categories}):
             raise InputError("You must create category {} before adding texts to it.".format("/".join(self.categories)))
 
+        for dateKey in ['compDate', 'pubDate']:
+            if hasattr(self, dateKey):
+                val = getattr(self, dateKey)
+                if not isinstance(val, list) or not all([isinstance(x, int) for x in val]):
+                    raise InputError(f"Optional attribute '{dateKey}' must be list of integers.")
+
         '''
         for cat in self.categories:
             if not hebrew_term(cat):


### PR DESCRIPTION
I added this to prevent us from adding compDate and pubDate values that are not lists of integers as someone did recently change compDate and pubDate of two texts to integers seemingly via the API.  (It isn't possible to make this mistake using the admin tool UI so I assume the only possibility is the API).