### PR TITLE
Banners don't jumble up the mobile navigation menu anymore!

### DIFF
--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -606,7 +606,7 @@ input.noselect {
   font-size: 18px;
 }
 .mobileNavMenu {
-  position: fixed;
+  position: absolute;
   height: calc(100% - 60px);
   box-sizing: border-box;
   top: 60px;

--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -616,6 +616,12 @@ input.noselect {
   z-index: 1000;
   overflow-y: scroll;
 }
+div:has(#bannerMessage) + .readerApp.singlePanel .mobileNavMenu {
+  position: fixed; /*This takes the 60px of the header plus 120px of the banner into account */
+  height: calc(100vh - 180px);
+  top: 180px;
+}
+
 .mobileNavMenu.closed {
   display: none;
 }

--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -606,7 +606,7 @@ input.noselect {
   font-size: 18px;
 }
 .mobileNavMenu {
-  position: absolute;
+  position: fixed;
   height: calc(100vh - 60px);
   box-sizing: border-box;
   top: 60px;
@@ -620,6 +620,12 @@ div:has(#bannerMessage) + .readerApp.singlePanel .mobileNavMenu {
   position: fixed; /*This takes the 60px of the header plus 120px of the banner into account */
   height: calc(100vh - 180px);
   top: 180px;
+}
+@supports not selector(:has(a, b)) {
+  /* Fallback for when :has() is unsupported */
+  .mobileNavMenu {
+    position: absolute;
+  }
 }
 
 .mobileNavMenu.closed {

--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -607,7 +607,7 @@ input.noselect {
 }
 .mobileNavMenu {
   position: absolute;
-  height: calc(100% - 60px);
+  height: calc(100vh - 60px);
   box-sizing: border-box;
   top: 60px;
   width: 100%;


### PR DESCRIPTION
A simple property change was made to ensure the navigation menu on mobile web is displayed properly when a banner is displayed.

In collaboration with @yonadavGit :)