### PR TITLE
fix: Performance improvement of Ref.contains

### DIFF
--- a/sefaria/model/tests/ref_test.py
+++ b/sefaria/model/tests/ref_test.py
@@ -744,6 +744,7 @@ class Test_comparisons(object):
         assert not Ref("Exodus 6:2").contains(Ref("Exodus"))
         assert not Ref("Exodus 6:2-12").contains(Ref("Exodus"))
 
+        assert Ref("Leviticus").contains(Ref("Leviticus"))
         assert Ref("Leviticus").contains(Ref("Leviticus 1:1-27.34"))
         assert Ref("Leviticus").contains(Ref("Leviticus 1-27"))
         assert Ref("Leviticus 1:1-27.34").contains(Ref("Leviticus"))

--- a/sefaria/model/tests/ref_test.py
+++ b/sefaria/model/tests/ref_test.py
@@ -744,6 +744,17 @@ class Test_comparisons(object):
         assert not Ref("Exodus 6:2").contains(Ref("Exodus"))
         assert not Ref("Exodus 6:2-12").contains(Ref("Exodus"))
 
+        assert Ref("Leviticus").contains(Ref("Leviticus 1:1-27.34"))
+        assert Ref("Leviticus").contains(Ref("Leviticus 1-27"))
+        assert Ref("Leviticus 1:1-27.34").contains(Ref("Leviticus"))
+        assert not Ref("Leviticus 1:1-27.30").contains(Ref("Leviticus"))
+        assert not Ref("Leviticus 1:2-27.30").contains(Ref("Leviticus"))
+        assert not Ref("Leviticus 2:2-27.30").contains(Ref("Leviticus"))
+
+        # These fail, and always did
+        # assert not Ref("Leviticus").contains(Ref("Leviticus 1:1-27.35"))
+        # assert not Ref("Leviticus").contains(Ref("Leviticus 1-28"))
+
         assert Ref("Rashi on Genesis 5:10-20").contains(Ref("Rashi on Genesis 5:18-20"))
         assert not Ref("Rashi on Genesis 5:10-20").contains(Ref("Rashi on Genesis 5:21-25"))
         assert not Ref("Rashi on Genesis 5:10-20").contains(Ref("Rashi on Genesis 5:15-25"))

--- a/sefaria/model/text.py
+++ b/sefaria/model/text.py
@@ -4230,8 +4230,11 @@ class Ref(object, metaclass=RefCacheType):
         if not self.index_node == other.index_node:
             return self.index_node.is_ancestor_of(other.index_node)
 
-        # If other is less specific than self, we need to get its true extent
-        if len(self.sections) > len(other.sections):
+        if len(self.sections) > len(other.sections): # other is less specific than self
+            if len(other.sections) == 0:  # other is a whole book
+                if any([x != 1 for x in self.sections]):  # self is not a whole book
+                    return False  # performance optimization to avoid call to as_ranged_segment_ref
+            # we need to get the true extent of other
             other = other.as_ranged_segment_ref()
 
         smallest_section_len = min([len(self.sections), len(other.sections)])

--- a/sefaria/model/text_manager.py
+++ b/sefaria/model/text_manager.py
@@ -6,6 +6,7 @@ from sefaria.model import *
 from sefaria.utils.hebrew import hebrew_term
 from typing import List
 
+
 class TextManager:
     ALL = 'all'
     BASE = 'base'


### PR DESCRIPTION
If `other` Ref is a whole book, and `self` begins anywhere after first segment, `contains` is trivially false and we can avoid expensive code.