### PR TITLE
Remove unused React dependencies from sefaria.js

### DIFF
--- a/static/js/sefaria/sefaria.js
+++ b/static/js/sefaria/sefaria.js
@@ -9,8 +9,6 @@ import Track from './track';
 import Hebrew from './hebrew';
 import Util from './util';
 import $ from './sefariaJquery';
-import {useContext} from "react";
-import {ContentLanguageContext} from "../context";
 
 
 let Sefaria = Sefaria || {


### PR DESCRIPTION
This PR addresses https://github.com/Sefaria/Sefaria-Project/issues/1693. 
It flagged the fact that React imports were left over in sefaria.js and created the impression (both to human and machine bundler alike) that sefaria.js is dependent upon React.  

The PR undoes commit https://github.com/Sefaria/Sefaria-Project/pull/1507/commits/1af87886e84b6eafe6ee2f0bd817d7d0c131af4c#diff-2f1b7852161a95e253017883a3aa2a5d372103e32b61cfd95ff57edc7ffaaf43 in PR 
https://github.com/Sefaria/Sefaria-Project/pull/1507/files#diff-2f1b7852161a95e253017883a3aa2a5d372103e32b61cfd95ff57edc7ffaaf43

This is done to ensure that sefaria.js uses vanilla js and does not become dependent on React