### PR TITLE
Period year

### DIFF
--- a/sefaria/model/timeperiod.py
+++ b/sefaria/model/timeperiod.py
@@ -225,6 +225,16 @@ class TimePeriod(abst.AbstractMongoRecord):
             else:
                 return topic.Topic({"properties.generation.value": self.symbol})
 
+    def determine_year_estimate(self):
+        start = getattr(self, 'start', None)
+        end = getattr(self, 'end', None)
+        if start != None and end != None:
+            return round((int(start) + int(end)) / 2)
+        elif start != None:
+            return int(start)
+        elif end != None:
+            return int(end)
+
 class TimePeriodSet(abst.AbstractMongoSet):
     recordClass = TimePeriod
 

--- a/sefaria/pagesheetrank.py
+++ b/sefaria/pagesheetrank.py
@@ -212,8 +212,8 @@ def init_pagerank_graph(ref_list=None):
                 refs = [Ref(r) for r in link.refs]
                 tp1 = refs[0].index.best_time_period()
                 tp2 = refs[1].index.best_time_period()
-                start1 = int(tp1.start) if tp1 else 3000
-                start2 = int(tp2.start) if tp2 else 3000
+                start1 = int(tp1.determine_year_estimate()) if tp1 else 3000
+                start2 = int(tp2.determine_year_estimate()) if tp2 else 3000
 
                 older_ref, newer_ref = (refs[0], refs[1]) if start1 < start2 else (refs[1], refs[0])
 


### PR DESCRIPTION
this PR should solve this problem in reindex ElasticSearch - https://sefaria.slack.com/archives/C1DAVPYJZ/p1699190830515399
it adds a new function to TimePeriod - determine_year_estimate, and uses it in page ranking rather than using the start attribute which is not a required attribute.