### PR TITLE
Allow banners/modals to render when there isn't a Hebrew localization

### DIFF
--- a/static/js/Misc.jsx
+++ b/static/js/Misc.jsx
@@ -2220,10 +2220,12 @@ const InterruptingMessage = ({
     // Don't show the modal on pages where the button link goes to since you're already there
     const excludedPaths = ["/donate", "/mobile", "/app", "/ways-to-give"];
     if (strapi.modal.buttonURL) {
-      excludedPaths.push(
-        new URL(strapi.modal.buttonURL.en).pathname,
-        new URL(strapi.modal.buttonURL.he).pathname
-      );
+      if (strapi.modal.buttonURL.en) {
+        excludedPaths.push(new URL(strapi.modal.buttonURL.en).pathname);
+      }
+      if (strapi.modal.buttonURL.he) {
+        excludedPaths.push(new URL(strapi.modal.buttonURL.he).pathname);
+      }
     }
     return excludedPaths.indexOf(window.location.pathname) === -1;
   };
@@ -2385,10 +2387,12 @@ const Banner = ({ onClose }) => {
     const excludedPaths = ["/donate", "/mobile", "/app", "/ways-to-give"];
     // Don't show the banner on pages where the button link goes to since you're already there
     if (strapi.banner.buttonURL) {
-      excludedPaths.push(
-        new URL(strapi.banner.buttonURL.en).pathname,
-        new URL(strapi.banner.buttonURL.he).pathname
-      );
+      if (strapi.banner.buttonURL.en) {
+        excludedPaths.push(new URL(strapi.banner.buttonURL.en).pathname);
+      }
+      if (strapi.banner.buttonURL.he) {
+        excludedPaths.push(new URL(strapi.banner.buttonURL.he).pathname);
+      }
     }
     return excludedPaths.indexOf(window.location.pathname) === -1;
   };


### PR DESCRIPTION
A bug was introduced in https://github.com/Sefaria/Sefaria-Project/pull/1663 that prevented banners/modals from showing up and the web app from loading if there was only a default English localization and not a Hebrew one. Banners were previously able to be rendered without a Hebrew localization, allowing banners to be targeted towards only English interface users. If a Hebrew localization was not defined, the button URL would cause a null reference error.