### PR TITLE
fix(Search): josephus doesnt freeze search

### DIFF
--- a/static/js/Header.jsx
+++ b/static/js/Header.jsx
@@ -332,10 +332,8 @@ class SearchBar extends Component {
           this.props.openTopic(d["topic_slug"]);
           this.props.onNavigate && this.props.onNavigate();
 
-        } else if (d["type"] === "Person" || d["type"] === "Topic" || d["type"] === "AuthorTopic"
-            || d["type"] === "Collection" || d["type"] === "TocCategory") {
+        } else if (d["type"] === "Person" || d["type"] === "Collection" || d["type"] === "TocCategory") {
           this.redirectToObject(d["type"], d["key"]);
-
         } else {
           Sefaria.track.event("Search", "Search Box Search", query);
           this.closeSearchAutocomplete();

--- a/static/js/Header.jsx
+++ b/static/js/Header.jsx
@@ -306,12 +306,10 @@ class SearchBar extends Component {
     Sefaria.getName(query)
       .then(d => {
         // If the query isn't recognized as a ref, but only for reasons of capitalization. Resubmit with recognizable caps.
-        if (Sefaria.isACaseVariant(query, d)) {
-          const repairedQuery = Sefaria.repairCaseVariant(query, d);
-          if (repairedQuery !== query) {
-            this.submitSearch(repairedQuery);
-            return;
-          }
+        const repairedCaseVariant = Sefaria.repairCaseVariant(query, d);
+        if (repairedCaseVariant !== query) {
+          this.submitSearch(repairedCaseVariant);
+          return;
         }
         const repairedQuery = Sefaria.repairGershayimVariant(query, d);
         if (repairedQuery !== query) {

--- a/static/js/Header.jsx
+++ b/static/js/Header.jsx
@@ -307,8 +307,11 @@ class SearchBar extends Component {
       .then(d => {
         // If the query isn't recognized as a ref, but only for reasons of capitalization. Resubmit with recognizable caps.
         if (Sefaria.isACaseVariant(query, d)) {
-          this.submitSearch(Sefaria.repairCaseVariant(query, d));
-          return;
+          const repairedQuery = Sefaria.repairCaseVariant(query, d);
+          if (repairedQuery !== query) {
+            this.submitSearch(repairedQuery);
+            return;
+          }
         }
         const repairedQuery = Sefaria.repairGershayimVariant(query, d);
         if (repairedQuery !== query) {
@@ -329,7 +332,8 @@ class SearchBar extends Component {
           this.props.openTopic(d["topic_slug"]);
           this.props.onNavigate && this.props.onNavigate();
 
-        } else if (d["type"] === "Person" || d["type"] === "Collection" || d["type"] === "TocCategory") {
+        } else if (d["type"] === "Person" || d["type"] === "Topic" || d["type"] === "AuthorTopic"
+            || d["type"] === "Collection" || d["type"] === "TocCategory") {
           this.redirectToObject(d["type"], d["key"]);
 
         } else {

--- a/static/js/sefaria/sefaria.js
+++ b/static/js/sefaria/sefaria.js
@@ -2001,20 +2001,22 @@ _media: {},
           data["completions"][0] != query.slice(0, data["completions"][0].length))
   },
   repairCaseVariant: function(query, data) {
-    // Used when isACaseVariant() is true to prepare the alternative
-    const completionArray = data["completion_objects"].map(x => x.title);
-    let normalizedQuery = query.toLowerCase();
-    let bestMatch = "";
-    let bestMatchLength = 0;
+    if (Sefaria.isACaseVariant(query, data)) {
+        const completionArray = data["completion_objects"].map(x => x.title);
+        let normalizedQuery = query.toLowerCase();
+        let bestMatch = "";
+        let bestMatchLength = 0;
 
-    completionArray.forEach((completion) => {
-        let normalizedCompletion = completion.toLowerCase();
-        if (normalizedQuery.includes(normalizedCompletion) && normalizedCompletion.length > bestMatchLength) {
-            bestMatch = completion;
-            bestMatchLength = completion.length;
-        }
-    });
-    return bestMatch + query.slice(bestMatch.length);
+        completionArray.forEach((completion) => {
+            let normalizedCompletion = completion.toLowerCase();
+            if (normalizedQuery.includes(normalizedCompletion) && normalizedCompletion.length > bestMatchLength) {
+                bestMatch = completion;
+                bestMatchLength = completion.length;
+            }
+        });
+        return bestMatch + query.slice(bestMatch.length);
+    }
+    return query;
   },
   repairGershayimVariant: function(query, data) {
     if (!data["is_ref"] && data.completions && !data.completions.includes(query)) {

--- a/static/js/sefaria/sefaria.js
+++ b/static/js/sefaria/sefaria.js
@@ -2002,7 +2002,7 @@ _media: {},
   },
   repairCaseVariant: function(query, data) {
     // Used when isACaseVariant() is true to prepare the alternative
-    const completionArray = data["completion_objects"].filter(x => x.type === 'ref').map(x => x.title);
+    const completionArray = data["completion_objects"].map(x => x.title);
     let normalizedQuery = query.toLowerCase();
     let bestMatch = "";
     let bestMatchLength = 0;


### PR DESCRIPTION
"josephus" was setting off an infinite recursion where repairCaseVariant returns "josephus" each time because it is designed to correct refs not topics/categories.  My solution is not call submitSearch if repairCaseVariant returns the same value as the inputted value and avoid the recursion.  I also noticed that topics won't get opened unless the search starts with "#" so I added a check to see if the type is "Topic" or "AuthorTopic".  