### PR TITLE
Check for db name existence

### DIFF
--- a/reader/views.py
+++ b/reader/views.py
@@ -4543,11 +4543,19 @@ def rollout_health_api(request):
         except Exception as e:
             logger.warn(f"Failed node healthcheck. Error: {e}")
             return False
+        
+    def is_database_reachable():
+        try:
+            from sefaria.system.database import db
+            return True
+        except SystemError as ivne:
+            return False
 
-    allReady = isRedisReachable() and isMultiserverReachable() and isNodeJsReachable()
+    allReady = isRedisReachable() and isMultiserverReachable() and isNodeJsReachable() and is_database_reachable()
 
     resp = {
         'allReady': allReady,
+        'dbConnected': f'Database Connection: {is_database_reachable()}',
         'multiserverReady': isMultiserverReachable(),
         'redisReady': isRedisReachable(),
         'nodejsReady': isNodeJsReachable(),

--- a/sefaria/system/database.py
+++ b/sefaria/system/database.py
@@ -9,6 +9,20 @@ from pymongo.errors import OperationFailure
 
 from sefaria.settings import *
 
+def check_db_exists(db_name):
+    dbnames = client.list_database_names()
+    return db_name in dbnames
+
+
+def connect_to_db(db_name):
+    if not check_db_exists(db_name):
+        raise SystemError(f'Database {db_name} does not exist!')
+    return client[db_name]
+
+def get_test_db():
+    return client[TEST_DB]
+
+
 if hasattr(sys, '_doc_build'):
     db = ""
 else:
@@ -37,13 +51,10 @@ else:
 
     # Now set the db variable to point to the Sefaria database in the server
     if not hasattr(sys, '_called_from_test'):
-        db = client[SEFARIA_DB]
+        db = connect_to_db(SEFARIA_DB)
     else:
-        db = client[TEST_DB] 
+        db = connect_to_db(TEST_DB)
 
-
-def get_test_db():
-    return client[TEST_DB]
 
 
 def drop_test():


### PR DESCRIPTION
(Duplicate of previous https://github.com/Sefaria/Sefaria-Project/pull/1655 in order to replace it being merged into a discarded branch)
This PR addresses the fact that mongo/pymongo does not error out by itself if you attempt to connect to a database on the server the client is connected to.

This adds functionality that will check the db name's existence on the server first and throw an exception if not, this blocking the website from functioning.

Also added a clause to the healthz health check, but that will probably never get called because now the code will error way before.