### PR TITLE
Change "non-profit" to "nonprofit" in all instances

### DIFF
--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -1057,7 +1057,7 @@ msgstr ""
 
 #: templates/static/en/about.html:6 templates/static/he/about.html:6
 msgid ""
-"Sefaria is a non-profit organization dedicated to building the future of "
+"Sefaria is a nonprofit organization dedicated to building the future of "
 "Jewish learning in an open and participatory way."
 msgstr ""
 
@@ -1091,7 +1091,7 @@ msgstr ""
 
 #: templates/static/jobs.html:6
 msgid ""
-"Job openings at Sefaria, a non-profit technology organization dedicated to "
+"Job openings at Sefaria, a nonprofit technology organization dedicated to "
 "building the Jewish future."
 msgstr ""
 

--- a/locale/he/LC_MESSAGES/django.po
+++ b/locale/he/LC_MESSAGES/django.po
@@ -1132,7 +1132,7 @@ msgstr "אודות ספריא"
 
 #: templates/static/en/about.html:6 templates/static/he/about.html:6
 msgid ""
-"Sefaria is a non-profit organization dedicated to building the future of "
+"Sefaria is a nonprofit organization dedicated to building the future of "
 "Jewish learning in an open and participatory way."
 msgstr ""
 "ספריא היא עמותה ללא מטרות רווה השואפת לעיצוב עתיד הלימוד היהודי כך שיהא פתוח "
@@ -1168,7 +1168,7 @@ msgstr "משרות בספריא"
 
 #: templates/static/jobs.html:6
 msgid ""
-"Job openings at Sefaria, a non-profit technology organization dedicated to "
+"Job openings at Sefaria, a nonprofit technology organization dedicated to "
 "building the Jewish future."
 msgstr ""
 "משרות פנויות בספריא, עמותה ללא מטרות רווח שמטרתה הבטחת העתיד הטכנולוגי של "

--- a/static/js/NavSidebar.jsx
+++ b/static/js/NavSidebar.jsx
@@ -97,7 +97,7 @@ const AboutSefaria = ({hideTitle}) => (
     <ModuleTitle h1={true}>A Living Library of Torah</ModuleTitle> : null }
     <InterfaceText>
       <EnglishText>
-          Sefaria is home to 3,000 years of Jewish texts. We are a non-profit organization offering free access to texts, translations,
+          Sefaria is home to 3,000 years of Jewish texts. We are a nonprofit organization offering free access to texts, translations,
           and commentaries so that everyone can participate in the ongoing process of studying, interpreting, and creating Torah.
         </EnglishText>
         <HebrewText>
@@ -135,7 +135,7 @@ const AboutTranslatedText = ({translationsSlug}) => {
     "fi": {title: "Tooran elävä kirjasto", body: "Sefaria on koti 3000 vuoden juutalaisille teksteille. Olemme voittoa tavoittelematon organisaatio, joka tarjoaa ilmaisen pääsyn teksteihin, käännöksiin ja kommentteihin, jotta kaikki voivat osallistua jatkuvaan Tooran opiskelu-, tulkkaus- ja luomisprosessiin."},
     "fr": {title: "Une bibliothèque vivante de la Torah", body: "Une bibliothèque de Torah vivante. Sefaria abrite 3 000 ans de textes juifs. Nous sommes une organisation à but non lucratif offrant un accès gratuit aux textes de la Torah, aux commentaires et aux traductions, afin que chacun puisse participer au processus infini de l'étude, de l'interprétation et de la création de la Torah."},
     "it": {title: "Una biblioteca vivente della Torah", body: "Sefaria ospita 3.000 anni di testi ebraici. Siamo un'organizzazione senza scopo di lucro che offre libero accesso a testi, traduzioni e commenti in modo che tutti possano partecipare al processo in corso di studio, interpretazione e creazione della Torah."},
-    "pl": {title: "Żywa Biblioteka Tory", body: "Sefaria jest domem dla 3000 lat żydowskich tekstów. Jesteśmy organizacją non-profit oferującą bezpłatny dostęp do tekstów, tłumaczeń i komentarzy, dzięki czemu każdy może uczestniczyć w bieżącym procesie studiowania, tłumaczenia i tworzenia Tory."},
+    "pl": {title: "Żywa Biblioteka Tory", body: "Sefaria jest domem dla 3000 lat żydowskich tekstów. Jesteśmy organizacją nonprofit oferującą bezpłatny dostęp do tekstów, tłumaczeń i komentarzy, dzięki czemu każdy może uczestniczyć w bieżącym procesie studiowania, tłumaczenia i tworzenia Tory."},
     "pt": {title: "Uma Biblioteca Viva da Torá", body: "Sefaria é o lar de 3.000 anos de textos judaicos. Somos uma organização sem fins lucrativos que oferece acesso gratuito a textos, traduções e comentários para que todos possam participar do processo contínuo de estudo, interpretação e criação da Torá."},
     "ru": {title: "Живая библиотека Торы", body: "Сефария является домом для еврейских текстов 3000-летней давности. Мы — некоммерческая организация, предлагающая бесплатный доступ к текстам, переводам и комментариям, чтобы каждый мог участвовать в продолжающемся процессе изучения, толкования и создания Торы."},
     "yi": {title: "א לעבעדיקע ביבליאטעק פון תורה", body: "אין ספֿריאַ איז אַ היים פֿון 3,000 יאָר ייִדישע טעקסטן. מיר זענען אַ נאַן-נוץ אָרגאַניזאַציע וואָס אָפפערס פריי אַקסעס צו טעקסטן, איבערזעצונגען און קאָמענטאַרן אַזוי אַז אַלעמען קענען אָנטייל נעמען אין די אָנגאָינג פּראָצעס פון לערנען, ינטערפּריטיישאַן און שאפן תורה."}
@@ -148,7 +148,7 @@ const AboutTranslatedText = ({translationsSlug}) => {
           translationLookup[translationsSlug]["body"] :
           <InterfaceText>
           <EnglishText>
-          Sefaria is home to 3,000 years of Jewish texts. We are a non-profit organization offering free access to texts, translations,
+          Sefaria is home to 3,000 years of Jewish texts. We are a nonprofit organization offering free access to texts, translations,
           and commentaries so that everyone can participate in the ongoing process of studying, interpreting, and creating Torah.
         </EnglishText>
         <HebrewText>
@@ -191,7 +191,7 @@ const TheJewishLibrary = ({hideTitle}) => (
 const SupportSefaria = ({blue}) => (
   <Module blue={blue}>
     <ModuleTitle>Support Sefaria</ModuleTitle>
-    <InterfaceText>Sefaria is an open source, non-profit project. Support us by making a tax-deductible donation.</InterfaceText>
+    <InterfaceText>Sefaria is an open source, nonprofit project. Support us by making a tax-deductible donation.</InterfaceText>
     <br />
     <DonateLink classes={"button small" + (blue ? " white" : "")} source={"NavSidebar-SupportSefaria"}>
       <img src="/static/img/heart.png" alt="donation icon" />

--- a/static/js/StaticPages.jsx
+++ b/static/js/StaticPages.jsx
@@ -1973,7 +1973,7 @@ const PoweredByPage = () => (
         />
         <Feature
             enTitle="Dicta"
-            enText="Dicta is a non-profit research organization based in Israel that applies cutting-edge machine learning and natural language processing (the ability of a computer program to understand human language as it is spoken and written) to the analysis of Hebrew texts. Sefaria and Dicta often collaborate, sharing texts and splitting the costs of shared projects. Dicta offers a broad range of tools for free use by anyone, including the ability to add nikud (vocalization) to text as you type, intuitive Talmud and Bible search, and more."
+            enText="Dicta is a nonprofit research organization based in Israel that applies cutting-edge machine learning and natural language processing (the ability of a computer program to understand human language as it is spoken and written) to the analysis of Hebrew texts. Sefaria and Dicta often collaborate, sharing texts and splitting the costs of shared projects. Dicta offers a broad range of tools for free use by anyone, including the ability to add nikud (vocalization) to text as you type, intuitive Talmud and Bible search, and more."
             enImg="/static/img/powered-by-landing-page/talmudsearch.dicta.org.il_.png"
             enImgAlt="Screenshot of Dicta"
             borderColor={palette.colors.lightblue}

--- a/static/js/StaticPages.jsx
+++ b/static/js/StaticPages.jsx
@@ -2904,7 +2904,7 @@ const JobsPageHeader = ({ jobsAreAvailable }) => {
                         </h2>
                         <p>
                             <span className="int-en">
-                                Sefaria is a non-profit organization dedicated to creating the
+                                Sefaria is a nonprofit organization dedicated to creating the
                                 future of Torah in an open and participatory way. We are assembling
                                 a free, living library of Jewish texts and their interconnections,
                                 in Hebrew and in translation.

--- a/static/js/sefaria/strings.js
+++ b/static/js/sefaria/strings.js
@@ -35,7 +35,7 @@ const Strings = {
     "Stay Connected": "הישארו מעודכנים",
     "Get updates on new texts, learning resources, features, and more.": "קבלו עדכונים על מקורות חדשים, כלי למידה חדשים ועוד.",
     "Support Sefaria": "תמכו בספריא",
-    "Sefaria is an open source, non-profit project. Support us by making a tax-deductible donation.": "ספריא היא מאגר פתוח וחינמי. תמכו בנו בעזרת תרומה.",
+    "Sefaria is an open source, nonprofit project. Support us by making a tax-deductible donation.": "ספריא היא מאגר פתוח וחינמי. תמכו בנו בעזרת תרומה.",
     "Make a Donation": "לתרומה",
     "Join the Conversation": "קחו חלק בשיח" ,
     "Explore the Community": "לעמוד הקהילה",

--- a/templates/static/app.html
+++ b/templates/static/app.html
@@ -334,7 +334,7 @@
             </div>
             <div id="mobilePageNonProfit">
                 <p class="int-en">
-                    Sefaria is a 501(c)(3) non-profit organization that creates open source software and publishes digital texts with open licenses.
+                    Sefaria is a 501(c)(3) nonprofit organization that creates open source software and publishes digital texts with open licenses.
                 </p>
                 <p class="int-he">
                     ספריא הוא אירגון ללא מטרת רווח לפי חוקי ארצות הברית אשר יוצר תוכנות חיפוש למקורות פתוחים לשימוש ומפרסם טקסטים דיגיטליים שאין עליהם זכויות יוצרים.

--- a/templates/static/aramaic-translation-contest.html
+++ b/templates/static/aramaic-translation-contest.html
@@ -154,7 +154,7 @@
                     <span class="int-he">אנו זקוקים לעזרתכם</span>
                 </h2>
                 <div class="description">
-                    <span class="int-en">Sefaria is an open source, non-profit project. Support us by making a tax-deductible donation.</span>
+                    <span class="int-en">Sefaria is an open source, nonprofit project. Support us by making a tax-deductible donation.</span>
                     <span class="int-he">פרויקט ספריא פתוח לקהל הרחב (open source) ללא מטרות רווח. תמכו בנו באמצעות תרומה פטורה ממס.</span>
                 </div>
                 <a href="/donate">

--- a/templates/static/dicta-thanks.html
+++ b/templates/static/dicta-thanks.html
@@ -30,7 +30,7 @@
                 </span>
             </p>
             <p>
-                <span class="int-en">Dicta is a non-profit organization that provides its products at no charge for the benefit of the public.</span>
+                <span class="int-en">Dicta is a nonprofit organization that provides its products at no charge for the benefit of the public.</span>
                 <span class="int-he">דיקטה היא עמותה ללא מטרת רווח המספקת את מוצריה ללא תשלום לטובת הכלל.</span>
             </p>
             <p>

--- a/templates/static/en/about.html
+++ b/templates/static/en/about.html
@@ -3,7 +3,7 @@
 
 {% block title %}{% trans "About Sefaria" %}{% endblock %}
 
-{% block description %}{% trans "Sefaria is a non-profit organization dedicated to building the future of Jewish learning in an open and participatory way." %}{% endblock %}
+{% block description %}{% trans "Sefaria is a nonprofit organization dedicated to building the future of Jewish learning in an open and participatory way." %}{% endblock %}
 
 {% block css %}
     #top #languageToggle {
@@ -47,7 +47,7 @@
                 </span>
             </p>
             <p>
-                <span class="int-en">Sefaria is a non-profit organization dedicated to building the future of Jewish learning in an open and participatory way.
+                <span class="int-en">Sefaria is a nonprofit organization dedicated to building the future of Jewish learning in an open and participatory way.
                     We are assembling a free living library of Jewish texts and their interconnections,
                     in Hebrew and in translation.
                     With these digital texts, we can create new, interactive interfaces for Web, tablet and mobile,
@@ -131,7 +131,7 @@
                     </span>
                 </section>
                 <section class="historyItem">
-                    <span class="int-en">Sefaria incorporates as a non-profit and hires its first employee – who remains at the company to this day!</span>
+                    <span class="int-en">Sefaria incorporates as a nonprofit and hires its first employee – who remains at the company to this day!</span>
                 </section>
                 <section class="historyItem">
                     <span class="int-en">The Sefaria library grows to 8.5 million words.</span>

--- a/templates/static/he/about.html
+++ b/templates/static/he/about.html
@@ -3,7 +3,7 @@
 
 {% block title %}{% trans "About Sefaria" %}{% endblock %}
 
-{% block description %}{% trans "Sefaria is a non-profit organization dedicated to building the future of Jewish learning in an open and participatory way." %}{% endblock %}
+{% block description %}{% trans "Sefaria is a nonprofit organization dedicated to building the future of Jewish learning in an open and participatory way." %}{% endblock %}
 
 {% block css %}
     #top #languageToggle {

--- a/templates/static/home.html
+++ b/templates/static/home.html
@@ -336,7 +336,7 @@
                     <span class="int-he">אנו זקוקים לעזרתכם</span>
                 </h2>
                 <div class="description systemText">
-                    <span class="int-en">Sefaria is an open source, non-profit project. Support us by making a tax-deductible donation.</span>
+                    <span class="int-en">Sefaria is an open source, nonprofit project. Support us by making a tax-deductible donation.</span>
                     <span class="int-he">פרויקט ספריא פתוח לקהל הרחב (open source) ללא מטרות רווח. תמכו בנו באמצעות תרומה פטורה ממס.</span>
                 </div>
                 <a href="/donate">

--- a/templates/static/jobs.html
+++ b/templates/static/jobs.html
@@ -3,7 +3,7 @@
 
 {% block title %}{% trans "Jobs at Sefaria" %}{% endblock %}
 
-{% block description %}{% trans "Job openings at Sefaria, a non-profit technology organization dedicated to building the Jewish future." %}{% endblock %}
+{% block description %}{% trans "Job openings at Sefaria, a nonprofit technology organization dedicated to building the Jewish future." %}{% endblock %}
 
 {% block content %}
 
@@ -22,7 +22,7 @@
             </h2>
             <p>
                 <span class="int-en">
-                    Sefaria is a non-profit organization dedicated to creating the future of Torah in an open and
+                    Sefaria is a nonprofit organization dedicated to creating the future of Torah in an open and
                     participatory way.
                     We are assembling a free, living library of Jewish texts and their interconnections, in Hebrew and
                     in translation.

--- a/templates/static/mobile.html
+++ b/templates/static/mobile.html
@@ -339,7 +339,7 @@
             </div>
             <div id="mobilePageNonProfit">
                 <p class="int-en">
-                    Sefaria is a 501(c)(3) non-profit organization that creates open source software and publishes digital texts with open licenses.
+                    Sefaria is a 501(c)(3) nonprofit organization that creates open source software and publishes digital texts with open licenses.
                 </p>
                 <p class="int-he">
                     ספריא הוא אירגון ללא מטרת רווח לפי חוקי ארצות הברית אשר יוצר תוכנות חיפוש למקורות פתוחים לשימוש ומפרסם טקסטים דיגיטליים שאין עליהם זכויות יוצרים.


### PR DESCRIPTION
Marketing and Communications has requested that "non-profit" be "nonprofit" instead in all visible text captions. All the relevant instances that are publicly visible have been changed. Caveat: I'm not sure if the instances specified in the Django translation strings files are actively used, but I changed them in case they are.