### PR TITLE
Allow "Chair" as a title for "Chairman"

### DIFF
--- a/static/js/StaticPages.jsx
+++ b/static/js/StaticPages.jsx
@@ -2712,26 +2712,23 @@ const BoardMember = ({ boardMember }) => (
 );
 
 const BoardMembers = ({ boardMembers }) => {
-    let chairmanBoardMember;
-    const chairmanIndex = boardMembers.findIndex(
-        (boardMember) =>
-            boardMember.teamMemberDetails.teamTitle.en.toLowerCase() ===
-            "chairman"
+    let chairBoardMember;
+    const chairIndex = boardMembers.findIndex((boardMember) =>
+        boardMember.teamMemberDetails.teamTitle.en.toLowerCase().includes("chair")
     );
-    if (chairmanIndex !== -1) {
-        chairmanBoardMember = boardMembers.splice(chairmanIndex, 1);
+    if (chairIndex !== -1) {
+        chairBoardMember = boardMembers.splice(chairIndex, 1);
     }
     const [cofounderBoardMembers, regularBoardMembers] = partition(
         boardMembers,
         (boardMember) =>
-            boardMember.teamMemberDetails.teamTitle.en.toLowerCase() ===
-            "co-founder"
+            boardMember.teamMemberDetails.teamTitle.en.toLowerCase().includes("founder")
     );
 
     return (
         <>
-            {chairmanBoardMember && (
-                <BoardMember boardMember={chairmanBoardMember[0]} />
+            {chairBoardMember && (
+                <BoardMember boardMember={chairBoardMember[0]} />
             )}
             {cofounderBoardMembers.map((boardMember) => (
                 <BoardMember key={boardMember.id} boardMember={boardMember} />


### PR DESCRIPTION
Currently, in the Board Members section of the Team page, the "chairman" is listed first and then the "co-founders" are listed next before the other board members. Marketing and Communications has requested that the title for Sefaria's current chairman to be "Chair" instead. 

This change was necessary to keep the chair first instead of being included with the other board members. This PR changes to allow for different variations to be used for those individuals' titles while still preserving the same ordering.

Should a more complex and custom ordering be needed in the future, each content entry for a team board member will need to be given a specified type instead of using their title as a workaround to determine their type.