### PR TITLE
fix(SearchFilters): changed 'path' regex to ignore books which the current book title is their prefix

### DIFF
--- a/sefaria/helper/search.py
+++ b/sefaria/helper/search.py
@@ -140,7 +140,9 @@ def get_filter_obj(type, filters, filter_fields):
 def make_filter(type, agg_type, agg_key):
     if type == "text":
         # filters with '/' might be leading to books. also, very unlikely they'll match an false positives
-        reg = re.escape(agg_key) + (".*" if "/" in agg_key else "/.*")
+        agg_key = agg_key.rstrip('/')
+        agg_key = re.escape(agg_key)
+        reg = f"{agg_key}|{agg_key}/.*"
         return Regexp(path=reg)
     elif type == "sheet":
         return Term(**{agg_type: agg_key})


### PR DESCRIPTION
bug fix:
search in book will return results for any book that starts with the book title you’re in. So searching in “Zohar” should return results for “Zohar Chadash” as well.