### PR TITLE
fix(Topics): display without links in the TOC but with links on topic pages

### DIFF
--- a/static/js/Misc.jsx
+++ b/static/js/Misc.jsx
@@ -60,7 +60,7 @@ const __filterChildrenByLanguage = (children, language) => {
   return newChildren;
 };
 
-const InterfaceText = ({text, html, markdown, children, context}) => {
+const InterfaceText = ({text, html, markdown, children, context, disallowedMarkdownElements=[]}) => {
   /**
    * Renders a single span for interface string with either class `int-en`` or `int-he` depending on Sefaria.interfaceLang.
    *  If passed explicit text or html objects as props with "en" and/or "he", will only use those to determine correct text or fallback text to display.
@@ -92,7 +92,7 @@ const InterfaceText = ({text, html, markdown, children, context}) => {
   return (
     html ?
       <span className={elemclasses} dangerouslySetInnerHTML={{__html: textResponse}}/>
-        : markdown ? <span className={elemclasses}><ReactMarkdown className={'reactMarkdown'} unwrapDisallowed={true} disallowedElements={['p']}>{textResponse}</ReactMarkdown></span>
+        : markdown ? <span className={elemclasses}><ReactMarkdown className={'reactMarkdown'} unwrapDisallowed={true} disallowedElements={['p', ...disallowedMarkdownElements]}>{textResponse}</ReactMarkdown></span>
                     : <span className={elemclasses}>{textResponse}</span>
   );
 };

--- a/static/js/TopicPage.jsx
+++ b/static/js/TopicPage.jsx
@@ -231,7 +231,7 @@ const TopicCategory = ({topic, topicTitle, setTopic, setNavTopic, compare, initi
               </a>
               {description ?
               <div className="navBlockDescription clamped">
-                <InterfaceText markdown={{en: description.en, he: description.he}} />
+                <InterfaceText markdown={{en: description.en, he: description.he}} disallowedMarkdownElements={['a']}/>
               </div>
               : null }
             </div>


### PR DESCRIPTION
We don't want to display links in markdown text in all places on the site, specifically in the topic TOC.  However, we still want other markdown tags to show, such as italics.  Therefore, I added a field to InterfaceText `disallowedMarkdownElements` which is a list of the elements you don't want to show in markdown.  In this case in the change I made in TopicPage.jsx, I pass ['a'] and links do not show up but italics does show up.