### PR TITLE
fix(Markdown): markdown in admin editors was not being validated

### DIFF
--- a/static/js/AdminEditor.jsx
+++ b/static/js/AdminEditor.jsx
@@ -13,13 +13,15 @@ const options_for_form = {
         label: "English Description",
         field: "enDescription",
         placeholder: "Add a description.",
-        type: 'textarea'
+        type: 'textarea',
+        markdown: true,
     },
     "Hebrew Description": {
         label: "Hebrew Description",
         field: "heDescription",
         placeholder: "Add a description.",
-        type: 'textarea'
+        type: 'textarea',
+        markdown: true
     },
     "Prompt": {label: "Prompt", field: "prompt", placeholder: "Add a prompt.", textarea: true},
     "English Short Description": {
@@ -136,7 +138,7 @@ const AdminEditor = ({title, data, close, catMenu, pictureUploader, updateData, 
     const preprocess = async () => {
         setValidatingLinks(true);
         for (const x of items) {
-            if (options_for_form[x]?.is_textarea) {
+            if (options_for_form[x]?.markdown) {
                 const field = options_for_form[x].field;
                 const valid_tags = await validateMarkdownLinks(data[field]);
                 if (!valid_tags) {


### PR DESCRIPTION
We were using a deprecated property `is_textarea` to determine whether to validate the markdown links in descriptions in Admin Editors.  I added a property `markdown` and changed the check so that it checks that the property `markdown` is True.  I only set this property to true for descriptions and not for any other field in admin editors, such as titles or captions.