### PR TITLE
fix(Source Editor): Prompts should be textareas not input elements

### DIFF
--- a/static/js/AdminEditor.jsx
+++ b/static/js/AdminEditor.jsx
@@ -21,7 +21,7 @@ const options_for_form = {
         placeholder: "Add a description.",
         type: 'textarea'
     },
-    "Prompt": {label: "Prompt", field: "prompt", placeholder: "Add a prompt.", textarea: true},
+    "Prompt": {label: "Prompt", field: "prompt", placeholder: "Add a prompt.", type: 'textarea'},
     "English Short Description": {
         label: "English Short Description for Table of Contents", field: "enCategoryDescription",
         placeholder: "Add a short description.", type: 'input'


### PR DESCRIPTION
In the admin editor, fields set as `type` equal to `textarea` are displayed using HTML textarea elements rather than input elements.  For prompts in the source editor, I had mistakenly set this incorrectly, so that it had a `textarea` property instead of having a `type` property that was set to `textarea`.