### PR TITLE
fix: fully convert tref to URL form before looking it up in the legac…

### DIFF
--- a/sefaria/helper/legacy_ref.py
+++ b/sefaria/helper/legacy_ref.py
@@ -33,6 +33,7 @@ class LegacyRefParsingData(AbstractMongoRecord):
     }
     ```
     To be used with LegacyRefParser classes in this module.
+    Current assumption is all trefs in the mapping (both old and mapped) are in URL form and are segment level.
     """
     collection = 'legacy_ref_data'
     criteria_field = 'title'
@@ -109,8 +110,9 @@ class MappingLegacyRefParser(LegacyRefParser):
         return range_list
 
     def __get_mapped_tref(self, legacy_tref: str) -> str:
-        # replace last space before sections with a period to conform with normal form
+        # replace last space before sections with a period to conform with url form
         legacy_tref = re.sub(r" (?=[\d.:ab]+$)", ".", legacy_tref)
+        legacy_tref = legacy_tref.replace(' ', '_')
         try:
             return self._mapping[legacy_tref]
         except KeyError as err:

--- a/sefaria/helper/legacy_ref.py
+++ b/sefaria/helper/legacy_ref.py
@@ -121,14 +121,14 @@ class MappingLegacyRefParser(LegacyRefParser):
     def __parse_segment_ref(self, legacy_tref: str) -> Ref:
         converted_tref = self.__get_mapped_tref(legacy_tref)
         converted_ref = Ref(converted_tref)
-        converted_ref.legacy_tref = legacy_tref
+        converted_ref.legacy_tref = legacy_tref.replace(" ", "_")
         return converted_ref
 
     def __parse_ranged_ref(self, legacy_tref: str) -> Ref:
         parsed_range_list = [self.__parse_segment_ref(temp_tref) for temp_tref in self.__range_list(legacy_tref)]
         parsed_range_list.sort(key=lambda x: x.order_id())  # not assuming mapping is in order
         ranged_oref = parsed_range_list[0].to(parsed_range_list[-1])
-        ranged_oref.legacy_tref = legacy_tref
+        ranged_oref.legacy_tref = legacy_tref.replace(" ", "_")
         return ranged_oref
 
 

--- a/sefaria/helper/legacy_ref.py
+++ b/sefaria/helper/legacy_ref.py
@@ -86,9 +86,21 @@ class MappingLegacyRefParser(LegacyRefParser):
         @param legacy_tref:
         @return:
         """
+        legacy_tref = self.__to_url_form(legacy_tref)
         if self.__is_ranged_ref(legacy_tref):
             return self.__parse_ranged_ref(legacy_tref)
         return self.__parse_segment_ref(legacy_tref)
+
+    @staticmethod
+    def __to_url_form(tref: str):
+        """
+        replace last space before sections with a period
+        AND
+        then replace remaining spaces with underscore
+        @param tref:
+        @return:
+        """
+        return re.sub(r" (?=[\d.:ab]+$)", ".", tref).replace(" ", "_")
 
     @staticmethod
     def __is_ranged_ref(tref: str) -> bool:
@@ -110,9 +122,6 @@ class MappingLegacyRefParser(LegacyRefParser):
         return range_list
 
     def __get_mapped_tref(self, legacy_tref: str) -> str:
-        # replace last space before sections with a period to conform with url form
-        legacy_tref = re.sub(r" (?=[\d.:ab]+$)", ".", legacy_tref)
-        legacy_tref = legacy_tref.replace(' ', '_')
         try:
             return self._mapping[legacy_tref]
         except KeyError as err:
@@ -121,14 +130,14 @@ class MappingLegacyRefParser(LegacyRefParser):
     def __parse_segment_ref(self, legacy_tref: str) -> Ref:
         converted_tref = self.__get_mapped_tref(legacy_tref)
         converted_ref = Ref(converted_tref)
-        converted_ref.legacy_tref = legacy_tref.replace(" ", "_")
+        converted_ref.legacy_tref = legacy_tref
         return converted_ref
 
     def __parse_ranged_ref(self, legacy_tref: str) -> Ref:
         parsed_range_list = [self.__parse_segment_ref(temp_tref) for temp_tref in self.__range_list(legacy_tref)]
         parsed_range_list.sort(key=lambda x: x.order_id())  # not assuming mapping is in order
         ranged_oref = parsed_range_list[0].to(parsed_range_list[-1])
-        ranged_oref.legacy_tref = legacy_tref.replace(" ", "_")
+        ranged_oref.legacy_tref = legacy_tref
         return ranged_oref
 
 

--- a/sefaria/helper/tests/legacy_ref_test.py
+++ b/sefaria/helper/tests/legacy_ref_test.py
@@ -46,14 +46,14 @@ def test_zohar_index(test_index_title):
 
 
 @pytest.fixture(scope="module", autouse=True)
-def test_zohar_mapping_data(test_index_title):
+def test_zohar_mapping_data(test_index_title, url_test_index_title):
     lrpd = LegacyRefParsingData({
         "index_title": test_index_title,
         "data": {
             "mapping": {
-                f"{test_index_title}.1.15a.1": f"{test_index_title}.1.42",
-                f"{test_index_title}.1.15a.2": f"{test_index_title}.1.42",
-                f"{test_index_title}.1.15a.3": f"{test_index_title}.1.43",
+                f"{url_test_index_title}.1.15a.1": f"{url_test_index_title}.1.42",
+                f"{url_test_index_title}.1.15a.2": f"{url_test_index_title}.1.42",
+                f"{url_test_index_title}.1.15a.3": f"{url_test_index_title}.1.43",
             },
         },
     })
@@ -66,15 +66,20 @@ def test_zohar_mapping_data(test_index_title):
 
 @pytest.fixture(scope="module")
 def test_index_title():
-    return "TestZohar"
+    return "Test Zohar"
 
 
 @pytest.fixture(scope="module")
-def old_and_new_trefs(request, test_index_title):
+def url_test_index_title(test_index_title):
+    return test_index_title.replace(" ", "_")
+
+
+@pytest.fixture(scope="module")
+def old_and_new_trefs(request, url_test_index_title):
     old_ref, new_ref = request.param
     # if new_ref is None, means mapping doesn't exist
-    new_ref = new_ref and f"{test_index_title}.{new_ref}"
-    return f"{test_index_title}.{old_ref}", new_ref
+    new_ref = new_ref and f"{url_test_index_title}.{new_ref}"
+    return f"{url_test_index_title}.{old_ref}", new_ref
 
 
 def get_book(tref):
@@ -143,12 +148,12 @@ class TestLegacyRefsTestIndex:
             assert converted_ref.legacy_tref == old_ref
             assert converted_ref.normal() == Ref(new_ref).normal()
 
-    def test_instantiate_ref_with_legacy_parse_fallback(self, test_index_title, old_and_new_trefs):
+    def test_instantiate_ref_with_legacy_parse_fallback(self, url_test_index_title, old_and_new_trefs):
         old_tref, new_tref = old_and_new_trefs
 
         oref = Ref.instantiate_ref_with_legacy_parse_fallback(old_tref)
         if new_tref is None:
-            assert oref.url() == test_index_title
+            assert oref.url() == url_test_index_title
             assert getattr(oref, 'legacy_tref', None) is None
         else:
             assert oref.url() == new_tref


### PR DESCRIPTION
…y ref mapping.

We recently launched a refactored version of Mekhilta. We found that the format of the mapping in the database doesn't conform to how the code assumes the mapping will look. Specifically, code generated a partial URL form (it replaced colons with periods but not spaces with underscores). The format in the DB is in complete URL form. I think the most standard way to fix this is to have the code fully convert the tref to URL form.