### PR TITLE
fix(legacy): replace input title with normalized title in case input …

### DIFF
--- a/sefaria/model/text.py
+++ b/sefaria/model/text.py
@@ -4873,6 +4873,8 @@ class Ref(object, metaclass=RefCacheType):
         except PartialRefInputError as e:
             matched_ref = Ref(e.matched_part)
             try:
+                # replace input title with normalized title in case input was an alt title
+                tref = tref.replace(e.matched_part, matched_ref.normal())
                 tref = Ref.__clean_tref(tref, matched_ref._lang)
                 legacy_ref_parser = legacy_ref_parser_handler[matched_ref.index.title]
                 return legacy_ref_parser.parse(tref)


### PR DESCRIPTION
…was an alt title

When input is "Mekhilta d'Rabbi Yishmael 18:1:5" (note, primary title is "Mekhilta DeRabbi Yishmael") then the legacy parser would fail because it couldn't find the ref in the mapping. This PR modifies the input tref to use the primary title.