### PR TITLE
fix(search): remove newline that was auto-added

### DIFF
--- a/helm-chart/sefaria-project/templates/cronjob/reindex-elasticsearch.yaml
+++ b/helm-chart/sefaria-project/templates/cronjob/reindex-elasticsearch.yaml
@@ -64,8 +64,7 @@ spec:
             command: ["bash"]
             args: [
               "-c",
-              "mkdir -p /log && touch /log/sefaria_book_errors.log && pip install numpy elasticsearch==8.8.2 git+https://github.com/Sefaria/elasticsearch-dsl-py@v8.0
-              .0#egg=elasticsearch-dsl && /app/run /app/scripts/scheduled/reindex_elasticsearch_cronjob.py"
+              "mkdir -p /log && touch /log/sefaria_book_errors.log && pip install numpy elasticsearch==8.8.2 git+https://github.com/Sefaria/elasticsearch-dsl-py@v8.0.0#egg=elasticsearch-dsl && /app/run /app/scripts/scheduled/reindex_elasticsearch_cronjob.py"
             ]
           restartPolicy: Never
           volumes:


### PR DESCRIPTION
It seems a new line was auto-added when files were moved to the "scheduled" folder.