### PR TITLE
helm(search): dont set Content-Type header.

### DIFF
--- a/helm-chart/sefaria-project/templates/configmap/nginx.yaml
+++ b/helm-chart/sefaria-project/templates/configmap/nginx.yaml
@@ -117,7 +117,6 @@ data:
         # allow urls which aren't caught by regex above
         location /api/search/ {
           rewrite ^/(?:api/search)/(.*)$ /$1 break;
-          proxy_set_header Content-Type application/json;  # es 6.0 requires this header
           proxy_set_header Authorization "Basic ${ELASTIC_AUTH_HEADER}";
           add_header 'Access-Control-Allow-Origin' '';
           proxy_pass http://elasticsearch_upstream/;


### PR DESCRIPTION
ES no longer requires this header to be set and it's problematic to set it to application/json because ES has a strange requirement that if Accept is set to "application/vnd.elasticsearch+json; compatible-with=8" (which is sent from our Python ES client) than Content-Type needs to be set to the same thing.