### PR TITLE
fix(search): move encapsulation of SearchTotal to search.js

### DIFF
--- a/static/js/SearchResultList.jsx
+++ b/static/js/SearchResultList.jsx
@@ -6,7 +6,7 @@ import extend from 'extend';
 import classNames from 'classnames';
 import $ from './sefaria/sefariaJquery';
 import Sefaria from './sefaria/sefaria';
-import { FilterNode } from './sefaria/search';
+import { SearchTotal } from "./sefaria/searchTotal";
 import SearchTextResult from './SearchTextResult';
 import SearchSheetResult from './SearchSheetResult';
 import SearchFilters from './SearchFilters';
@@ -76,34 +76,6 @@ const SearchTopic = (props) => {
 }
 
 
-class SearchTotal {
-    constructor({value=0, relation="eq"} = {}) {
-        this._value = value;
-        this._relation = relation;
-    }
-    getValue = () => this._value;
-    add = (num) => this._value += num;
-    asString = () => `${this._value.addCommas()}${this._getRelationString()}`;
-    _getRelationString = () => this._relation === 'gte' ? '+' : '';
-    combine = (other) => {
-        if (!(other instanceof SearchTotal)) {
-          throw new TypeError('Parameter must be an instance of SearchTotal.');
-        }
-        const newValue = this.getValue() + other.getValue();
-        let newRelation = this._relation;
-        if (other._relation === 'gte' || this._relation === 'gte') {
-          newRelation = 'gte';
-        }
-        return new SearchTotal({value: newValue, relation: newRelation});
-    };
-}
-
-
-function createSearchTotal(total) {
-    return new SearchTotal(total);
-}
-
-
 class SearchResultList extends Component {
     constructor(props) {
       super(props);
@@ -130,7 +102,7 @@ class SearchResultList extends Component {
           //console.log("Loaded cached query for")
           //console.log(args);
           this.state.hits[t] = this.state.hits[t].concat(cachedQuery.hits.hits);
-          this.state.totals[t] = createSearchTotal(cachedQuery.hits.total);
+          this.state.totals[t] = cachedQuery.hits.total;
           this.state.pagesLoaded[t] += 1;
           args.start = this.state.pagesLoaded[t] * this.querySize[t];
           if (t === "text") {
@@ -350,7 +322,7 @@ class SearchResultList extends Component {
       args.success = data => {
               this.updateRunningQuery(type, null);
               if (this.state.pagesLoaded[type] === 0) { // Skip if pages have already been loaded from cache, but let aggregation processing below occur
-                const currTotal = createSearchTotal(data.hits.total);
+                const currTotal = data.hits.total;
                 let state = {
                   hits: extend(this.state.hits, {[type]: data.hits.hits}),
                   totals: extend(this.state.totals, {[type]: currTotal}),
@@ -363,7 +335,7 @@ class SearchResultList extends Component {
                 });
                 const filter_label = (request_applied && request_applied.length > 0) ? (' - ' + request_applied.join('|')) : '';
                 const query_label = props.query + filter_label;
-                Sefaria.track.event("Search", `${this.props.searchInBook? "SidebarSearch ": ""}Query: ${type}`, query_label, createSearchTotal(data.hits.total).getValue());
+                Sefaria.track.event("Search", `${this.props.searchInBook? "SidebarSearch ": ""}Query: ${type}`, query_label, data.hits.total.getValue());
               }
 
               if (data.aggregations) {

--- a/static/js/sefaria/search.js
+++ b/static/js/sefaria/search.js
@@ -2,6 +2,7 @@ import $ from './sefariaJquery';
 import extend from 'extend';
 import FilterNode from './FilterNode';
 import SearchState from './searchState';
+import { SearchTotal } from "./searchTotal";
 
 
 class Search {
@@ -9,8 +10,8 @@ class Search {
       this.searchIndexText = searchIndexText;
       this.searchIndexSheet = searchIndexSheet;
       this._cache = {};
-      this.sefariaQueryQueue = {hits: {hits:[], total: 0, max_score: 0.0}, lastSeen: -1};
-      this.dictaQueryQueue = {lastSeen: -1, hits: {total: 0, hits:[]}};
+      this.sefariaQueryQueue = {hits: {hits:[], total: new SearchTotal(), max_score: 0.0}, lastSeen: -1};
+      this.dictaQueryQueue = {lastSeen: -1, hits: {total: new SearchTotal(), hits:[]}};
       this.queryDictaFlag = true;
       this.dictaCounts = null;
       this.sefariaSheetsResult = null;
@@ -47,6 +48,7 @@ class Search {
                 processData: false,
                 dataType: 'json',
                 success: data => {
+                    data.hits.total = new SearchTotal(data.hits.total);
                     this.cache(cacheKey, data);
                     resolve(data)
                 },
@@ -103,7 +105,7 @@ class Search {
         return new Promise((resolve, reject) => {
 
             if (this.queryDictaFlag && args.type === "text") {
-                if (this.dictaQueryQueue.lastSeen + 1 >= this.dictaQueryQueue.hits.total && ('start' in args && args['start'] > 0)) {
+                if (this.dictaQueryQueue.lastSeen + 1 >= this.dictaQueryQueue.hits.total.getValue() && ('start' in args && args['start'] > 0)) {
                     /* don't make new queries if results are exhausted.
                      * 'start' is omitted on first query (defaults to 0). On a first query, we'll always want to query.
                      */
@@ -125,6 +127,7 @@ class Search {
                         contentType: 'application/json; charset=UTF-8',
                         data: jsonData,
                         success: data => {
+                            data.total = new SearchTotal({value: data.total});
                             this.cache(cacheKey, data);
                             resolve(data);
                         },
@@ -134,7 +137,7 @@ class Search {
 
             }
             else {
-                resolve({total: 0, hits: []});
+                resolve({total: new SearchTotal(), hits: []});
             }
         }).then(x => {
             if (args.type === "sheet") {
@@ -244,15 +247,16 @@ class Search {
         }
         if (!!filters.length) {
             const expression = new RegExp(`^(${filters.join('|')})(\/.*|$)`);
-            result.hits.total = this.buckets.reduce((total, currentBook) => {
+            const accumulatedTotal = this.buckets.reduce((total, currentBook) => {
                 if (expression.test(currentBook.key)) {
                     total += currentBook.doc_count;
                 }
                 return total
             }, 0);
+            result.hits.total = new SearchTotal({value: accumulatedTotal});
         }
         else {
-            result.hits.total = this.sefariaQueryQueue.hits.total + this.dictaQueryQueue.hits.total;
+            result.hits.total = this.sefariaQueryQueue.hits.total.combine(this.dictaQueryQueue.hits.total);
         }
 
         let sefariaHits = (this.queryDictaFlag)
@@ -327,8 +331,8 @@ class Search {
             if (args.type === 'text') {
                 this.dictaCounts = null;
                 this.queryDictaFlag = this.isDictaQuery(args);
-                this.sefariaQueryQueue = {hits: {hits: [], total: 0, max_score: 0.0}, lastSeen: -1};
-                this.dictaQueryQueue = {lastSeen: -1, hits: {total: 0, hits: []}};
+                this.sefariaQueryQueue = {hits: {hits: [], total: new SearchTotal(), max_score: 0.0}, lastSeen: -1};
+                this.dictaQueryQueue = {lastSeen: -1, hits: {total: new SearchTotal(), hits: []}};
                 this.queryAborter.abort();
             }
         }

--- a/static/js/sefaria/search.js
+++ b/static/js/sefaria/search.js
@@ -105,7 +105,8 @@ class Search {
         return new Promise((resolve, reject) => {
 
             if (this.queryDictaFlag && args.type === "text") {
-                if (this.dictaQueryQueue.lastSeen + 1 >= this.dictaQueryQueue.hits.total.getValue() && ('start' in args && args['start'] > 0)) {
+                if (this.dictaQueryQueue.lastSeen + 1 >= this.dictaQueryQueue.hits.total.getValue() &&
+                    ('start' in args && args['start'] > 0)) {
                     /* don't make new queries if results are exhausted.
                      * 'start' is omitted on first query (defaults to 0). On a first query, we'll always want to query.
                      */

--- a/static/js/sefaria/searchTotal.js
+++ b/static/js/sefaria/searchTotal.js
@@ -1,0 +1,23 @@
+export class SearchTotal {
+    constructor({value=0, relation="eq"} = {}) {
+        this._value = value;
+        this._relation = relation;
+    }
+    getValue = () => this._value;
+    add = (num) => this._value += num;
+    asString = () => `${this._value.addCommas()}${this._getRelationString()}`;
+    _getRelationString = () => this._relation === 'gte' ? '+' : '';
+    combine = (other) => {
+        if (!(other instanceof SearchTotal)) {
+            throw new TypeError('Parameter must be an instance of SearchTotal.');
+        }
+        const newValue = this.getValue() + other.getValue();
+        let newRelation = this._relation;
+        if (other._relation === 'gte' || this._relation === 'gte') {
+            newRelation = 'gte';
+        }
+        return new SearchTotal({value: newValue, relation: newRelation});
+    };
+}
+
+


### PR DESCRIPTION
This ensures that both Dicta and Sefaria queries are using the same format of SearchTotal.