### PR TITLE
fix(linker): fix order of parameters

### DIFF
--- a/sefaria/helper/linker.py
+++ b/sefaria/helper/linker.py
@@ -52,8 +52,8 @@ class _FindRefsTextOptions:
     @attr version_preferences_by_corpus: dict of dicts of the form { <corpus>: { <lang>: <vtitle> }}
     """
 
-    debug: bool = False
     with_text: bool = False
+    debug: bool = False
     max_segments: int = 0
     version_preferences_by_corpus: dict = None
 

--- a/sefaria/helper/tests/linker_test.py
+++ b/sefaria/helper/tests/linker_test.py
@@ -131,8 +131,8 @@ class TestFindRefsHelperClasses:
         assert find_refs_text.lang == 'en'
 
     def test_find_refs_text_options(self):
-        find_refs_text_options = linker._FindRefsTextOptions(True, True, 10, {})
-        assert find_refs_text_options.debug
+        find_refs_text_options = linker._FindRefsTextOptions(True, False, 10, {})
+        assert not find_refs_text_options.debug
         assert find_refs_text_options.with_text
         assert find_refs_text_options.max_segments == 10
         assert find_refs_text_options.version_preferences_by_corpus == {}


### PR DESCRIPTION
Passed wrong order of parameters to FindRefsTextOptions. Also, modified test to test this case. Fixes https://github.com/Sefaria/Sefaria-Project/issues/1786