### PR TITLE
Bug/sc 24663/fix ref topic api so that it also uses datasource

### DIFF
--- a/sefaria/helper/topic.py
+++ b/sefaria/helper/topic.py
@@ -1254,8 +1254,11 @@ def delete_ref_topic_link(tref, to_topic, link_type, lang):
 
     topic_link = {"toTopic": to_topic, "linkType": link_type, 'ref': tref, 'dataSource': 'learning-team'}
     link = RefTopicLink().load(topic_link)
-    if link is None:
-        return {"error": f"Link between {tref} and {to_topic} doesn't exist."}
+    if link is None:  # first check if there is a link with dataSource 'learning-team', then just check if there is any link
+        topic_link = {"toTopic": to_topic, "linkType": link_type, 'ref': tref}
+        link = RefTopicLink().load(topic_link)
+        if link is None:
+            return {"error": f"Link between {tref} and {to_topic} doesn't exist."}
 
     if lang in link.order.get('availableLangs', []):
         link.order['availableLangs'].remove(lang)

--- a/sefaria/helper/topic.py
+++ b/sefaria/helper/topic.py
@@ -1150,7 +1150,7 @@ def edit_topic_source(slug, orig_tref, new_tref="", creating_new_link=True,
     topic_obj = Topic.init(slug)
     if topic_obj is None:
         return {"error": "Topic does not exist."}
-    ref_topic_dict = {"toTopic": slug, "linkType": linkType, "ref": orig_tref}
+    ref_topic_dict = {"toTopic": slug, "linkType": linkType, "ref": orig_tref, "dataSource": 'learning-team'}
     link = RefTopicLink().load(ref_topic_dict)
     link_already_existed = link is not None
     if not link_already_existed:
@@ -1249,7 +1249,7 @@ def delete_ref_topic_link(tref, to_topic, link_type, lang):
     if Topic.init(to_topic) is None:
         return {"error": f"Topic {to_topic} doesn't exist."}
 
-    topic_link = {"toTopic": to_topic, "linkType": link_type, 'ref': tref}
+    topic_link = {"toTopic": to_topic, "linkType": link_type, 'ref': tref, 'dataSource': 'learning-team'}
     link = RefTopicLink().load(topic_link)
     if link is None:
         return {"error": f"Link between {tref} and {to_topic} doesn't exist."}

--- a/sefaria/helper/topic.py
+++ b/sefaria/helper/topic.py
@@ -1218,9 +1218,12 @@ def update_order_of_topic_sources(topic, sources, uid, lang='en'):
              ref = Ref(s['ref']).normal()
         except InputError as e:
             return {"error": f"Invalid ref {s['ref']}"}
-        link = RefTopicLink().load({"toTopic": topic, "linkType": "about", "ref": ref})
+        link = RefTopicLink().load({"toTopic": topic, "linkType": "about", "ref": ref, 'dataSource': 'learning-team'})
         if link is None:
-            return {"error": f"Link between {topic} and {s['ref']} doesn't exist."}
+            # first see if there's a learning-team link and if not look for any reftopiclink that matches
+            link = RefTopicLink().load({"toTopic": topic, "linkType": "about", "ref": ref})
+            if link is None:
+                return {"error": f"Link between {topic} and {s['ref']} doesn't exist."}
         order = getattr(link, 'order', {})
         if lang not in order.get('availableLangs', []) :
             return {"error": f"Link between {topic} and {s['ref']} does not exist in '{lang}'."}


### PR DESCRIPTION
Changed the way the API posts, deletes, and sorts sources.  In both deleting and sorting, the reasoning here was to look first for learning team links (i.e.  links with dataSource 'learning-team'), but if not found, still look for a topic link without a specified dataSource because sometimes admins may be trying to delete or sort links that they themselves did not create.