### PR TITLE
fix(Category Editor): fix typo origEnTitle => origEn

### DIFF
--- a/static/js/Misc.jsx
+++ b/static/js/Misc.jsx
@@ -1288,7 +1288,7 @@ const CategoryEditorWrapper = ({toggle, data, type}) => {
 }
 
 const CategoryAdderWrapper = ({toggle, data, type}) => {
-      const origData = {origEnTitle: ""};
+      const origData = {origEn: ""};
       switch (type) {
         case "cats":
           return <CategoryEditor origData={origData} close={toggle} origPath={data}/>;


### PR DESCRIPTION
The bug was that we currently cannot create new categories using the Category Editor.  This is because of this typo corrected below.  `origEnTitle` should be `origEn`, as that is the name of the property in the CategoryEditor component.