### PR TITLE
fix(translations): make sure fill_in_missing_segments is either 1 or 0

### DIFF
--- a/static/js/sefaria/sefaria.js
+++ b/static/js/sefaria/sefaria.js
@@ -500,7 +500,8 @@ Sefaria = extend(Sefaria, {
     const versions = requiredVersions.map(obj =>
         Sefaria.makeParamsStringForAPIV3(obj.language, obj.versionTitle)
     );
-    const url = `${host}${endPoint}${ref}?version=${versions.join('&version=')}&fill_in_missing_segments=${mergeText}`;
+    const mergeTextInt = mergeText ? 1 : 0;
+    const url = `${host}${endPoint}${ref}?version=${versions.join('&version=')}&fill_in_missing_segments=${mergeTextInt}`;
     return url;
   },
   getTextsFromAPIV3: async function(ref, requiredVersions, mergeText) {


### PR DESCRIPTION
[This commit](https://github.com/Sefaria/Sefaria-Project/commit/9f6b71eb) seems to be the cause of the issue. The v3 text API gets sent false as a boolean parameter. Running this through bool and int yields an error because int("false") isn’t valid in Python.

This PR makes sure the client sends 1 or 0 to the server.