### PR TITLE
Updating Emails

### DIFF
--- a/reader/views.py
+++ b/reader/views.py
@@ -3309,7 +3309,7 @@ def global_activity(request, page=1):
     if page > 40:
         return render_template(request,'static/generic.html', None, {
             "title": "Activity Unavailable",
-            "content": "You have requested a page deep in Sefaria's history.<br><br>For performance reasons, this page is unavailable. If you need access to this information, please <a href='mailto:dev@sefaria.org'>email us</a>."
+            "content": "You have requested a page deep in Sefaria's history.<br><br>For performance reasons, this page is unavailable. If you need access to this information, please <a href='mailto:developers@sefaria.org'>email us</a>."
         })
 
     if "api" in request.GET:
@@ -3352,7 +3352,7 @@ def user_activity(request, slug, page=1):
     if page > 40:
         return render_template(request,'static/generic.html', None, {
             "title": "Activity Unavailable",
-            "content": "You have requested a page deep in Sefaria's history.<br><br>For performance reasons, this page is unavailable. If you need access to this information, please <a href='mailto:dev@sefaria.org'>email us</a>."
+            "content": "You have requested a page deep in Sefaria's history.<br><br>For performance reasons, this page is unavailable. If you need access to this information, please <a href='mailto:developers@sefaria.org'>email us</a>."
         })
 
     q              = {"user": profile.id}

--- a/reader/views.py
+++ b/reader/views.py
@@ -3309,7 +3309,7 @@ def global_activity(request, page=1):
     if page > 40:
         return render_template(request,'static/generic.html', None, {
             "title": "Activity Unavailable",
-            "content": "You have requested a page deep in Sefaria's history.<br><br>For performance reasons, this page is unavailable. If you need access to this information, please <a href='mailto:developers@sefaria.org'>email us</a>."
+            "content": "You have requested a page deep in Sefaria's history.<br><br>For performance reasons, this page is unavailable. If you need access to this information, please <a href='mailto:hello@sefaria.org'>email us</a>."
         })
 
     if "api" in request.GET:
@@ -3352,7 +3352,7 @@ def user_activity(request, slug, page=1):
     if page > 40:
         return render_template(request,'static/generic.html', None, {
             "title": "Activity Unavailable",
-            "content": "You have requested a page deep in Sefaria's history.<br><br>For performance reasons, this page is unavailable. If you need access to this information, please <a href='mailto:developers@sefaria.org'>email us</a>."
+            "content": "You have requested a page deep in Sefaria's history.<br><br>For performance reasons, this page is unavailable. If you need access to this information, please <a href='mailto:hello@sefaria.org'>email us</a>."
         })
 
     q              = {"user": profile.id}

--- a/static/js/s1/editor.js
+++ b/static/js/s1/editor.js
@@ -607,7 +607,7 @@ $(function() {
 
         if (sjs.current.isComplex) {
             sjs.hideAbout();
-            sjs.alert.message("This text is not user editable - please email dev@sefaria.org");
+            sjs.alert.message("This text is not user editable - please email corrections@sefaria.org");
             return;
         }
 		if (!sjs._uid) {

--- a/templates/500.html
+++ b/templates/500.html
@@ -14,15 +14,14 @@
             <p>
                 <span class="int-en">
                     Unfortunately, we've encountered an error.
-                    An email has been sent automatically to our developers.
                     If you have any questions about the problem,
                     or think you can help us figure out what went wrong,
-                    please email our <a href="mailto:dev@sefaria.org" target="_blank">development team</a>.
+                    please email <a href="mailto:hello@sefaria.org" target="_blank">us</a>.
                 </span>
                 <span class="int-he">
-                    לצערנו ארעה תקלה במערכת. מייל בעניין כבר נשלח אל המפתחים שלנו.
+                    לצערנו ארעה תקלה במערכת.
                     אם יש לכם שאלות נוספות לגבי התקלה,
-                    או שביכלתכם להבין את התקלה ולעזור לאתר אותה, נשמח לשמוע <a href="mailto:dev@sefaria.org" target="_blank">במייל אל צוות המפתחים</a>.
+                    או שביכלתכם להבין את התקלה ולעזור לאתר אותה,  <a href="mailto:hello@sefaria.org" target="_blank">נשמח לשמוע</a>.
                 </span>
             </p>
         </div>


### PR DESCRIPTION
## Description
The goal of this PR is to update the email contacts provided throughout the repo, from dev@sefaria.org to the more appropriate address. 

**NOTE:** We still use dev@sefaria.org for configuration purposes, and for sending emails to hello@sefaria.org on occaision. 

## Changes made:
1. In `reader/views.py` - Change two instances of errors to contact hello@sefaria.org instead of dev@sefaria.org. 
2. In `templates/500.html` - Remove "an email has been automatically sent to our developers" and tweak language to "contact us" (versus "contact our developer team"). Use hello@sefaria.org instead of dev@sefaria.org. 
3. In `static/js/s1/editor.js` - When a logged-in user attempts to edit a locked text, refer them to corrections@sefaria.org as opposed to dev@sefaria.org. 