### PR TITLE
bug(timeperiod): Return string from LifePeriod class

### DIFF
--- a/sefaria/model/timeperiod.py
+++ b/sefaria/model/timeperiod.py
@@ -256,7 +256,7 @@ class LifePeriod(TimePeriod):
     def period_string(self, lang):
 
         if getattr(self, "start", None) == None and getattr(self, "end", None) == None:
-            return
+            return ""
 
         labels = self.getYearLabels(lang)
         approxMarker = self.getApproximateMarkers(lang)


### PR DESCRIPTION
This bug occurs in:
"en": re.sub(r'[()]', '', tp.period_string("en")),

as period_string method is expected to returns a string. By returning None we break the regex code and the topic doesn't load for any topic without a time period (see https://www.sefaria.org.il/topics/tzadok for example)

Bug detected on Sentry:
https://sefaria.sentry.io/issues/4604800087/?project=4505401833684992&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=30d&stream_index=10