### PR TITLE
Python3.9

### DIFF
--- a/build/base-web/Dockerfile
+++ b/build/base-web/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-bullseye
+FROM python:3.9-bullseye
 
 
 # Django Environment Variables
@@ -15,8 +15,7 @@ ENV DEBUG       false
 # Install re2 for Python
 
 RUN pip3 install cython
-RUN git clone https://code.googlesource.com/re2 && cd re2 && make && make install && cd / && pip3 install https://github.com/andreasvc/pyre2/archive/3e01eba6ba3eabd1359ef5e16c938c8866deea70.zip
+RUN apt-get update -y && apt-get install -y npm varnish && apt-get clean
+RUN pip3 install google-re2
 
-
-RUN apt-get update && apt-get install --yes npm varnish && apt-get clean
 RUN mkdir -p /app/log && mkdir -p /app/sefaria && mkdir -p /log

--- a/build/base-web/Dockerfile
+++ b/build/base-web/Dockerfile
@@ -12,8 +12,5 @@ ENV DJANGO_PORT 80
 ENV NODEJS_PORT 3000
 ENV DEBUG       false
 
-RUN pip3 install cython
 RUN apt-get update -y && apt-get install -y npm varnish && apt-get clean
-RUN pip3 install google-re2
-
 RUN mkdir -p /app/log && mkdir -p /app/sefaria && mkdir -p /log

--- a/build/base-web/Dockerfile
+++ b/build/base-web/Dockerfile
@@ -12,8 +12,6 @@ ENV DJANGO_PORT 80
 ENV NODEJS_PORT 3000
 ENV DEBUG       false
 
-# Install re2 for Python
-
 RUN pip3 install cython
 RUN apt-get update -y && apt-get install -y npm varnish && apt-get clean
 RUN pip3 install google-re2

--- a/build/web/Dockerfile
+++ b/build/web/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/production-deployment/base-web:v3.9-bullseye
+FROM us-east1-docker.pkg.dev/production-deployment/base-web:v3.9-bullseye
 ARG TYPE=build-prod
 
 WORKDIR /app/

--- a/build/web/Dockerfile
+++ b/build/web/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/production-deployment/base-web:v3.7-bullseye
+FROM gcr.io/production-deployment/base-web:v3.9-bullseye
 ARG TYPE=build-prod
 
 WORKDIR /app/

--- a/build/web/Dockerfile
+++ b/build/web/Dockerfile
@@ -1,4 +1,4 @@
-FROM us-east1-docker.pkg.dev/production-deployment/base-web:v3.9-bullseye
+FROM us-east1-docker.pkg.dev/production-deployment/containers/base-web:3.9-bullseye
 ARG TYPE=build-prod
 
 WORKDIR /app/

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,7 +49,7 @@ py2-py3-django-email-as-username==1.7.1
 pymongo==3.12.*
 pytest==6.1.1
 pytz
-pyyaml==5.3.1
+pyyaml==6.0.1
 rauth==0.7.3
 redis==3.5.3
 regex==2020.10.23

--- a/requirements.txt
+++ b/requirements.txt
@@ -65,6 +65,7 @@ babel
 python-bidi
 requests
 Cerberus
+google-re2
 
 #opentelemetry-distro
 #opentelemetry-exporter-otlp

--- a/sefaria/model/autospell.py
+++ b/sefaria/model/autospell.py
@@ -14,15 +14,10 @@ from sefaria.model import *
 from sefaria.model.schema import SheetLibraryNode
 from sefaria.utils import hebrew
 from sefaria.model.following import aggregate_profiles
-
+import re2 as re
 import structlog
 logger = structlog.get_logger(__name__)
 
-try:
-    import re2 as re
-except ImportError:
-    logger.warning("Failed to load 're2'.  Falling back to 're' for regular expression parsing. See https://github.com/sefaria/Sefaria-Project/wiki/Regular-Expression-Engines")
-    import re
 
 letter_scope = "\u05b0\u05b1\u05b2\u05b3\u05b4\u05b5\u05b6\u05b7\u05b8\u05b9\u05ba\u05bb\u05bc\u05bd" \
             + "\u05c1\u05c2" \

--- a/sefaria/model/autospell.py
+++ b/sefaria/model/autospell.py
@@ -20,7 +20,6 @@ logger = structlog.get_logger(__name__)
 
 try:
     import re2 as re
-    re.set_fallback_notification(re.FALLBACK_WARNING)
 except ImportError:
     logger.warning("Failed to load 're2'.  Falling back to 're' for regular expression parsing. See https://github.com/sefaria/Sefaria-Project/wiki/Regular-Expression-Engines")
     import re

--- a/sefaria/model/schema.py
+++ b/sefaria/model/schema.py
@@ -13,7 +13,6 @@ logger = structlog.get_logger(__name__)
 
 try:
     import re2 as re
-    re.set_fallback_notification(re.FALLBACK_WARNING)
 except ImportError:
     logger.warning("Failed to load 're2'.  Falling back to 're' for regular expression parsing. See https://github.com/Sefaria/Sefaria-Project/wiki/Regular-Expression-Engines")
     import re

--- a/sefaria/model/schema.py
+++ b/sefaria/model/schema.py
@@ -5,17 +5,10 @@ from typing import Optional, List
 
 import structlog
 from functools import reduce
-
+import re2 as re
 from sefaria.system.decorators import conditional_graceful_exception
 
-
 logger = structlog.get_logger(__name__)
-
-try:
-    import re2 as re
-except ImportError:
-    logger.warning("Failed to load 're2'.  Falling back to 're' for regular expression parsing. See https://github.com/Sefaria/Sefaria-Project/wiki/Regular-Expression-Engines")
-    import re
 
 import regex
 from . import abstract as abst

--- a/sefaria/model/text.py
+++ b/sefaria/model/text.py
@@ -379,15 +379,10 @@ class Index(abst.AbstractMongoRecord, AbstractIndex):
         full_title_list = list(self.alt_titles_dict(lang).keys())
         alt_titles = list(map(re.escape, full_title_list))
         reg = '(?P<title>' + '|'.join(sorted(alt_titles, key=len, reverse=True)) + r')($|[:., ]+)'
-        try:
-            # increase max memory b/c re2 is RAM limited and the titles regex exceeds this limit
-            options = re.Options()
-            options.max_mem = 384 * 1024 * 1024
-            reg = re.compile(reg, options=options)
-        except AttributeError:
-            reg = re.compile(reg)
-
-        return reg
+        # increase max memory b/c re2 is RAM limited and the titles regex exceeds this limit
+        options = re.Options()
+        options.max_mem = 384 * 1024 * 1024
+        return re.compile(reg, options=options)
 
     def get_alt_struct_node(self, title, lang=None):
         if not lang:
@@ -5603,13 +5598,10 @@ class Library(object):
         reg = self._title_regexes.get(key)
         if not reg:
             re_string = self.all_titles_regex_string(lang, with_terms, citing_only)
-            try:
-                # increase max memory b/c re2 is RAM limited and the titles regex exceeds this limit
-                options = re.Options()
-                options.max_mem = 512 * 1024 * 1024
-                reg = re.compile(re_string, options=options)
-            except AttributeError:
-                reg = re.compile(re_string)
+            # increase max memory b/c re2 is RAM limited and the titles regex exceeds this limit
+            options = re.Options()
+            options.max_mem = 512 * 1024 * 1024
+            reg = re.compile(re_string, options=options)
             self._title_regexes[key] = reg
         return reg
 

--- a/sefaria/model/text.py
+++ b/sefaria/model/text.py
@@ -385,7 +385,9 @@ class Index(abst.AbstractMongoRecord, AbstractIndex):
         alt_titles = list(map(re.escape, full_title_list))
         reg = '(?P<title>' + '|'.join(sorted(alt_titles, key=len, reverse=True)) + r')($|[:., ]+)'
         try:
-            reg = re.compile(reg, max_mem=384 * 1024 * 1024)
+            options = re.Options()
+            options.max_mem = 384 * 1024 * 1024
+            reg = re.compile(reg, options=options)
         except TypeError:
             reg = re.compile(reg)
 
@@ -5606,7 +5608,9 @@ class Library(object):
         if not reg:
             re_string = self.all_titles_regex_string(lang, with_terms, citing_only)
             try:
-                reg = re.compile(re_string, max_mem=512 * 1024 * 1024)
+                options = re.Options()
+                options.max_mem = 512 * 1024 * 1024
+                reg = re.compile(re_string, options=options)
             except TypeError:
                 reg = re.compile(re_string)
             self._title_regexes[key] = reg

--- a/sefaria/model/text.py
+++ b/sefaria/model/text.py
@@ -388,7 +388,7 @@ class Index(abst.AbstractMongoRecord, AbstractIndex):
             options = re.Options()
             options.max_mem = 384 * 1024 * 1024
             reg = re.compile(reg, options=options)
-        except TypeError:
+        except AttributeError:
             reg = re.compile(reg)
 
         return reg
@@ -5611,7 +5611,7 @@ class Library(object):
                 options = re.Options()
                 options.max_mem = 512 * 1024 * 1024
                 reg = re.compile(re_string, options=options)
-            except TypeError:
+            except AttributeError:
                 reg = re.compile(re_string)
             self._title_regexes[key] = reg
         return reg

--- a/sefaria/model/text.py
+++ b/sefaria/model/text.py
@@ -19,7 +19,6 @@ from collections import defaultdict
 from bs4 import BeautifulSoup, Tag
 try:
     import re2 as re
-    re.set_fallback_notification(re.FALLBACK_WARNING)
 except ImportError:
     logger.warning("Failed to load 're2'.  Falling back to 're' for regular expression parsing. See https://github.com/sefaria/Sefaria-Project/wiki/Regular-Expression-Engines")
     import re

--- a/sefaria/model/text.py
+++ b/sefaria/model/text.py
@@ -17,12 +17,7 @@ import json
 import itertools
 from collections import defaultdict
 from bs4 import BeautifulSoup, Tag
-try:
-    import re2 as re
-except ImportError:
-    logger.warning("Failed to load 're2'.  Falling back to 're' for regular expression parsing. See https://github.com/sefaria/Sefaria-Project/wiki/Regular-Expression-Engines")
-    import re
-
+import re2 as re
 from . import abstract as abst
 from .schema import deserialize_tree, SchemaNode, VirtualNode, DictionaryNode, JaggedArrayNode, TitledTreeNode, DictionaryEntryNode, SheetNode, AddressTalmud, Term, TermSet, TitleGroup, AddressType
 from sefaria.system.database import db

--- a/sefaria/model/text.py
+++ b/sefaria/model/text.py
@@ -380,6 +380,7 @@ class Index(abst.AbstractMongoRecord, AbstractIndex):
         alt_titles = list(map(re.escape, full_title_list))
         reg = '(?P<title>' + '|'.join(sorted(alt_titles, key=len, reverse=True)) + r')($|[:., ]+)'
         try:
+            # increase max memory b/c re2 is RAM limited and the titles regex exceeds this limit
             options = re.Options()
             options.max_mem = 384 * 1024 * 1024
             reg = re.compile(reg, options=options)
@@ -5603,6 +5604,7 @@ class Library(object):
         if not reg:
             re_string = self.all_titles_regex_string(lang, with_terms, citing_only)
             try:
+                # increase max memory b/c re2 is RAM limited and the titles regex exceeds this limit
                 options = re.Options()
                 options.max_mem = 512 * 1024 * 1024
                 reg = re.compile(re_string, options=options)


### PR DESCRIPTION
- Upgrade base-web to Python 3.9
- Move from pyre2 to google-re2 which is now the standard python implementation of re2