### PR TITLE
Curr versions

### DIFF
--- a/reader/views.py
+++ b/reader/views.py
@@ -339,7 +339,7 @@ def make_panel_dict(oref, versionEn, versionHe, filter, versionFilter, mode, **k
         index_details = library.get_index(oref.normal()).contents(with_content_counts=True)
         index_details["relatedTopics"] = get_topics_for_book(oref.normal(), annotate=True)
         if kwargs.get('extended notes', 0) and (versionEn is not None or versionHe is not None):
-            currVersions = {"en": versionEn, "he": versionHe}
+            currVersions = {"en": {'versionTitle': versionEn}, "he": {'versionTitle': versionHe}}
             if versionEn is not None and versionHe is not None:
                 curr_lang = kwargs.get("panelDisplayLanguage", "en")
                 for key in list(currVersions.keys()):
@@ -370,8 +370,8 @@ def make_panel_dict(oref, versionEn, versionHe, filter, versionFilter, mode, **k
             "ref": oref.normal(),
             "refs": [oref.normal()] if not oref.is_spanning() else [r.normal() for r in oref.split_spanning_ref()],
             "currVersions": {
-                "en": versionEn,
-                "he": versionHe,
+                "en": {'versionTitle': versionEn},
+                "he": {'versionTitle': versionHe},
             },
             "filter": filter,
             "versionFilter": versionFilter,
@@ -401,7 +401,7 @@ def make_panel_dict(oref, versionEn, versionHe, filter, versionFilter, mode, **k
             panel["settings"] = settings_override
         if mode != "Connections" and oref != None:
             try:
-                text_family = TextFamily(oref, version=panel["currVersions"]["en"], lang="en", version2=panel["currVersions"]["he"], lang2="he", commentary=False,
+                text_family = TextFamily(oref, version=panel["currVersions"]["en"]['versionTitle'], lang="en", version2=panel["currVersions"]["he"]['versionTitle'], lang2="he", commentary=False,
                                   context=True, pad=True, alts=True, wrapLinks=False, translationLanguagePreference=kwargs.get("translationLanguagePreference", None)).contents()
             except NoVersionFoundError:
                 text_family = {}

--- a/static/js/AddToSourceSheet.jsx
+++ b/static/js/AddToSourceSheet.jsx
@@ -110,8 +110,8 @@ class AddToSourceSheetBox extends Component {
       } else if (this.props.srefs) { //regular use - this is currently the case when the component is loaded in the sidepanel or in the modal component via profiles and notes pages
         source.refs = this.props.srefs;
         const { en, he } = this.props.currVersions ? this.props.currVersions : {"en": null, "he": null}; //the text we are adding may be non-default version
-        if (he) { source["version-he"] = he; }
-        if (en) { source["version-en"] = en; }
+        if (he) { source["version-he"] = he.versionTitle; }
+        if (en) { source["version-en"] = en.versionTitle; }
 
         // If something is highlighted and main panel language is not bilingual:
         // Use passed in language to determine which version this highlight covers.

--- a/static/js/BookPage.jsx
+++ b/static/js/BookPage.jsx
@@ -67,7 +67,7 @@ class BookPage extends Component {
   }
   getData() {
     // Gets data about this text from cache, which may be null.
-    return Sefaria.text(this.getDataRef(), {context: 1, enVersion: this.props.currVersions.en, heVersion: this.props.currVersions.he});
+    return Sefaria.text(this.getDataRef(), {context: 1, enVersion: this.props.currVersions.en?.versionTitle, heVersion: this.props.currVersions.he?.versionTitle});
   }
   loadData() {
     // Ensures data this text is in cache, rerenders after data load if needed
@@ -89,7 +89,7 @@ class BookPage extends Component {
     let currObjectVersions = {en: null, he: null};
     for(let [lang,ver] of Object.entries(this.props.currVersions)){
       if(!!ver){
-        let fullVer = versions.find(version => version.versionTitle == ver && version.language == lang);
+        let fullVer = versions.find(version => version.versionTitle == ver.versionTitle && version.language == lang);
         currObjectVersions[lang] = fullVer ? fullVer : null;
       }
     }
@@ -131,10 +131,10 @@ class BookPage extends Component {
     currentVersion.merged = !!(currentVersion.sources);
     return currentVersion;
   }
-  openVersion(version, language) {
+  openVersion(version, language, versionLanguageFamily) {
     // Selects a version and closes this menu to show it.
     // Calling this functon wihtout parameters resets to default
-    this.props.selectVersion(version, language);
+    this.props.selectVersion(version, language, versionLanguageFamily);
     this.props.close();
   }
   isBookToc() {

--- a/static/js/ConnectionsPanel.jsx
+++ b/static/js/ConnectionsPanel.jsx
@@ -89,8 +89,8 @@ class ConnectionsPanel extends Component {
       this.props.setConnectionsMode("Resources");
     }
 
-    if (prevProps.currVersions.en !== this.props.currVersions.en ||
-      prevProps.currVersions.he !== this.props.currVersions.he ||
+    if (!Sefaria.areCurrVersionObjectsEqual(prevProps.currVersions.en, this.props.currVersions.en) ||
+      !Sefaria.areCurrVersionObjectsEqual(prevProps.currVersions.he, this.props.currVersions.he) ||
       prevProps.masterPanelLanguage !== this.props.masterPanelLanguage ||
       prevProps.srefs[0] !== this.props.srefs[0]) {
       this.getCurrentVersions();
@@ -234,7 +234,7 @@ class ConnectionsPanel extends Component {
   getData(cb) {
     // Gets data about this text from cache, which may be null.
     const versionPref = Sefaria.versionPreferences.getVersionPref(this.props.srefs[0]);
-    return Sefaria.getText(this.props.srefs[0], { context: 1, enVersion: this.props.currVersions.en, heVersion: this.props.currVersions.he, translationLanguagePreference: this.props.translationLanguagePreference, versionPref}).then(cb);
+    return Sefaria.getText(this.props.srefs[0], { context: 1, enVersion: this.props.currVersions.en?.versionTitle, heVersion: this.props.currVersions.he?.versionTitle, translationLanguagePreference: this.props.translationLanguagePreference, versionPref}).then(cb);
   }
   getVersionFromData(d, lang) {
     //d - data received from this.getData()
@@ -1279,7 +1279,7 @@ const AdvancedToolsList = ({srefs, canEditText, currVersions, setConnectionsMode
       let currentLangParam;
       const langCode = masterPanelLanguage.slice(0, 2);
       if (currVersions[langCode]) {
-        refString += "/" + encodeURIComponent(langCode) + "/" + encodeURIComponent(currVersions[langCode]);
+        refString += "/" + encodeURIComponent(langCode) + "/" + encodeURIComponent(currVersions[langCode].versionTitle);
       }
       let path = "/edit/" + refString;
       let nextParam = "?next=" + encodeURIComponent(currentPath);

--- a/static/js/ExtendedNotes.jsx
+++ b/static/js/ExtendedNotes.jsx
@@ -13,7 +13,7 @@ class ExtendedNotes extends Component {
     this.state = {'notesLanguage': Sefaria.interfaceLang, 'extendedNotes': '', 'langToggle': false};
   }
   getVersionData(versionList){
-    const versionTitle = this.props.currVersions['en'] ? this.props.currVersions['en'] : this.props.currVersions['he'];
+    const versionTitle = this.props.currVersions['en'] ? this.props.currVersions['en'].versionTitle : this.props.currVersions['he'].versionTitle;
     const thisVersion = versionList.filter(x=>x.versionTitle===versionTitle)[0];
     let extendedNotes = {'english': thisVersion.extendedNotes, 'hebrew': thisVersion.extendedNotesHebrew};
 

--- a/static/js/ReaderApp.jsx
+++ b/static/js/ReaderApp.jsx
@@ -219,7 +219,6 @@ class ReaderApp extends Component {
     document.removeEventListener('copy', this.handleCopyEvent);
   }
   componentDidUpdate(prevProps, prevState) {
-    console.log(0, this.state,prevState )
     $(".content").off("scroll.scrollPosition").on("scroll.scrollPosition", this.setScrollPositionInHistory); // when .content may have rerendered
 
     if (this.justPopped) {

--- a/static/js/ReaderApp.jsx
+++ b/static/js/ReaderApp.jsx
@@ -219,6 +219,7 @@ class ReaderApp extends Component {
     document.removeEventListener('copy', this.handleCopyEvent);
   }
   componentDidUpdate(prevProps, prevState) {
+    console.log(0, this.state,prevState )
     $(".content").off("scroll.scrollPosition").on("scroll.scrollPosition", this.setScrollPositionInHistory); // when .content may have rerendered
 
     if (this.justPopped) {
@@ -333,7 +334,7 @@ class ReaderApp extends Component {
       Sefaria.track.setContentLanguage(contentLanguages.join(" | "));
 
       // Set Versions - per text panel
-      var versionTitles = textPanels.map(p => p.currVersions.en ? `${p.currVersions.en}(en)`: (p.currVersions.he ? `${p.currVersions.he}(he)` : 'default version'));
+      var versionTitles = textPanels.map(p => p.currVersions.en ? `${p.currVersions.en.versionTitle}(en)`: (p.currVersions.he ? `${p.currVersions.he.versionTitle}(he)` : 'default version'));
       Sefaria.track.setVersionTitle(versionTitles.join(" | "));
 
       // Set Sidebar usages
@@ -385,8 +386,8 @@ class ReaderApp extends Component {
           (next.mode === "Connections" && !prev.refs.compare(next.refs)) ||
           (next.currentlyVisibleRef !== prev.currentlyVisibleRef) ||
           (next.connectionsMode !== prev.connectionsMode) ||
-          (prev.currVersions.en !== next.currVersions.en) ||
-          (prev.currVersions.he !== next.currVersions.he) ||
+          (!Sefaria.areCurrVersionObjectsEqual(prev.currVersions.en, next.currVersions.en)) ||
+          (!Sefaria.areCurrVersionObjectsEqual(prev.currVersions.he, next.currVersions.he)) ||
           (prev.searchQuery != next.searchQuery) ||
           (prev.searchTab != next.searchTab) ||
           (prev.tab !== next.tab) ||
@@ -1150,7 +1151,7 @@ toggleSignUpModal(modalContentKind = SignUpModalKind.Default) {
       let slug = path.slice(14);
       this.openTranslationsPage(slug);
     } else if (Sefaria.isRef(path.slice(1))) {
-      const currVersions = {en: params.get("ven"), he: params.get("vhe")};
+      const currVersions = {en: {versionTitle: params.get("ven")}, he: {versionTitle: params.get("vhe")}};
       const options = {showHighlight: path.slice(1).indexOf("-") !== -1};   // showHighlight when ref is ranged
       openPanel(Sefaria.humanRef(path.slice(1)), currVersions, options);
     } else {
@@ -1283,8 +1284,8 @@ toggleSignUpModal(modalContentKind = SignUpModalKind.Default) {
           !nextPanel.refs || nextPanel.refs.length == 0 ||
           !prevPanel.refs || prevPanel.refs.length == 0 ) { return false; }
       if (nextPanel.refs.compare(prevPanel.refs)) {
-        if (nextPanel.currVersions.en !== prevPanel.currVersions.en) { return true; }
-        if (nextPanel.currVersions.he !== prevPanel.currVersions.he) { return true; }
+        if (!Sefaria.areCurrVersionObjectsEqual(nextPanel.currVersions.en, prevPanel.currVersions.en)) { return true; }
+        if (!Sefaria.areCurrVersionObjectsEqual(nextPanel.currVersions.he, prevPanel.currVersions.he)) { return true; }
         //console.log('didPanelRefChange?', nextPanel.highlightedRefs, prevPanel.highlightedRefs);
         return !((nextPanel.highlightedRefs || []).compare(prevPanel.highlightedRefs || []));
       } else {
@@ -1331,14 +1332,14 @@ toggleSignUpModal(modalContentKind = SignUpModalKind.Default) {
     }
     return { dependentPanel, isDependentPanelConnections };
   }
-  selectVersion(n, versionName, versionLanguage) {
+  selectVersion(n, versionTitle, versionLanguage, languageFamilyName) {
     // Set the version for panel `n`.
     const panel = this.state.panels[n];
     const oRef = Sefaria.ref(panel.refs[0]);
-    if (versionName && versionLanguage) {
-      panel.currVersions[versionLanguage] = versionName;
-      this.setCachedVersion(oRef.indexTitle, versionLanguage, versionName);
-      Sefaria.track.event("Reader", "Choose Version", `${oRef.indexTitle} / ${versionName} / ${versionLanguage}`)
+    if (versionTitle && versionLanguage) {
+      panel.currVersions[versionLanguage] = {versionTitle, languageFamilyName};
+      this.setCachedVersion(oRef.indexTitle, versionLanguage, versionTitle, languageFamilyName);
+      Sefaria.track.event("Reader", "Choose Version", `${oRef.indexTitle} / ${versionTitle} / ${versionLanguage}`)
     } else {
       panel.currVersions[versionLanguage] = null;
       Sefaria.track.event("Reader", "Choose Version", `${oRef.indexTitle} / default version / ${panel.settings.language}`)
@@ -1379,37 +1380,37 @@ toggleSignUpModal(modalContentKind = SignUpModalKind.Default) {
     Object.assign(panel, updatePanelObj);
     this.setState({panels: this.state.panels});
   }
-  viewExtendedNotes(n, method, title, versionLanguage, versionName) {
+  viewExtendedNotes(n, method, title, versionLanguage, versionTitle, languageFamilyName) {
     const panel = this.state.panels[n];
     panel.bookRef = title;
     panel.currVersions = {'en': null, 'he': null}; // ensure only 1 version is set
-    panel.currVersions[versionLanguage] = versionName;
+    panel.currVersions[versionLanguage] = {versionTitle, languageFamilyName};
     if (method === "toc") {
       panel.menuOpen = "extended notes";
     }
     else if (method === "Connections") {
       panel.connectionsMode = "extended notes";
     }
-    this.setState({panels: this.state.panels});
+   this.setState({panels: this.state.panels});
   }
   backFromExtendedNotes(n, bookRef, currVersions){
     const panel = this.state.panels[n];
     panel.menuOpen = panel.currentlyVisibleRef ? "text toc" : "book toc";
     panel.bookRef = bookRef;
     panel.currVersions = currVersions;
-    this.setState({panels: this.state.panels});
+   this.setState({panels: this.state.panels});
   }
   // this.state.defaultVersion is a depth 2 dictionary - keyed: bookname, language
   getCachedVersion(indexTitle, language) {
     if ((!indexTitle) || (!(this.state.defaultVersions[indexTitle]))) { return null; }
     return (language) ? (this.state.defaultVersions[indexTitle][language] || null) : this.state.defaultVersions[indexTitle];
   }
-  setCachedVersion(indexTitle, language, versionTitle) {
+  setCachedVersion(indexTitle, language, versionTitle, languageFamilyName) {
     this.state.defaultVersions[indexTitle] = this.state.defaultVersions[indexTitle] || {};
-    this.state.defaultVersions[indexTitle][language] = versionTitle;  // Does this need a setState?  I think not.
+      this.state.defaultVersions[indexTitle][language] = {versionTitle, languageFamilyName};  // Does this need a setState?  I think not.
   }
   setDefaultOption(option, value) {
-    if (value !== this.state.defaultPanelSettings[option]) {
+   if (value !== this.state.defaultPanelSettings[option]) {
       this.state.defaultPanelSettings[option] = value;
       this.setState(this.state);
     }
@@ -1488,7 +1489,7 @@ toggleSignUpModal(modalContentKind = SignUpModalKind.Default) {
     if (connectionPanel) {
       newPanels.push(connectionPanel);
     }
-    this.setState({panels: newPanels});
+   this.setState({panels: newPanels});
     if (saveLastPlace) {
       this.saveLastPlace(panel, n + 1, !!connectionPanel);
     }
@@ -1560,7 +1561,7 @@ toggleSignUpModal(modalContentKind = SignUpModalKind.Default) {
       panel = {...panel, ...textListState};
     }
     newPanels[n] = this.makePanelState(panel);
-    this.setState({panels: newPanels});
+   this.setState({panels: newPanels});
   }
   setTextListHighlight(n, refs) {
     // Set the textListHighlight for panel `n` to `refs`

--- a/static/js/ReaderPanel.jsx
+++ b/static/js/ReaderPanel.jsx
@@ -174,12 +174,19 @@ class ReaderPanel extends Component {
     this.showBaseText(ref, replaceHistory, currVersions, [], false);  // don't attempt to convert commentary to base ref when opening from connections panel
   }
   updateCurrVersionsToMatchAPIResult(enVTitle, heVTitle) {
+    if (this.state.currVersions.en?.APIResult === enVTitle && this.state.currVersions.he?.APIResult === heVTitle) {
+      return;
+    }
     const newVersions = {
-        ...this.state.currVersions,
-        enAPIResult: enVTitle,
-        heAPIResult: heVTitle,
+        en: {
+          ...this.state.currVersions.en,
+          APIResult: enVTitle,
+        },
+        he: {
+          ...this.state.currVersions.he,
+          APIResult: heVTitle,
+        }
     };
-    if (Sefaria.util.object_equals(this.state.currVersions, newVersions)) { return; }
     this.conditionalSetState({ currVersions: newVersions });
   }
   openConnectionsPanel(ref, additionalState) {
@@ -690,7 +697,6 @@ class ReaderPanel extends Component {
           highlightedNode={this.state.highlightedNode}
           highlightedRefsInSheet={this.state.highlightedRefsInSheet}
           scrollToHighlighted={this.state.scrollToHighlighted}
-          onRefClick={this.handleCitationClick}
           onSegmentClick={this.handleSheetSegmentClick}
           onCitationClick={this.handleCitationClick}
           openSheet={this.openSheet}
@@ -806,7 +812,6 @@ class ReaderPanel extends Component {
                     currentRef={this.state.currentlyVisibleRef}
                     openNav={this.openMenu.bind(null, "navigation")}
                     openDisplaySettings={this.openDisplaySettings}
-                    selectVersion={this.props.selectVersion}
                     showBaseText={this.showBaseText} />);
 
     } else if (this.state.menuOpen === "text toc") {
@@ -927,7 +932,6 @@ class ReaderPanel extends Component {
             setTopic={this.setTopic}
             setNavTopic={this.setNavigationTopic}
             openTopics={this.openMenu.bind(null, "topics")}
-            showBaseText={this.props.onNavTextClick || this.showBaseText}
             openNav={this.openMenu.bind(null, "navigation")}
             openSearch={this.openSearch}
             close={this.closeMenus}
@@ -1084,7 +1088,6 @@ class ReaderPanel extends Component {
         <div ref={this.readerContentRef} className={classes} onKeyDown={this.handleKeyPress} role="region" id={"panel-"+this.props.panelPosition}>
           {hideReaderControls ? null :
           <ReaderControls
-            showBaseText={this.showBaseText}
             hasSidebar={this.state.hasSidebar}
             toggleSheetEditMode={this.toggleSheetEditMode}
             currentRef={this.state.currentlyVisibleRef}
@@ -1242,7 +1245,7 @@ class ReaderControls extends Component {
      */
     if (!this.shouldShowVersion()) { return; }
     Sefaria.getTranslations(this.props.currentRef).then(versions => {
-      const enVTitle = this.props.currVersions.enAPIResult;
+      const enVTitle = this.props.currVersions.en.APIResult;
       if (!enVTitle) {
         // merged version from API
         this.setDisplayVersionTitle({});
@@ -1275,7 +1278,7 @@ class ReaderControls extends Component {
   componentDidUpdate(prevProps, prevState) {
     if (
       this.shouldShowVersion() !== this.shouldShowVersion(prevProps) ||
-      this.props.currVersions !== prevProps.currVersions
+      !Sefaria.areCurrVersionObjectsEqual(this.props.currVersions, prevProps.currVersions)
     ) {
       this.loadTranslations();
     }
@@ -1422,7 +1425,6 @@ class ReaderControls extends Component {
 }
 ReaderControls.propTypes = {
   settings:                PropTypes.object.isRequired,
-  showBaseText:            PropTypes.func.isRequired,
   setOption:               PropTypes.func.isRequired,
   setConnectionsMode:      PropTypes.func.isRequired,
   setConnectionsCategory:  PropTypes.func.isRequired,

--- a/static/js/SearchTextResult.jsx
+++ b/static/js/SearchTextResult.jsx
@@ -64,7 +64,7 @@ class SearchTextResult extends Component {
             } else {
                 Sefaria.track.event("Search", "Search Result Text Click", `${this.props.query} - ${parsedRef.ref}/${s.version}/${s.lang}`);
             }
-            this.props.onResultClick(parsedRef.ref, {[s.lang]: s.version}, {textHighlights});
+            this.props.onResultClick(parsedRef.ref, {[s.lang]: {versionTitle: s.version}}, {textHighlights});
         }
     }
     get_snippet_markup(data) {

--- a/static/js/Sheet.jsx
+++ b/static/js/Sheet.jsx
@@ -109,7 +109,6 @@ class Sheet extends Component {
           sheetNotice={sheet.sheetNotice}
           sources={sheet.sources}
           title={sheet.title}
-          onRefClick={this.props.onRefClick}
           handleClick={this.handleClick}
           sheetSourceClick={this.props.onSegmentClick}
           highlightedNode={this.props.highlightedNode}

--- a/static/js/SheetMetadata.jsx
+++ b/static/js/SheetMetadata.jsx
@@ -512,8 +512,6 @@ SheetMetadata.propTypes = {
   narrowPanel:      PropTypes.bool,
   close:            PropTypes.func.isRequired,
   openNav:          PropTypes.func.isRequired,
-  showBaseText:     PropTypes.func.isRequired,
-  selectVersion:    PropTypes.func,
   interfaceLang:    PropTypes.string,
 };
 

--- a/static/js/TextColumn.jsx
+++ b/static/js/TextColumn.jsx
@@ -78,8 +78,8 @@ class TextColumn extends Component {
       this.scrollToHighlighted();
 
     } else if ((this.props.settings.language !== prevProps.settings.language) ||
-        (prevProps.currVersions.en !== this.props.currVersions.en) ||
-        (prevProps.currVersions.he !== this.props.currVersions.he)) {
+        !Sefaria.areCurrVersionObjectsEqual(prevProps.currVersions.en, this.props.currVersions.en) ||
+        !Sefaria.areCurrVersionObjectsEqual(prevProps.currVersions.he, this.props.currVersions.he)) {
       // When the content the changes but we are anchored on a line, scroll to it
       // console.log("scroll to highlighted on text content change")
       this.scrollToHighlighted();

--- a/static/js/TopicPage.jsx
+++ b/static/js/TopicPage.jsx
@@ -422,7 +422,7 @@ const PortalNavSideBar = ({portal, entriesToDisplayList}) => {
 };
 
 const TopicPage = ({
-  tab, topic, topicTitle, setTopic, setNavTopic, openTopics, multiPanel, showBaseText, navHome,
+  tab, topic, topicTitle, setTopic, setNavTopic, openTopics, multiPanel, navHome,
   toggleSignUpModal, openDisplaySettings, setTab, openSearch, translationLanguagePreference, versionPref,
   topicTestVersion, onSetTopicSort, topicSort
 }) => {
@@ -592,7 +592,6 @@ TopicPage.propTypes = {
   openTopics:          PropTypes.func.isRequired,
   setTab:              PropTypes.func.isRequired,
   multiPanel:          PropTypes.bool,
-  showBaseText:        PropTypes.func,
   navHome:             PropTypes.func,
   openDisplaySettings: PropTypes.func,
   toggleSignUpModal:   PropTypes.func,

--- a/static/js/TranslationsBox.jsx
+++ b/static/js/TranslationsBox.jsx
@@ -167,7 +167,7 @@ class VersionsTextList extends Component {
   }
   render() {
     const [vTitle, language] = Sefaria.deconstructVersionsKey(this.props.vFilter[0]);
-    const currSelectedVersions = {[language]: vTitle};
+    const currSelectedVersions = {[language]: {versionTitle: vTitle}};
     const onRangeClick = (sref) => {this.props.onRangeClick(sref, false, currSelectedVersions)};
     return !this.state.loaded || !this.props.vFilter.length ?
       (<LoadingMessage />) :

--- a/static/js/UserHistoryPanel.jsx
+++ b/static/js/UserHistoryPanel.jsx
@@ -11,10 +11,6 @@ import {
   TextPassage
 } from './Story';
 import {
-  CategoryColorLine,
-  MenuButton,
-  DisplaySettingsButton,
-  TextBlockLink,
   LanguageToggleButton,
   LoadingMessage,
   InterfaceText,

--- a/static/js/VersionBlock/VersionBlock.jsx
+++ b/static/js/VersionBlock/VersionBlock.jsx
@@ -66,7 +66,7 @@ class VersionBlockUtils {
       if (renderMode === 'book-page') {
           window.location = `/${firstSectionRef}?v${version.language}=${version.versionTitle.replace(/\s/g,'_')}`;
       } else {
-          openVersionInReader(version.versionTitle, version.language);
+          openVersionInReader(version.versionTitle, version.language, version.languageFamilyName);
       }
       Sefaria.setVersionPreference(currRef, version.versionTitle, version.language);
   }
@@ -172,7 +172,7 @@ class VersionBlock extends Component {
   }
   openExtendedNotes(e){
     e.preventDefault();
-    this.props.viewExtendedNotes(this.props.version.title, this.props.version.language, this.props.version.versionTitle);
+    this.props.viewExtendedNotes(this.props.version.title, this.props.version.language, this.props.version.versionTitle, this.props.version.languageFamilyName);
   }
   makeVersionNotes(){
     if (!this.props.showNotes) {

--- a/static/js/VersionBlock/VersionBlockWithPreview.jsx
+++ b/static/js/VersionBlock/VersionBlockWithPreview.jsx
@@ -9,7 +9,8 @@ import {OpenConnectionTabButton} from "../TextList";
 function VersionBlockWithPreview({currentRef, version, currObjectVersions, openVersionInSidebar, openVersionInReader, isSelected, srefs, onRangeClick}) {
     const opeInSidebar = VersionBlockUtils.openVersionInSidebar.bind(null, currentRef, version, currObjectVersions, openVersionInSidebar);
     function openInTabCallback(sref) {
-        onRangeClick(sref, false, {[version.language]: version.versionTitle});
+        const {versionTitle, languageFamilyName} = version;
+        onRangeClick(sref, false, {[version.language]: {versionTitle, languageFamilyName}});
     }
     return (
         <div className='versionBlock with-preview'>

--- a/static/js/sefaria/sefaria.js
+++ b/static/js/sefaria/sefaria.js
@@ -990,6 +990,10 @@ Sefaria = extend(Sefaria, {
     }
     return data;
   }, */
+  areCurrVersionObjectsEqual: function(version1, version2) {
+      console.log(555, version1, version2)
+      return version1?.versionTitle === version2?.versionTitle && version1?.languageFamilyName === version2?.languageFamilyName;
+  },
   _index: {}, // Cache for text index records
    index: function(text, index) {
     if (!index) {

--- a/static/js/sefaria/sefaria.js
+++ b/static/js/sefaria/sefaria.js
@@ -991,7 +991,6 @@ Sefaria = extend(Sefaria, {
     return data;
   }, */
   areCurrVersionObjectsEqual: function(version1, version2) {
-      console.log(555, version1, version2)
       return version1?.versionTitle === version2?.versionTitle && version1?.languageFamilyName === version2?.languageFamilyName;
   },
   _index: {}, // Cache for text index records

--- a/static/js/sefaria/util.js
+++ b/static/js/sefaria/util.js
@@ -50,7 +50,6 @@ class Util {
     }
     static getUrlVersionsParams(currVersions, i=0) {
       currVersions = this.getCurrVersionsWithoutAPIResultFields(currVersions);
-      console.log(111, currVersions);
       if (currVersions) {
         return Object.entries(currVersions)
           .filter(([vlang, version]) => !!version?.versionTitle)

--- a/static/js/sefaria/util.js
+++ b/static/js/sefaria/util.js
@@ -50,10 +50,11 @@ class Util {
     }
     static getUrlVersionsParams(currVersions, i=0) {
       currVersions = this.getCurrVersionsWithoutAPIResultFields(currVersions);
+      console.log(111, currVersions);
       if (currVersions) {
         return Object.entries(currVersions)
-          .filter(([vlang, vtitle]) => !!vtitle)
-          .map(([vlang, vtitle]) =>`&v${vlang}${i > 1 ? i : ""}=${this.encodeVtitle(vtitle)}`)
+          .filter(([vlang, version]) => !!version?.versionTitle)
+          .map(([vlang, version]) =>`&v${vlang}${i > 1 ? i : ""}=${this.encodeVtitle(version.versionTitle)}`)
           .join("");
       } else {
         return "";


### PR DESCRIPTION
This PR is a wide refactor. It changes the currVersions object to include an object for any language (he and en) rather than a string. The idea is to enable it to include other details and not only versionTitle. In some cases it adds to the object also the languageFamilyName (in some cases this data is not available to pu it in the object).
