### PR TITLE
Fix pydantic

### DIFF
--- a/build/linker/Dockerfile
+++ b/build/linker/Dockerfile
@@ -49,6 +49,5 @@ ENV PATH=/usr/local/nvidia/bin:$PATH
 ENV LD_LIBRARY_PATH=/usr/local/nvidia/lib64/
 ENV LD_PRELOAD=/usr/local/nvidia/lib64/libnvidia-ml.so
 
-# the version of pydantic installed with spacy is currently broken. force upgrade to fixed version of pydantic.
-RUN pip install spacy[cuda116]~=3.5.0 pydantic~=1.10.0
+RUN pip install spacy[cuda116]~=3.7.0
 

--- a/build/linker/Dockerfile
+++ b/build/linker/Dockerfile
@@ -49,5 +49,6 @@ ENV PATH=/usr/local/nvidia/bin:$PATH
 ENV LD_LIBRARY_PATH=/usr/local/nvidia/lib64/
 ENV LD_PRELOAD=/usr/local/nvidia/lib64/libnvidia-ml.so
 
-RUN pip install spacy[cuda116]==3.4.1
+# the version of pydantic installed with spacy is currently broken. force upgrade to fixed version of pydantic.
+RUN pip install spacy[cuda116]~=3.5.0 pydantic~=1.10.0
 


### PR DESCRIPTION
The latest upgrade to python 3.9 broke the linker pod. This PR upgrades spacy to the latest version which fixes an issue in a dependency with pydantic.