### PR TITLE
Bug/sc 25982/index editor doesn t work with jerusalem

### DIFF
--- a/reader/views.py
+++ b/reader/views.py
@@ -1661,6 +1661,7 @@ def index_api(request, title, raw=False):
         # use the update function if update is in the params
 
         func = tracker.update if request.GET.get("update", False) else tracker.add
+        dont_modify_schema = bool(int(request.GET.get("dont_modify_schema", False)))
         j = json.loads(request.POST.get("json"))
         if not j:
             return jsonResponse({"error": "Missing 'json' parameter in post data."})
@@ -1681,7 +1682,9 @@ def index_api(request, title, raw=False):
         else:
             title = j.get("oldTitle", j.get("title"))
             try:
-                library.get_index(title)  # getting the index just to tell if it exists
+                book = library.get_index(title)
+                if dont_modify_schema:   # ignore any 'schema' that was passed in
+                    j['schema'] = book.contents()['schema']
                 # Only allow staff and the person who submitted a text to edit
                 if not request.user.is_staff and not user_started_text(request.user.id, title):
                    return jsonResponse({"error": "{} is protected from change.<br/><br/>See a mistake?<br/>Email hello@sefaria.org.".format(title)})

--- a/reader/views.py
+++ b/reader/views.py
@@ -26,7 +26,6 @@ from django.contrib.admin.views.decorators import staff_member_required
 from django.utils.encoding import iri_to_uri
 from django.utils.translation import ugettext as _
 from django.views.decorators.csrf import ensure_csrf_cookie, csrf_exempt, csrf_protect, requires_csrf_token
-from django.views.decorators.http import require_http_methods
 from django.contrib.auth.models import User
 from django import http
 from django.utils import timezone

--- a/reader/views.py
+++ b/reader/views.py
@@ -1661,7 +1661,6 @@ def index_api(request, title, raw=False):
         # use the update function if update is in the params
 
         func = tracker.update if request.GET.get("update", False) else tracker.add
-        dont_modify_schema = bool(int(request.GET.get("dont_modify_schema", False)))
         j = json.loads(request.POST.get("json"))
         if not j:
             return jsonResponse({"error": "Missing 'json' parameter in post data."})
@@ -1682,9 +1681,7 @@ def index_api(request, title, raw=False):
         else:
             title = j.get("oldTitle", j.get("title"))
             try:
-                book = library.get_index(title)
-                if dont_modify_schema:   # ignore any 'schema' that was passed in
-                    j['schema'] = book.contents()['schema']
+                library.get_index(title)  # getting the index just to tell if it exists
                 # Only allow staff and the person who submitted a text to edit
                 if not request.user.is_staff and not user_started_text(request.user.id, title):
                    return jsonResponse({"error": "{} is protected from change.<br/><br/>See a mistake?<br/>Email hello@sefaria.org.".format(title)})

--- a/reader/views.py
+++ b/reader/views.py
@@ -1670,13 +1670,9 @@ def index_api(request, title, raw=False):
             book = library.get_index(title)
         except BookNameError:
             pass
-        if 'schema' not in j:
-            if book:
-                # if book already exists and no schema provided, use old schema
-                j['schema'] = book.contents()['schema']
-            else:
-                # book doesn't exist and didn't receive a schema so flag it
-                return jsonResponse({"error": "A new index must be created with a schema."})
+        if 'schema' not in j and book:
+            # if book already exists and no schema provided, use old schema
+            j['schema'] = book.contents()['schema']
 
         #todo: move this to texts_api, pass the changes down through the tracker and text chunk
         #if "versionTitle" in j:

--- a/sefaria/model/text.py
+++ b/sefaria/model/text.py
@@ -527,65 +527,6 @@ class Index(abst.AbstractMongoRecord, AbstractIndex):
             if not d.get("categories"):
                 raise InputError("Please provide category for Index record: {}.".format(d.get("title")))
 
-            # Data is being loaded from dict in old format, rewrite to new format
-            # Assumption is that d has a complete title collection
-            if "schema" not in d:
-                node = getattr(self, "nodes", None)
-                if node:
-                    node._init_title_defaults()
-                else:
-                    node = JaggedArrayNode()
-
-                node.key = d.get("title")
-
-                if node.is_flat():
-                    sn = d.pop("sectionNames", None)
-                    if sn:
-                        node.sectionNames = sn
-                        node.depth = len(node.sectionNames)
-                    else:
-                        raise InputError("Please specify section names for Index record.")
-
-                    if d["categories"][0] == "Talmud":
-                        node.addressTypes = ["Talmud", "Integer"]
-                        if d["categories"][1] == "Bavli" and d.get("heTitle") and not self.is_dependant_text():
-                            node.checkFirst = {
-                                "he": "משנה" + " " + d.get("heTitle"),
-                                "en": "Mishnah " + d.get("title")
-                            }
-                    elif d["categories"][0] == "Mishnah":
-                        node.addressTypes = ["Perek", "Mishnah"]
-                    else:
-                        if getattr(node, "addressTypes", None) is None:
-                            node.addressTypes = ["Integer" for _ in range(node.depth)]
-
-                    l = d.pop("length", None)
-                    if l:
-                        node.lengths = [l]
-
-                    ls = d.pop("lengths", None)
-                    if ls:
-                        node.lengths = ls  #overwrite if index.length is already there
-
-                #Build titles
-                node.add_title(d["title"], "en", True)
-
-                tv = d.pop("titleVariants", None)
-                if tv:
-                    for t in tv:
-                        lang = "he" if has_hebrew(t) else "en"
-                        node.add_title(t, lang)
-
-                ht = d.pop("heTitle", None)
-                if ht:
-                    node.add_title(ht, "he", True)
-
-                htv = d.pop("heTitleVariants", None)
-                if htv:
-                    for t in htv:
-                        node.add_title(t, "he")
-
-                d["schema"] = node.serialize()
 
             # todo: should this functionality be on load()?
             if "oldTitle" in d and "title" in d and d["oldTitle"] != d["title"]:

--- a/sefaria/model/text.py
+++ b/sefaria/model/text.py
@@ -527,6 +527,8 @@ class Index(abst.AbstractMongoRecord, AbstractIndex):
             if not d.get("categories"):
                 raise InputError("Please provide category for Index record: {}.".format(d.get("title")))
 
+            if 'schema' not in d:
+                raise InputError(f"Please provide schema for Index record: {d.get('title')}")
 
             # todo: should this functionality be on load()?
             if "oldTitle" in d and "title" in d and d["oldTitle"] != d["title"]:

--- a/sefaria/model/user_profile.py
+++ b/sefaria/model/user_profile.py
@@ -875,23 +875,6 @@ def is_user_staff(uid):
     except:
         return False
 
-
-def user_started_text(uid, title):
-    """
-    Returns true if uid was responsible for first adding 'title'
-    to the library.
-
-    This checks for the oldest matching index change record for 'title'.
-    If someone other than the initiator changed the text's title, this function
-    will incorrectly report False, but this matches our intended behavior to
-    lock name changes after an admin has stepped in.
-    """
-    log = db.history.find({"title": title}).sort([["date", -1]]).limit(1)
-    if len(log):
-        return log[0]["user"] == uid
-    return False
-
-
 def annotate_user_list(uids):
     """
     Returns a list of dictionaries giving details (names, profile links)

--- a/static/js/BookPage.jsx
+++ b/static/js/BookPage.jsx
@@ -1182,9 +1182,9 @@ const EditTextInfo = function({initTitle, close}) {
     }
     let postJSON = JSON.stringify(postIndex);
     let title = enTitle.replace(/ /g, "_");
-    let url = `/api/v2/raw/index/${title}?dont_modify_schema=1`;  // we are modifying attributes in the existing Index but dont want to touch schema
+    let url = "/api/v2/raw/index/" + title;
     if ("oldTitle" in index.current) {
-      url += "&update=1";
+      url += "?update=1";
     }
     toggleInProgress();
     $.post(url,  {"json": postJSON}, function(data) {

--- a/static/js/BookPage.jsx
+++ b/static/js/BookPage.jsx
@@ -1182,9 +1182,9 @@ const EditTextInfo = function({initTitle, close}) {
     }
     let postJSON = JSON.stringify(postIndex);
     let title = enTitle.replace(/ /g, "_");
-    let url = "/api/v2/raw/index/" + title;
+    let url = `/api/v2/raw/index/${title}?dont_modify_schema=1`;  // we are modifying attributes in the existing Index but dont want to touch schema
     if ("oldTitle" in index.current) {
-      url += "?update=1";
+      url += "&update=1";
     }
     toggleInProgress();
     $.post(url,  {"json": postJSON}, function(data) {


### PR DESCRIPTION
The Index Editor did not work with any Jerusalem Talmud text as well as some other texts because of two things: 1) the Index Editor never passed a 'schema' value to the API and 2) we have very old code (mostly from 2014) that, if no schema is passed, makes up a schema based on reasonable defaults.  However, those reasonable defaults do not work in all cases.  For example, it assumes Talmud texts' addressTypes are ["Daf", "Integer"] which they are not in the case of Jerusalem Talmud texts.  My code makes two changes.  First it removes in sefaria/model/text.py the 10 year old code because it is unnecessary.  When Content Engineers work, they provide a 'schema' in the post_index function.    Why was this 10 year old code there in the first place?  The comment there explains:            
           # Data is being loaded from dict in old format, rewrite to new format
            # Assumption is that d has a complete title collection
But we no longer use this old format where we have indices without schemas so I removed the code.

I also made changes to the POST Index API:
The core change is here -- If 'schema' is not passed to the POST Index API, check whether the book already exists.  If the book doesn't exist, return an error.  If the book already exists, just use the schema that it already has.  Therefore, there's no reason to create a new schema as either a content engineer provides one or it already exists.
```
if 'schema' not in j and book:
        # if book already exists and no schema provided, use old schema
        j['schema'] = book.contents()['schema']
```
