### PR TITLE
fix(Topics): dont cascade title change to slug

### DIFF
--- a/sefaria/model/topic.py
+++ b/sefaria/model/topic.py
@@ -126,11 +126,6 @@ class Topic(abst.SluggedAbstractMongoRecord, AbstractTitledObject):
     def set_titles(self, titles):
         self.title_group = TitleGroup(titles)
 
-    def add_title(self, text, lang, primary=False, replace_primary=False):
-        super(Topic, self).add_title(text, lang, primary=primary, replace_primary=replace_primary)
-        if lang == 'en' and primary:
-            self.set_slug_to_primary_title()
-
     def title_is_transliteration(self, title, lang):
         return self.title_group.get_title_attr(title, lang, 'transliteration') is not None
 


### PR DESCRIPTION
We no longer want slugs to change based on a title change.  The entire `add_title` of topic.py was dedicated to cascading a primary title change to the slug and so I removed this function.  Now, changing the primary title can be done and the slug does not change.
https://app.shortcut.com/sefaria/story/24547/fix-issues-created-by-renaming-topic-titles