### PR TITLE
Feature/sc 21757/place a message next to the add to sheet

### DIFF
--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -8716,13 +8716,6 @@ h3.aboutSheetHeader {
   color: var(--dark-grey);
 }
 
-.gDocAdvertBanner {
-  top: 60px;
-  position: absolute;
-  width: 100%;
-  z-index: 101;
-}
-
 .aboutSheetPanel hr {
   height: 0px;
   border: 1px solid var(--light-grey);

--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -1787,9 +1787,9 @@ div.interfaceLinks-row a {
   margin-top: 18px;
   width: 99px;
   height: 30px;
-  border-radius: 6px;
 }
 .gDocAdvertBox #installNow a {
+  border-radius: 6px;
   text-align: center;
   background: #FFFFFF;
   color: #666666;

--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -1788,13 +1788,17 @@ div.interfaceLinks-row a {
   width: 99px;
   height: 30px;
 }
+.interface-hebrew .gDocAdvertBox #installNow {
+  width: 120px;
+}
+
 .gDocAdvertBox #installNow a {
   border-radius: 6px;
   text-align: center;
   background: #FFFFFF;
   color: #666666;
   text-decoration: none;
-  padding: 4px;
+  padding: 4px 9px;
   font-family: "Roboto", "Helvetica Neue", "Helvetica", sans-serif;;
   font-size: 16px;
   font-weight: 400;

--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -1768,7 +1768,7 @@ div.interfaceLinks-row a {
 
 .gDocAdvertBox {
   margin-top: 50px;
-  background: #EDEDEC;
+  background: var(--lighter-grey);
   padding: 20px;
   border-radius: 6px;
 }
@@ -1778,7 +1778,7 @@ div.interfaceLinks-row a {
   font-weight: 400;
   line-height: 19px;
   letter-spacing: 0em;
-  color: #666666;
+  color: var(--dark-grey);
 }
 .gDocAdvertBox span #newExtension {
   font-weight: 600;
@@ -1796,17 +1796,17 @@ div.interfaceLinks-row a {
   border-radius: 6px;
   text-align: center;
   background: #FFFFFF;
-  color: #666666;
+  color: var(--dark-grey);
   text-decoration: none;
   padding: 4px 9px;
-  font-family: "Roboto", "Helvetica Neue", "Helvetica", sans-serif;;
+  font-family: "Roboto", "Helvetica Neue", "Helvetica", sans-serif;
   font-size: 16px;
   font-weight: 400;
   line-height: 19px;
   letter-spacing: 0em;
 }
 .gDocAdvertBox a {
-  font-family: Roboto;
+  font-family: "Roboto", "Helvetica Neue", "Helvetica", sans-serif;
   font-size: 16px;
   font-weight: 400;
   line-height: 19px;

--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -758,7 +758,7 @@ div:has(#bannerMessage) + .readerApp.singlePanel .mobileNavMenu {
   margin-inline-start: 23px;
   margin-top: 3px;
 }
-.loggedIn .help { 
+.loggedIn .help {
   margin-inline-start: 17px;
 }
 .loggedIn .help img {
@@ -2332,7 +2332,7 @@ div.interfaceLinks-row a {
 }
 .imageWithCaptionPhoto{
   border: 1px solid #EDEDEC;
-  max-width: 100%; 
+  max-width: 100%;
   height: auto;
   padding: 0 44;
   top: 121px;
@@ -2377,7 +2377,7 @@ div.interfaceLinks-row a {
   .topicImage{
     padding-left: 0;
     padding-right: 0;
-    margin-top: 30px;  
+    margin-top: 30px;
     display: flex;
     flex-direction: column;
     justify-content: center;
@@ -5505,8 +5505,8 @@ body .ui-autocomplete.dictionary-toc-autocomplete .ui-menu-item a.ui-state-focus
 .segment.enOnly .en{
   display: initial;
 }
-/* 
-This is an attempt to fix dictionary entries in this layout (hebrew continuous) from having the headwords flip to the right instead of left. 
+/*
+This is an attempt to fix dictionary entries in this layout (hebrew continuous) from having the headwords flip to the right instead of left.
 But not to use a display block directive that might break continuous mode for other English only texts
  */
 .readerPanel.hebrew.continuous .segment.enOnly .en{
@@ -8666,6 +8666,13 @@ h3.aboutSheetHeader {
 .translationsHeader .translationsDesc {
   font-size: var(--sans-serif-body-font-size);
   color: var(--dark-grey);
+}
+
+.gDocAdvertBanner {
+  top: 60px;
+  position: absolute;
+  width: 100%;
+  z-index: 101;
 }
 
 .aboutSheetPanel hr {

--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -1765,6 +1765,50 @@ div.interfaceLinks-row a {
 .singlePanel .recentlyViewed #history span {
   color: var(--medium-grey);
 }
+
+.gDocAdvertBox {
+  margin-top: 50px;
+  background: #EDEDEC;
+  padding: 20px;
+  border-radius: 6px;
+}
+.gDocAdvertBox span  {
+  font-family: "Roboto", "Helvetica Neue", "Helvetica", sans-serif;;
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 19px;
+  letter-spacing: 0em;
+  color: #666666;
+}
+.gDocAdvertBox span #newExtension {
+  font-weight: 600;
+}
+.gDocAdvertBox #installNow {
+  margin-top: 18px;
+  width: 99px;
+  height: 30px;
+  border-radius: 6px;
+}
+.gDocAdvertBox #installNow a {
+  text-align: center;
+  background: #FFFFFF;
+  color: #666666;
+  text-decoration: none;
+  padding: 4px;
+  font-family: "Roboto", "Helvetica Neue", "Helvetica", sans-serif;;
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 19px;
+  letter-spacing: 0em;
+}
+.gDocAdvertBox a {
+  font-family: Roboto;
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 19px;
+  letter-spacing: 0em;
+  text-decoration: underline;
+}
 .readerPanel .navSidebarModule h3,
 .readerPanel .navSidebarModule h1,
 .readerPanel .bookPage h3{

--- a/static/js/AddToSourceSheet.jsx
+++ b/static/js/AddToSourceSheet.jsx
@@ -11,7 +11,7 @@ import PropTypes from 'prop-types';
 import Component from 'react-class';
 import sanitizeHtml  from 'sanitize-html';
 import { SignUpModalKind } from './sefaria/signupModalContent';
-import { GDocAdvertBox } from './Misc';
+import { GDocAdvertBox } from './Promotions';
 
 
 

--- a/static/js/AddToSourceSheet.jsx
+++ b/static/js/AddToSourceSheet.jsx
@@ -11,7 +11,7 @@ import PropTypes from 'prop-types';
 import Component from 'react-class';
 import sanitizeHtml  from 'sanitize-html';
 import { SignUpModalKind } from './sefaria/signupModalContent';
-import { GDocAdvertBox, GDocAdvertBanner } from './TextColumnBanner';
+import { GDocAdvertBox } from './Misc.jsx';
 
 
 

--- a/static/js/AddToSourceSheet.jsx
+++ b/static/js/AddToSourceSheet.jsx
@@ -11,7 +11,7 @@ import PropTypes from 'prop-types';
 import Component from 'react-class';
 import sanitizeHtml  from 'sanitize-html';
 import { SignUpModalKind } from './sefaria/signupModalContent';
-import { GDocAdvertBox } from './Misc.jsx';
+import { GDocAdvertBox } from './Misc';
 
 
 

--- a/static/js/AddToSourceSheet.jsx
+++ b/static/js/AddToSourceSheet.jsx
@@ -11,6 +11,8 @@ import PropTypes from 'prop-types';
 import Component from 'react-class';
 import sanitizeHtml  from 'sanitize-html';
 import { SignUpModalKind } from './sefaria/signupModalContent';
+import { GDocAdvertBox, GDocAdvertBanner } from './TextColumnBanner';
+
 
 
 class AddToSourceSheetBox extends Component {
@@ -244,6 +246,7 @@ class AddToSourceSheetBox extends Component {
           <span className="int-en noselect">Add to Sheet</span>
           <span className="int-he noselect">הוספה לדף המקורות</span>
         </div>
+        <GDocAdvertBox/>
       </div>);
   }
 }

--- a/static/js/Header.jsx
+++ b/static/js/Header.jsx
@@ -14,7 +14,7 @@ import {
   LanguageToggleButton,
   DonateLink
 } from './Misc';
-
+import { GDocAdvertBanner } from './TextColumnBanner';
 
 class Header extends Component {
   constructor(props) {
@@ -101,6 +101,7 @@ class Header extends Component {
       boxShadow: this.props.hasBoxShadow,
       mobile: !this.props.multiPanel
     });
+    console.log(this.props)
     return (
       <div className={headerClasses} role="banner">
         <div className={headerInnerClasses}>
@@ -117,6 +118,7 @@ class Header extends Component {
           close={this.props.onMobileMenuButtonClick} />
         }
         <GlobalWarningMessage />
+        <GDocAdvertBanner />
       </div>
     );
   }

--- a/static/js/Header.jsx
+++ b/static/js/Header.jsx
@@ -118,7 +118,6 @@ class Header extends Component {
           close={this.props.onMobileMenuButtonClick} />
         }
         <GlobalWarningMessage />
-        <GDocAdvertBanner />
       </div>
     );
   }

--- a/static/js/Header.jsx
+++ b/static/js/Header.jsx
@@ -14,7 +14,6 @@ import {
   LanguageToggleButton,
   DonateLink
 } from './Misc';
-import { GDocAdvertBanner } from './TextColumnBanner';
 
 class Header extends Component {
   constructor(props) {

--- a/static/js/Header.jsx
+++ b/static/js/Header.jsx
@@ -100,7 +100,6 @@ class Header extends Component {
       boxShadow: this.props.hasBoxShadow,
       mobile: !this.props.multiPanel
     });
-    console.log(this.props)
     return (
       <div className={headerClasses} role="banner">
         <div className={headerInnerClasses}>

--- a/static/js/Misc.jsx
+++ b/static/js/Misc.jsx
@@ -23,8 +23,6 @@ import Cookies from "js-cookie";
 import {EditTextInfo} from "./BookPage";
 import ReactMarkdown from 'react-markdown';
 import TrackG4 from "./sefaria/trackG4";
-import {trackSidebarAdClick, trackSidebarAdImpression} from "./Promotions";
-const cookie = Sefaria._inBrowser ? $.cookie : Sefaria.util.cookie;
 
 /**
  * Component meant to simply denote a language specific string to go inside an InterfaceText element
@@ -62,35 +60,7 @@ const __filterChildrenByLanguage = (children, language) => {
   let newChildren = chlArr.filter(x=> x.type == currLangComponent);
   return newChildren;
 };
-const GDocAdvertText = () => {
-    return    <InterfaceText>
-                <EnglishText> Add texts directly to your Google Docs with our <span id="newExtension">new extension</span>! <a href="https://sefaria.org/sheets/529099?origin=AddToSheetsPromo">Learn more</a></EnglishText>
-                <HebrewText> הוסיפו טקסטים מספריא ישירות לקובץ גוגל עם <span id="newExtension">התוסף החדש</span> שלנו! <a href="https://sefaria.org/sheets/529099?origin=AddToSheetsPromo">למדו עוד</a></HebrewText>
-             </InterfaceText>;
-}
-const GDocAdvertBox = () => {
-    const firstRender = useRef(true);
-    useEffect(() => {
-        if (firstRender.current) {
-          firstRender.current = false;
-          if (!cookie(gdocInstalled)) { // on first render and "Install Now" has never been clicked before
-              trackSidebarAdImpression(gdocsCampaign);
-          }
-        }
-      })
-    const gdocsCampaign = {campaignId: "GDocs_Promo_AddToSheet"};
-    const gdocInstalled = 'gdoc_installed';
-    const handleInstall = () => {
-        cookie(gdocInstalled, JSON.stringify(1), {path: "/"});
-        trackSidebarAdClick(gdocsCampaign);
-    }
-    return !cookie(gdocInstalled) &&
-            <div className="gDocAdvertBox">
-              <GDocAdvertText/>
-              <div id="installNow"><a href={'https://workspace.google.com/marketplace/app/sefaria/849562338091?utm_source=SefariaOrg&utm_medium=SidebarAdButton&utm_campaign=AddToSheetPromotion&utm_content=InstallFromAddToSheet'}
-                                      onClick={handleInstall}><InterfaceText>Install Now</InterfaceText></a></div>
-            </div>;
-}
+
 
 const InterfaceText = ({text, html, markdown, children, context, disallowedMarkdownElements=[]}) => {
   /**
@@ -3375,6 +3345,5 @@ export {
   requestWithCallBack,
   OnInView,
   TopicPictureUploader,
-  ImageWithCaption,
-  GDocAdvertBox
+  ImageWithCaption
 };

--- a/static/js/Misc.jsx
+++ b/static/js/Misc.jsx
@@ -23,6 +23,7 @@ import Cookies from "js-cookie";
 import {EditTextInfo} from "./BookPage";
 import ReactMarkdown from 'react-markdown';
 import TrackG4 from "./sefaria/trackG4";
+import {trackSidebarAdClick, trackSidebarAdImpression} from "./Promotions";
 const cookie = Sefaria._inBrowser ? $.cookie : Sefaria.util.cookie;
 
 /**
@@ -61,7 +62,6 @@ const __filterChildrenByLanguage = (children, language) => {
   let newChildren = chlArr.filter(x=> x.type == currLangComponent);
   return newChildren;
 };
-
 const GDocAdvertText = () => {
     return    <InterfaceText>
                 <EnglishText> Add texts directly to your Google Docs with our <span id="newExtension">new extension</span>! <a href="https://sefaria.org/sheets/529099?origin=AddToSheetsPromo">Learn more</a></EnglishText>
@@ -74,19 +74,21 @@ const GDocAdvertBox = () => {
         if (firstRender.current) {
           firstRender.current = false;
           if (!cookie(gdocInstalled)) { // on first render and "Install Now" has never been clicked before
-              gtag('event', 'promotion_shown', {loc: 'Resources Panel'});
+              trackSidebarAdImpression(gdocsCampaign);
           }
         }
       })
+    const gdocsCampaign = {campaignId: "GDocs_Promo_AddToSheet"};
     const gdocInstalled = 'gdoc_installed';
     const handleInstall = () => {
         cookie(gdocInstalled, JSON.stringify(1), {path: "/"});
+        trackSidebarAdClick(gdocsCampaign);
     }
     return !cookie(gdocInstalled) &&
             <div className="gDocAdvertBox">
-                <GDocAdvertText/>
-                <div id="installNow"><a href={'https://workspace.google.com/marketplace/app/sefaria/849562338091?utm_source=SefariaOrg&utm_medium=SidebarAdButton&utm_campaign=AddToSheetPromotion&utm_content=InstallFromAddToSheet'}
-                                        onClick={handleInstall}><InterfaceText>Install Now</InterfaceText></a></div>
+              <GDocAdvertText/>
+              <div id="installNow"><a href={'https://workspace.google.com/marketplace/app/sefaria/849562338091?utm_source=SefariaOrg&utm_medium=SidebarAdButton&utm_campaign=AddToSheetPromotion&utm_content=InstallFromAddToSheet'}
+                                      onClick={handleInstall}><InterfaceText>Install Now</InterfaceText></a></div>
             </div>;
 }
 

--- a/static/js/Misc.jsx
+++ b/static/js/Misc.jsx
@@ -60,6 +60,35 @@ const __filterChildrenByLanguage = (children, language) => {
   return newChildren;
 };
 
+const GDocAdvertText = () => {
+    return    <InterfaceText>
+                <EnglishText> Add texts directly to your Google Docs with our <span id="newExtension">new extension</span>! <a href="https://sefaria.org/sheets/529099?origin=AddToSheetsPromo">Learn more</a></EnglishText>
+                <HebrewText> הוסיפו טקסטים מספריא ישירות לקובץ גוגל עם <span id="newExtension">התוסף החדש</span> שלנו! <a href="https://sefaria.org/sheets/529099?origin=AddToSheetsPromo">למדו עוד</a></HebrewText>
+             </InterfaceText>;
+}
+const GDocAdvertBox = () => {
+    const ref = useRef(true);
+    useEffect(() => {
+        const firstRender = ref.current;
+        if (firstRender) {
+          ref.current = false;
+          if (!cookie(gdocInstalled)) { // on first render and "Install Now" has never been clicked before
+              gtag('event', 'promotion_shown', {loc: 'Resources Panel'});
+          }
+        }
+      })
+    const gdocInstalled = 'gdoc_installed';
+    const handleInstall = () => {
+        cookie(gdocInstalled, JSON.stringify(1), {path: "/"});
+    }
+    return !cookie(gdocInstalled) &&
+            <div className="gDocAdvertBox">
+                <GDocAdvertText/>
+                <div id="installNow"><a href={'https://workspace.google.com/marketplace/app/sefaria/849562338091?utm_source=SefariaOrg&utm_medium=SidebarAdButton&utm_campaign=AddToSheetPromotion&utm_content=InstallFromAddToSheet'}
+                                        onClick={handleInstall}><InterfaceText>Install Now</InterfaceText></a></div>
+            </div>;
+}
+
 const InterfaceText = ({text, html, markdown, children, context, disallowedMarkdownElements=[]}) => {
   /**
    * Renders a single span for interface string with either class `int-en`` or `int-he` depending on Sefaria.interfaceLang.
@@ -3343,5 +3372,6 @@ export {
   requestWithCallBack,
   OnInView,
   TopicPictureUploader,
-  ImageWithCaption
+  ImageWithCaption,
+  GDocAdvertBox
 };

--- a/static/js/Misc.jsx
+++ b/static/js/Misc.jsx
@@ -23,6 +23,8 @@ import Cookies from "js-cookie";
 import {EditTextInfo} from "./BookPage";
 import ReactMarkdown from 'react-markdown';
 import TrackG4 from "./sefaria/trackG4";
+const cookie = Sefaria._inBrowser ? $.cookie : Sefaria.util.cookie;
+
 /**
  * Component meant to simply denote a language specific string to go inside an InterfaceText element
  * ```
@@ -67,11 +69,10 @@ const GDocAdvertText = () => {
              </InterfaceText>;
 }
 const GDocAdvertBox = () => {
-    const ref = useRef(true);
+    const firstRender = useRef(true);
     useEffect(() => {
-        const firstRender = ref.current;
-        if (firstRender) {
-          ref.current = false;
+        if (firstRender.current) {
+          firstRender.current = false;
           if (!cookie(gdocInstalled)) { // on first render and "Install Now" has never been clicked before
               gtag('event', 'promotion_shown', {loc: 'Resources Panel'});
           }

--- a/static/js/Promotions.jsx
+++ b/static/js/Promotions.jsx
@@ -152,7 +152,6 @@ function trackSidebarAdClick(ad) {
     adType: "sidebar",
   });
 }
-const cookie = Sefaria._inBrowser ? $.cookie : Sefaria.util.cookie;
 const GDocAdvertText = () => {
     const learnMoreLink = "https://sefaria.org/sheets/529099?origin=AddToSheetsPromo"
     return    <InterfaceText>
@@ -164,12 +163,13 @@ const GDocAdvertBox = React.memo(() => {
     const gdocsCampaignId = "GDocs_Promo_AddToSheet";
     const installNowLink = 'https://workspace.google.com/marketplace/app/sefaria/849562338091?utm_source=SefariaOrg&utm_medium=SidebarAdButton&utm_campaign=AddToSheetPromotion&utm_content=InstallFromAddToSheet';
     const gdocsCampaignAd = {campaignId: gdocsCampaignId};
-    const gdocInstalled = 'gdoc_installed';
+    const gdocInstalledKey = 'gdoc_installed';
     const handleInstall = () => {
-        cookie(gdocInstalled, JSON.stringify(1), {path: "/"});
+        localStorage.setItem(gdocInstalledKey, "true");
         trackSidebarAdClick(gdocsCampaignAd);
     }
-    return !cookie(gdocInstalled) &&
+    const hasGdocInstalled = gdocInstalledKey in localStorage && JSON.parse(localStorage.getItem(gdocInstalledKey));
+    return !hasGdocInstalled &&
         <OnInView onVisible={() => trackSidebarAdImpression(gdocsCampaignAd)}>
             <div className="gDocAdvertBox">
               <GDocAdvertText/>

--- a/static/js/Promotions.jsx
+++ b/static/js/Promotions.jsx
@@ -1,8 +1,9 @@
-import React, { useState, useContext, useEffect } from "react";
+import React, {useState, useContext, useEffect, useRef} from "react";
 import { AdContext, StrapiDataProvider, StrapiDataContext } from "./context";
 import classNames from "classnames";
 import Sefaria from "./sefaria/sefaria";
-import { OnInView } from "./Misc";
+import {EnglishText, HebrewText, InterfaceText, OnInView} from "./Misc";
+import $ from "./sefaria/sefariaJquery";
 
 const Promotions = () => {
   const [inAppAds, setInAppAds] = useState(Sefaria._inAppAds); // local cache
@@ -151,6 +152,32 @@ function trackSidebarAdClick(ad) {
     adType: "sidebar",
   });
 }
+const cookie = Sefaria._inBrowser ? $.cookie : Sefaria.util.cookie;
+const GDocAdvertText = () => {
+    const learnMoreLink = "https://sefaria.org/sheets/529099?origin=AddToSheetsPromo"
+    return    <InterfaceText>
+                <EnglishText> Add texts directly to your Google Docs with our <span id="newExtension">new extension</span>! <a href={learnMoreLink}>Learn more</a></EnglishText>
+                <HebrewText> הוסיפו טקסטים מספריא ישירות לקובץ גוגל עם <span id="newExtension">התוסף החדש</span> שלנו! <a href={learnMoreLink}>למדו עוד</a></HebrewText>
+             </InterfaceText>;
+}
+const GDocAdvertBox = React.memo(() => {
+    const gdocsCampaignId = "GDocs_Promo_AddToSheet";
+    const installNowLink = 'https://workspace.google.com/marketplace/app/sefaria/849562338091?utm_source=SefariaOrg&utm_medium=SidebarAdButton&utm_campaign=AddToSheetPromotion&utm_content=InstallFromAddToSheet';
+    const gdocsCampaignAd = {campaignId: gdocsCampaignId};
+    const gdocInstalled = 'gdoc_installed';
+    const handleInstall = () => {
+        cookie(gdocInstalled, JSON.stringify(1), {path: "/"});
+        trackSidebarAdClick(gdocsCampaignAd);
+    }
+    return !cookie(gdocInstalled) &&
+        <OnInView onVisible={() => trackSidebarAdImpression(gdocsCampaignAd)}>
+            <div className="gDocAdvertBox">
+              <GDocAdvertText/>
+              <div id="installNow"><a href={installNowLink}
+                                      onClick={handleInstall}><InterfaceText>Install Now</InterfaceText></a></div>
+            </div>
+          </OnInView>;
+});
 
 // Don't continuously rerender a SidebarAd if the parent component decides to rerender
 // This is done to prevent multiple views from registering from OnInView
@@ -218,4 +245,4 @@ const SidebarAd = React.memo(({ context, matchingAd }) => {
   );
 });
 
-export { Promotions, trackSidebarAdImpression, trackSidebarAdClick };
+export { Promotions, GDocAdvertBox };

--- a/static/js/Promotions.jsx
+++ b/static/js/Promotions.jsx
@@ -152,6 +152,7 @@ function trackSidebarAdClick(ad) {
     adType: "sidebar",
   });
 }
+const cookie = Sefaria._inBrowser ? $.cookie : Sefaria.util.cookie;
 const GDocAdvertText = () => {
     const learnMoreLink = "https://sefaria.org/sheets/529099?origin=AddToSheetsPromo"
     return    <InterfaceText>
@@ -163,13 +164,12 @@ const GDocAdvertBox = React.memo(() => {
     const gdocsCampaignId = "GDocs_Promo_AddToSheet";
     const installNowLink = 'https://workspace.google.com/marketplace/app/sefaria/849562338091?utm_source=SefariaOrg&utm_medium=SidebarAdButton&utm_campaign=AddToSheetPromotion&utm_content=InstallFromAddToSheet';
     const gdocsCampaignAd = {campaignId: gdocsCampaignId};
-    const gdocInstalledKey = 'gdoc_installed';
+    const gdocInstalled = 'gdoc_installed';
     const handleInstall = () => {
-        localStorage.setItem(gdocInstalledKey, "true");
+        cookie(gdocInstalled, JSON.stringify(1), {path: "/"});
         trackSidebarAdClick(gdocsCampaignAd);
     }
-    const hasGdocInstalled = gdocInstalledKey in localStorage && JSON.parse(localStorage.getItem(gdocInstalledKey));
-    return !hasGdocInstalled &&
+    return !cookie(gdocInstalled) &&
         <OnInView onVisible={() => trackSidebarAdImpression(gdocsCampaignAd)}>
             <div className="gDocAdvertBox">
               <GDocAdvertText/>

--- a/static/js/Promotions.jsx
+++ b/static/js/Promotions.jsx
@@ -218,4 +218,4 @@ const SidebarAd = React.memo(({ context, matchingAd }) => {
   );
 });
 
-export { Promotions };
+export { Promotions, trackSidebarAdImpression, trackSidebarAdClick };

--- a/static/js/TextColumnBanner.jsx
+++ b/static/js/TextColumnBanner.jsx
@@ -114,10 +114,29 @@ const OpenTransBanner = ({ openTranslations }) => {
  * @returns {JSX.Element}
  * @constructor
  */
+
+const GDocAdvertText = () => {
+    return    <InterfaceText>
+                <EnglishText> Add texts directly to your Google Docs with our <span id="newExtension">new extension</span>! <a href="https://www.sefaria.org/sheets/529099">Learn more</a></EnglishText>
+                <HebrewText> הוסיפו טקסטים מספריא ישירות לקובץ עם <span id="newExtension">התוסף החדש</span> שלנו! <a href="https://www.sefaria.org/sheets/529099">למדו עוד</a></HebrewText>
+             </InterfaceText>;
+}
+const GDocInstallLink = 'https://workspace.google.com/marketplace/app/sefaria/849562338091';
+export const GDocAdvertBox = () => {
+    const handleInstall = () => {
+        // set cookie and google analytics
+    }
+    return !cookie("gdoc_installed") &&
+            <div className="gDocAdvertBox">
+                <GDocAdvertText/>
+                <div id="installNow"><a href={GDocInstallLink} onClick={handleInstall}>Install Now</a></div>
+            </div>;
+}
+
 export const GDocAdvertBanner = () => {
     const buttons = [{
         text: "Install Now",
-        onClick: () => { window.location.href = 'https://workspace.google.com/marketplace/app/sefaria/849562338091'; },
+        onClick: () => { window.location.href = GDocInstallLink; },
         sideEffect: "close",
     }];
     const onClose = () => {
@@ -125,15 +144,11 @@ export const GDocAdvertBanner = () => {
     };
 
 
-
     return (
       !cookie("gdoc_advert_banner_shown") && document.location.href.includes('/sheets/') ?
       <div className="gDocAdvertBanner">
         <TextColumnBanner buttons={buttons} onClose={onClose}>
-            <InterfaceText>
-                <EnglishText> Add texts directly to your Google Docs with our new extension! <a href="https://www.sefaria.org/sheets/529099">Learn more</a></EnglishText>
-                <HebrewText> הוסיפו טקסטים מספריא ישירות לקובץ עם התוסף החדש שלנו! <a href="https://www.sefaria.org/sheets/529099">למדו עוד</a></HebrewText>
-            </InterfaceText>
+            <GDocAdvertText/>
         </TextColumnBanner>
       </div> : null
     );

--- a/static/js/TextColumnBanner.jsx
+++ b/static/js/TextColumnBanner.jsx
@@ -1,4 +1,4 @@
-import React, {useState, useRef, useEffect} from "react";
+import React, {useState} from "react";
 import Sefaria  from './sefaria/sefaria';
 import $  from './sefaria/sefariaJquery';
 import {
@@ -108,13 +108,6 @@ const OpenTransBanner = ({ openTranslations }) => {
         </TextColumnBanner>
     );
 };
-
-/**
- *
- * @returns {JSX.Element}
- * @constructor
- */
-
 
 /**
  * Banner which appears right above text column and informs a user of an action they can take

--- a/static/js/TextColumnBanner.jsx
+++ b/static/js/TextColumnBanner.jsx
@@ -1,4 +1,4 @@
-import React, {useState} from "react";
+import React, {useState, useRef, useEffect} from "react";
 import Sefaria  from './sefaria/sefaria';
 import $  from './sefaria/sefariaJquery';
 import {
@@ -114,51 +114,6 @@ const OpenTransBanner = ({ openTranslations }) => {
  * @returns {JSX.Element}
  * @constructor
  */
-
-const GDocAdvertText = () => {
-    const handleLearnMore = () => {
-        gtag('event', 'gdoc_learn_more');
-    }
-    return    <InterfaceText>
-                <EnglishText> Add texts directly to your Google Docs with our <span id="newExtension">new extension</span>! <a href="https://www.sefaria.org/sheets/529099" onClick={handleLearnMore}>Learn more</a></EnglishText>
-                <HebrewText> הוסיפו טקסטים מספריא ישירות לקובץ עם <span id="newExtension">התוסף החדש</span> שלנו! <a href="https://www.sefaria.org/sheets/529099" onClick={handleLearnMore}>למדו עוד</a></HebrewText>
-             </InterfaceText>;
-}
-const GDocInstallLink = 'https://workspace.google.com/marketplace/app/sefaria/849562338091';
-export const GDocAdvertBox = () => {
-    const gdocInstalled = 'gdoc_installed';
-    const handleInstall = () => {
-        cookie(gdocInstalled, JSON.stringify(1), {path: "/"});
-        gtag('event', 'gdoc_installed', {loc: 'Resources Panel'});
-    }
-    return !cookie(gdocInstalled) &&
-            <div className="gDocAdvertBox">
-                <GDocAdvertText/>
-                <div id="installNow"><a href={GDocInstallLink} onClick={handleInstall}>Install Now</a></div>
-            </div>;
-}
-
-export const GDocAdvertBanner = () => {
-    const buttons = [{
-        text: "Install Now",
-        onClick: () => { window.location.href = GDocInstallLink; },
-        sideEffect: "close",
-    }];
-    const onClose = () => {
-        cookie("gdoc_advert_banner_shown", JSON.stringify(1), {path: "/"});
-    };
-
-
-    return (
-      !cookie("gdoc_advert_banner_shown") && document.location.href.includes('/sheets/') ?
-      <div className="gDocAdvertBanner">
-        <TextColumnBanner buttons={buttons} onClose={onClose}>
-            <GDocAdvertText/>
-        </TextColumnBanner>
-      </div> : null
-    );
-};
-
 
 
 /**

--- a/static/js/TextColumnBanner.jsx
+++ b/static/js/TextColumnBanner.jsx
@@ -116,17 +116,22 @@ const OpenTransBanner = ({ openTranslations }) => {
  */
 
 const GDocAdvertText = () => {
+    const handleLearnMore = () => {
+        gtag('event', 'gdoc_learn_more');
+    }
     return    <InterfaceText>
-                <EnglishText> Add texts directly to your Google Docs with our <span id="newExtension">new extension</span>! <a href="https://www.sefaria.org/sheets/529099">Learn more</a></EnglishText>
-                <HebrewText> הוסיפו טקסטים מספריא ישירות לקובץ עם <span id="newExtension">התוסף החדש</span> שלנו! <a href="https://www.sefaria.org/sheets/529099">למדו עוד</a></HebrewText>
+                <EnglishText> Add texts directly to your Google Docs with our <span id="newExtension">new extension</span>! <a href="https://www.sefaria.org/sheets/529099" onClick={handleLearnMore}>Learn more</a></EnglishText>
+                <HebrewText> הוסיפו טקסטים מספריא ישירות לקובץ עם <span id="newExtension">התוסף החדש</span> שלנו! <a href="https://www.sefaria.org/sheets/529099" onClick={handleLearnMore}>למדו עוד</a></HebrewText>
              </InterfaceText>;
 }
 const GDocInstallLink = 'https://workspace.google.com/marketplace/app/sefaria/849562338091';
 export const GDocAdvertBox = () => {
+    const gdocInstalled = 'gdoc_installed';
     const handleInstall = () => {
-        // set cookie and google analytics
+        cookie(gdocInstalled, JSON.stringify(1), {path: "/"});
+        gtag('event', 'gdoc_installed', {loc: 'Resources Panel'});
     }
-    return !cookie("gdoc_installed") &&
+    return !cookie(gdocInstalled) &&
             <div className="gDocAdvertBox">
                 <GDocAdvertText/>
                 <div id="installNow"><a href={GDocInstallLink} onClick={handleInstall}>Install Now</a></div>

--- a/static/js/TextColumnBanner.jsx
+++ b/static/js/TextColumnBanner.jsx
@@ -109,6 +109,36 @@ const OpenTransBanner = ({ openTranslations }) => {
     );
 };
 
+/**
+ *
+ * @returns {JSX.Element}
+ * @constructor
+ */
+export const GDocAdvertBanner = () => {
+    const buttons = [{
+        text: "Install Now",
+        onClick: () => { window.location.href = 'https://workspace.google.com/marketplace/app/sefaria/849562338091'; },
+        sideEffect: "close",
+    }];
+    const onClose = () => {
+        cookie("gdoc_advert_banner_shown", JSON.stringify(1), {path: "/"});
+    };
+
+
+
+    return (
+      !cookie("gdoc_advert_banner_shown") && document.location.href.includes('/sheets/') ?
+      <div className="gDocAdvertBanner">
+        <TextColumnBanner buttons={buttons} onClose={onClose}>
+            <InterfaceText>
+                <EnglishText> Add texts directly to your Google Docs with our new extension! <a href="https://www.sefaria.org/sheets/529099">Learn more</a></EnglishText>
+                <HebrewText> הוסיפו טקסטים מספריא ישירות לקובץ עם התוסף החדש שלנו! <a href="https://www.sefaria.org/sheets/529099">למדו עוד</a></HebrewText>
+            </InterfaceText>
+        </TextColumnBanner>
+      </div> : null
+    );
+};
+
 
 
 /**

--- a/static/js/sefaria/strings.js
+++ b/static/js/sefaria/strings.js
@@ -514,6 +514,8 @@ const Strings = {
     "Author": "מחבר",
     "Authors": "מחברים",
 
+    "Install Now": "התקינו עכשיו",
+
     //Topics
     "Wikipedia": "ויקיפדיה",
     "Jewish Encyclopedia": "האנציקלופדיה היהודית",


### PR DESCRIPTION
This is an ad in the Connections Panel below the "Ad to Sheet" button.  It displays an "Install Now".  The ad displays unless the user has clicked "Install Now" in the past.  Moreover, the first time it renders it calls google analytics and "Install Now" calls google analytics so that we know how many times the button was seen vs. clicked.