### PR TITLE
chore(index from queue): add elastic admin creds to index from queue …

### DIFF
--- a/helm-chart/sefaria-project/templates/cronjob/index-from-queue.yaml
+++ b/helm-chart/sefaria-project/templates/cronjob/index-from-queue.yaml
@@ -28,6 +28,8 @@ spec:
           - name: index-from-queue
             image: "{{ .Values.web.containerImage.imageRegistry }}:{{ .Values.web.containerImage.tag }}"
             env:
+            - name: SEARCH_HOST
+              value: "{{ .Values.nginx.SEARCH_HOST }}" 
             - name: REDIS_HOST
               value: "redis-{{ .Values.deployEnv }}"
             - name: NODEJS_HOST

--- a/helm-chart/sefaria-project/templates/cronjob/index-from-queue.yaml
+++ b/helm-chart/sefaria-project/templates/cronjob/index-from-queue.yaml
@@ -36,6 +36,8 @@ spec:
               value: "varnish-{{ .Values.deployEnv }}-{{ .Release.Revision }}"
             envFrom:
             - secretRef:
+                name: {{ template "sefaria.secrets.elasticAdmin" . }}
+            - secretRef:
                 name: {{ .Values.secrets.localSettings.ref }}
                 optional: true
             - secretRef:


### PR DESCRIPTION
…cronjob.

The cronjob needs admin access so it can add documents to elastic search. This is the same access that the reindex elastic search cronjob has.