### PR TITLE
Add reference to 2023 annual report & change URL path to be dynamic

### DIFF
--- a/reader/views.py
+++ b/reader/views.py
@@ -4329,13 +4329,18 @@ def serve_static_by_lang(request, page):
     return render_template(request,'static/{}/{}.html'.format(request.LANGUAGE_CODE, page), None, {})
 
 
+# TODO: This really should be handled by a CMS :)
 def annual_report(request, report_year):
     pdfs = {
         '2020': STATIC_URL + 'files/Sefaria 2020 Annual Report.pdf',
         '2021': 'https://indd.adobe.com/embed/98a016a2-c4d1-4f06-97fa-ed8876de88cf?startpage=1&allowFullscreen=true',
         '2022': STATIC_URL + 'files/Sefaria_AnnualImpactReport_R14.pdf',
+        '2023': 'https://issuu.com/sefariaimpact/docs/sefaria_2023_impact_report?fr=sMmRkNTcyMzMyNTk',
     }
-    if report_year not in pdfs:
+    # Assume the most recent year as default when one is not provided
+    if not report_year:
+        report_year = max(pdfs.keys()) # Earlier versions of Python do not preserve insertion order in dictionaries :(
+    elif report_year not in pdfs:
         raise Http404
     # Renders a simple template, does not extend base.html
     return render(request, template_name='static/annualreport.html', context={'reportYear': report_year, 'pdfURL': pdfs[report_year]})

--- a/sites/sefaria/urls.py
+++ b/sites/sefaria/urls.py
@@ -102,5 +102,5 @@ site_urlpatterns +=[
     url(r'^ideasforteaching/?$',lambda x: HttpResponseRedirect(STATIC_URL + 'files/Sefaria_Teacher_Generated_Ideas_for_Your_Classroom.pdf')),
     url(r'^strategicplan/?$',lambda x: HttpResponseRedirect(STATIC_URL + 'files/Sefaria_Strategic_Plan.pdf')),
     url(r'^annualreport2021?$', lambda x: HttpResponseRedirect('/annualreport/2021')), # Added for backwards compatability for old links that might still point to this
-    url(r'^annualreport/(?P<report_year>\d+)$', reader_views.annual_report),
+    url(r'^annualreport(/(?P<report_year>\d+)/?|/?)$', reader_views.annual_report),
 ]

--- a/static/js/Footer.jsx
+++ b/static/js/Footer.jsx
@@ -47,7 +47,7 @@ class Footer extends Component {
                 <Link href="/team" en="Team" he="צוות" />
                 <Link href="/testimonials" en="Testimonials" he="חוות דעת" />
                 <Link href="/metrics" en="Metrics" he="מדדים" />
-                <Link href="/annualreport/2022" en="Annual Report" he='דו"ח שנתי' />
+                <Link href="/annualreport" en="Annual Report" he='דו"ח שנתי' />
                 <Link href="/terms" en="Terms of Use" he="תנאי שימוש" />
                 <Link href="/privacy-policy" en="Privacy Policy" he="מדיניות פרטיות" />
             </Section>

--- a/static/js/StaticPages.jsx
+++ b/static/js/StaticPages.jsx
@@ -1743,7 +1743,7 @@ const DonatePage = () => (
                         rounded={true}
                         tall={false}
                         newTab={true}
-                        href="/static/files/Sefaria_AnnualImpactReport_R14.pdf"
+                        href="/annualreport"
                         he_href=""
                         he=""
                         en="Read Here"


### PR DESCRIPTION
## Context
Every year, a new annual impact report is created and links need to be changed in more than one place when the report is ready for the Sefarian world abroad. 

## Solution
To handle this scenario and minimize the amount of code changes, the path for the annual report will now be `/annualreport` in links instead of `/annualreport/<year>/`. The default path will now refer to the most recent report. However, the ability to refer to specific years by the path will still be allowed and to ensure backwards compatibility with previously given out links as was previously done.

## Changes
* Footer link to annual report is now `/annualreport`
* Link on _Ways to Give_ page is now `/annualreport`
* The endpoint function for that path now handles both URL patterns `/annualreport` and  `/annualreport/<year>/`
* The function determines which is the most recent year to use for the default case
* An entry for the 2023 annual report was added to an Issuu reader