### PR TITLE
feat(Reader Panel): Show segment as highlighted whenever the sidebar is open

### DIFF
--- a/reader/views.py
+++ b/reader/views.py
@@ -376,16 +376,19 @@ def make_panel_dict(oref, versionEn, versionHe, filter, versionFilter, mode, **k
             "filter": filter,
             "versionFilter": versionFilter,
         }
-        if filter and len(filter):
-            panel["connectionsMode"], delete_filter = get_connections_mode(filter)
-            if panel["connectionsMode"] == "ConnectionsList":
-                panel['filter'] = [x.replace(" ConnectionsList", "") for x in panel['filter']]
-                if len(panel['filter']) == 1:
-                    panel['connectionsCategory'] = panel['filter'][0]
-            if panel['connectionsMode'] == "WebPagesList":
-                panel['webPagesFilter'] = [x.replace("WebPage:", "") for x in panel['filter']][0]
-            if delete_filter:
-                del panel['filter']
+        if filter is not None:
+            panel["highlightedRefs"] = kwargs.get("highlightedRefs", None)
+            panel["showHighlight"] = kwargs.get('showHighlight', None)
+            if len(filter):
+                panel["connectionsMode"], delete_filter = get_connections_mode(filter)
+                if panel["connectionsMode"] == "ConnectionsList":
+                    panel['filter'] = [x.replace(" ConnectionsList", "") for x in panel['filter']]
+                    if len(panel['filter']) == 1:
+                        panel['connectionsCategory'] = panel['filter'][0]
+                if panel['connectionsMode'] == "WebPagesList":
+                    panel['webPagesFilter'] = [x.replace("WebPage:", "") for x in panel['filter']][0]
+                if delete_filter:
+                    del panel['filter']
         settings_override = {}
         panelDisplayLanguage = kwargs.get("connectionsPanelDisplayLanguage", None) if mode == "Connections" else kwargs.get("panelDisplayLanguage", None)
         aliyotOverride = kwargs.get("aliyotOverride")
@@ -553,6 +556,8 @@ def text_panels(request, ref, version=None, lang=None, sheet=None):
             lang2 = request.GET.get("lang2", None)
             if lang2:
                 kwargs["connectionsPanelDisplayLanguage"] = lang2 if lang2 in ["en", "he"] else lang1 if lang1 in ["en", "he"] else request.interfaceLang[0:2]
+            kwargs["highlightedRefs"] = [oref.normal()]
+            kwargs["showHighlight"] = True
         if request.GET.get("aliyot", None):
             kwargs["aliyotOverride"] = "aliyotOn" if int(request.GET.get("aliyot")) == 1 else "aliyotOff"
         kwargs["selectedWords"] = request.GET.get("lookup", None)


### PR DESCRIPTION
Bug: When the sidebar is open, the base ref that was clicked to open the sidebar is not always highlighted.
Solution:  Whenever the sidebar is open, some `with=` is present in the sidebar currently presented in the code by the variable `filter.`  Therefore, on the backend when this `filter` is present the backend can create panels with `highlightedRefs` and `showHighlight` already set.  By doing so, when the sidebar is open, the base ref is always highlighted.

A confusing feature of the previously existing implementation is when the sidebar is first opened, `with=all` is represented by a `filter` value of an empty list.  When Rashi is open in the sidebar, `filter = ["Rashi"]` and finally, when the sidebar is not open, `filter` is None.  Therefore, you can have a `filter` value of an empty list, a list with a string, or None, and in order to differentiate between an empty list and None, I tested that `filter is not None` instead of simply `bool(filter)` [on this line](https://github.com/Sefaria/Sefaria-Project/pull/1869/files#diff-26c40bdd3eeaef442340754126fdbcb1ed9e451eb3bb31c02cb78053f5702eaaR379)