### PR TITLE
fix(search): undo change that generalized how nginx connects to ES up…

### DIFF
--- a/helm-chart/sefaria-project/templates/configmap/nginx.yaml
+++ b/helm-chart/sefaria-project/templates/configmap/nginx.yaml
@@ -86,8 +86,7 @@ data:
       }
 
       upstream elasticsearch_upstream {
-        # TODO template this properly so that nginx can redirect properly
-        server ${SEARCH_HOST}:${SEARCH_PORT};
+        server ${SEARCH_HOST}:9200;
         keepalive 32;
       }
 


### PR DESCRIPTION
…stream.

Before this, nginx was trying to connect to the dev cluster for the ES upstream and crashing. Nginx doesn't need to connect to dev while prod search is broken.