### PR TITLE
fix(Topic Editor): couldnt create new topic because slug was empty

### DIFF
--- a/reader/views.py
+++ b/reader/views.py
@@ -3115,6 +3115,7 @@ def add_new_topic_api(request):
         isTopLevelDisplay = data["category"] == Topic.ROOT
         t = Topic({'slug': "", "isTopLevelDisplay": isTopLevelDisplay, "data_source": "sefaria", "numSources": 0})
         update_topic_titles(t, **data)
+        t.set_slug_to_primary_title()
         if not isTopLevelDisplay:  # not Top Level so create an IntraTopicLink to category
             new_link = IntraTopicLink({"toTopic": data["category"], "fromTopic": t.slug, "linkType": "displays-under", "dataSource": "sefaria"})
             new_link.save()


### PR DESCRIPTION
In the past, topic title changes would cascade to the slug.  Recently, we changed things so that topic title changes would not cascade and change the slug.  This caused the Topic Editor to stop working because it relied on the old way.  I added a line to directly set the slug based on the primary title.