### PR TITLE
Temporary fix for donation links

### DIFF
--- a/sites/sefaria/urls.py
+++ b/sites/sefaria/urls.py
@@ -77,8 +77,8 @@ site_urlpatterns = [
 
 # Redirects to Wikis etc
 site_urlpatterns += [
-    url(r'^donate/mobile?$', lambda x: HttpResponseRedirect('https://donate.sefaria.org/en?c_src=mobile-app' if x.interfaceLang == 'english' else 'https://donate.sefaria.org/he?c_src=mobile-app')),
-    url(r'^donate/?$', lambda x: HttpResponseRedirect('https://donate.sefaria.org/en' if x.interfaceLang == 'english' else 'https://donate.sefaria.org/he')),
+    url(r'^donate/mobile?$', lambda x: HttpResponseRedirect('https://donate.sefaria.org/' if x.interfaceLang == 'english' else 'https://donate.sefaria.org/he?c_src=mobile-app')),
+    url(r'^donate/?$', lambda x: HttpResponseRedirect('https://donate.sefaria.org/' if x.interfaceLang == 'english' else 'https://donate.sefaria.org/he')),
     url(r'^wiki/?$', lambda x: HttpResponseRedirect('https://github.com/Sefaria/Sefaria-Project/wiki')),
     url(r'^developers/?$', lambda x: HttpResponseRedirect('https://github.com/Sefaria/Sefaria-Project/wiki#developers')),
     url(r'^request-a-text/?$', lambda x: HttpResponseRedirect('https://goo.gl/forms/ru33ivawo7EllQxa2')),

--- a/static/js/StaticPages.jsx
+++ b/static/js/StaticPages.jsx
@@ -1436,7 +1436,7 @@ const DonatePage = () => (
                 heText=""
                 enButtonText="Donate Now"
                 heButtonText=""
-                enButtonUrl="https://donate.sefaria.org/en"
+                enButtonUrl="https://donate.sefaria.org/"
                 heButtonUrl="https://donate.sefaria.org/he"
                 borderColor="#004E5F"
             />,
@@ -1492,7 +1492,7 @@ const DonatePage = () => (
                 <HeaderWithColorAccentBlockAndText
                     enTitle="Donate Online"
                     heTitle=""
-                    enText="<p>Make a donation by <strong>credit card, PayPal, GooglePay, ApplePay, Venmo, or bank transfer</strong> on our <a href='http://donate.sefaria.org/en'>main donation page</a>.</p>"
+                    enText="<p>Make a donation by <strong>credit card, PayPal, GooglePay, ApplePay, Venmo, or bank transfer</strong> on our <a href='http://donate.sefaria.org/'>main donation page</a>.</p>"
                     heText=""
                     colorBar="#AB4E66"
                 />,
@@ -1604,7 +1604,7 @@ const DonatePage = () => (
         <Accordian
             enTitle="Can I still donate from outside the USA?"
             heTitle=""
-            enText="<p>Yes! Donors outside of the USA may make a gift online  – via credit card, PayPal, GooglePay, ApplePay, Venmo, and bank transfer – <a href='https://donate.sefaria.org/en'>on this page</a> On this page you can modify your currency. You can also <a href='https://sefaria.formstack.com/forms/wire_request'>make a wire transfer</a>.</p>"
+            enText="<p>Yes! Donors outside of the USA may make a gift online  – via credit card, PayPal, GooglePay, ApplePay, Venmo, and bank transfer – <a href='https://donate.sefaria.org/'>on this page</a> On this page you can modify your currency. You can also <a href='https://sefaria.formstack.com/forms/wire_request'>make a wire transfer</a>.</p>"
             heText=""
             colorBar="#7F85A9"
         />

--- a/templates/static/the-sefaria-story.html
+++ b/templates/static/the-sefaria-story.html
@@ -43,7 +43,7 @@
 
 
         <div class="single-button center int-en">
-            <a class="button big blue control-elem" href="https://donate.sefaria.org/en" target="_blank">
+            <a class="button big blue control-elem" href="https://donate.sefaria.org/" target="_blank">
                 Donate Now
             </a>
         </div>


### PR DESCRIPTION
### Problem
There is currently a problem with Classy: when a campaign uses the short URL with "en", it redirects to Classy's main page instead of the campaign page. This is a bug with Classy and not with any of our configurations.

### Solution
As a temporary workaround until the bug is resolved on Classy's side, links have been changed to point to Sefaria's main campaign donation page.

### TLDR
https://donate.sefaria.org/en redirects to https://classy.org and can't be changed right now