### PR TITLE
Change docs url for the linker

### DIFF
--- a/templates/static/linker.html
+++ b/templates/static/linker.html
@@ -88,9 +88,9 @@
         </p>
 
         <div class="buttonBox">
-        <a class="button" href="https://github.com/Sefaria/Sefaria-Project/wiki/Sefaria-Auto-Linker-v3">
-            <span class="int-en">Read the details on GitHub</span>
-            <span class="int-he">קראו פרטים נוספים בגיטהאב</span>
+        <a class="button" href="https://developers.sefaria.org/docs/linker-v3">
+            <span class="int-en">Read the details in our Developer Docs</span>
+            <span class="int-he">קראו פרטים נוספים בפורטל המפתחים שלנו</span>
         </a>
         </div>
 


### PR DESCRIPTION
This PR just redirects the button that leads to the linker install docs from the old Github location to the developer docs site.