### PR TITLE
Change default on new users to all use "new" sheet editor

### DIFF
--- a/sefaria/model/user_profile.py
+++ b/sefaria/model/user_profile.py
@@ -395,7 +395,7 @@ class UserProfile(object):
 
         # new editor
         self.show_editor_toggle = False
-        self.uses_new_editor = False
+        self.uses_new_editor = True
 
         # Fundraising
         self.is_sustainer = False


### PR DESCRIPTION
This PR changes the default init of a new UserProfile object and makes it so all new users default to having their profile direct them to the newer of the 2 source sheet editors, something that was previously only enabled for a select group of beta user testers. 