### PR TITLE
Fix Capitalization 

### DIFF
--- a/docs/openAPI.json
+++ b/docs/openAPI.json
@@ -5106,7 +5106,7 @@
             "description": "Successful response"
           }
         },
-        "summary": "Recommended topics API",
+        "summary": "Recommended Topics",
         "description": "Given a list of refs this API returns the most used topics associated with them. It's a fast way of identifying potential shared topics amongst disperate references.\n\nn.b. The `ref_list` param is not required for a post request."
       },
       "parameters": [


### PR DESCRIPTION
Currently the `Recommended topics` title (called `summary` in the spec) has topics lowercase, as opposed to capitalized. This PR removes the word `API` and shifts to all uppercase to ensure consistency with our other endpoints in the devportal. 
<img width="189" alt="Screen Shot 2024-05-16 at 10 01 44" src="https://github.com/Sefaria/Sefaria-Project/assets/36717225/1fff8c1c-6261-493e-b77b-d372e0507e00">
