### PR TITLE
fix(topic pages): encode uri components that go into api/bulktext.

### DIFF
--- a/static/js/sefaria/sefaria.js
+++ b/static/js/sefaria/sefaria.js
@@ -479,10 +479,11 @@ Sefaria = extend(Sefaria, {
     let refStrs = [""];
     refs.map(ref => {
       let last = refStrs[refStrs.length-1];
-      if (encodeURI(`${hostStr}${last}|${ref}${paramStr}`).length > MAX_URL_LENGTH) {
-        refStrs.push(ref)
+      const encodedRef = encodeURIComponent(ref)
+      if (`${hostStr}${last}|${encodedRef}${paramStr}`.length > MAX_URL_LENGTH) {
+        refStrs.push(encodedRef)
       } else {
-        refStrs[refStrs.length-1] += last.length ? `|${ref}` : ref;
+        refStrs[refStrs.length-1] += last.length ? `|${encodedRef}` : encodedRef;
       }
     });
 


### PR DESCRIPTION
This helps prevent characters like ? in refs from ruining the URL. Example ref that caused problems because of the question mark: `Covenant and Conversation; Numbers; The Wilderness Years, Nasso, What Counts? 28-30`.