### PR TITLE
feat(topic page): compute alt text for topic image

### DIFF
--- a/static/js/Misc.jsx
+++ b/static/js/Misc.jsx
@@ -3288,11 +3288,17 @@ const Autocompleter = ({getSuggestions, showSuggestionsOnSelect, inputPlaceholde
     )
 }
 
+const imgAltTextFactory = (caption) => {
+  const lang = Sefaria.interfaceLang === "hebrew" ? 'he' : 'en';
+  const fallBackMessage = lang === 'he' ? "Illustrative image" : "תמונה להמחשה";
+  const captionMessage = caption[lang];
+  if(captionMessage) {return captionMessage} else {return fallBackMessage}
+}
 const ImageWithCaption = ({photoLink, caption }) => {
-  
+  const altText = imgAltTextFactory(caption)
   return (
     <div>
-        <img class="imageWithCaptionPhoto" src={photoLink}/>
+        <img class="imageWithCaptionPhoto" src={photoLink} alt={altText}/>
         <div class="imageCaption"> 
           <InterfaceText text={caption} />
         </div>

--- a/static/js/Misc.jsx
+++ b/static/js/Misc.jsx
@@ -3289,9 +3289,7 @@ const Autocompleter = ({getSuggestions, showSuggestionsOnSelect, inputPlaceholde
 }
 
 const getImgAltText = (caption) => {
-  const fallBackMessage = Sefaria._('Illustrative image');
-  const captionMessage = Sefaria._v(caption);
-  if(captionMessage) {return captionMessage} else {return fallBackMessage};
+return Sefaria._v(caption) || Sefaria._('Illustrative image');
 }
 const ImageWithCaption = ({photoLink, caption }) => {
   return (

--- a/static/js/Misc.jsx
+++ b/static/js/Misc.jsx
@@ -3288,17 +3288,15 @@ const Autocompleter = ({getSuggestions, showSuggestionsOnSelect, inputPlaceholde
     )
 }
 
-const imgAltTextFactory = (caption) => {
-  const lang = Sefaria.interfaceLang === "hebrew" ? 'he' : 'en';
-  const fallBackMessage = lang === 'he' ? "Illustrative image" : "תמונה להמחשה";
-  const captionMessage = caption[lang];
-  if(captionMessage) {return captionMessage} else {return fallBackMessage}
+const getImgAltText = (caption) => {
+  const fallBackMessage = Sefaria._('Illustrative image');
+  const captionMessage = Sefaria._v(caption);
+  if(captionMessage) {return captionMessage} else {return fallBackMessage};
 }
 const ImageWithCaption = ({photoLink, caption }) => {
-  const altText = imgAltTextFactory(caption)
   return (
     <div>
-        <img class="imageWithCaptionPhoto" src={photoLink} alt={altText}/>
+        <img class="imageWithCaptionPhoto" src={photoLink} alt={getImgAltText(caption)}/>
         <div class="imageCaption"> 
           <InterfaceText text={caption} />
         </div>

--- a/static/js/sefaria/strings.js
+++ b/static/js/sefaria/strings.js
@@ -103,6 +103,9 @@ const Strings = {
     "Reset": "לאתחל",
     "Search Topics": "חפש נושאים",
 
+    // Topic Images
+    "Illustrative image" : "תמונה להמחשה",
+
 
     // Community Page
     "From the Community: Today on Sefaria": "מן הקהילה: היום בספריא",


### PR DESCRIPTION
Alt text for images:

The featured topic image
Use the caption
If there is a limit to length for alt, truncate accordingly
For EN UI, use EN caption or fall back on "Illustrative image"
For HE UI, use HE caption or fall back on " תמונה להמחשה "