### PR TITLE
Add tooltip to reader options icon

### DIFF
--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -4992,6 +4992,10 @@ body .ui-autocomplete.dictionary-toc-autocomplete .ui-menu-item a.ui-state-focus
 .readerOptions .int-he img {
     height: 18px;
 }
+.rightButtons .readerOptionsTooltip.tooltip-toggle::before {
+    top: 47px;
+    left: -50px;
+}
 .rightButtons .readerOptions {
   vertical-align: middle;
 }

--- a/static/js/Misc.jsx
+++ b/static/js/Misc.jsx
@@ -1350,7 +1350,7 @@ class DisplaySettingsButton extends Component {
     let style = this.props.placeholder ? {visibility: "hidden"} : {};
     let icon;
     const altText = Sefaria._('Text display options')
-    const classes = classNames({readerOptionsTooltip: 1, "tooltip-toggle": true});
+    const classes = "readerOptionsTooltip tooltip-toggle";
 
     if (Sefaria._siteSettings.TORAH_SPECIFIC) {
       icon =
@@ -1374,9 +1374,8 @@ class DisplaySettingsButton extends Component {
                 onKeyPress={function(e) {e.charCode == 13 ? this.props.onClick(e):null}.bind(this)}>
                 {icon}
               </a>
-          </ToolTipped>
-
-              );
+            </ToolTipped>
+            );
   }
 }
 DisplaySettingsButton.propTypes = {

--- a/static/js/Misc.jsx
+++ b/static/js/Misc.jsx
@@ -1350,7 +1350,7 @@ class DisplaySettingsButton extends Component {
     let style = this.props.placeholder ? {visibility: "hidden"} : {};
     let icon;
     const altText = Sefaria._('Text display options')
-    const classes = classNames({saveButton: 1, "tooltip-toggle": true});
+    const classes = classNames({readerOptionsTooltip: 1, "tooltip-toggle": true});
 
     if (Sefaria._siteSettings.TORAH_SPECIFIC) {
       icon =

--- a/static/js/Misc.jsx
+++ b/static/js/Misc.jsx
@@ -1347,10 +1347,9 @@ class CloseButton extends Component {
 
 class DisplaySettingsButton extends Component {
   render() {
-    // let style = this.props.placeholder ? {visibility: "hidden"} : {};
-    let icon;
     let style = this.props.placeholder ? {visibility: "hidden"} : {};
-    const altText = "Text display options";
+    let icon;
+    const altText = Sefaria._('Text display options')
     const classes = classNames({saveButton: 1, "tooltip-toggle": true});
 
     if (Sefaria._siteSettings.TORAH_SPECIFIC) {

--- a/static/js/Misc.jsx
+++ b/static/js/Misc.jsx
@@ -1347,8 +1347,11 @@ class CloseButton extends Component {
 
 class DisplaySettingsButton extends Component {
   render() {
-    let style = this.props.placeholder ? {visibility: "hidden"} : {};
+    // let style = this.props.placeholder ? {visibility: "hidden"} : {};
     let icon;
+    let style = this.props.placeholder ? {visibility: "hidden"} : {};
+    const altText = "Text display options";
+    const classes = classNames({saveButton: 1, "tooltip-toggle": true});
 
     if (Sefaria._siteSettings.TORAH_SPECIFIC) {
       icon =
@@ -1359,17 +1362,22 @@ class DisplaySettingsButton extends Component {
     } else {
       icon = <span className="textIcon">Aa</span>;
     }
-    return (<a
-              className="readerOptions"
-              tabIndex="0"
-              role="button"
-              aria-haspopup="true"
-              aria-label="Toggle Reader Menu Display Settings"
-              style={style}
-              onClick={this.props.onClick}
-              onKeyPress={function(e) {e.charCode == 13 ? this.props.onClick(e):null}.bind(this)}>
-              {icon}
-            </a>);
+    return (
+            <ToolTipped {...{ altText, classes}}>
+                <a
+                className="readerOptions"
+                tabIndex="0"
+                role="button"
+                aria-haspopup="true"
+                aria-label="Toggle Reader Menu Display Settings"
+                style={style}
+                onClick={this.props.onClick}
+                onKeyPress={function(e) {e.charCode == 13 ? this.props.onClick(e):null}.bind(this)}>
+                {icon}
+              </a>
+          </ToolTipped>
+
+              );
   }
 }
 DisplaySettingsButton.propTypes = {

--- a/static/js/sefaria/strings.js
+++ b/static/js/sefaria/strings.js
@@ -273,6 +273,7 @@ const Strings = {
     "Location: ": "מיקום: ",
     "Translations": "תרגומים",
     "Uncategorized": "לא מסווג",
+    "Text display options": "אפשרויות תצוגת טקסט",
 
     // Collections
     "Collections": "אסופות",


### PR DESCRIPTION
At the top of the reader is a toolbar including an A/Aleph icon which opens the "Reader Options" control. The task here is to add a fast-acting tooltip which is triggered by hover on the icon.
We have this functionality today right next to the Reader Options icon - the bookmark icon has a fast-acting tooltip and we can simply re-use whatever code powers that.. changing the message of course.
Tooltip EN - Text display options
Tooltip HE - אפשרויות תצוגת טקסט