### PR TITLE
Feature/sc 27523/sheets green create button

### DIFF
--- a/static/js/Sheets/GenericComponents.jsx
+++ b/static/js/Sheets/GenericComponents.jsx
@@ -1,6 +1,13 @@
 import {InterfaceText} from "../Misc";
 import classNames from "classnames";
 const Button = ({img, href, children, classes={}}) => {
+    /*
+        Generic button component that links to an href, and displays text and optionally an image
+     @param {component} img -- expected HTML img component
+     @param {string} href -- Where should the button link to?
+     @param {children} -- Text of the button
+     @param {obj} -- JS object of properties to be passed to classNames such as {small: 1}
+     */
   classes = {button: 1, ...classes};
   return <a className={classNames(classes)} href={href}>
           {img}

--- a/static/js/Sheets/GenericComponents.jsx
+++ b/static/js/Sheets/GenericComponents.jsx
@@ -1,0 +1,11 @@
+import {InterfaceText} from "../Misc";
+
+const Button = (img, href, children, classes={}) => {
+  classes = {button: 1, ...classes};
+  return <a className={classNames(classes)} href={href}>
+          {img}
+          <InterfaceText>{children}</InterfaceText>
+          </a>
+}
+
+export { Button }

--- a/static/js/Sheets/GenericComponents.jsx
+++ b/static/js/Sheets/GenericComponents.jsx
@@ -1,6 +1,6 @@
 import {InterfaceText} from "../Misc";
-
-const Button = (img, href, children, classes={}) => {
+import classNames from "classnames";
+const Button = ({img, href, children, classes={}}) => {
   classes = {button: 1, ...classes};
   return <a className={classNames(classes)} href={href}>
           {img}


### PR DESCRIPTION
This is a first pass (and thus a draft pull request) of the generic Button component.  It assumes children is text and can optionally display an image.  Example usages: 
```
const CreateSheetsButton = () => {
  const img = <img src="/static/icons/new-sheet-black.svg" alt="make a sheet icon" id="sheetsButton"/>;
  return <Button img={img} classes={{small: 1}} href="/sheets/new">Create</Button>
}
```
and
```
<Button classes={{getStarted: 1}} href="/sheets/393695">Get Started</Button>
```