### PR TITLE
Fix topic ordering issues

### DIFF
--- a/reader/views.py
+++ b/reader/views.py
@@ -2167,7 +2167,7 @@ def related_api(request, tref):
             "sheets": get_sheets_for_ref(tref),
             "notes": [],  # get_notes(oref, public=True) # Hiding public notes for now
             "webpages": get_webpages_for_ref(tref),
-            "topics": get_topics_for_ref(tref, annotate=True),
+            "topics": get_topics_for_ref(tref, request.interfaceLang, annotate=True),
             "manuscripts": ManuscriptPageSet.load_set_for_client(tref),
             "media": get_media_for_ref(tref),
             "guides": GuideSet.load_set_for_client(tref)
@@ -3057,7 +3057,7 @@ def topic_page(request, topic, test_version=None):
             "en": topic_obj.get_primary_title('en'),
             "he": topic_obj.get_primary_title('he')
         },
-        "topicData": _topic_page_data(topic),
+        "topicData": _topic_page_data(topic, request.interfaceLang),
     }
 
     if test_version is not None:
@@ -3167,7 +3167,7 @@ def topics_api(request, topic, v2=False):
         annotate_time_period = bool(int(request.GET.get("annotate_time_period", False)))
         with_indexes = bool(int(request.GET.get("with_indexes", False)))
         ref_link_type_filters = set(filter(lambda x: len(x) > 0, request.GET.get("ref_link_type_filters", "").split("|")))
-        response = get_topic(v2, topic, with_html=with_html, with_links=with_links, annotate_links=annotate_links, with_refs=with_refs, group_related=group_related, annotate_time_period=annotate_time_period, ref_link_type_filters=ref_link_type_filters, with_indexes=with_indexes)
+        response = get_topic(v2, topic, request.interfaceLang, with_html=with_html, with_links=with_links, annotate_links=annotate_links, with_refs=with_refs, group_related=group_related, annotate_time_period=annotate_time_period, ref_link_type_filters=ref_link_type_filters, with_indexes=with_indexes)
         return jsonResponse(response, callback=request.GET.get("callback", None))
     elif request.method == "POST":
         if not request.user.is_staff:
@@ -3253,7 +3253,7 @@ def topic_ref_api(request, tref):
     annotate = bool(int(data.get("annotate", False)))
 
     if request.method == "GET":
-        response = get_topics_for_ref(tref, annotate)
+        response = get_topics_for_ref(tref, request.interfaceLang, annotate)
         return jsonResponse(response, callback=request.GET.get("callback", None))
     else:
         if not request.user.is_staff:
@@ -3279,8 +3279,8 @@ _CAT_REF_LINK_TYPE_FILTER_MAP = {
     'authors': ['popular-writing-of'],
 }
 
-def _topic_page_data(topic):
-    _topic_data(topic=topic, annotate_time_period=True)
+def _topic_page_data(topic, lang):
+    _topic_data(topic=topic, lang=lang, annotate_time_period=True)
 
 
 def _topic_data(**kwargs):

--- a/sefaria/helper/topic.py
+++ b/sefaria/helper/topic.py
@@ -1265,8 +1265,6 @@ def update_order_of_topic_sources(topic, sources, uid, lang='en'):
         if link is None:
             return {"error": f"Link between {topic} and {s['ref']} doesn't exist."}
         order = getattr(link, 'order', {})
-        if lang not in order.get('availableLangs', []) :
-            return {"error": f"Link between {topic} and {s['ref']} does not exist in '{lang}'."}
         ref_to_link[s['ref']] = link
 
     # now update curatedPrimacy data

--- a/sefaria/helper/topic.py
+++ b/sefaria/helper/topic.py
@@ -1297,20 +1297,11 @@ def delete_ref_topic_link(tref, to_topic, link_type, lang):
     if link is None:
         return {"error": f"Link between {tref} and {to_topic} doesn't exist."}
 
-    if lang in link.order.get('availableLangs', []):
-        link.order['availableLangs'].remove(lang)
-    if lang in link.order.get('curatedPrimacy', []):
-        link.order['curatedPrimacy'].pop(lang)
-
-    if len(link.order.get('availableLangs', [])) > 0:
-        link.save()
+    if link.can_delete():
+        link.delete()
         return {"status": "ok"}
-    else:   # deleted in both hebrew and english so delete link object
-        if link.can_delete():
-            link.delete()
-            return {"status": "ok"}
-        else:
-            return {"error": f"Cannot delete link between {tref} and {to_topic}."}
+    else:
+        return {"error": f"Cannot delete link between {tref} and {to_topic}."}
 
 
 def add_image_to_topic(topic_slug, image_uri, en_caption, he_caption):

--- a/sefaria/helper/topic.py
+++ b/sefaria/helper/topic.py
@@ -1295,11 +1295,20 @@ def delete_ref_topic_link(tref, to_topic, link_type, lang):
     if link is None:
         return {"error": f"Link between {tref} and {to_topic} doesn't exist."}
 
-    if link.can_delete():
-        link.delete()
+    if lang in link.order.get('availableLangs', []):
+        link.order['availableLangs'].remove(lang)
+    if lang in link.order.get('curatedPrimacy', []):
+        link.order['curatedPrimacy'].pop(lang)
+
+    if len(link.order.get('availableLangs', [])) > 0:
+        link.save()
         return {"status": "ok"}
-    else:
-        return {"error": f"Cannot delete link between {tref} and {to_topic}."}
+    else:   # deleted in both hebrew and english so delete link object
+        if link.can_delete():
+            link.delete()
+            return {"status": "ok"}
+        else:
+            return {"error": f"Cannot delete link between {tref} and {to_topic}."}
 
 
 def add_image_to_topic(topic_slug, image_uri, en_caption, he_caption):

--- a/sefaria/helper/topic.py
+++ b/sefaria/helper/topic.py
@@ -1184,10 +1184,11 @@ def edit_topic_source(slug, orig_tref, new_tref="", creating_new_link=True,
     if topic_obj is None:
         return {"error": "Topic does not exist."}
     ref_topic_dict = {"toTopic": slug, "linkType": linkType, "ref": orig_tref}
-    link = RefTopicLink().load(ref_topic_dict)
-    link_already_existed = link is not None
-    if not link_already_existed:
-        link = RefTopicLink(ref_topic_dict)
+    # we don't know what link is being targeted b/c we don't know the dataSource.
+    # we'll guess that the most likely candidate is the link with the highest curatedPrimacy
+    link_set = RefTopicLinkSet(ref_topic_dict, sort=[["order.curatedPrimacy", -1]]).array()
+    link_already_existed = len(link_set) > 0
+    link = link_set[0] if link_already_existed else RefTopicLink(ref_topic_dict)
 
     if not hasattr(link, 'order'):
         link.order = {}

--- a/sefaria/helper/topic.py
+++ b/sefaria/helper/topic.py
@@ -248,12 +248,11 @@ def sort_refs_by_relevance(a, b, lang="english"):
         return 0
     if bool(aord) != bool(bord):
         return int(bool(bord)) - int(bool(aord))
-    for curr_lang in ("english", "hebrew"):
-        short_lang = curr_lang[:2]
-        aprimacy = curated_primacy(aord, short_lang)
-        bprimacy = curated_primacy(bord, short_lang)
-        if lang == curr_lang and (aprimacy > 0 or bprimacy > 0):
-            return bprimacy - aprimacy
+    short_lang = lang[:2]
+    aprimacy = curated_primacy(aord, short_lang)
+    bprimacy = curated_primacy(bord, short_lang)
+    if aprimacy > 0 or bprimacy > 0:
+        return bprimacy - aprimacy
     if aord.get('pr', 0) != bord.get('pr', 0):
         return bord.get('pr', 0) - aord.get('pr', 0)
     return (bord.get('numDatasource', 0) * bord.get('tfidf', 0)) - (aord.get('numDatasource', 0) * aord.get('tfidf', 0))

--- a/sefaria/helper/topic.py
+++ b/sefaria/helper/topic.py
@@ -17,6 +17,22 @@ from sefaria.helper.descriptions import create_era_link
 logger = structlog.get_logger(__name__)
 
 def get_topic(v2, topic, lang, with_html=True, with_links=True, annotate_links=True, with_refs=True, group_related=True, annotate_time_period=False, ref_link_type_filters=None, with_indexes=True):
+    """
+    Helper function for api/topics/<slug>
+    TODO fill in rest of parameters
+    @param v2:
+    @param topic: slug of topic to get data for
+    @param lang: the language of the user to sort the ref links by
+    @param with_html: True if description should be returned with HTML. If false, HTML is stripped.
+    @param with_links: Should intra-topic links be returned. If true, return dict has a `links` key
+    @param annotate_links:
+    @param with_refs:
+    @param group_related:
+    @param annotate_time_period:
+    @param ref_link_type_filters:
+    @param with_indexes:
+    @return:
+    """
     topic_obj = Topic.init(topic)
     if topic_obj is None:
         return {}
@@ -236,6 +252,12 @@ def get_topic_by_parasha(parasha:str) -> Topic:
 def sort_refs_by_relevance(a, b, lang="english"):
     """
     This function should mimic behavior of `refSort` in TopicPage.jsx.
+    It is a comparison function that takes two items from the list and returns the corresponding integer to indicate which should go first. To be used with `cmp_to_key`.
+    It considers the following criteria in order:
+    - If one object has an `order` key and another doesn't, the one with the `order` key comes first
+    - curatedPrimacy, higher comes first
+    - pagerank, higher comes first
+    - numDatasource (how many distinct links have this ref/topic pair) multiplied by tfidf (a bit complex, in short how "central" to this topic is the vocab used in this ref), higher comes first
     @param lang: language to sort by. Defaults to "english".
     @return:
     """

--- a/sefaria/helper/topic.py
+++ b/sefaria/helper/topic.py
@@ -3,7 +3,7 @@ from tqdm import tqdm
 from pymongo import UpdateOne, InsertOne
 from typing import Optional, Union
 from collections import defaultdict
-from functools import cmp_to_key
+from functools import cmp_to_key, partial
 from sefaria.model import *
 from sefaria.model.place import process_topic_place_change
 from sefaria.system.exceptions import InputError
@@ -16,7 +16,7 @@ from sefaria import tracker
 from sefaria.helper.descriptions import create_era_link
 logger = structlog.get_logger(__name__)
 
-def get_topic(v2, topic, with_html=True, with_links=True, annotate_links=True, with_refs=True, group_related=True, annotate_time_period=False, ref_link_type_filters=None, with_indexes=True):
+def get_topic(v2, topic, lang, with_html=True, with_links=True, annotate_links=True, with_refs=True, group_related=True, annotate_time_period=False, ref_link_type_filters=None, with_indexes=True):
     topic_obj = Topic.init(topic)
     if topic_obj is None:
         return {}
@@ -45,7 +45,7 @@ def get_topic(v2, topic, with_html=True, with_links=True, annotate_links=True, w
     if with_links:
         response['links'] = group_links_by_type('intraTopic', intra_links, annotate_links, group_related)
     if with_refs:
-        ref_links = sort_and_group_similar_refs(ref_links)
+        ref_links = sort_and_group_similar_refs(ref_links, lang)
         if v2:
             ref_links = group_links_by_type('refTopic', ref_links, False, False)
         response['refs'] = ref_links
@@ -169,8 +169,8 @@ def iterate_and_merge(new_ref_links, new_link, subset_ref_map, temp_subset_refs)
                 new_ref_links[index] = merge_props_for_similar_refs(new_ref_links[index], new_link)
     return new_ref_links
 
-def sort_and_group_similar_refs(ref_links):
-    ref_links.sort(key=cmp_to_key(sort_refs_by_relevance))
+def sort_and_group_similar_refs(ref_links, lang):
+    ref_links.sort(key=cmp_to_key(partial(sort_refs_by_relevance, lang=lang)))
     subset_ref_map = defaultdict(list)
     new_ref_links = []
     for link in ref_links:
@@ -233,15 +233,27 @@ def get_topic_by_parasha(parasha:str) -> Topic:
     return Topic().load({"parasha": parasha})
 
 
-def sort_refs_by_relevance(a, b):
+def sort_refs_by_relevance(a, b, lang="english"):
+    """
+    This function should mimic behavior of `refSort` in TopicPage.jsx.
+    @param lang: language to sort by. Defaults to "english".
+    @return:
+    """
     aord = a.get('order', {})
     bord = b.get('order', {})
+    def curated_primacy(order_dict, lang):
+        return order_dict.get("curatedPrimacy", {}).get(lang, 0)
+
     if not aord and not bord:
         return 0
     if bool(aord) != bool(bord):
-        return len(bord) - len(aord)
-    if aord.get("curatedPrimacy") or bord.get("curatedPrimacy"):
-        return len(bord.get("curatedPrimacy", {})) - len(aord.get("curatedPrimacy", {}))
+        return int(bool(bord)) - int(bool(aord))
+    for curr_lang in ("english", "hebrew"):
+        short_lang = curr_lang[:2]
+        aprimacy = curated_primacy(aord, short_lang)
+        bprimacy = curated_primacy(bord, short_lang)
+        if lang == curr_lang and (aprimacy > 0 or bprimacy > 0):
+            return bprimacy - aprimacy
     if aord.get('pr', 0) != bord.get('pr', 0):
         return bord.get('pr', 0) - aord.get('pr', 0)
     return (bord.get('numDatasource', 0) * bord.get('tfidf', 0)) - (aord.get('numDatasource', 0) * aord.get('tfidf', 0))
@@ -318,7 +330,7 @@ def ref_topic_link_prep(link):
         link['dataSource']['slug'] = data_source_slug
     return link
 
-def get_topics_for_ref(tref, annotate=False):
+def get_topics_for_ref(tref, lang="english", annotate=False):
     serialized = [l.contents() for l in Ref(tref).topiclinkset()]
     if annotate:
         if len(serialized) > 0:
@@ -329,7 +341,7 @@ def get_topics_for_ref(tref, annotate=False):
     for link in serialized:
         ref_topic_link_prep(link)
 
-    serialized.sort(key=cmp_to_key(sort_refs_by_relevance))
+    serialized.sort(key=cmp_to_key(partial(sort_refs_by_relevance, lang=lang)))
     return serialized
 
 

--- a/static/js/Misc.jsx
+++ b/static/js/Misc.jsx
@@ -1177,7 +1177,7 @@ const ReorderEditorWrapper = ({toggle, type, data}) => {
             return [];
         }
         // a topic can be connected to refs in one language and not in another so filter out those that are not in current interface lang
-        refs = refs.filter((x) => !x.is_sheet && x?.order?.availableLangs?.includes(Sefaria.interfaceLang.slice(0, 2)));
+        refs = refs.filter((x) => !x.is_sheet);
         // then sort the refs and take only first 30 sources because admins don't want to reorder hundreds of sources
         return refs.sort((a, b) => refSort('relevance', [a.ref, a], [b.ref, b])).slice(0, 30);
     }

--- a/static/js/Misc.jsx
+++ b/static/js/Misc.jsx
@@ -1186,7 +1186,7 @@ const ReorderEditorWrapper = ({toggle, type, data}) => {
         return {
           url: `/api/source/reorder?topic=${data.slug}&lang=${Sefaria.interfaceLang}`,
           redirect: `/topics/${data.slug}`,
-          origItems: _filterAndSortRefs(data.refs?.about?.refs) || [],
+          origItems: _filterAndSortRefs(data.tabs?.sources?.refs) || [],
         }
       }
       switch (type) {  // at /texts or /topics

--- a/static/js/TopicPage.jsx
+++ b/static/js/TopicPage.jsx
@@ -118,7 +118,6 @@ const refSort = (currSortOption, a, b) => {
       if (bAvailLangs.indexOf('en') > -1) { return 1; }
       return 0;
     }
-    else if (a.order.custom_order !== b.order.custom_order) { return b.order.custom_order - a.order.custom_order; }  // custom_order, when present, should trump other data
     else if (a.order.pr !== b.order.pr) {
         return b.order.pr - a.order.pr;
     }

--- a/static/js/TopicPage.jsx
+++ b/static/js/TopicPage.jsx
@@ -104,8 +104,6 @@ const refSort = (currSortOption, a, b) => {
     return a.order.comp_date - b.order.comp_date;
   }
   else {
-    const aAvailLangs = a.order.availableLangs;
-    const bAvailLangs = b.order.availableLangs;
     if ((Sefaria.interfaceLang === 'english') &&
       (a.order.curatedPrimacy.en > 0 || b.order.curatedPrimacy.en > 0)) {
       return b.order.curatedPrimacy.en - a.order.curatedPrimacy.en; }
@@ -113,6 +111,8 @@ const refSort = (currSortOption, a, b) => {
       (a.order.curatedPrimacy.he > 0 || b.order.curatedPrimacy.he > 0)) {
       return b.order.curatedPrimacy.he - a.order.curatedPrimacy.he;
     }
+    const aAvailLangs = a.order.availableLangs;
+    const bAvailLangs = b.order.availableLangs;
     if (Sefaria.interfaceLang === 'english' && aAvailLangs.length !== bAvailLangs.length) {
       if (aAvailLangs.indexOf('en') > -1) { return -1; }
       if (bAvailLangs.indexOf('en') > -1) { return 1; }


### PR DESCRIPTION
This fixes a few issues with inconsistent sorting found by the learning team:

- If a source appears multiple times on the page, editing will prefer the one with the highest curatedPrimacy
- Server-side and client-side relevance sorting are now (hopefully) identical
- Don't filter sources that don't have text in `interfaceLanguage` in the admin reorder view since this doesn't match how sources are sorted in the client-side code.