### PR TITLE
fix(topics): overwrite RefTopicLink._sanitize.

### DIFF
--- a/sefaria/model/topic.py
+++ b/sefaria/model/topic.py
@@ -835,6 +835,16 @@ class RefTopicLink(abst.AbstractMongoRecord):
             self.ref = Ref(self.ref).normal()
             self.expandedRefs = [r.normal() for r in Ref(self.ref).all_segment_refs()]
 
+    def _sanitize(self):
+        for lang in ("en", "he"):
+            description = getattr(self, "descriptions", {}).get(lang)
+            if description:
+                for field in ("title", "prompt"):
+                    value = description.get(field)
+                    if value:
+                        description[field] = bleach.clean(value, tags=self.ALLOWED_TAGS, attributes=self.ALLOWED_ATTRS)
+                self.descriptions[lang] = description
+
     def _validate(self):
         Topic.validate_slug_exists(self.toTopic)
         TopicLinkType.validate_slug_exists(self.linkType, 0)

--- a/sefaria/model/topic.py
+++ b/sefaria/model/topic.py
@@ -836,6 +836,11 @@ class RefTopicLink(abst.AbstractMongoRecord):
             self.expandedRefs = [r.normal() for r in Ref(self.ref).all_segment_refs()]
 
     def _sanitize(self):
+        """
+        Sanitize the "title" and "prompt" for all descriptions.
+        Since they're human editable they are candidates for XSS.
+        @return:
+        """
         for lang in ("en", "he"):
             description = getattr(self, "descriptions", {}).get(lang)
             if description:


### PR DESCRIPTION
Default inherited from abstract.py mangles Refs with ampersands in them. The new implementation avoids that and instead sanitizes title and prompt which can actually be vectors for attack.