### PR TITLE
Remove Community Menu Items

### DIFF
--- a/static/js/CommunityPage.jsx
+++ b/static/js/CommunityPage.jsx
@@ -20,10 +20,8 @@ const CommunityPage = ({multiPanel, toggleSignUpModal, initialWidth}) => {
   const [dataLoaded, setDataLoaded] = useState(!!Sefaria.community);
 
   const sidebarModules = [
-    {type: "JoinTheConversation"},
     {type: dataLoaded ? "WhoToFollow" : null, props: {toggleSignUpModal}},
     {type: "Promo"},
-    {type: "ExploreCollections"},
     {type: "SupportSefaria", props: {blue: true}},
     {type: "StayConnected"},
   ];

--- a/static/js/Footer.jsx
+++ b/static/js/Footer.jsx
@@ -55,7 +55,6 @@ class Footer extends Component {
             <Section en="Tools" he="כלים">
                 <Link href="/educators" en="Teach with Sefaria" he="מלמדים עם ספריא" />
                 <Link href="/calendars" en="Learning Schedules" he="לוח לימוד יומי" />
-                <Link href="/sheets" en="Source Sheets" he="דפי מקורות" />
                 <Link href="/visualizations" en="Visualizations" he="תרשימים גרפיים" />
                 <Link href="/mobile" en="Mobile Apps" he="ספריא בנייד" />
                 <Link href="/daf-yomi" en="Daf Yomi" he="דף יומי" />

--- a/static/js/Header.jsx
+++ b/static/js/Header.jsx
@@ -51,7 +51,6 @@ class Header extends Component {
           <a className="home" href="/" >{logo}</a> : null }
           <a href="/texts" className="textLink"><InterfaceText context="Header">Texts</InterfaceText></a>
           <a href="/topics" className="textLink"><InterfaceText>Topics</InterfaceText></a>
-          <a href="/community" className="textLink"><InterfaceText>Community</InterfaceText></a>
           <DonateLink classes={"textLink donate"} source={"Header"}><InterfaceText>Donate</InterfaceText></DonateLink>
         </div>
 
@@ -214,10 +213,6 @@ const MobileNavMenu = ({onRefClick, showSearch, openTopic, openURL, close, visib
       <a href="/topics" onClick={close}>
         <img src="/static/icons/topic.svg" />
         <InterfaceText>Topics</InterfaceText>
-      </a>
-      <a href="/community" onClick={close}>
-        <img src="/static/icons/community.svg" />
-        <InterfaceText>Community</InterfaceText>
       </a>
       <a href="/calendars" onClick={close}>
         <img src="/static/icons/calendar.svg" />

--- a/static/js/NavSidebar.jsx
+++ b/static/js/NavSidebar.jsx
@@ -241,8 +241,6 @@ const Resources = () => (
     <h3><InterfaceText context="ResourcesModule">Resources</InterfaceText></h3>
     <div className="linkList">
       <IconLink text="Mobile Apps" url="/mobile" icon="mobile.svg" />
-      <IconLink text="Create with Sefaria" url="/sheets" icon="sheet.svg" />
-      <IconLink text="Collections" url="/collections" icon="collection.svg" />
       <IconLink text="Teach with Sefaria" url="/educators" icon="educators.svg" />
       <IconLink text="Visualizations" url="/visualizations" icon="visualizations.svg" />
       <IconLink text="Torah Tab" url="/torah-tab" icon="torah-tab.svg" />

--- a/static/js/TextsPage.jsx
+++ b/static/js/TextsPage.jsx
@@ -93,7 +93,6 @@ const TextsPage = ({categories, settings, setCategories, onCompareBack, openSear
     multiPanel ? {type: "RecentlyViewed", props: {toggleSignUpModal}} : {type: null},
     {type: "Translations"},
     {type: "LearningSchedules"},
-    {type: "JoinTheCommunity"},
     {type: "Resources"},
   ];
 

--- a/static/js/TopicPageAll.jsx
+++ b/static/js/TopicPageAll.jsx
@@ -45,7 +45,6 @@ class TopicPageAll extends Component {
     const sidebarModules = [
       {type: "Promo"},
       {type: "TrendingTopics"},
-      {type: "JoinTheConversation"},
       {type: "GetTheApp"},
       {type: "SupportSefaria"},
     ];

--- a/static/js/TopicsPage.jsx
+++ b/static/js/TopicsPage.jsx
@@ -50,7 +50,6 @@ const TopicsPage = ({setNavTopic, multiPanel, initialWidth}) => {
   const sidebarModules = [
     multiPanel ? {type: "AboutTopics"} : {type: null},
     {type: "TrendingTopics"},
-    {type: "JoinTheConversation"},
     {type: "GetTheApp"},
     {type: "SupportSefaria"},
   ];


### PR DESCRIPTION
## Description
Remove community menu links from homepage (`Collections`, `Join the Conversation`, `Join the Community`). 
The `<Modules />` component in `NavSidebar.jsx` renders the sub-modules based on what's needed in the sidebar where `<NavSidebar />` is called. The core code for these widgets remains inside the `NavSidebar.jsx` file, and they remain as possible modules within `<Modules />`  for `<NavSidebar />` to call (i.e. so they can be called on the `Community` page without breaking functionality). 

The strategy here was to remove the links and the specific `Join the Conversation`/`Join the Community` where they are called, so within the library no one will encounter these widgets. 

Additionally, the `Collections` and `Community` links were removed. 

## Code changes:
1. `static/js/CommunityPage.jsx` - Remove `JoinTheConversation` and `ExploreCollections` from the modules to be rendered in the sidebar. 
2. `static/js/Footer.jsx` - Remove the `Source Sheets` link from the footer. 
3. `static/js/Header.jsx` - Remove the `Community` link from the header.
4. `static/js/NavSidebar.jsx` - Remove `Create with Sefaria` and `Collections` from the homepage sidebar
5. `static/js/TextsPage.jsx` - Remove `JoinTheCommunity` module from rendering in the sidebar
6. `static/js/TopicPageAll.jsx` - Remove `JoinTheConversation` module from rendering in the sidebar
7. `static/js/TopicsPage.jsx` - Remove `JoinTheConversation` module from rendering in the sidebar


## Testing functionality
- All of the pages changes were made on still work
- The /community page still works as well, no broken functionality

