### PR TITLE
fix(topics): load post data using more standard `request.body`

### DIFF
--- a/reader/views.py
+++ b/reader/views.py
@@ -3270,7 +3270,7 @@ def topic_ref_api(request, tref):
 
 @staff_member_required
 def reorder_sources(request):
-    sources = json.loads(request.POST["json"]).get("sources", [])
+    sources = json.loads(request.body).get("sources", [])
     slug = request.GET.get('topic')
     lang = 'en' if request.GET.get('lang') == 'english' else 'he'
     return jsonResponse(update_order_of_topic_sources(slug, sources, request.user.id, lang=lang))


### PR DESCRIPTION
In refactoring the way the admin editor client sends requests, this view started to break because it's using an older standard for how to load the post data.