### PR TITLE
Fix sefer hachinukh linker

### DIFF
--- a/sefaria/model/linker/ref_resolver.py
+++ b/sefaria/model/linker/ref_resolver.py
@@ -143,21 +143,15 @@ class ResolvedRef(abst.Cloneable):
         return self.node.get_children(self.ref)
 
     def contains(self, other: 'ResolvedRef') -> bool:
-        if other.ref and self.ref:
-            return self.ref.contains(other.ref)
+        """
+        Does `self` contain `other`. If `self.ref` and `other.ref` aren't None, this is just ref comparison.
+        Otherwise, see if the schema/altstruct node that back `self` contains `other`'s node.
+        @param other:
+        @return:
+        """
         if not other.node or not self.node:
             return False
-        if isinstance(other.node, NamedReferenceableBookNode) and isinstance(other.node._titled_tree_node, schema.AltStructNode):
-            other_node = other.node._titled_tree_node
-            if isinstance(self.node, NamedReferenceableBookNode) and isinstance(self.node._titled_tree_node, schema.AltStructNode):
-                return self.node._titled_tree_node.is_ancestor_of(other_node)
-            # other is alt struct and self has a ref
-            # check that every leaf node is contained by self's ref
-            return all([self.ref.contains(child.ref()) for child in other_node.get_leaf_nodes()])
-        # self is alt struct and other has a ref
-        # check if any leaf node contains other's ref
-        return any([child.ref().contains(other.ref) for child in self.node._titled_tree_node.get_leaf_nodes()])
-
+        return self.node.contains(other.node, self.ref, other.ref)
 
     @property
     def order_key(self):

--- a/sefaria/model/linker/tests/linker_test.py
+++ b/sefaria/model/linker/tests/linker_test.py
@@ -186,7 +186,7 @@ crrd = create_raw_ref_data
 
     [crrd(['@זהר חדש', '@בראשית']), ['Zohar Chadash, Bereshit']],
     [crrd(['@מסכת', '@סופרים', '#ב', '#ג']), ['Tractate Soferim 2:3']],
-    [crrd(['@אדר"נ', '#ב', '#ג']), ["Avot D'Rabbi Natan 2:3"]],
+    [crrd(['@אדר"נ', '#ב', '#ג']), ["Avot DeRabbi Natan 2:3"]],
     [crrd(['@פרק השלום', '#ג']), ["Tractate Derekh Eretz Zuta, Section on Peace 3"]],
     [crrd(['@ד"א זוטא', '@פרק השלום', '#ג']), ["Tractate Derekh Eretz Zuta, Section on Peace 3"]],
     [crrd(['@ספר החינוך', '@לך לך', '#ב']), ['Sefer HaChinukh 2']],

--- a/sefaria/model/schema.py
+++ b/sefaria/model/schema.py
@@ -1489,7 +1489,11 @@ class SchemaNode(TitledTreeNode):
         return self.traverse_to_list(lambda n, i: list(n.all_children()) if n.is_virtual else [n])[1:]
 
     def __eq__(self, other):
-        return self.address() == other.address()
+        try:
+            return self.address() == other.address()
+        except AttributeError:
+            # in case `other` isn't a SchemaNode
+            return False
 
     def __ne__(self, other):
         return not self.__eq__(other)


### PR DESCRIPTION
The linker requires a ResolvedRef to match all RefParts in the input to be considered valid. In the case where there are redundant parts we end of with two (or more) ResolvedRefs each of which only matches some of the RefParts. However, there may a some combination of ResolvedRefs that overlap and when combined span all the RefParts.

For example: ספר חיונוך לך לך ב. Currently the linker catches two partial matches: ספר החינוך ב and ספר החינוך לך לך. There is already logic to try to merge these. However since ספר החינוך לך לך matches an AltStructNode which has no associated ref (since this node has ArrayMapNode children but is not itself an ArrayMapNode) there wasn't an easy way to check for overlapping matches. This PR allows for this.