### PR TITLE
fix(helm): Add a timeout to the postgres db connection

### DIFF
--- a/helm-chart/sefaria-project/templates/configmap/local-settings-file.yaml
+++ b/helm-chart/sefaria-project/templates/configmap/local-settings-file.yaml
@@ -70,6 +70,9 @@ data:
             'PASSWORD': os.getenv("DATABASES_PASSWORD"),
             'HOST': os.getenv("DATABASES_HOST"),
             'PORT': os.getenv("DATABASES_PORT"),
+            'OPTIONS': {
+                'connect_timeout': 20, # timeout for connecting in seconds
+            },
         }
     }
 

--- a/helm-chart/sefaria-project/templates/rollout/web.yaml
+++ b/helm-chart/sefaria-project/templates/rollout/web.yaml
@@ -76,7 +76,8 @@ spec:
       - name: web
         image: "{{ .Values.web.containerImage.imageRegistry }}:{{ .Values.web.containerImage.tag }}"
         imagePullPolicy: Always
-        args: [ "python manage.py migrate && gunicorn sefaria.wsgi --access-logfile - --error-logfile - --timeout 300 --threads {{ .Values.web.resources.web.gunicornThreadCount }} --worker-tmp-dir /dev/shm -b 0.0.0.0:80" ]
+        args: [ "python manage.py migrate --verbosity 3 && gunicorn sefaria.wsgi --access-logfile - --error-logfile - --timeout 300 --threads {{ .Values.web.resources.web
+        .gunicornThreadCount }} --worker-tmp-dir /dev/shm -b 0.0.0.0:80" ]
         env:
           # WEB_CONCURRENCY is used for determining the number of server workers
           - name: WEB_CONCURRENCY

--- a/helm-chart/sefaria-project/templates/rollout/web.yaml
+++ b/helm-chart/sefaria-project/templates/rollout/web.yaml
@@ -76,8 +76,7 @@ spec:
       - name: web
         image: "{{ .Values.web.containerImage.imageRegistry }}:{{ .Values.web.containerImage.tag }}"
         imagePullPolicy: Always
-        args: [ "python manage.py migrate --verbosity 3 && gunicorn sefaria.wsgi --access-logfile - --error-logfile - --timeout 300 --threads {{ .Values.web.resources.web
-        .gunicornThreadCount }} --worker-tmp-dir /dev/shm -b 0.0.0.0:80" ]
+        args: [ "python manage.py migrate --verbosity 3 && gunicorn sefaria.wsgi --access-logfile - --error-logfile - --timeout 300 --threads {{ .Values.web.resources.web.gunicornThreadCount }} --worker-tmp-dir /dev/shm -b 0.0.0.0:80" ]
         env:
           # WEB_CONCURRENCY is used for determining the number of server workers
           - name: WEB_CONCURRENCY


### PR DESCRIPTION
 This is to explore if the db is a culprit in the environment not being able to spin up under certain conditions (sandboxes)

