### PR TITLE
Fix Space API Bug

### DIFF
--- a/sefaria/model/tests/text_test.py
+++ b/sefaria/model/tests/text_test.py
@@ -812,15 +812,16 @@ class TestVersionActualLanguage:
             for attr in expected_attrs[version_key]:
                 assert getattr(version, attr) == expected_attrs[version_key][attr]
 
+@pytest.mark.parametrize(('text_with_html', 'text_without_html'),
+                         [
+                         ["</big>בּ<big>ְרֵאשִׁ֖ית בָּרָ֣א אֱלֹהִ֑ים אֵ֥ת הַשָּׁמַ֖יִם וְאֵ֥ת הָאָֽרֶץ",
+                          "בְּרֵאשִׁ֖ית בָּרָ֣א אֱלֹהִ֑ים אֵ֥ת הַשָּׁמַ֖יִם וְאֵ֥ת הָאָֽרֶץ"],
+                         [
+                             "Happy is the <big>man</big> who has not followed the counsel of the wicked,<br/>or taken the path of sinners,<br>or joined the company of the insolent;",
+                             "Happy is the man who has not followed the counsel of the wicked, or taken the path of sinners, or joined the company of the insolent;"]
+                         ])
 
-def test_remove_html():
-    pasuk_with_html = "</big>בּ<big>ְרֵאשִׁ֖ית בָּרָ֣א אֱלֹהִ֑ים אֵ֥ת הַשָּׁמַ֖יִם וְאֵ֥ת הָאָֽרֶץ"
-    pasuk_without_html = "בְּרֵאשִׁ֖ית בָּרָ֣א אֱלֹהִ֑ים אֵ֥ת הַשָּׁמַ֖יִם וְאֵ֥ת הָאָֽרֶץ"
-
-    pasuk_with_br = "Happy is the <big>man</big> who has not followed the counsel of the wicked,<br/>or taken the path of sinners,<br>or joined the company of the insolent;"
-    pasuk_without_br = "Happy is the man who has not followed the counsel of the wicked, or taken the path of sinners, or joined the company of the insolent;"
-
-    assert model.TextChunk.remove_html(pasuk_with_html) == pasuk_without_html
-    assert model.TextChunk.remove_html(pasuk_with_br) == pasuk_without_br
+def test_remove_html(text_with_html, text_without_html):
+    assert model.TextChunk.remove_html(text_with_html) == text_without_html
 
 

--- a/sefaria/model/tests/text_test.py
+++ b/sefaria/model/tests/text_test.py
@@ -811,3 +811,16 @@ class TestVersionActualLanguage:
             version = getattr(self, version_key)
             for attr in expected_attrs[version_key]:
                 assert getattr(version, attr) == expected_attrs[version_key][attr]
+
+
+def test_remove_html():
+    pasuk_with_html = "</big>בּ<big>ְרֵאשִׁ֖ית בָּרָ֣א אֱלֹהִ֑ים אֵ֥ת הַשָּׁמַ֖יִם וְאֵ֥ת הָאָֽרֶץ"
+    pasuk_without_html = "בְּרֵאשִׁ֖ית בָּרָ֣א אֱלֹהִ֑ים אֵ֥ת הַשָּׁמַ֖יִם וְאֵ֥ת הָאָֽרֶץ"
+
+    pasuk_with_br = "Happy is the <big>man</big> who has not followed the counsel of the wicked,<br>or taken the path of sinners,<br>or joined the company of the insolent;"
+    pasuk_without_br = "Happy is the man who has not followed the counsel of the wicked, or taken the path of sinners, or joined the company of the insolent;"
+
+    assert model.TextChunk.remove_html(pasuk_with_html) == pasuk_without_html
+    assert model.TextChunk.remove_html(pasuk_with_br) == pasuk_without_br
+
+

--- a/sefaria/model/tests/text_test.py
+++ b/sefaria/model/tests/text_test.py
@@ -817,7 +817,7 @@ def test_remove_html():
     pasuk_with_html = "</big>בּ<big>ְרֵאשִׁ֖ית בָּרָ֣א אֱלֹהִ֑ים אֵ֥ת הַשָּׁמַ֖יִם וְאֵ֥ת הָאָֽרֶץ"
     pasuk_without_html = "בְּרֵאשִׁ֖ית בָּרָ֣א אֱלֹהִ֑ים אֵ֥ת הַשָּׁמַ֖יִם וְאֵ֥ת הָאָֽרֶץ"
 
-    pasuk_with_br = "Happy is the <big>man</big> who has not followed the counsel of the wicked,<br/>or taken the path of sinners,<br/>or joined the company of the insolent;"
+    pasuk_with_br = "Happy is the <big>man</big> who has not followed the counsel of the wicked,<br/>or taken the path of sinners,<br>or joined the company of the insolent;"
     pasuk_without_br = "Happy is the man who has not followed the counsel of the wicked, or taken the path of sinners, or joined the company of the insolent;"
 
     assert model.TextChunk.remove_html(pasuk_with_html) == pasuk_without_html

--- a/sefaria/model/tests/text_test.py
+++ b/sefaria/model/tests/text_test.py
@@ -817,7 +817,7 @@ def test_remove_html():
     pasuk_with_html = "</big>בּ<big>ְרֵאשִׁ֖ית בָּרָ֣א אֱלֹהִ֑ים אֵ֥ת הַשָּׁמַ֖יִם וְאֵ֥ת הָאָֽרֶץ"
     pasuk_without_html = "בְּרֵאשִׁ֖ית בָּרָ֣א אֱלֹהִ֑ים אֵ֥ת הַשָּׁמַ֖יִם וְאֵ֥ת הָאָֽרֶץ"
 
-    pasuk_with_br = "Happy is the <big>man</big> who has not followed the counsel of the wicked,<br>or taken the path of sinners,<br>or joined the company of the insolent;"
+    pasuk_with_br = "Happy is the <big>man</big> who has not followed the counsel of the wicked,<br/>or taken the path of sinners,<br/>or joined the company of the insolent;"
     pasuk_without_br = "Happy is the man who has not followed the counsel of the wicked, or taken the path of sinners, or joined the company of the insolent;"
 
     assert model.TextChunk.remove_html(pasuk_with_html) == pasuk_without_html

--- a/sefaria/model/text.py
+++ b/sefaria/model/text.py
@@ -1174,10 +1174,18 @@ class AbstractTextRecord(object):
         if isinstance(t, list):
             for i, v in enumerate(t):
                 if isinstance(v, str):
+                    tags = re.findall('<[^>]+>', t[i])
+                    for tag in tags:
+                        if tag == "<br>":
+                            t[i] = re.sub("<br>", " ", v)
                     t[i] = re.sub('<[^>]+>', "", v)
                 else:
                     t[i] = AbstractTextRecord.remove_html(v)
         elif isinstance(t, str):
+            tags = re.findall('<[^>]+>', t)
+            for tag in tags:
+                if tag == "<br>":
+                    t = re.sub("<br>", " ", t)
             t = re.sub('<[^>]+>', "", t)
         else:
             return False

--- a/sefaria/model/text.py
+++ b/sefaria/model/text.py
@@ -1174,11 +1174,11 @@ class AbstractTextRecord(object):
         if isinstance(t, list):
             for i, v in enumerate(t):
                 if isinstance(v, str):
-                    t[i] = re.sub('<[^>]+>', " ", v)
+                    t[i] = re.sub('<[^>]+>', "", v)
                 else:
                     t[i] = AbstractTextRecord.remove_html(v)
         elif isinstance(t, str):
-            t = re.sub('<[^>]+>', " ", t)
+            t = re.sub('<[^>]+>', "", t)
         else:
             return False
         return t

--- a/sefaria/model/text.py
+++ b/sefaria/model/text.py
@@ -1174,7 +1174,7 @@ class AbstractTextRecord(object):
 
         def conditional_replace(match):
             tag = match.group()
-            if tag == "<br/>":
+            if tag in ["<br/>", "<br>"]:
                 return " "
             return ""
 

--- a/sefaria/model/text.py
+++ b/sefaria/model/text.py
@@ -1171,22 +1171,21 @@ class AbstractTextRecord(object):
 
     @staticmethod
     def remove_html(t):
+
+        def conditional_replace(match):
+            tag = match.group()
+            if tag == "<br/>":
+                return " "
+            return ""
+
         if isinstance(t, list):
             for i, v in enumerate(t):
                 if isinstance(v, str):
-                    tags = re.findall('<[^>]+>', t[i])
-                    for tag in tags:
-                        if tag == "<br>":
-                            t[i] = re.sub("<br>", " ", v)
-                    t[i] = re.sub('<[^>]+>', "", v)
+                    t[i] = re.sub('<[^>]+>', conditional_replace, v)
                 else:
                     t[i] = AbstractTextRecord.remove_html(v)
         elif isinstance(t, str):
-            tags = re.findall('<[^>]+>', t)
-            for tag in tags:
-                if tag == "<br>":
-                    t = re.sub("<br>", " ", t)
-            t = re.sub('<[^>]+>', "", t)
+            t = re.sub('<[^>]+>', conditional_replace, t)
         else:
             return False
         return t


### PR DESCRIPTION
## Description
When using the texts API with the `return format` param set to `'text_only'`, there was an extra space left where HTML tags were taken out. (See the image below, the ב was originally wrapped in `<big></big>` tags, which are being stripped out in this case). 

<img width="848" alt="Screen Shot 2024-07-04 at 11 43 59" src="https://github.com/Sefaria/Sefaria-Project/assets/36717225/732e73d6-2aee-4878-8367-00785175dd04">



## Code Changes
1. In `sefaria/model/text.py` in `AbstractTextRecord`, I modified the `remove_html` function to replace the tags with an empty string, as opposed to a space. If the tag is `<br>` then it is replaced with a space. 
2. In `sefaria/model/tests/text_test.py` I added a test to make sure we handle both cases (`<br>` vs all other html tags) as expected. 

## Notes
- Recommendations for further testing?