### PR TITLE
Make ref part type more lenient

### DIFF
--- a/sefaria/model/linker/ref_part.py
+++ b/sefaria/model/linker/ref_part.py
@@ -443,7 +443,7 @@ class RawRef(RawNamedEntity):
         """
         start_char, end_char = span_char_inds(part.span)
         pivot = len(part.text) - len(str_end) + start_char
-        aspan = part.span.doc.char_span(0, pivot, alignment_mode='contract')
+        aspan = part.span.doc.char_span(start_char, pivot, alignment_mode='contract')
         bspan = part.span.doc.char_span(pivot, end_char, alignment_mode='contract')
         if aspan is None or bspan is None:
             raise InputError(f"Couldn't break on token boundaries for strings '{self.text[0:pivot]}' and '{self.text[pivot:end_char]}'")

--- a/sefaria/model/linker/tests/linker_test.py
+++ b/sefaria/model/linker/tests/linker_test.py
@@ -105,6 +105,9 @@ crrd = create_raw_ref_data
     # Base text context
     [crrd(['@ובתוס\'', '#דכ"ז ע"ב', '*ד"ה והלכתא'], "Rashi on Berakhot 2a"), ("Tosafot on Berakhot 27b:14:2",)],  # shared context child via graph context
 
+    # Mis-classified part types
+    [crrd(['@ושו"ע', "#אה״ע", "#סי׳ כ״ח", "#סעיף א"]), ("Shulchan Arukh, Even HaEzer 28:1",)],
+
     # Ibid
     [crrd(['&שם', '#ז'], prev_trefs=["Genesis 1"]), ["Genesis 7", "Genesis 1:7"]],  # ambiguous ibid
     [crrd(['&Ibid', '#12'], prev_trefs=["Exodus 1:7"], lang='en'), ["Exodus 1:12", "Exodus 12"]],  # ambiguous ibid when context is segment level (not clear if this is really ambiguous. maybe should only have segment level result)


### PR DESCRIPTION
## Description
loosen requirement that trie lookups for book names needs to match NAMED parts.
Now it can match any type but can only split NAMED parts.