### PR TITLE
fix(requirements): remove ~= from requirements.txt.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -68,7 +68,7 @@ requests
 Cerberus
 celery[redis]
 google-re2
-dnspython~=2.5.0
+dnspython==2.5.0
 
 #opentelemetry-distro
 #opentelemetry-exporter-otlp


### PR DESCRIPTION
This may be breaking the mobile content server build which is using an older version of pip (version 20).