### PR TITLE
Bug/sc 28279/text truncation fails for source on zimri

### DIFF
--- a/sefaria/utils/tests/util_test.py
+++ b/sefaria/utils/tests/util_test.py
@@ -59,3 +59,10 @@ class TestTruncateString:
         max_length = 24
         expected_output = "string with length of 24"
         assert truncate_string(string, min_length, max_length) == expected_output
+
+    def test_long_string_with_html_closing_tag_after_max_length(self):
+        string = 'This is a long string aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa <i>a</i>'
+        min_length = 10
+        max_length = 22
+        expected_output = "This is a long string…"
+        assert truncate_string(string, min_length, max_length) == expected_output

--- a/sefaria/utils/util.py
+++ b/sefaria/utils/util.py
@@ -472,7 +472,7 @@ def truncate_string(string, min_length, max_length):
         while min_length <= pos:
             while pos in html_element_indices:
                 pos = html_element_indices[pos] - 1
-            if string[pos] == break_char:
+            if string[pos] == break_char and pos <= max_length:
                 return string[:pos] + "…"
             pos -= 1
     return string


### PR DESCRIPTION
## Description
Fix for the truncate_string function. The function didn't handle properly cases where the first closing tag of an html element appeared after the "max-length" limit, an example of it is the truncation of Akeidat Yitzchak 83:1:6 found at the Zimri topic page.

## Code Changes
Added condition that ensures the result is shorter than "max_length", and a test that would've failed without the fix.