### PR TITLE
fix: only staff member can add index or edit text info.

### DIFF
--- a/reader/views.py
+++ b/reader/views.py
@@ -1242,6 +1242,7 @@ def edit_text(request, ref=None, lang=None, version=None):
     })
 
 @ensure_csrf_cookie
+@staff_member_required
 @sanitize_get_params
 def edit_text_info(request, title=None, new_title=None):
     """


### PR DESCRIPTION
## Description
only staff member can add index or edit text info

## Code Changes
staff_member_required decorator wad added to edit_text_info in reader/views.py.