### PR TITLE
Fix "flash" of "no jobs" on Jobs page

### DIFF
--- a/static/js/StaticPages.jsx
+++ b/static/js/StaticPages.jsx
@@ -3021,6 +3021,7 @@ const NoJobsNotice = () => {
 const JobsPage = memo(() => {
     const [groupedJobPostings, setGroupedJobPostings] = useState({});
     const [error, setError] = useState(null);
+    const [loading, setLoading] = useState(true);
 
     const fetchJobsJSON = async () => {
         const currentDateTime = new Date().toISOString();
@@ -3069,6 +3070,7 @@ const JobsPage = memo(() => {
     };
     
     const loadJobPostings = async () => {
+        setLoading(true);
         if (typeof STRAPI_INSTANCE !== "undefined" && STRAPI_INSTANCE) {
             try {
                 const jobsData = await fetchJobsJSON();
@@ -3102,20 +3104,24 @@ const JobsPage = memo(() => {
         } else {
             setError("Error: Sefaria's CMS cannot be reached");
         }
+        setLoading(false);
     };
 
     useEffect(() => {
         loadJobPostings();
     }, []);
 
+    const jobsAvailable = Object.keys(groupedJobPostings)?.length;
     return (
         <div>
             {error ? (
                 <h1>{error}</h1>
+            ) : loading ? (
+                <h1>Loading...</h1>
             ) : (
                 <>
-                    <JobsPageHeader jobsAreAvailable={Object.keys(groupedJobPostings)?.length} />
-                    {Object.keys(groupedJobPostings)?.length ? (
+                    <JobsPageHeader jobsAreAvailable={jobsAvailable} />
+                    {jobsAvailable ? (
                         <GroupedJobPostings groupedJobPostings={groupedJobPostings} />
                     ) : (
                         <NoJobsNotice />

--- a/static/js/StaticPages.jsx
+++ b/static/js/StaticPages.jsx
@@ -4,6 +4,8 @@ import {
     TwoOrThreeBox,
     ResponsiveNBox,
     NBox, InterfaceText,
+    LoadingMessage,
+    LoadingRing,
 } from './Misc';
 import {NewsletterSignUpForm} from "./NewsletterSignUpForm";
 import palette from './sefaria/palette';
@@ -3117,7 +3119,10 @@ const JobsPage = memo(() => {
             {error ? (
                 <h1>{error}</h1>
             ) : loading ? (
-                <h1>Loading...</h1>
+                <>
+                    <LoadingMessage />
+                    <LoadingRing />
+                </>
             ) : (
                 <>
                     <JobsPageHeader jobsAreAvailable={jobsAvailable} />


### PR DESCRIPTION
## Description
The jobs page shows that there are "no jobs" while the data call to Strapi is being made. On slow internet connections, the job listings can take a short while to load, while the user may be given the impression that there are no jobs and leave without waiting. This PR fixes that to show that the page is in a loading state until it's received the result of the call. 

## Code Changes
* A new state variable was added to keep tracking of the loading state for the network call. Once the call is received, the status of whether there are job listings available becomes known.
* The status of whether there are jobs listing available was also refactored to variable
