### PR TITLE
Bug/sc 28476/error when trying to add captions for images

### DIFF
--- a/reader/views.py
+++ b/reader/views.py
@@ -78,7 +78,7 @@ from io import BytesIO
 from sefaria.utils.user import delete_user_account
 from django.core.mail import EmailMultiAlternatives
 from babel import Locale
-from sefaria.helper.topic import update_topic, update_topic_titles
+from sefaria.helper.topic import update_topic
 from sefaria.helper.category import update_order_of_category_children, check_term
 
 if USE_VARNISH:
@@ -3108,7 +3108,9 @@ def add_new_topic_api(request):
         data = json.loads(request.POST["json"])
         isTopLevelDisplay = data["category"] == Topic.ROOT
         t = Topic({'slug': "", "isTopLevelDisplay": isTopLevelDisplay, "data_source": "sefaria", "numSources": 0})
-        update_topic_titles(t, **data)
+        titles = data.get('titles')
+        if titles:
+            t.set_titles(titles)
         t.set_slug_to_primary_title()
         if not isTopLevelDisplay:  # not Top Level so create an IntraTopicLink to category
             new_link = IntraTopicLink({"toTopic": data["category"], "fromTopic": t.slug, "linkType": "displays-under", "dataSource": "sefaria"})

--- a/sefaria/helper/topic.py
+++ b/sefaria/helper/topic.py
@@ -1073,16 +1073,25 @@ def topic_change_category(topic_obj, new_category, old_category="", rebuild=Fals
 def update_topic_titles(topic, title="", heTitle="", **kwargs):
     new_primary = {"en": title, "he": heTitle}
     titles = kwargs['titles']
-    enPrimary = [title['text'] for title in titles if title.get('primary', False) and title['lang'] == 'en'][0]
-    hePrimary = [title['text'] for title in titles if title.get('primary', False) and title['lang'] == 'he'][0]
+    # enPrimary = [title['text'] for title in titles if title.get('primary', False) and title['lang'] == 'en'][0]
+    # hePrimary = [title['text'] for title in titles if title.get('primary', False) and title['lang'] == 'he'][0]
+    enPrimary = [title for title in titles if title.get('primary', False) and title['lang'] == 'en'][0]
+    hePrimary = [title for title in titles if title.get('primary', False) and title['lang'] == 'he'][0]
     new_primary = {"en": enPrimary, "he": hePrimary}
+
+    enNonPrimary = [title for title in titles if not title.get('primary', False) and title['lang'] == 'en']
+    heNonPrimary = [title for title in titles if not title.get('primary', False) and title['lang'] == 'he']
+    nonPrimary = {'en': enNonPrimary, 'he': heNonPrimary}
+
     for lang in ['en', 'he']:   # first remove all titles and add new primary and then alt titles
         for title in topic.get_titles(lang):
             topic.remove_title(title, lang)
-        topic.add_title(new_primary[lang], lang, True, False)
-        if 'altTitles' in kwargs:
-            for title in kwargs['altTitles'][lang]:
-                topic.add_title(title, lang)
+        topic.add_title(new_primary[lang]['text'], lang, True, False, disambiguation=new_primary[lang].get("disambiguation", ""))
+        # if 'altTitles' in kwargs:
+        if nonPrimary:
+            # for title in kwargs['altTitles'][lang]:
+            for title in nonPrimary[lang]:
+                topic.add_title(title['text'], lang, disambiguation=title.get("disambiguation", ""))
     return topic
 
 

--- a/sefaria/helper/topic.py
+++ b/sefaria/helper/topic.py
@@ -1071,7 +1071,6 @@ def topic_change_category(topic_obj, new_category, old_category="", rebuild=Fals
     return topic_obj
 
 def update_topic_titles(topic, title="", heTitle="", **kwargs):
-    new_primary = {"en": title, "he": heTitle}
     titles = kwargs['titles']
     # enPrimary = [title['text'] for title in titles if title.get('primary', False) and title['lang'] == 'en'][0]
     # hePrimary = [title['text'] for title in titles if title.get('primary', False) and title['lang'] == 'he'][0]

--- a/sefaria/helper/topic.py
+++ b/sefaria/helper/topic.py
@@ -1070,26 +1070,22 @@ def topic_change_category(topic_obj, new_category, old_category="", rebuild=Fals
         rebuild_topic_toc(topic_obj, category_changed=True)
     return topic_obj
 
+def get_primary_title(titles, lang):
+    return next((title for title in titles if title.get('primary', False) and title['lang'] == lang), None)
+
+def get_non_primary_titles(titles, lang):
+    return [title for title in titles if not title.get('primary', False) and title['lang'] == lang]
 def update_topic_titles(topic, title="", heTitle="", **kwargs):
     titles = kwargs['titles']
-    # enPrimary = [title['text'] for title in titles if title.get('primary', False) and title['lang'] == 'en'][0]
-    # hePrimary = [title['text'] for title in titles if title.get('primary', False) and title['lang'] == 'he'][0]
-    enPrimary = [title for title in titles if title.get('primary', False) and title['lang'] == 'en'][0]
-    hePrimary = [title for title in titles if title.get('primary', False) and title['lang'] == 'he'][0]
-    new_primary = {"en": enPrimary, "he": hePrimary}
-
-    enNonPrimary = [title for title in titles if not title.get('primary', False) and title['lang'] == 'en']
-    heNonPrimary = [title for title in titles if not title.get('primary', False) and title['lang'] == 'he']
-    nonPrimary = {'en': enNonPrimary, 'he': heNonPrimary}
+    new_primary_titles = {"en": get_primary_title(titles, 'en'), "he": get_primary_title(titles, 'he')}
+    new_non_primary_titles = {"en": get_non_primary_titles(titles, 'en'), "he": get_non_primary_titles(titles, 'he')}
 
     for lang in ['en', 'he']:   # first remove all titles and add new primary and then alt titles
         for title in topic.get_titles(lang):
             topic.remove_title(title, lang)
-        topic.add_title(new_primary[lang]['text'], lang, True, False, disambiguation=new_primary[lang].get("disambiguation", ""))
-        # if 'altTitles' in kwargs:
-        if nonPrimary:
-            # for title in kwargs['altTitles'][lang]:
-            for title in nonPrimary[lang]:
+        topic.add_title(new_primary_titles[lang]['text'], lang, True, False, disambiguation=new_primary_titles[lang].get("disambiguation", ""))
+        if new_non_primary_titles:
+            for title in new_non_primary_titles[lang]:
                 topic.add_title(title['text'], lang, disambiguation=title.get("disambiguation", ""))
     return topic
 

--- a/sefaria/helper/topic.py
+++ b/sefaria/helper/topic.py
@@ -1070,26 +1070,6 @@ def topic_change_category(topic_obj, new_category, old_category="", rebuild=Fals
         rebuild_topic_toc(topic_obj, category_changed=True)
     return topic_obj
 
-def get_primary_title(titles, lang):
-    return next((title for title in titles if title.get('primary', False) and title['lang'] == lang), None)
-
-def get_non_primary_titles(titles, lang):
-    return [title for title in titles if not title.get('primary', False) and title['lang'] == lang]
-def update_topic_titles(topic, title="", heTitle="", **kwargs):
-    titles = kwargs['titles']
-    new_primary_titles = {"en": get_primary_title(titles, 'en'), "he": get_primary_title(titles, 'he')}
-    new_non_primary_titles = {"en": get_non_primary_titles(titles, 'en'), "he": get_non_primary_titles(titles, 'he')}
-
-    for lang in ['en', 'he']:   # first remove all titles and add new primary and then alt titles
-        for title in topic.get_titles(lang):
-            topic.remove_title(title, lang)
-        topic.add_title(new_primary_titles[lang]['text'], lang, True, False, disambiguation=new_primary_titles[lang].get("disambiguation", ""))
-        if new_non_primary_titles:
-            for title in new_non_primary_titles[lang]:
-                topic.add_title(title['text'], lang, disambiguation=title.get("disambiguation", ""))
-    return topic
-
-
 def update_authors_place_and_time(topic, dataSource='learning-team-editing-tool', **kwargs):
     # update place info added to author, then update year and era info
     if not hasattr(topic, 'properties'):
@@ -1129,7 +1109,9 @@ def update_topic(topic, **kwargs):
     """
     old_category = ""
     orig_slug = topic.slug
-    update_topic_titles(topic, **kwargs)
+    new_titles = kwargs.get('titles')
+    if new_titles:
+        topic.set_titles(new_titles)
     if kwargs.get('category') == 'authors':
         topic = update_authors_place_and_time(topic, **kwargs)
 

--- a/sefaria/helper/topic.py
+++ b/sefaria/helper/topic.py
@@ -1102,8 +1102,8 @@ def update_topic(topic, **kwargs):
     """
     Can update topic object's title, hebrew title, category, description, and categoryDescription fields
     :param topic: (Topic) The topic to update
-    :param **kwargs can be title, heTitle, category, description, categoryDescription, and rebuild_toc where `title`, `heTitle`,
-         and `category` are strings. `description` and `categoryDescription` are dictionaries where the fields are `en` and `he`.
+    :param **kwargs can be titles, category, description, categoryDescription, and rebuild_toc where `titles` is a list
+     of title objects as they are represented in the database, and `category` is a string. `description` and `categoryDescription` are dictionaries where the fields are `en` and `he`.
          The `category` parameter should be the slug of the new category. `rebuild_topic_toc` is a boolean and is assumed to be True
     :return: (model.Topic) The modified topic
     """

--- a/sefaria/helper/topic.py
+++ b/sefaria/helper/topic.py
@@ -1072,6 +1072,10 @@ def topic_change_category(topic_obj, new_category, old_category="", rebuild=Fals
 
 def update_topic_titles(topic, title="", heTitle="", **kwargs):
     new_primary = {"en": title, "he": heTitle}
+    titles = kwargs['titles']
+    enPrimary = [title['text'] for title in titles if title.get('primary', False) and title['lang'] == 'en'][0]
+    hePrimary = [title['text'] for title in titles if title.get('primary', False) and title['lang'] == 'he'][0]
+    new_primary = {"en": enPrimary, "he": hePrimary}
     for lang in ['en', 'he']:   # first remove all titles and add new primary and then alt titles
         for title in topic.get_titles(lang):
             topic.remove_title(title, lang)

--- a/sefaria/helper/topic.py
+++ b/sefaria/helper/topic.py
@@ -1100,7 +1100,7 @@ def update_author_era(topic_obj, dataSource='learning-team-editing-tool', **kwar
 
 def update_topic(topic, **kwargs):
     """
-    Can update topic object's title, hebrew title, category, description, and categoryDescription fields
+    Can update topic object's titles, category, description, and categoryDescription fields
     :param topic: (Topic) The topic to update
     :param **kwargs can be titles, category, description, categoryDescription, and rebuild_toc where `titles` is a list
      of title objects as they are represented in the database, and `category` is a string. `description` and `categoryDescription` are dictionaries where the fields are `en` and `he`.

--- a/sefaria/model/schema.py
+++ b/sefaria/model/schema.py
@@ -123,7 +123,7 @@ class TitleGroup(object):
         self.titles = [t for t in self.titles if not (t["lang"] == lang and t["text"] == text)]
         return self
 
-    def add_title(self, text, lang, primary=False, replace_primary=False, presentation="combined", disambiguation=''):
+    def add_title(self, text, lang, primary=False, replace_primary=False, presentation="combined"):
         """
         :param text: Text of the title
         :param language:  Language code of the title (e.g. "en" or "he")
@@ -150,8 +150,7 @@ class TitleGroup(object):
 
         if presentation == "alone" or presentation == "both":
             d["presentation"] = presentation
-        if disambiguation:
-            d['disambiguation'] = disambiguation
+
         has_primary = any([x for x in self.titles if x["lang"] == lang and x.get("primary")])
         if has_primary and primary:
             if not replace_primary:
@@ -172,16 +171,15 @@ class AbstractTitledObject(object):
         self.add_title(en_title, 'en', primary=True)
         self.add_title(he_title, 'he', primary=True)
 
-    def add_title(self, text, lang, primary=False, replace_primary=False, disambiguation=''):
+    def add_title(self, text, lang, primary=False, replace_primary=False):
         """
         :param text: Text of the title
         :param language:  Language code of the title (e.g. "en" or "he")
         :param primary: Is this a primary title?
         :param replace_primary: must be true to replace an existing primary title
-        :param disambiguation:
         :return: the object
         """
-        return self.title_group.add_title(text, lang, primary, replace_primary, disambiguation=disambiguation)
+        return self.title_group.add_title(text, lang, primary, replace_primary)
 
     def remove_title(self, text, lang):
         return self.title_group.remove_title(text, lang)

--- a/sefaria/model/schema.py
+++ b/sefaria/model/schema.py
@@ -123,7 +123,7 @@ class TitleGroup(object):
         self.titles = [t for t in self.titles if not (t["lang"] == lang and t["text"] == text)]
         return self
 
-    def add_title(self, text, lang, primary=False, replace_primary=False, presentation="combined"):
+    def add_title(self, text, lang, primary=False, replace_primary=False, presentation="combined", disambiguation=''):
         """
         :param text: Text of the title
         :param language:  Language code of the title (e.g. "en" or "he")
@@ -150,7 +150,8 @@ class TitleGroup(object):
 
         if presentation == "alone" or presentation == "both":
             d["presentation"] = presentation
-
+        if disambiguation:
+            d['disambiguation'] = disambiguation
         has_primary = any([x for x in self.titles if x["lang"] == lang and x.get("primary")])
         if has_primary and primary:
             if not replace_primary:
@@ -171,15 +172,16 @@ class AbstractTitledObject(object):
         self.add_title(en_title, 'en', primary=True)
         self.add_title(he_title, 'he', primary=True)
 
-    def add_title(self, text, lang, primary=False, replace_primary=False):
+    def add_title(self, text, lang, primary=False, replace_primary=False, disambiguation=''):
         """
         :param text: Text of the title
         :param language:  Language code of the title (e.g. "en" or "he")
         :param primary: Is this a primary title?
         :param replace_primary: must be true to replace an existing primary title
+        :param disambiguation:
         :return: the object
         """
-        return self.title_group.add_title(text, lang, primary, replace_primary)
+        return self.title_group.add_title(text, lang, primary, replace_primary, disambiguation=disambiguation)
 
     def remove_title(self, text, lang):
         return self.title_group.remove_title(text, lang)

--- a/sefaria/model/tests/topic_test.py
+++ b/sefaria/model/tests/topic_test.py
@@ -3,6 +3,7 @@ from sefaria.model.topic import Topic, TopicSet, IntraTopicLink, RefTopicLink, T
 from sefaria.model.text import Ref
 from sefaria.system.database import db
 from sefaria.system.exceptions import SluggedMongoRecordMissingError
+from sefaria.helper.topic import update_topic
 
 
 def make_topic(slug):
@@ -163,6 +164,16 @@ class TestTopics(object):
         assert "<script>" not in t.description["en"]
         assert "<script>" not in t.description["he"]
         assert "<script>" not in t.slug
+
+    def test_update_topic(self, topic_graph):
+        ts = topic_graph['topics']
+        t1 = ts['1']
+        update_topic(t1, titles=[{"text": "Tamar", "lang" : "en", "primary": True},
+                                {"text": "תמר", "lang": "he", "primary":True, "disambiguation": "יהודה"}])
+        assert t1.titles == [{"text": "Tamar", "lang" : "en", "primary": True},
+                                {"text": "תמר", "lang": "he", "primary":True, "disambiguation": "יהודה"}]
+
+
 
 
 

--- a/sefaria/model/tests/topic_test.py
+++ b/sefaria/model/tests/topic_test.py
@@ -173,6 +173,15 @@ class TestTopics(object):
         assert t1.titles == [{"text": "Tamar", "lang" : "en", "primary": True},
                                 {"text": "תמר", "lang": "he", "primary":True, "disambiguation": "יהודה"}]
 
+        update_topic(t1, description={"en": "abcdefg"})
+        assert t1.description == {"en": "abcdefg"}
+
+        with pytest.raises(Exception):
+            update_topic(t1, titles=[{"a": "Tamar", "b" : "en"},
+                                {"c": "תמר", "lang": "d", "disambiguation": "יהודה"}])
+        with pytest.raises(Exception):
+            update_topic(t1, slug='abc')
+
 
 
 

--- a/sefaria/model/tests/topic_test.py
+++ b/sefaria/model/tests/topic_test.py
@@ -165,23 +165,6 @@ class TestTopics(object):
         assert "<script>" not in t.description["he"]
         assert "<script>" not in t.slug
 
-    def test_update_topic(self, topic_graph):
-        ts = topic_graph['topics']
-        t1 = ts['1']
-        update_topic(t1, titles=[{"text": "Tamar", "lang" : "en", "primary": True},
-                                {"text": "תמר", "lang": "he", "primary":True, "disambiguation": "יהודה"}])
-        assert t1.titles == [{"text": "Tamar", "lang" : "en", "primary": True},
-                                {"text": "תמר", "lang": "he", "primary":True, "disambiguation": "יהודה"}]
-
-        update_topic(t1, description={"en": "abcdefg"})
-        assert t1.description == {"en": "abcdefg"}
-
-        with pytest.raises(Exception):
-            update_topic(t1, titles=[{"a": "Tamar", "b" : "en"},
-                                {"c": "תמר", "lang": "d", "disambiguation": "יהודה"}])
-        with pytest.raises(Exception):
-            update_topic(t1, slug='abc')
-
 
 
 

--- a/sefaria/model/topic.py
+++ b/sefaria/model/topic.py
@@ -383,7 +383,7 @@ class Topic(abst.SluggedAbstractMongoRecord, AbstractTitledObject):
                 title += ' [Ambiguous]'
         return title
 
-    def get_titles(self, lang=None, with_disambiguation=False):
+    def get_titles(self, lang=None, with_disambiguation=True):
         if with_disambiguation:
             titles = []
             for title in self.get_titles_object():

--- a/sefaria/model/topic.py
+++ b/sefaria/model/topic.py
@@ -380,7 +380,7 @@ class Topic(abst.SluggedAbstractMongoRecord, AbstractTitledObject):
             if disambig_text:
                 title += f' ({disambig_text})'
             elif getattr(self, 'isAmbiguous', False) and len(title) > 0:
-                title += ' (Ambiguous)'
+                title += ' [Ambiguous]'
         return title
 
     def get_titles(self, lang=None, with_disambiguation=True):

--- a/sefaria/model/topic.py
+++ b/sefaria/model/topic.py
@@ -383,7 +383,7 @@ class Topic(abst.SluggedAbstractMongoRecord, AbstractTitledObject):
                 title += ' [Ambiguous]'
         return title
 
-    def get_titles(self, lang=None, with_disambiguation=True):
+    def get_titles(self, lang=None, with_disambiguation=False):
         if with_disambiguation:
             titles = []
             for title in self.get_titles_object():

--- a/static/js/TopicEditor.jsx
+++ b/static/js/TopicEditor.jsx
@@ -157,8 +157,8 @@ const TopicEditor = ({origData, onCreateSuccess, close, origWasCat}) => {
         //convert title and altTitles to the database format, including extraction of disambiguation from title string
         postData['titles'].push(createPrimaryTitleObj(data, 'en'));
         postData['titles'].push(createPrimaryTitleObj(data, 'he'));
-        postData['titles'].concat(createNonPrimaryTitleObjArray(data, 'en'));
-        postData['titles'].concat(createNonPrimaryTitleObjArray(data, 'he'));
+        postData['titles'] = postData['titles'].concat(createNonPrimaryTitleObjArray(data, 'en'));
+        postData['titles'] = postData['titles'].concat(createNonPrimaryTitleObjArray(data, 'he'));
 
         // add image if image or caption changed
         const origImageURI = origData?.origImage?.image_uri || "";

--- a/static/js/TopicEditor.jsx
+++ b/static/js/TopicEditor.jsx
@@ -116,9 +116,24 @@ const TopicEditor = ({origData, onCreateSuccess, close, origWasCat}) => {
 
     const prepData = () => {
         // always add category, title, heTitle, altTitles
-        let postData = { category: data.catSlug, title: data.enTitle, heTitle: data.heTitle, altTitles: {}};
+        let postData = { category: data.catSlug, title: data.enTitle, heTitle: data.heTitle, altTitles: {}, titles: []};
         postData.altTitles.en = data.enAltTitles.map(x => x.name); // alt titles implemented using TitleVariants which contains list of objects with 'name' property.
         postData.altTitles.he = data.heAltTitles.map(x => x.name);
+
+        postData['titles'].push({'text': data['enTitle'], "lang": 'en', 'primary': true})
+        postData['titles'].push({'text': data['heTitle'], "lang": 'he', 'primary': true})
+        const enAltTitles = data['enAltTitles'];
+        const heAltTitles = data['heAltTitles'];
+        if (Array.isArray(enAltTitles)) {
+            enAltTitles.forEach((title, index) => {
+                postData['titles'].push({'text': title['name'], "lang": 'en'})
+            });
+        }
+        if (Array.isArray(heAltTitles)) {
+            heAltTitles.forEach((title, index) => {
+                postData['titles'].push({'text': title['name'], "lang": 'he'})
+            });
+        };
 
         // add image if image or caption changed
         const origImageURI = origData?.origImage?.image_uri || "";

--- a/static/js/TopicEditor.jsx
+++ b/static/js/TopicEditor.jsx
@@ -114,24 +114,49 @@ const TopicEditor = ({origData, onCreateSuccess, close, origWasCat}) => {
              .finally(() => setSavingStatus(false));
     }
 
+    const extractDisambiguationFromTitle = function(titleText){
+        let regex = /\((.+)\)$/;
+        let matches = titleText.match(regex);
+        let insideBrackets = matches ? matches[1] : null;
+        // let newString = titleText.replace(regex, "");
+        return insideBrackets
+    }
+    const removeDisambiguationFromTitle = function(titleText){
+        let regex = /\((.+)\)$/;
+        let newString = titleText.replace(regex, "");
+        console.log(newString);
+        return newString
+    }
     const prepData = () => {
         // always add category, title, heTitle, altTitles
         let postData = { category: data.catSlug, title: data.enTitle, heTitle: data.heTitle, altTitles: {}, titles: []};
         postData.altTitles.en = data.enAltTitles.map(x => x.name); // alt titles implemented using TitleVariants which contains list of objects with 'name' property.
         postData.altTitles.he = data.heAltTitles.map(x => x.name);
 
-        postData['titles'].push({'text': data['enTitle'], "lang": 'en', 'primary': true})
-        postData['titles'].push({'text': data['heTitle'], "lang": 'he', 'primary': true})
+        let enPrimaryTitleObj = {'text': removeDisambiguationFromTitle(data.enTitle), "lang": 'en', "primary": true};
+        let enDisambiguation = extractDisambiguationFromTitle(data.enTitle);
+        if (enDisambiguation) {enPrimaryTitleObj["disambiguation"]=enDisambiguation};
+        let hePrimaryTitleObj = {'text': removeDisambiguationFromTitle(data.heTitle), "lang": 'he', "primary": true};
+        let heDisambiguation = extractDisambiguationFromTitle(data.heTitle);
+        if (heDisambiguation) {hePrimaryTitleObj["disambiguation"]=heDisambiguation};
+        postData['titles'].push(enPrimaryTitleObj)
+        postData['titles'].push(hePrimaryTitleObj)
         const enAltTitles = data['enAltTitles'];
         const heAltTitles = data['heAltTitles'];
         if (Array.isArray(enAltTitles)) {
             enAltTitles.forEach((title, index) => {
-                postData['titles'].push({'text': title['name'], "lang": 'en'})
+                let titleObj = {'text': removeDisambiguationFromTitle(title['name']), "lang": 'en'};
+                let disambiguation = extractDisambiguationFromTitle(title['name']);
+                if (disambiguation) {titleObj["disambiguation"]=disambiguation}
+                postData['titles'].push(titleObj)
             });
         }
         if (Array.isArray(heAltTitles)) {
             heAltTitles.forEach((title, index) => {
-                postData['titles'].push({'text': title['name'], "lang": 'he'})
+                let titleObj = {'text': removeDisambiguationFromTitle(title['name']), "lang": 'he'};
+                let disambiguation = extractDisambiguationFromTitle(title['name']);
+                if (disambiguation) {titleObj["disambiguation"]=disambiguation};
+                postData['titles'].push(titleObj);
             });
         };
 

--- a/static/js/TopicEditor.jsx
+++ b/static/js/TopicEditor.jsx
@@ -117,22 +117,19 @@ const TopicEditor = ({origData, onCreateSuccess, close, origWasCat}) => {
     }
 
     const extractDisambiguationFromTitle = function(titleText){
-        return titleText.match(disambiguationExtractionRegex);
+        return titleText.match(disambiguationExtractionRegex)?.[1];
     }
     const removeDisambiguationFromTitle = function(titleText){
         return titleText.replace(disambiguationExtractionRegex, "").trimEnd();
     }
 
-    const createPrimaryTitleObj = function(data, lang){
-        const fieldName = lang == 'en' ? 'enTitle' : 'heTitle';
-        let primaryTitleObj = {'text': removeDisambiguationFromTitle(data[fieldName]), "lang": lang, "primary": true};
-        let disambiguation = extractDisambiguationFromTitle(data[fieldName]);
+    const createPrimaryTitleObj = function(rawTitle, lang){
+        let primaryTitleObj = {'text': removeDisambiguationFromTitle(rawTitle), "lang": lang, "primary": true};
+        let disambiguation = extractDisambiguationFromTitle(rawTitle);
         if (disambiguation) {primaryTitleObj["disambiguation"]=disambiguation};
         return primaryTitleObj;
     };
-    const createNonPrimaryTitleObjArray = function(data, lang){
-        const fieldName = lang == 'en' ? 'enAltTitles' : 'heAltTitles';
-        const altTitles = data[fieldName];
+    const createNonPrimaryTitleObjArray = function(altTitles, lang){
         const titleObjArray = []
         if (Array.isArray(altTitles)) {
             altTitles.forEach((title, index) => {
@@ -147,15 +144,15 @@ const TopicEditor = ({origData, onCreateSuccess, close, origWasCat}) => {
 
     const prepData = () => {
         // always add category, title, heTitle, altTitles
-        let postData = { category: data.catSlug, title: data.enTitle, heTitle: data.heTitle, altTitles: {}, titles: []};
-        postData.altTitles.en = data.enAltTitles.map(x => x.name); // alt titles implemented using TitleVariants which contains list of objects with 'name' property.
-        postData.altTitles.he = data.heAltTitles.map(x => x.name);
+        let postData = { category: data.catSlug, titles: []};
+        // postData.altTitles.en = data.enAltTitles.map(x => x.name); // alt titles implemented using TitleVariants which contains list of objects with 'name' property.
+        // postData.altTitles.he = data.heAltTitles.map(x => x.name);
 
         //convert title and altTitles to the database format, including extraction of disambiguation from title string
-        postData['titles'].push(createPrimaryTitleObj(data, 'en'));
-        postData['titles'].push(createPrimaryTitleObj(data, 'he'));
-        postData['titles'] = postData['titles'].concat(createNonPrimaryTitleObjArray(data, 'en'));
-        postData['titles'] = postData['titles'].concat(createNonPrimaryTitleObjArray(data, 'he'));
+        postData['titles'].push(createPrimaryTitleObj(data.enTitle, 'en'));
+        postData['titles'].push(createPrimaryTitleObj(data.heTitle, 'he'));
+        postData['titles'] = postData['titles'].concat(createNonPrimaryTitleObjArray(data.enAltTitles, 'en'));
+        postData['titles'] = postData['titles'].concat(createNonPrimaryTitleObjArray(data.heAltTitles, 'he'));
 
         // add image if image or caption changed
         const origImageURI = origData?.origImage?.image_uri || "";

--- a/static/js/TopicEditor.jsx
+++ b/static/js/TopicEditor.jsx
@@ -131,28 +131,24 @@ const TopicEditor = ({origData, onCreateSuccess, close, origWasCat}) => {
     };
     const createNonPrimaryTitleObjArray = function(altTitles, lang){
         const titleObjArray = []
-        if (Array.isArray(altTitles)) {
-            altTitles.forEach((title, index) => {
-                let titleObj = {'text': removeDisambiguationFromTitle(title['name']), "lang": lang};
-                let disambiguation = extractDisambiguationFromTitle(title['name']);
-                if (disambiguation) {titleObj["disambiguation"]=disambiguation}
-                titleObjArray.push(titleObj)
-            });
-        }
+        altTitles.forEach((title) => {
+            let titleObj = {'text': removeDisambiguationFromTitle(title), "lang": lang};
+            let disambiguation = extractDisambiguationFromTitle(title);
+            if (disambiguation) {titleObj["disambiguation"]=disambiguation}
+            titleObjArray.push(titleObj)
+        });
         return titleObjArray
     };
 
     const prepData = () => {
         // always add category, title, heTitle, altTitles
         let postData = { category: data.catSlug, titles: []};
-        // postData.altTitles.en = data.enAltTitles.map(x => x.name); // alt titles implemented using TitleVariants which contains list of objects with 'name' property.
-        // postData.altTitles.he = data.heAltTitles.map(x => x.name);
 
         //convert title and altTitles to the database format, including extraction of disambiguation from title string
         postData['titles'].push(createPrimaryTitleObj(data.enTitle, 'en'));
         postData['titles'].push(createPrimaryTitleObj(data.heTitle, 'he'));
-        postData['titles'] = postData['titles'].concat(createNonPrimaryTitleObjArray(data.enAltTitles, 'en'));
-        postData['titles'] = postData['titles'].concat(createNonPrimaryTitleObjArray(data.heAltTitles, 'he'));
+        postData['titles'] = postData['titles'].concat(createNonPrimaryTitleObjArray(data.enAltTitles.map(x => x.name), 'en'));
+        postData['titles'] = postData['titles'].concat(createNonPrimaryTitleObjArray(data.heAltTitles.map(x => x.name), 'he'));
 
         // add image if image or caption changed
         const origImageURI = origData?.origImage?.image_uri || "";

--- a/static/js/TopicEditor.jsx
+++ b/static/js/TopicEditor.jsx
@@ -35,6 +35,8 @@ const TopicEditor = ({origData, onCreateSuccess, close, origWasCat}) => {
     const [isChanged, setIsChanged] = useState(false);
     const [changedPicture, setChangedPicture] = useState(false);
 
+    const disambiguationExtractionRegex = /\((.+)\)$/;
+
     const toggle = function() {
       setSavingStatus(savingStatus => !savingStatus);
     }
@@ -115,15 +117,10 @@ const TopicEditor = ({origData, onCreateSuccess, close, origWasCat}) => {
     }
 
     const extractDisambiguationFromTitle = function(titleText){
-        let regex = /\((.+)\)$/;
-        let matches = titleText.match(regex);
-        let insideBrackets = matches ? matches[1] : null;
-        return insideBrackets
+        return titleText.match(disambiguationExtractionRegex);
     }
     const removeDisambiguationFromTitle = function(titleText){
-        let regex = /\((.+)\)$/;
-        let newTitle = titleText.replace(regex, "");
-        return newTitle
+        return titleText.replace(disambiguationExtractionRegex, "").trimEnd();
     }
 
     const createPrimaryTitleObj = function(data, lang){

--- a/static/js/TopicEditor.jsx
+++ b/static/js/TopicEditor.jsx
@@ -118,47 +118,47 @@ const TopicEditor = ({origData, onCreateSuccess, close, origWasCat}) => {
         let regex = /\((.+)\)$/;
         let matches = titleText.match(regex);
         let insideBrackets = matches ? matches[1] : null;
-        // let newString = titleText.replace(regex, "");
         return insideBrackets
     }
     const removeDisambiguationFromTitle = function(titleText){
         let regex = /\((.+)\)$/;
-        let newString = titleText.replace(regex, "");
-        console.log(newString);
-        return newString
+        let newTitle = titleText.replace(regex, "");
+        return newTitle
     }
+
+    const createPrimaryTitleObj = function(data, lang){
+        const fieldName = lang == 'en' ? 'enTitle' : 'heTitle';
+        let primaryTitleObj = {'text': removeDisambiguationFromTitle(data[fieldName]), "lang": lang, "primary": true};
+        let disambiguation = extractDisambiguationFromTitle(data[fieldName]);
+        if (disambiguation) {primaryTitleObj["disambiguation"]=disambiguation};
+        return primaryTitleObj;
+    };
+    const createNonPrimaryTitleObjArray = function(data, lang){
+        const fieldName = lang == 'en' ? 'enAltTitles' : 'heAltTitles';
+        const altTitles = data[fieldName];
+        const titleObjArray = []
+        if (Array.isArray(altTitles)) {
+            altTitles.forEach((title, index) => {
+                let titleObj = {'text': removeDisambiguationFromTitle(title['name']), "lang": lang};
+                let disambiguation = extractDisambiguationFromTitle(title['name']);
+                if (disambiguation) {titleObj["disambiguation"]=disambiguation}
+                titleObjArray.push(titleObj)
+            });
+        }
+        return titleObjArray
+    };
+
     const prepData = () => {
         // always add category, title, heTitle, altTitles
         let postData = { category: data.catSlug, title: data.enTitle, heTitle: data.heTitle, altTitles: {}, titles: []};
         postData.altTitles.en = data.enAltTitles.map(x => x.name); // alt titles implemented using TitleVariants which contains list of objects with 'name' property.
         postData.altTitles.he = data.heAltTitles.map(x => x.name);
 
-        let enPrimaryTitleObj = {'text': removeDisambiguationFromTitle(data.enTitle), "lang": 'en', "primary": true};
-        let enDisambiguation = extractDisambiguationFromTitle(data.enTitle);
-        if (enDisambiguation) {enPrimaryTitleObj["disambiguation"]=enDisambiguation};
-        let hePrimaryTitleObj = {'text': removeDisambiguationFromTitle(data.heTitle), "lang": 'he', "primary": true};
-        let heDisambiguation = extractDisambiguationFromTitle(data.heTitle);
-        if (heDisambiguation) {hePrimaryTitleObj["disambiguation"]=heDisambiguation};
-        postData['titles'].push(enPrimaryTitleObj)
-        postData['titles'].push(hePrimaryTitleObj)
-        const enAltTitles = data['enAltTitles'];
-        const heAltTitles = data['heAltTitles'];
-        if (Array.isArray(enAltTitles)) {
-            enAltTitles.forEach((title, index) => {
-                let titleObj = {'text': removeDisambiguationFromTitle(title['name']), "lang": 'en'};
-                let disambiguation = extractDisambiguationFromTitle(title['name']);
-                if (disambiguation) {titleObj["disambiguation"]=disambiguation}
-                postData['titles'].push(titleObj)
-            });
-        }
-        if (Array.isArray(heAltTitles)) {
-            heAltTitles.forEach((title, index) => {
-                let titleObj = {'text': removeDisambiguationFromTitle(title['name']), "lang": 'he'};
-                let disambiguation = extractDisambiguationFromTitle(title['name']);
-                if (disambiguation) {titleObj["disambiguation"]=disambiguation};
-                postData['titles'].push(titleObj);
-            });
-        };
+        //convert title and altTitles to the database format, including extraction of disambiguation from title string
+        postData['titles'].push(createPrimaryTitleObj(data, 'en'));
+        postData['titles'].push(createPrimaryTitleObj(data, 'he'));
+        postData['titles'].concat(createNonPrimaryTitleObjArray(data, 'en'));
+        postData['titles'].concat(createNonPrimaryTitleObjArray(data, 'he'));
 
         // add image if image or caption changed
         const origImageURI = origData?.origImage?.image_uri || "";


### PR DESCRIPTION
## Description
The "disambiguation" field of topic titles was not sent to the client. As a result, when editing a topic with disambiguations in its title, the inconsistency prevented the server from properly updating the topic object. This PR fixes the issue by making the client extract the disambiguation from the title string and format the title object similarly to how it is represented in the database. The server code was also modified to accommodate the new format.

## Code Changes
update_topic_titles in server
prepData in TopicEditor.jsx

