### PR TITLE
18 translation version name in title bar

### DIFF
--- a/e2e-tests/globals.ts
+++ b/e2e-tests/globals.ts
@@ -5,6 +5,11 @@ export const LANGUAGES = {
     'HE': 'hebrew',
 }
 
+export const SOURCE_LANGUAGES = {
+    'EN': 'div.toggleOption.english',
+    'HE': 'div.toggleOption.hebrew',
+}
+
 export const cookieObject = {
     "name": "interfaceLang",
     "value": DEFAULT_LANGUAGE,

--- a/e2e-tests/tests/interface-language-is-sticky.spec.ts
+++ b/e2e-tests/tests/interface-language-is-sticky.spec.ts
@@ -1,0 +1,38 @@
+import {test, expect} from '@playwright/test';
+import {goToPageWithLang, getPathAndParams} from "../utils";
+import {LANGUAGES} from '../globals'
+
+[
+    {interfaceLanguage: 'Hebrew', sourceLanguage: 'English', interfaceLanguageToggle: LANGUAGES.HE, sourceLanguageToggle: 'div.toggleOption.english', expectedSourceText: 'When God began to create', expectedBilingualText: '', expectedInterfaceText: 'מקורות' },
+    {interfaceLanguage: 'Hebrew', sourceLanguage: 'Bilingual', interfaceLanguageToggle: LANGUAGES.HE, sourceLanguageToggle: 'div.toggleOption.bilingual', expectedSourceText: 'רֵאשִׁ֖ית בָּרָ֣א אֱלֹהִ֑ים אֵ֥ת הַשָּׁמַ֖יִם וְאֵ֥ת הָאָֽרֶץ׃', expectedBilingualText: 'When God began to create', expectedInterfaceText: 'מקורות' },
+    {interfaceLanguage: 'Hebrew', sourceLanguage: 'Hebrew', interfaceLanguageToggle: LANGUAGES.HE, sourceLanguageToggle: 'div.toggleOption.hebrew', expectedSourceText: 'רֵאשִׁ֖ית בָּרָ֣א אֱלֹהִ֑ים אֵ֥ת הַשָּׁמַ֖יִם וְאֵ֥ת הָאָֽרֶץ׃', expectedBilingualText: '', expectedInterfaceText: 'מקורות' },
+    {interfaceLanguage: 'English', sourceLanguage: 'English', interfaceLanguageToggle: LANGUAGES.EN, sourceLanguageToggle: 'div.toggleOption.english', expectedSourceText: 'When God began to create', expectedBilingualText: '', expectedInterfaceText: 'Texts' },
+    {interfaceLanguage: 'English', sourceLanguage: 'Bilingual', interfaceLanguageToggle: LANGUAGES.EN, sourceLanguageToggle: 'div.toggleOption.bilingual', expectedSourceText: 'רֵאשִׁ֖ית בָּרָ֣א אֱלֹהִ֑ים אֵ֥ת הַשָּׁמַ֖יִם וְאֵ֥ת הָאָֽרֶץ׃', expectedBilingualText: 'When God began to create', expectedInterfaceText: 'Texts' },
+    {interfaceLanguage: 'English', sourceLanguage: 'Hebrew', interfaceLanguageToggle: LANGUAGES.EN, sourceLanguageToggle: 'div.toggleOption.hebrew', expectedSourceText: 'רֵאשִׁ֖ית בָּרָ֣א אֱלֹהִ֑ים אֵ֥ת הַשָּׁמַ֖יִם וְאֵ֥ת הָאָֽרֶץ׃', expectedBilingualText: '', expectedInterfaceText: 'Texts' }
+
+].forEach(({interfaceLanguage, sourceLanguage, interfaceLanguageToggle, sourceLanguageToggle, expectedSourceText, expectedBilingualText, expectedInterfaceText}) => {
+    test(`${interfaceLanguage} Interface Language with ${sourceLanguage} Source`, async ({ context }) => {
+
+        // Navigating to Bereshit with selected Interface Language, Hebrew or English
+        const page = await goToPageWithLang(context,'/Genesis.1',`${interfaceLanguageToggle}`)
+        
+        // Clicking on the Source Language toggle
+        await page.getByAltText('Toggle Reader Menu Display Settings').click()
+
+        // Selecting Source Language
+        await page.getByRole('radiogroup', {name: 'Language'}).locator(`${sourceLanguageToggle}`).click()
+    
+        // Locating the source text segment, then verifying translation
+        await expect(page.locator('div.segmentNumber').first().locator('..').locator('p')).toContainText(`${expectedSourceText}`)
+
+        // Checking out the second part of the text, if 'Bilingual' is selected
+        if(`${sourceLanguage}` === 'Bilingual'){
+            await expect(page.locator('div.segmentNumber').first().locator('..').locator('p span').last()).toContainText(`${expectedBilingualText}`)
+        }
+    
+        // Validate Hebrew interface language is still toggled
+        const textLink = page.locator('a.textLink').first()
+        await expect(textLink).toHaveText(`${expectedInterfaceText}`)
+
+    })
+})

--- a/e2e-tests/tests/translation-version-name-appears-in-title.spec.ts
+++ b/e2e-tests/tests/translation-version-name-appears-in-title.spec.ts
@@ -1,0 +1,46 @@
+import {test, expect} from '@playwright/test';
+import {goToPageWithLang} from "../utils";
+import {LANGUAGES} from '../globals'
+
+[
+    {interfaceLanguage: 'Hebrew', interfaceLanguageToggle: LANGUAGES.HE, translations: 'תרגומים', currentlySelected: 'נוכחי', secondTranslation: 'חומש רש״י, רבי שרגא זילברשטיין', thirdTranslation: '«Да» project'},
+    {interfaceLanguage: 'English', interfaceLanguageToggle: LANGUAGES.EN, translations: 'Translations', currentlySelected: 'Currently Selected', secondTranslation: 'The Rashi chumash by Rabbi Shraga Silverstein', thirdTranslation: '«Да» project'}
+].forEach(({interfaceLanguage, interfaceLanguageToggle, translations, currentlySelected, secondTranslation, thirdTranslation}) => {
+    test(`${interfaceLanguage} - translation name appears in title`, async ({ context }) => {
+
+        // Navigate to Bereshit in specified Interface Language
+        const page = await goToPageWithLang(context,'/Genesis.1', `${interfaceLanguageToggle}`)
+
+        // Retain the translation name locator
+        const translationNameInTitle = page.locator('span.readerTextVersion')
+
+        // Click on the text title
+        await translationNameInTitle.click()
+        
+        // Click on Translations
+        await page.getByRole('link', {name: `${translations}`}).click()
+        
+        // Wait for Translations side-bar to load
+        await page.waitForSelector('h3')
+
+        // Check if the default translation in the title matches the selected translation
+        const defaultTranslation = await translationNameInTitle.textContent()
+        await expect(page.locator('div.version-with-preview-title-line', {hasText: defaultTranslation}).getByRole('link')).toHaveText(`${currentlySelected}`)
+
+        // Translation name list
+        const translationNames = [`${secondTranslation}`, `${thirdTranslation}`]
+
+        // Utilizing this for-loop, as async issues were noticed with foreach
+        for(let i = 0; i < translationNames.length; i++){
+        
+            // "Select" another translation.  Directly using Select vs בחירה is unnecessary due to DOM structure
+            await page.locator('div.version-with-preview-title-line', {hasText: translationNames[i]}).getByRole('link').click()
+
+            // Validate selected translation is reflected in title
+            await expect(translationNameInTitle).toHaveText(translationNames[i])
+
+            // Validate selected translation says 'Currently Selected'
+            await expect(page.locator('div.version-with-preview-title-line', {hasText: translationNames[i]}).getByRole('link')).toHaveText(`${currentlySelected}`)
+        }
+    })
+})

--- a/e2e-tests/tests/translation-version-name-appears-in-title.spec.ts
+++ b/e2e-tests/tests/translation-version-name-appears-in-title.spec.ts
@@ -1,15 +1,40 @@
 import {test, expect} from '@playwright/test';
-import {goToPageWithLang} from "../utils";
-import {LANGUAGES} from '../globals'
+import {goToPageWithLang, changeLanguageOfText} from "../utils";
+import {LANGUAGES, SOURCE_LANGUAGES} from '../globals'
 
 [
-    {interfaceLanguage: 'Hebrew', interfaceLanguageToggle: LANGUAGES.HE, translations: 'תרגומים', currentlySelected: 'נוכחי', secondTranslation: 'חומש רש״י, רבי שרגא זילברשטיין', thirdTranslation: '«Да» project'},
-    {interfaceLanguage: 'English', interfaceLanguageToggle: LANGUAGES.EN, translations: 'Translations', currentlySelected: 'Currently Selected', secondTranslation: 'The Rashi chumash by Rabbi Shraga Silverstein', thirdTranslation: '«Да» project'}
-].forEach(({interfaceLanguage, interfaceLanguageToggle, translations, currentlySelected, secondTranslation, thirdTranslation}) => {
-    test(`${interfaceLanguage} - translation name appears in title`, async ({ context }) => {
+    // Hebrew Interface and Hebrew Source
+    /*
+    {interfaceLanguage: 'Hebrew', interfaceLanguageToggle: LANGUAGES.HE, sourceLanguage: SOURCE_LANGUAGES.HE,
+        translations: 'תרגומים', currentlySelected: 'נוכחי', 
+        secondTranslation: 'חומש רש״י, רבי שרגא זילברשטיין', thirdTranslation: '«Да» project'}, 
+    */
+
+    // Hebrew Interface and English Source
+    {interfaceLanguage: 'Hebrew', interfaceLanguageToggle: LANGUAGES.HE, sourceLanguage: SOURCE_LANGUAGES.EN,
+        translations: 'תרגומים', currentlySelected: 'נוכחי', 
+        secondTranslation: 'The Schocken Bible, Everett Fox, 1995 ©', thirdTranslation: '«Да» project'}, 
+
+    // English Interface and Hebrew Source
+    /*
+    {interfaceLanguage: 'English', interfaceLanguageToggle: LANGUAGES.EN, sourceLanguage: SOURCE_LANGUAGES.HE,
+        translations: 'תרגומים', currentlySelected: 'נוכחי', 
+        secondTranslation: 'The Schocken Bible, Everett Fox, 1995 ©', thirdTranslation: '«Да» project'}, 
+    */
+   
+    // English Interface and English Source
+    {interfaceLanguage: 'English', interfaceLanguageToggle: LANGUAGES.EN, sourceLanguage: SOURCE_LANGUAGES.EN,
+        translations: 'Translations', currentlySelected: 'Currently Selected', 
+        secondTranslation: 'The Schocken Bible, Everett Fox, 1995 ©', thirdTranslation: '«Да» project'}
+
+].forEach(({interfaceLanguage, interfaceLanguageToggle, sourceLanguage, translations, currentlySelected, secondTranslation, thirdTranslation}) => {
+    test(`${interfaceLanguage} - translation name appears in title for ${sourceLanguage} source text`, async ({ context }) => {
 
         // Navigate to Bereshit in specified Interface Language
         const page = await goToPageWithLang(context,'/Genesis.1', `${interfaceLanguageToggle}`)
+
+        // Change the Source Language of the text
+        await changeLanguageOfText(page, `${sourceLanguage}`)
 
         // Retain the translation name locator
         const translationNameInTitle = page.locator('span.readerTextVersion')

--- a/e2e-tests/utils.ts
+++ b/e2e-tests/utils.ts
@@ -1,4 +1,4 @@
-import {DEFAULT_LANGUAGE, LANGUAGES, testUser} from './globals'
+import {DEFAULT_LANGUAGE, LANGUAGES, SOURCE_LANGUAGES, testUser} from './globals'
 import {BrowserContext}  from 'playwright-core';
 import type { Page } from 'playwright-core';
 
@@ -65,4 +65,13 @@ export const goToPageWithUser = async (context: BrowserContext, url: string, use
 export const getPathAndParams = (url: string) => {
     const urlObj = new URL(url);
     return urlObj.pathname + urlObj.search;
+}
+
+export const changeLanguageOfText = async (page: Page, sourceLanguage: string) => {
+    // Clicking on the Source Language toggle
+    await page.getByAltText('Toggle Reader Menu Display Settings').click()
+
+    // Selecting Source Language
+    await page.getByRole('radiogroup', {name: 'Language'}).locator(sourceLanguage).click()
+
 }


### PR DESCRIPTION
## Description
A test to cover this test case: https://github.com/Sefaria/Sefaria-Playwright-Tests/issues/18

Includes:
* Parameterized tests for all Interface and Source language combinations
* Abstracted source language function for this and future purposes
* New Global variable for source language selection, pointing to DOM locators.

## Code Changes
_The following changes were made to the files below_

## Notes
Issue noted with Hebrew sources - the translation title doesn't appear by default. Such cases are commented out in the test parameters.