### PR TITLE
fix(Category API): allow for json or body in POST

### DIFF
--- a/reader/views.py
+++ b/reader/views.py
@@ -2438,10 +2438,7 @@ def category_api(request, path=None):
         else:
             return jsonResponse({"error": "Only Sefaria Moderators can add or delete categories."})
 
-        if "json" in request.POST:
-            j = request.POST.get("json")
-        else:
-            j = request.body
+        j = request.body
         if not j:
             return jsonResponse({"error": "Missing data in POST request."})
         j = json.loads(j)

--- a/reader/views.py
+++ b/reader/views.py
@@ -2438,9 +2438,12 @@ def category_api(request, path=None):
         else:
             return jsonResponse({"error": "Only Sefaria Moderators can add or delete categories."})
 
-        j = request.POST.get("json")
+        if "json" in request.POST:
+            j = request.POST.get("json")
+        else:
+            j = request.body
         if not j:
-            return jsonResponse({"error": "Missing 'json' parameter in post data."})
+            return jsonResponse({"error": "Missing data in POST request."})
         j = json.loads(j)
         update = int(request.GET.get("update", False))
         new_category = Category().load({"path": j["path"]})


### PR DESCRIPTION
## Description
Previously, the Category API assumed a 'json' parameter being passed in request.POST, but adminEditorApiRequest in sefaria.js passes a POST body instead.  Therefore, the Category Editor stopped working.

## Code Changes
I simply allowed for both options  -- 'json' in request.POST or a body -- in case someone wants to edit the category not using the Admin Editor.