### PR TITLE
Requirements organize

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,7 @@ psycopg2==2.8.6 #for dev: psycopg2-binary==2.8.6
 py2-py3-django-email-as-username==1.7.1
 pymongo==3.12.*
 pytest==6.1.1
-python-bidi==0.6.0
+python-bidi
 pytz
 pyyaml==6.0.1
 rauth==0.7.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,7 @@ psycopg2==2.8.6 #for dev: psycopg2-binary==2.8.6
 py2-py3-django-email-as-username==1.7.1
 pymongo==3.12.*
 pytest==6.1.1
-python-bidi #for devs on intel devices:python-bidi==0.4.2
+python-bidi==0.4.2
 pytz
 pyyaml==6.0.1
 rauth==0.7.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,11 +49,11 @@ p929==0.6.1
 pathos==0.2.6
 pillow==10.0.1; sys_platform != 'linux'
 pillow==8.0.1; sys_platform == 'linux'
-#psycopg2==2.8.6 #for dev: psycopg2-binary
+psycopg2==2.8.6 #for dev: psycopg2-binary==2.8.6
 py2-py3-django-email-as-username==1.7.1
 pymongo==3.12.*
 pytest==6.1.1
-python-bidi
+python-bidi #for devs on intel devices:python-bidi==0.4.2
 pytz
 pyyaml==6.0.1
 rauth==0.7.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,18 @@
 Appium-Python-Client==1.2.0
-apscheduler==3.6.
+Cerberus
+PyJWT==1.7.1 # pinned b/c current version 2.0.0 breaks simplejwt. waiting for 2.0.1
+apscheduler==3.6.*
+babel
 bleach==1.4.2
 boto3==1.16.6
 bs4==0.0.1
+celery[redis]
 convertdate==2.2.2
 cython==0.29.14
 dateutils==0.6.12
 datrie==0.8.2
 deepdiff==3.3.0
 diff_match_patch==20200713
-django_mobile==0.7.0
 django-anymail==7.2.*
 django-debug-toolbar==2.2 # not used in prod
 django-recaptcha==2.0.6
@@ -18,18 +21,22 @@ django-structlog==1.6.2
 django-user-agents==0.4.0
 django-webpack-loader==1.4.1
 django==1.11.*
+django_mobile==0.7.0
 djangorestframework @ https://github.com/encode/django-rest-framework/archive/3.11.1.tar.gz
 djangorestframework_simplejwt==3.3.0
-PyJWT==1.7.1 # pinned b/c current version 2.0.0 breaks simplejwt. waiting for 2.0.1
+dnspython~=2.5.0
 elasticsearch==8.8.2
-git+https://github.com/Sefaria/elasticsearch-dsl-py@v8.0.0#egg=elasticsearch-dsl
-git+https://github.com/Sefaria/LLM@v1.0.3#egg=sefaria_llm_interface&subdirectory=app/llm_interface
 geojson==2.5.0
 geopy==2.3.0
 gevent==20.12.0; sys_platform != 'darwin'
+git+https://github.com/Sefaria/LLM@v1.0.3#egg=sefaria_llm_interface&subdirectory=app/llm_interface
+git+https://github.com/Sefaria/elasticsearch-dsl-py@v8.0.0#egg=elasticsearch-dsl
 google-api-python-client==1.12.5
+google-auth-oauthlib==0.4.2
+google-auth==1.24.0
 google-cloud-logging==1.15.1
 google-cloud-storage==1.32.0
+google-re2
 gunicorn==20.0.4
 html5lib==0.9999999
 httplib2==0.18.1
@@ -38,37 +45,31 @@ jedi==0.18.1 # Ipython was previosuly pinned at 7.18 because Jedi 0.18 broke it.
 jsonpickle==1.4.1
 lxml==4.6.1
 mailchimp==2.0.9
-google-auth==1.24.0
-google-auth-oauthlib==0.4.2
 p929==0.6.1
 pathos==0.2.6
-pillow==8.0.1; sys_platform == 'linux'
 pillow==10.0.1; sys_platform != 'linux'
-psycopg2==2.8.6
+pillow==8.0.1; sys_platform == 'linux'
+#psycopg2==2.8.6 #for dev: psycopg2-binary
 py2-py3-django-email-as-username==1.7.1
 pymongo==3.12.*
 pytest==6.1.1
+python-bidi
 pytz
 pyyaml==6.0.1
 rauth==0.7.3
 redis==3.5.3
 regex==2020.10.23
+requests
 roman==3.3
 selenium==3.141.0
+sentry-sdk==1.26.0
 tqdm==4.51.0
 ua-parser==0.10.0
 undecorated==0.3.0
 unicodecsv==0.14.1
 unidecode==1.1.1
 user-agents==2.2.0
-sentry-sdk==1.26.0
-babel
-python-bidi
-requests
-Cerberus
-celery[redis]
-google-re2
-dnspython~=2.5.0
+
 
 #opentelemetry-distro
 #opentelemetry-exporter-otlp

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,7 @@ psycopg2==2.8.6 #for dev: psycopg2-binary==2.8.6
 py2-py3-django-email-as-username==1.7.1
 pymongo==3.12.*
 pytest==6.1.1
-python-bidi==0.4.2
+python-bidi==0.6.0
 pytz
 pyyaml==6.0.1
 rauth==0.7.3

--- a/sefaria/image_generator.py
+++ b/sefaria/image_generator.py
@@ -1,10 +1,6 @@
 from PIL import Image, ImageDraw, ImageFont
 import textwrap
-try:
-    from bidi import get_display
-except:
-    from bidi.algorithm import get_display
-
+from bidi.algorithm import get_display
 import re
 from django.http import HttpResponse
 import io

--- a/sefaria/image_generator.py
+++ b/sefaria/image_generator.py
@@ -1,6 +1,10 @@
 from PIL import Image, ImageDraw, ImageFont
 import textwrap
-from bidi import get_display
+try:
+    from bidi import get_display
+except:
+    from bidi.algorithm import get_display
+
 import re
 from django.http import HttpResponse
 import io


### PR DESCRIPTION
This PR does 2 things: 

1. It alphabetizes (well, sort of pip is weird) the requirements file

2. It re-introduces the fallback import that existed in older versions of python-bidi. This lib went through a change that re-implemented it in Rust and caused much despair and broke `api/img-gen` for Hebrew previews, changed the import syntax and caused platform specific install issues. 
A further version update restored the old python implementation. This PR restores the code to the use the latest version and the older python implementation and fixes issues in https://github.com/Sefaria/Sefaria-Project/pull/1975 