### PR TITLE
Disable Strapi for Banners, Modals, Sidebar Ads

### DIFF
--- a/static/js/Promotions.jsx
+++ b/static/js/Promotions.jsx
@@ -11,7 +11,8 @@ const Promotions = () => {
   const context = useContext(AdContext);
   const strapi = useContext(StrapiDataContext);
   useEffect(() => {
-    if (strapi.dataFromStrapiHasBeenReceived) {
+    // Disable Strapi for Sidebar Ads during Unbounce trial
+    if (false && strapi.dataFromStrapiHasBeenReceived) {
       Sefaria._inAppAds = [];
 
       const sidebarAds = strapi.strapiData?.sidebarAds?.data;

--- a/static/js/ReaderApp.jsx
+++ b/static/js/ReaderApp.jsx
@@ -2248,23 +2248,17 @@ toggleSignUpModal(modalContentKind = SignUpModalKind.Default) {
     var classes = classNames(classDict);
 
     return (
-      // The Strapi context is put at the highest level of scope so any component or children within ReaderApp can use the static content received
-      // InterruptingMessage modals and Banners will always render if available but stay hidden initially
-      <StrapiDataProvider>
-        <AdContext.Provider value={this.getUserContext()}>
-          <div id="readerAppWrap">
-            <InterruptingMessage />
-            <Banner onClose={this.setContainerMode} />
-            <div className={classes} onClick={this.handleInAppLinkClick}>
-              {header}
-              {panels}
-              {signUpModal}
-              {communityPagePreviewControls}
-              <CookiesNotification />
-            </div>
+      <AdContext.Provider value={this.getUserContext()}>
+        <div id="readerAppWrap">
+          <div className={classes} onClick={this.handleInAppLinkClick}>
+            {header}
+            {panels}
+            {signUpModal}
+            {communityPagePreviewControls}
+            <CookiesNotification />
           </div>
-        </AdContext.Provider>
-      </StrapiDataProvider>
+        </div>
+      </AdContext.Provider>
     );
   }
 }

--- a/static/js/context.js
+++ b/static/js/context.js
@@ -19,7 +19,8 @@ function StrapiDataProvider({ children }) {
   const [modal, setModal] = useState(null);
   const [banner, setBanner] = useState(null);
   useEffect(() => {
-    if (STRAPI_INSTANCE) {
+    // Disable Strapi API calls during Unbounce trial
+    if (false && typeof STRAPI_INSTANCE !== "undefined" && STRAPI_INSTANCE) {
       const getStrapiData = async () => {
         let getDateWithoutTime = (date) => date.toISOString().split("T")[0];
         let getJSONDateStringInLocalTimeZone = (date) => {


### PR DESCRIPTION
## Description
Strapi is being disabled during the trial of using Unbounce for banners and modals. Code changes were minimally made to prevent having to comment out or directly remove code. Sidebar Ads will be inaccessible during this trial. Modals will still be accessible by the mobile application.

## Code Changes
* The Banner and InterruptingMessage components were removed
* The StrapiDataContext provider was removed
* Prevent the execution of Strapi API calls by adding a `false` boolean to the conditionals