### PR TITLE
fix(Topic Pages): getBulkText bug that led it to generate long URLs

### DIFF
--- a/static/js/sefaria/sefaria.js
+++ b/static/js/sefaria/sefaria.js
@@ -479,10 +479,9 @@ Sefaria = extend(Sefaria, {
     let refStrs = [""];
     refs.map(ref => {
       let last = refStrs[refStrs.length-1];
-      const encodedRef = encodeURIComponent(ref);
-      const encodedFullURL = encodeURIComponent(`${hostStr}${last}|${ref}${paramStr}`);
-      if (encodedFullURL.length > MAX_URL_LENGTH) {
-        refStrs.push(encodedRef);
+      const encodedRef = encodeURIComponent(ref)
+      if (`${hostStr}${last}|${encodedRef}${paramStr}`.length > MAX_URL_LENGTH) {
+        refStrs.push(encodedRef)
       } else {
         refStrs[refStrs.length-1] += last.length ? `|${encodedRef}` : encodedRef;
       }

--- a/static/js/sefaria/sefaria.js
+++ b/static/js/sefaria/sefaria.js
@@ -479,9 +479,10 @@ Sefaria = extend(Sefaria, {
     let refStrs = [""];
     refs.map(ref => {
       let last = refStrs[refStrs.length-1];
-      const encodedRef = encodeURIComponent(ref)
-      if (`${hostStr}${last}|${encodedRef}${paramStr}`.length > MAX_URL_LENGTH) {
-        refStrs.push(encodedRef)
+      const encodedRef = encodeURIComponent(ref);
+      const encodedFullURL = encodeURIComponent(`${hostStr}${last}|${ref}${paramStr}`);
+      if (encodedFullURL.length > MAX_URL_LENGTH) {
+        refStrs.push(encodedRef);
       } else {
         refStrs[refStrs.length-1] += last.length ? `|${encodedRef}` : encodedRef;
       }

--- a/static/js/sefaria/sefaria.js
+++ b/static/js/sefaria/sefaria.js
@@ -479,16 +479,16 @@ Sefaria = extend(Sefaria, {
     let refStrs = [""];
     refs.map(ref => {
       let last = refStrs[refStrs.length-1];
-      const encodedRef = encodeURIComponent(ref)
-      if (`${hostStr}${last}|${encodedRef}${paramStr}`.length > MAX_URL_LENGTH) {
-        refStrs.push(encodedRef)
+      const encodedFullURL = encodeURI(`${hostStr}${last}|${ref}${paramStr}`);
+      if (encodedFullURL.length > MAX_URL_LENGTH) {
+        refStrs.push(ref)
       } else {
-        refStrs[refStrs.length-1] += last.length ? `|${encodedRef}` : encodedRef;
+        refStrs[refStrs.length-1] += last.length ? `|${ref}` : ref;
       }
     });
 
     let promises = refStrs.map(refStr => this._cachedApiPromise({
-      url: `${hostStr}${refStr}${paramStr}`,
+      url: `${hostStr}${encodeURIComponent(refStr)}${paramStr}`,
       key: refStr + paramStr,
       store: this._bulkTexts
     }));


### PR DESCRIPTION
## Description
The URLs were over 3800 characters because the pipe character gets encoded with 3 characters: "%7C", but the comparison treated the pipe character as one character.

## Code Changes
Instead of comparing the length of `${hostStr}${last}|${encodedRef}${paramStr}` to 3800, it's necessary to encode `${hostStr}${last}|${ref}${paramStr}` and compare that to 3800 instead.  