### PR TITLE
fix(Topic Pages): encodeURI should be used instead of encodeURIComponent

### DIFF
--- a/static/js/sefaria/sefaria.js
+++ b/static/js/sefaria/sefaria.js
@@ -486,9 +486,8 @@ Sefaria = extend(Sefaria, {
         refStrs[refStrs.length-1] += last.length ? `|${ref}` : ref;
       }
     });
-
     let promises = refStrs.map(refStr => this._cachedApiPromise({
-      url: `${hostStr}${encodeURIComponent(refStr)}${paramStr}`,
+      url: encodeURI(`${hostStr}${refStr}${paramStr}`),
       key: refStr + paramStr,
       store: this._bulkTexts
     }));


### PR DESCRIPTION
## Description
This addresses getBulkText sending out 3800 character URLs.

## Code Changes
Even though a previous attempt was supposed to have fixed this, in one case, encodeURI was used and in another, encodeURIComponent.  This is problematic because encodeURI doesn't encode colons so the previous attempted fix did not do the job.  This PR makes both cases encodeURI.