### PR TITLE
fix(Category Editor): do not look for books that are not in the category being reordered

### DIFF
--- a/sefaria/helper/category.py
+++ b/sefaria/helper/category.py
@@ -186,16 +186,15 @@ def update_order_of_category_children(cat, uid, subcategoriesAndBooks):
     results = []
     for subcategoryOrBook in subcategoriesAndBooks:
         order += 5
-        try:
-            obj = Index().load({'title': subcategoryOrBook, 'categories': cat_path})
-            assert obj is not None
-            obj = obj.contents(raw=True)
-            obj['order'] = [order]
-            result = tracker.update(uid, Index, obj)
-        except AssertionError:
-            obj = Category().load({"path": cat_path+[subcategoryOrBook]}).contents()
-            obj['order'] = order
-            result = tracker.update(uid, Category, obj)
+        book = Index().load({'title': subcategoryOrBook, 'categories': cat_path})
+        if book:
+            book = book.contents(raw=True)
+            book['order'] = [order]
+            result = tracker.update(uid, Index, book)
+        else:
+            cat = Category().load({"path": cat_path+[subcategoryOrBook]}).contents()
+            cat['order'] = order
+            result = tracker.update(uid, Category, cat)
         results.append(result.contents())
     return results
 

--- a/sefaria/helper/category.py
+++ b/sefaria/helper/category.py
@@ -187,10 +187,12 @@ def update_order_of_category_children(cat, uid, subcategoriesAndBooks):
     for subcategoryOrBook in subcategoriesAndBooks:
         order += 5
         try:
-            obj = library.get_index(subcategoryOrBook).contents(raw=True)
+            obj = Index().load({'title': subcategoryOrBook, 'categories': cat_path})
+            assert obj is not None
+            obj = obj.contents(raw=True)
             obj['order'] = [order]
             result = tracker.update(uid, Index, obj)
-        except BookNameError as e:
+        except AssertionError:
             obj = Category().load({"path": cat_path+[subcategoryOrBook]}).contents()
             obj['order'] = order
             result = tracker.update(uid, Category, obj)


### PR DESCRIPTION
## Description
We sometimes have categories with a book inside the category with the same title. For example, the category "Zohar" has the book "Zohar" inside of it.  The Category Editor doesn't work properly in this case.  

## Code Changes
The Category Editor previously would look to re-order a book without checking that its path is inside the category being re-ordered.  This was a reasonable assumption to make in most situations, but in the above case, this means that the book "Zohar" could get re-ordered when the intention was to re-order the category "Zohar".  I fixed this by only looking for books to re-order that are actually inside the category being re-ordered.  In the code, this means an Index is only loaded when its `categories` property is identical to the `cat_path` being re-ordered. 