### PR TITLE
Feature/sc 19410/always show add button in new editor

### DIFF
--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -10205,7 +10205,7 @@ span.purim-emoji img{
   position: relative;
   pointer-events:none;
   background-color: transparent;
-  margin-left: 50px;
+  margin-inline-start: 50px;
 }
 .editorAddInterface:before {
   content: "";

--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -10247,6 +10247,10 @@ background-color: white;
   pointer-events: none;
   display: inline-block;
 }
+.hidden.editorAddInterface::before {
+    display: none;
+}
+
 
 .addInterfaceInput .textPreview {
   border-inline-start: 4px solid;

--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -10193,11 +10193,13 @@ span.purim-emoji img{
 .interface-english .spacer:only-of-type.empty:before,
 .interface-english .spacer:only-of-type.empty:before {
   content: "Write something... ";
+  margin-inline-start: 50px;
 }
 .interface-hebrew .sheetItem:only-of-type.empty .SheetOutsideText:before,
 .interface-hebrew .spacer:only-of-type.empty:before,
 .interface-hebrew .spacer:only-of-type.empty:before {
   content: "לכתוב משהו...";
+  margin-inline-start: 50px;
 }
 .editorAddInterface {
   position: relative;

--- a/static/js/Editor.jsx
+++ b/static/js/Editor.jsx
@@ -1202,33 +1202,27 @@ const Element = (props) => {
             const focused = useFocused();
             const selected = useSelected();
             // console.log(focused);
+            const moveAnchorToEndOfCurrentNode = () => {
+                const { selection } = editor;
+
+                  if (selection && Range.isCollapsed(selection)) {
+                    const { anchor } = selection;
+                    const node = Editor.node(editor, anchor);
+
+                    if (node) {
+                      const [, path] = node;
+                      const endPoint = Editor.end(editor, path);
+
+                      Transforms.select(editor, {
+                        anchor: endPoint,
+                        focus: endPoint
+                      });
+                    }
+                  }
+        };
             const insertNewLine = function (){
-                  // Get the current selection
-              const { selection } = editor;
-              if (!selection) return;
-
-              // Get the current node
-              const [currentNode] = Editor.node(editor, selection);
-
-              // Create a new empty paragraph node
-              const newNode = {
-                type: 'SheetOutsideText',
-                children: [{ text: '' }],
-              };
-
-              // Get the current path
-              const currentPath = Editor.path(editor, selection);
-
-              // Insert the new node after the current node
-              Transforms.insertNodes(editor, newNode, {
-                at: Editor.after(editor, currentPath),
-              });
-
-              // Get the path to the new node
-              const newPath = Editor.after(editor, currentPath);
-
-              // Move the selection to the new node
-              Transforms.select(editor, newPath);
+              moveAnchorToEndOfCurrentNode();
+              editor.insertBreak();
             }
 
                 const addNewLineClasses = {

--- a/static/js/Editor.jsx
+++ b/static/js/Editor.jsx
@@ -1062,6 +1062,8 @@ const AddInterface = ({ attributes, children, element }) => {
 
 const Element = (props) => {
     const { attributes, children, element } = props;
+    console.log("new element of type ", element.type);
+    const editor = useSlate();
     const sheetItemClasses = {
         sheetItem: 1,
         empty: !(Node.string(element)),
@@ -1103,13 +1105,37 @@ const Element = (props) => {
             );
         case 'SheetOutsideText':
                 const SheetOutsideTextClasses = `SheetOutsideText segment ${element.lang}`;
+                const active = false;
+                const addInterfaceClasses = {
+                 active: active,
+                editorAddInterface: 1,
+                };
+                const enterEvent = new KeyboardEvent('keyup', {
+                    key: 'Enter',
+                    code: 'Enter',
+                    keyCode: 13,
+                    charCode: 13,
+                    which: 13,
+                    bubbles: true // Ensures the event bubbles up through the DOM
+                });
+                const simulateEnter = function (){
+                    // event.currentTarget.dispatchEvent(enterEvent);
+                    // Transforms.insertNodes(editor, {type: 'spacer', children: [{text: ""}]});
+                    // editor.insertBreak();
+                    // const curHeaderPath = getClosestSheetElement(editor, editor.selection.focus.path, "header")[1]
+                    // Transforms.insertNodes(editor, {type: 'SheetOutsideText', children: [{text: ""}]}, {at: editor.selection.focus.path});
+                    Transforms.setNodes(editor, {type: 'SheetOutsideText', children: [{text: ""}]}, {at: editor.selection.focus.path});
+
+                }
                 return (
+                <div role="button" title={active ? "Close menu" : "Add a source, image, or other media"} contentEditable={!active} suppressContentEditableWarning={true} aria-label={active ? "Close menu" : "Add a source, image, or other media"} className={classNames(addInterfaceClasses)} onClick={simulateEnter}>
                   <div className={classNames(sheetItemClasses)} {...attributes} data-sheet-node={element.node}>
                     <div className={SheetOutsideTextClasses} {...attributes}>
                         {children}
                     </div>
                     <div className="clearFix"></div>
                   </div>
+                </div>
             );
 
 
@@ -2488,7 +2514,7 @@ const SefariaEditor = (props) => {
     const editorContainer = useRef();
     const [sheet, setSheet] = useState(props.data);
     const initValue = [{type: "sheet", children: [{text: ""}]}];
-    const renderElement = useCallback(props => <Element {...props} />, []);
+    const renderElement = useCallback(props => <Element {...props}/>, []);
     const [value, setValue] = useState(initValue);
     const [currentDocument, setCurrentDocument] = useState(initValue);
     const [unsavedChanges, setUnsavedChanges] = useState(false);
@@ -2947,7 +2973,6 @@ const SefariaEditor = (props) => {
         () => withTables(withSefariaSheet(withLinks(withHistory(withReact(createEditor()))))),
         []
     );
-
 
     return (
         <div ref={editorContainer} onClick={props.handleClick}>

--- a/static/js/Editor.jsx
+++ b/static/js/Editor.jsx
@@ -1201,7 +1201,6 @@ const Element = (props) => {
         case 'paragraph':
             const focused = useFocused();
             const selected = useSelected();
-            // console.log(focused);
             const moveAnchorToEndOfCurrentNode = () => {
                 const { selection } = editor;
 
@@ -1226,7 +1225,6 @@ const Element = (props) => {
             }
 
                 const addNewLineClasses = {
-                 // active: active,
                 hidden: !selected,
                 editorAddInterface: 1,
                 };

--- a/static/js/Editor.jsx
+++ b/static/js/Editor.jsx
@@ -1062,7 +1062,7 @@ const AddInterface = ({ attributes, children, element }) => {
 
 const Element = (props) => {
     const { attributes, children, element } = props;
-    console.log("new element of type ", element.type);
+    // console.log("new element ", element.children, "is of type: " ,element.type);
     const editor = useSlate();
     const sheetItemClasses = {
         sheetItem: 1,
@@ -1110,32 +1110,25 @@ const Element = (props) => {
                  active: active,
                 editorAddInterface: 1,
                 };
-                const enterEvent = new KeyboardEvent('keyup', {
-                    key: 'Enter',
-                    code: 'Enter',
-                    keyCode: 13,
-                    charCode: 13,
-                    which: 13,
-                    bubbles: true // Ensures the event bubbles up through the DOM
-                });
+
                 const simulateEnter = function (){
                     // event.currentTarget.dispatchEvent(enterEvent);
                     // Transforms.insertNodes(editor, {type: 'spacer', children: [{text: ""}]});
                     // editor.insertBreak();
                     // const curHeaderPath = getClosestSheetElement(editor, editor.selection.focus.path, "header")[1]
                     // Transforms.insertNodes(editor, {type: 'SheetOutsideText', children: [{text: ""}]}, {at: editor.selection.focus.path});
-                    Transforms.setNodes(editor, {type: 'SheetOutsideText', children: [{text: ""}]}, {at: editor.selection.focus.path});
+                    Transforms.setNodes(editor, {type: 'spacer'}, {at: editor.selection.focus.path});
 
                 }
                 return (
-                <div role="button" title={active ? "Close menu" : "Add a source, image, or other media"} contentEditable={!active} suppressContentEditableWarning={true} aria-label={active ? "Close menu" : "Add a source, image, or other media"} className={classNames(addInterfaceClasses)} onClick={simulateEnter}>
+                // <div role="button" title={active ? "Close menu" : "Add a source, image, or other media"} contentEditable={!active} suppressContentEditableWarning={true} aria-label={active ? "Close menu" : "Add a source, image, or other media"} className={classNames(addInterfaceClasses)} onClick={simulateEnter}>
                   <div className={classNames(sheetItemClasses)} {...attributes} data-sheet-node={element.node}>
                     <div className={SheetOutsideTextClasses} {...attributes}>
                         {children}
                     </div>
                     <div className="clearFix"></div>
                   </div>
-                </div>
+                // </div>
             );
 
 
@@ -1206,11 +1199,38 @@ const Element = (props) => {
               <div className="sourceContentText">{children}</div>
             )
         case 'paragraph':
+            const focused = useFocused();
+            const selected = useSelected();
+            // console.log(focused);
+            const simulateEnterp = function (){
+                    const { selection } = editor;
+                    const currentNodePath = Editor.path(editor, selection);
+                    const nextLinePath = Editor.after(editor, currentNodePath);
+                    Transforms.insertNodes(
+                      editor,
+                      { type: 'spacer', children: [{ text: "" }] },
+                      { at: nextLinePath }
+                    );
+                      const newSelection = {
+                            anchor: Editor.point(editor, nextLinePath),
+                            focus: Editor.point(editor, nextLinePath),
+                          };
+                      Transforms.select(editor, newSelection);
+                }
+
+                const activep = false;
+                const addInterfaceClassesp = {
+                 active: active,
+                hidden: !selected,
+                editorAddInterface: 1,
+                };
             const pClasses = {center: element["text-align"] == "center" };
             return (
+                <div role="button" title={activep ? "Close menu" : "paragraph"} contentEditable={!activep} suppressContentEditableWarning={true} aria-label={activep ? "Close menu" : "Add a source, image, or other media"} className={classNames(addInterfaceClassesp)} onClick={simulateEnterp}>
                 <div className={classNames(pClasses)} {...attributes}>
                     {element.loading ? <div className="sourceLoader"></div> : null}
                     {children}
+                </div>
                 </div>
             );
         case 'bulleted-list':

--- a/static/js/Editor.jsx
+++ b/static/js/Editor.jsx
@@ -1201,6 +1201,18 @@ const Element = (props) => {
         case 'paragraph':
             const focused = useFocused();
             const selected = useSelected();
+            const isMultiNodeSelection = () => {
+              if (!editor.selection) return false;
+
+              const [start, end] = Range.edges(editor.selection);
+
+              // Get the path to the start and end of the selection
+              const startPath = start.path;
+              const endPath = end.path;
+
+              // If the start and end paths are different, it means multiple nodes are selected
+              return !Path.equals(startPath, endPath);
+            };
             const moveAnchorToEndOfCurrentNode = () => {
                 const { selection } = editor;
 
@@ -1225,10 +1237,10 @@ const Element = (props) => {
               editor.insertBreak();
             }
 
-                const addNewLineClasses = {
-                hidden: !(focused && selected),
-                editorAddInterface: 1,
-                };
+            const addNewLineClasses = {
+            hidden: isMultiNodeSelection() || !selected,
+            editorAddInterface: 1,
+            };
             const pClasses = {center: element["text-align"] == "center" };
             return (
                 <div role="button" title={"paragraph"} contentEditable={true} suppressContentEditableWarning={true} aria-label={"Add new line"} className={classNames(addNewLineClasses)} onClick={insertNewLine}>

--- a/static/js/Editor.jsx
+++ b/static/js/Editor.jsx
@@ -158,7 +158,27 @@ const isMultiNodeSelection = (editor) => {
 
   // If the start and end paths are different, it means multiple nodes are selected
   return !Path.equals(startPath, endPath);
-    };
+};
+
+const moveAnchorToEndOfCurrentNode = (editor) => {
+    const { selection } = editor;
+
+      if (selection && Range.isCollapsed(selection)) {
+        const { anchor } = selection;
+        const node = Editor.node(editor, anchor);
+
+        if (node) {
+          const [, path] = node;
+          const endPoint = Editor.end(editor, path);
+
+          Transforms.select(editor, {
+            anchor: endPoint,
+            focus: endPoint
+          });
+        }
+      }
+};
+
 
 export const deserialize = el => {
     if (el.nodeType === 3) {
@@ -1074,7 +1094,6 @@ const AddInterface = ({ attributes, children, element }) => {
 
 const Element = (props) => {
     const { attributes, children, element } = props;
-    // console.log("new element ", element.children, "is of type: " ,element.type);
     const editor = useSlate();
 
 
@@ -1126,14 +1145,12 @@ const Element = (props) => {
                 };
 
                 return (
-                // <div role="button" title={active ? "Close menu" : "Add a source, image, or other media"} contentEditable={!active} suppressContentEditableWarning={true} aria-label={active ? "Close menu" : "Add a source, image, or other media"} className={classNames(addInterfaceClasses)} onClick={simulateEnter}>
                   <div className={classNames(sheetItemClasses)} {...attributes} data-sheet-node={element.node}>
                     <div className={SheetOutsideTextClasses} {...attributes}>
                         {children}
                     </div>
                     <div className="clearFix"></div>
                   </div>
-                // </div>
             );
 
 
@@ -1204,30 +1221,9 @@ const Element = (props) => {
               <div className="sourceContentText">{children}</div>
             )
         case 'paragraph':
-            const focused = useFocused();
             const selected = useSelected();
-
-            const moveAnchorToEndOfCurrentNode = () => {
-                const { selection } = editor;
-
-                  if (selection && Range.isCollapsed(selection)) {
-                    const { anchor } = selection;
-                    const node = Editor.node(editor, anchor);
-
-                    if (node) {
-                      const [, path] = node;
-                      const endPoint = Editor.end(editor, path);
-
-                      Transforms.select(editor, {
-                        anchor: endPoint,
-                        focus: endPoint
-                      });
-                    }
-                  }
-            };
-
             const insertNewLine = function (){
-              moveAnchorToEndOfCurrentNode();
+              moveAnchorToEndOfCurrentNode(editor);
               editor.insertBreak();
             }
 

--- a/static/js/Editor.jsx
+++ b/static/js/Editor.jsx
@@ -1202,31 +1202,43 @@ const Element = (props) => {
             const focused = useFocused();
             const selected = useSelected();
             // console.log(focused);
-            const simulateEnterp = function (){
-                    const { selection } = editor;
-                    const currentNodePath = Editor.path(editor, selection);
-                    const nextLinePath = Editor.after(editor, currentNodePath);
-                    Transforms.insertNodes(
-                      editor,
-                      { type: 'spacer', children: [{ text: "" }] },
-                      { at: nextLinePath }
-                    );
-                      const newSelection = {
-                            anchor: Editor.point(editor, nextLinePath),
-                            focus: Editor.point(editor, nextLinePath),
-                          };
-                      Transforms.select(editor, newSelection);
-                }
+            const insertNewLine = function (){
+                  // Get the current selection
+              const { selection } = editor;
+              if (!selection) return;
 
-                const activep = false;
-                const addInterfaceClassesp = {
-                 active: active,
+              // Get the current node
+              const [currentNode] = Editor.node(editor, selection);
+
+              // Create a new empty paragraph node
+              const newNode = {
+                type: 'SheetOutsideText',
+                children: [{ text: '' }],
+              };
+
+              // Get the current path
+              const currentPath = Editor.path(editor, selection);
+
+              // Insert the new node after the current node
+              Transforms.insertNodes(editor, newNode, {
+                at: Editor.after(editor, currentPath),
+              });
+
+              // Get the path to the new node
+              const newPath = Editor.after(editor, currentPath);
+
+              // Move the selection to the new node
+              Transforms.select(editor, newPath);
+            }
+
+                const addNewLineClasses = {
+                 // active: active,
                 hidden: !selected,
                 editorAddInterface: 1,
                 };
             const pClasses = {center: element["text-align"] == "center" };
             return (
-                <div role="button" title={activep ? "Close menu" : "paragraph"} contentEditable={!activep} suppressContentEditableWarning={true} aria-label={activep ? "Close menu" : "Add a source, image, or other media"} className={classNames(addInterfaceClassesp)} onClick={simulateEnterp}>
+                <div role="button" title={"paragraph"} contentEditable={true} suppressContentEditableWarning={true} aria-label={"Add new line"} className={classNames(addNewLineClasses)} onClick={insertNewLine}>
                 <div className={classNames(pClasses)} {...attributes}>
                     {element.loading ? <div className="sourceLoader"></div> : null}
                     {children}

--- a/static/js/Editor.jsx
+++ b/static/js/Editor.jsx
@@ -2382,7 +2382,6 @@ const HoverMenu = (opt) => {
 
         if (
             !selection ||
-            isMultiNodeSelection(editor) ||
             !ReactEditor.isFocused(editor) ||
             Range.isCollapsed(selection) ||
             Editor.string(editor, selection) === '' ||

--- a/static/js/Editor.jsx
+++ b/static/js/Editor.jsx
@@ -147,6 +147,18 @@ const format_to_html_lookup = format_tag_pairs.reduce((obj, item) => {
    return {node: bottom, path: bottomPath}
  };
 
+const isMultiNodeSelection = (editor) => {
+  if (!editor.selection) return false;
+
+  const [start, end] = Range.edges(editor.selection);
+
+  // Get the path to the start and end of the selection
+  const startPath = start.path;
+  const endPath = end.path;
+
+  // If the start and end paths are different, it means multiple nodes are selected
+  return !Path.equals(startPath, endPath);
+    };
 
 export const deserialize = el => {
     if (el.nodeType === 3) {
@@ -1064,6 +1076,8 @@ const Element = (props) => {
     const { attributes, children, element } = props;
     // console.log("new element ", element.children, "is of type: " ,element.type);
     const editor = useSlate();
+
+
     const sheetItemClasses = {
         sheetItem: 1,
         empty: !(Node.string(element)),
@@ -1111,15 +1125,6 @@ const Element = (props) => {
                 editorAddInterface: 1,
                 };
 
-                const simulateEnter = function (){
-                    // event.currentTarget.dispatchEvent(enterEvent);
-                    // Transforms.insertNodes(editor, {type: 'spacer', children: [{text: ""}]});
-                    // editor.insertBreak();
-                    // const curHeaderPath = getClosestSheetElement(editor, editor.selection.focus.path, "header")[1]
-                    // Transforms.insertNodes(editor, {type: 'SheetOutsideText', children: [{text: ""}]}, {at: editor.selection.focus.path});
-                    Transforms.setNodes(editor, {type: 'spacer'}, {at: editor.selection.focus.path});
-
-                }
                 return (
                 // <div role="button" title={active ? "Close menu" : "Add a source, image, or other media"} contentEditable={!active} suppressContentEditableWarning={true} aria-label={active ? "Close menu" : "Add a source, image, or other media"} className={classNames(addInterfaceClasses)} onClick={simulateEnter}>
                   <div className={classNames(sheetItemClasses)} {...attributes} data-sheet-node={element.node}>
@@ -1201,18 +1206,7 @@ const Element = (props) => {
         case 'paragraph':
             const focused = useFocused();
             const selected = useSelected();
-            const isMultiNodeSelection = () => {
-              if (!editor.selection) return false;
 
-              const [start, end] = Range.edges(editor.selection);
-
-              // Get the path to the start and end of the selection
-              const startPath = start.path;
-              const endPath = end.path;
-
-              // If the start and end paths are different, it means multiple nodes are selected
-              return !Path.equals(startPath, endPath);
-            };
             const moveAnchorToEndOfCurrentNode = () => {
                 const { selection } = editor;
 
@@ -1238,7 +1232,7 @@ const Element = (props) => {
             }
 
             const addNewLineClasses = {
-            hidden: isMultiNodeSelection() || !selected,
+            hidden: isMultiNodeSelection(editor) || !selected,
             editorAddInterface: 1,
             };
             const pClasses = {center: element["text-align"] == "center" };
@@ -2388,6 +2382,7 @@ const HoverMenu = (opt) => {
 
         if (
             !selection ||
+            isMultiNodeSelection(editor) ||
             !ReactEditor.isFocused(editor) ||
             Range.isCollapsed(selection) ||
             Editor.string(editor, selection) === '' ||

--- a/static/js/Editor.jsx
+++ b/static/js/Editor.jsx
@@ -1218,14 +1218,15 @@ const Element = (props) => {
                       });
                     }
                   }
-        };
+            };
+
             const insertNewLine = function (){
               moveAnchorToEndOfCurrentNode();
               editor.insertBreak();
             }
 
                 const addNewLineClasses = {
-                hidden: !selected,
+                hidden: !(focused && selected),
                 editorAddInterface: 1,
                 };
             const pClasses = {center: element["text-align"] == "center" };

--- a/static/js/Editor.jsx
+++ b/static/js/Editor.jsx
@@ -148,11 +148,10 @@ const format_to_html_lookup = format_tag_pairs.reduce((obj, item) => {
  };
 
 const isMultiNodeSelection = (editor) => {
-  if (!editor.selection) return false;
+  if (!editor.selection) {return false}
 
   const [start, end] = Range.edges(editor.selection);
 
-  // Get the path to the start and end of the selection
   const startPath = start.path;
   const endPath = end.path;
 
@@ -160,23 +159,27 @@ const isMultiNodeSelection = (editor) => {
   return !Path.equals(startPath, endPath);
 };
 
+const insertNewLine = (editor) => {
+  moveAnchorToEndOfCurrentNode(editor);
+  editor.insertBreak();
+}
 const moveAnchorToEndOfCurrentNode = (editor) => {
-    const { selection } = editor;
+  const { selection } = editor;
 
-      if (selection && Range.isCollapsed(selection)) {
-        const { anchor } = selection;
-        const node = Editor.node(editor, anchor);
+  if (selection && Range.isCollapsed(selection)) {
+    const { anchor } = selection;
+    const node = Editor.node(editor, anchor);
 
-        if (node) {
-          const [, path] = node;
-          const endPoint = Editor.end(editor, path);
+    if (node) {
+      const [, path] = node;
+      const endPoint = Editor.end(editor, path);
 
-          Transforms.select(editor, {
-            anchor: endPoint,
-            focus: endPoint
-          });
-        }
-      }
+      Transforms.select(editor, {
+        anchor: endPoint,
+        focus: endPoint
+      });
+    }
+  }
 };
 
 
@@ -1138,12 +1141,6 @@ const Element = (props) => {
             );
         case 'SheetOutsideText':
                 const SheetOutsideTextClasses = `SheetOutsideText segment ${element.lang}`;
-                const active = false;
-                const addInterfaceClasses = {
-                 active: active,
-                editorAddInterface: 1,
-                };
-
                 return (
                   <div className={classNames(sheetItemClasses)} {...attributes} data-sheet-node={element.node}>
                     <div className={SheetOutsideTextClasses} {...attributes}>
@@ -1222,10 +1219,6 @@ const Element = (props) => {
             )
         case 'paragraph':
             const selected = useSelected();
-            const insertNewLine = function (){
-              moveAnchorToEndOfCurrentNode(editor);
-              editor.insertBreak();
-            }
 
             const addNewLineClasses = {
             hidden: isMultiNodeSelection(editor) || !selected,
@@ -1233,11 +1226,11 @@ const Element = (props) => {
             };
             const pClasses = {center: element["text-align"] == "center" };
             return (
-                <div role="button" title={"paragraph"} contentEditable={true} suppressContentEditableWarning={true} aria-label={"Add new line"} className={classNames(addNewLineClasses)} onClick={insertNewLine}>
-                <div className={classNames(pClasses)} {...attributes}>
-                    {element.loading ? <div className="sourceLoader"></div> : null}
-                    {children}
-                </div>
+                <div role="button" title={"paragraph"} contentEditable suppressContentEditableWarning aria-label={"Add new line"} className={classNames(addNewLineClasses)} onClick={() => insertNewLine(editor)}>
+                    <div className={classNames(pClasses)} {...attributes}>
+                        {element.loading ? <div className="sourceLoader"></div> : null}
+                        {children}
+                    </div>
                 </div>
             );
         case 'bulleted-list':


### PR DESCRIPTION
## Description
The "Add Source" button should stay visible after the user starts typing. Clicking it will add a new line.

## Code Changed
I wrapped also "paragraph" nodes with a "button" div, providing this button div with "onClick" functionality of moving the anchor to end of line and invoking the already-implemented (overridden) editor "insertBreak" function