### PR TITLE
fix(Connections Panel): only open Commentary in the Connections Panel…

### DIFF
--- a/static/js/BookPage.jsx
+++ b/static/js/BookPage.jsx
@@ -383,7 +383,7 @@ class TextTableOfContents extends Component {
       if(this.props?.close){
         this.props.close();
       }
-      this.props.navigatePanel ? this.props.navigatePanel(ref, this.props.currVersions) : this.props.showBaseText(ref, false, this.props.currVersions);
+      this.props.navigatePanel ? this.props.navigatePanel(ref, this.props.currVersions) : this.props.showBaseText(ref, false, this.props.currVersions, [], true, true);
       e.preventDefault();
     }
   }

--- a/static/js/ReaderApp.jsx
+++ b/static/js/ReaderApp.jsx
@@ -1434,7 +1434,8 @@ toggleSignUpModal(modalContentKind = SignUpModalKind.Default) {
     this.state.panels = []; // temporarily clear panels directly in state, set properly with setState in openPanelAt
     this.openPanelAt(0, ref, currVersions, options);
   }
-  openPanelAt(n, ref, currVersions, options, replace, convertCommentaryRefToBaseRef=true, replaceHistory=false, saveLastPlace=true) {
+  openPanelAt(n, ref, currVersions, options, replace, convertCommentaryRefToBaseRef=true,
+              replaceHistory=false, saveLastPlace=true, openCommentarySidePanel=false) {
     /* Open a new panel or replace existing panel. If book level, Open book toc
     * @param {int} n: Open new panel after `n` with the new ref
     * @param {string} ref: ref to use for new panel.  `ref` can refer to book, actual ref, or sheet.
@@ -1444,6 +1445,7 @@ toggleSignUpModal(modalContentKind = SignUpModalKind.Default) {
     * @param {bool} convertCommentaryRefToBaseRef: if true and ref is commentary ref (Rashi on Genesis 3:3:1), open Genesis 3:3 with Rashi's comments in the sidebar
     * @param {bool} replaceHistory: can be true when openPanelAt is called from showBaseText in cases of ref normalizing in TextRange when we want to replace history with normalized ref
     * @param {bool} saveLastPlace: whether to save user history.
+    * @param {bool} openCommentarySidePanel: if false, commentary ref will only open in side panel if depth of ref is 3. see `Sefaria.isCommentaryRefWithBaseText()`
     */
     this.replaceHistory = Boolean(replaceHistory);
     const parsedRef = Sefaria.parseRef(ref);
@@ -1463,7 +1465,7 @@ toggleSignUpModal(modalContentKind = SignUpModalKind.Default) {
     } else {  // Text
       let filter = [];
       let filterRef;
-      if (convertCommentaryRefToBaseRef && Sefaria.isCommentaryRefWithBaseText(ref)) {
+      if (convertCommentaryRefToBaseRef && Sefaria.isCommentaryRefWithBaseText(ref, openCommentarySidePanel)) {
         // getBaseRefAndFilter breaks up the ref "Rashi on Genesis 1:1:4" into filter "Rashi" and ref "Genesis 1:1",
         // so `filterRef` is needed to store the entire "Rashi on Genesis 1:1:4"
         filterRef = Sefaria.humanRef(ref);

--- a/static/js/ReaderApp.jsx
+++ b/static/js/ReaderApp.jsx
@@ -1435,7 +1435,7 @@ toggleSignUpModal(modalContentKind = SignUpModalKind.Default) {
     this.openPanelAt(0, ref, currVersions, options);
   }
   openPanelAt(n, ref, currVersions, options, replace, convertCommentaryRefToBaseRef=true,
-              replaceHistory=false, saveLastPlace=true, openCommentarySidePanel=false) {
+              replaceHistory=false, saveLastPlace=true, forceOpenCommentaryPanel=false) {
     /* Open a new panel or replace existing panel. If book level, Open book toc
     * @param {int} n: Open new panel after `n` with the new ref
     * @param {string} ref: ref to use for new panel.  `ref` can refer to book, actual ref, or sheet.
@@ -1445,7 +1445,8 @@ toggleSignUpModal(modalContentKind = SignUpModalKind.Default) {
     * @param {bool} convertCommentaryRefToBaseRef: if true and ref is commentary ref (Rashi on Genesis 3:3:1), open Genesis 3:3 with Rashi's comments in the sidebar
     * @param {bool} replaceHistory: can be true when openPanelAt is called from showBaseText in cases of ref normalizing in TextRange when we want to replace history with normalized ref
     * @param {bool} saveLastPlace: whether to save user history.
-    * @param {bool} openCommentarySidePanel: if false, commentary ref will only open in side panel if depth of ref is 3. see `Sefaria.isCommentaryRefWithBaseText()`
+    * @param {bool} forceOpenCommentaryPanel: If true, the commentary side panel will open regardless of the ref's depth.
+    *                                       If false, side panel will only open if ref is depth 3 or greater; see `Sefaria.isCommentaryRefWithBaseText()`
     */
     this.replaceHistory = Boolean(replaceHistory);
     const parsedRef = Sefaria.parseRef(ref);
@@ -1465,7 +1466,7 @@ toggleSignUpModal(modalContentKind = SignUpModalKind.Default) {
     } else {  // Text
       let filter = [];
       let filterRef;
-      if (convertCommentaryRefToBaseRef && Sefaria.isCommentaryRefWithBaseText(ref, openCommentarySidePanel)) {
+      if (convertCommentaryRefToBaseRef && Sefaria.isCommentaryRefWithBaseText(ref, forceOpenCommentaryPanel)) {
         // getBaseRefAndFilter breaks up the ref "Rashi on Genesis 1:1:4" into filter "Rashi" and ref "Genesis 1:1",
         // so `filterRef` is needed to store the entire "Rashi on Genesis 1:1:4"
         filterRef = Sefaria.humanRef(ref);

--- a/static/js/ReaderPanel.jsx
+++ b/static/js/ReaderPanel.jsx
@@ -239,10 +239,12 @@ class ReaderPanel extends Component {
   setPreviousSettings(backButtonSettings) {
     this.setState({ backButtonSettings });
   }
-  showBaseText(ref, replaceHistory, currVersions={en: null, he: null}, filter=[], convertCommentaryRefToBaseRef=true) {
+  showBaseText(ref, replaceHistory, currVersions={en: null, he: null}, filter=[],
+               convertCommentaryRefToBaseRef=true, openCommentarySidePanel = false) {
     /* Set the current primary text `ref`, which may be either a string or an array of strings.
     * @param {bool} `replaceHistory` - whether to replace browser history rather than push for this change
     * @param {bool} `convertCommentaryRefToBaseRef` - whether to try to convert commentary refs like "Rashi on Genesis 3:2" to "Genesis 3:2"
+    * @param {bool} `openCommentarySidePanel` - see `Sefaria.isCommentaryRefWithBaseText()`
     */
     if (!ref) { return; }
     this.replaceHistory = Boolean(replaceHistory);
@@ -269,7 +271,7 @@ class ReaderPanel extends Component {
       this.props.saveLastPlace({ mode: "Text", refs, currVersions, settings: this.state.settings }, this.props.panelPosition);
     }
     this.props.openPanelAt(this.props.panelPosition, ref, currVersions, {settings: this.state.settings},
-                          true, convertCommentaryRefToBaseRef, this.replaceHistory, false);
+                          true, convertCommentaryRefToBaseRef, this.replaceHistory, false, openCommentarySidePanel);
   }
   openSheet(sheetRef, replaceHistory) {
     this.replaceHistory = Boolean(replaceHistory);

--- a/static/js/ReaderPanel.jsx
+++ b/static/js/ReaderPanel.jsx
@@ -240,11 +240,11 @@ class ReaderPanel extends Component {
     this.setState({ backButtonSettings });
   }
   showBaseText(ref, replaceHistory, currVersions={en: null, he: null}, filter=[],
-               convertCommentaryRefToBaseRef=true, openCommentarySidePanel = false) {
+               convertCommentaryRefToBaseRef=true, forceOpenCommentaryPanel = false) {
     /* Set the current primary text `ref`, which may be either a string or an array of strings.
     * @param {bool} `replaceHistory` - whether to replace browser history rather than push for this change
     * @param {bool} `convertCommentaryRefToBaseRef` - whether to try to convert commentary refs like "Rashi on Genesis 3:2" to "Genesis 3:2"
-    * @param {bool} `openCommentarySidePanel` - see `Sefaria.isCommentaryRefWithBaseText()`
+    * @param {bool} `forceOpenCommentaryPanel` - see `Sefaria.isCommentaryRefWithBaseText()`
     */
     if (!ref) { return; }
     this.replaceHistory = Boolean(replaceHistory);
@@ -271,7 +271,7 @@ class ReaderPanel extends Component {
       this.props.saveLastPlace({ mode: "Text", refs, currVersions, settings: this.state.settings }, this.props.panelPosition);
     }
     this.props.openPanelAt(this.props.panelPosition, ref, currVersions, {settings: this.state.settings},
-                          true, convertCommentaryRefToBaseRef, this.replaceHistory, false, openCommentarySidePanel);
+                          true, convertCommentaryRefToBaseRef, this.replaceHistory, false, forceOpenCommentaryPanel);
   }
   openSheet(sheetRef, replaceHistory) {
     this.replaceHistory = Boolean(replaceHistory);

--- a/static/js/sefaria/sefaria.js
+++ b/static/js/sefaria/sefaria.js
@@ -2240,14 +2240,21 @@ _media: {},
        */
       return book?.dependence === "Commentary" && !!book?.base_text_titles && !!book?.base_text_mapping && book?.base_text_titles.length === 1;
   },
-  isCommentaryRefWithBaseText(ref) {
+  isCommentaryRefWithBaseText(ref, openCommentarySidePanel) {
       /* This is a helper function for openPanelAt. Determines whether the ref(s) are part of a commentary
        * with a base_text_mapping to one and only one base_text_title.
        * Example: "Ibn Ezra on Genesis 3" returns True because this commentary has a base_text_mapping to one and only one book, Genesis.
-       * @param {string/array of strings} ref: if array, checks the first ref
+       * @param {string/array of strings} ref: if ref is an array, checks the first ref
+       * @param {bool} openCommentarySidePanel: if false, only open the commentary in the side panel if the depth is >= 3.
        */
       let refToCheck = Array.isArray(ref) ? ref[0] : ref;
       const parsedRef = Sefaria.parseRef(refToCheck);
+      const depth = parsedRef.sections.length;
+      if (!openCommentarySidePanel && depth < 3) {
+          // This is because in some Talmud commentaries and in complex texts where the node has a depth less than 3,
+          // it can be difficult to know what comments to show in the sidebar
+          return false;
+      }
       const book = Sefaria.index(parsedRef.index);
       if (!this.isCommentaryWithBaseText(book)) {
           return false;

--- a/static/js/sefaria/sefaria.js
+++ b/static/js/sefaria/sefaria.js
@@ -2273,19 +2273,20 @@ _media: {},
        */
       return book?.dependence === "Commentary" && !!book?.base_text_titles && !!book?.base_text_mapping && book?.base_text_titles.length === 1;
   },
-  isCommentaryRefWithBaseText(ref, openCommentarySidePanel) {
+  isCommentaryRefWithBaseText(ref, forceOpenCommentaryPanel) {
       /* This is a helper function for openPanelAt. Determines whether the ref(s) are part of a commentary
        * with a base_text_mapping to one and only one base_text_title.
        * Example: "Ibn Ezra on Genesis 3" returns True because this commentary has a base_text_mapping to one and only one book, Genesis.
        * @param {string/array of strings} ref: if ref is an array, checks the first ref
-       * @param {bool} openCommentarySidePanel: if false, only open the commentary in the side panel if the depth is >= 3.
+       * @param {bool} forceOpenCommentaryPanel: If true, the commentary side panel will open regardless of the ref's depth.
+       *                                        If false, side panel will only open if ref is depth 3 or greater.
        */
       let refToCheck = Array.isArray(ref) ? ref[0] : ref;
       const parsedRef = Sefaria.parseRef(refToCheck);
       const depth = parsedRef.sections.length;
-      if (!openCommentarySidePanel && depth < 3) {
+      if (!forceOpenCommentaryPanel && depth < 3) {
           // This is because in some Talmud commentaries and in complex texts where the node has a depth less than 3,
-          // it can be difficult to know what comments to show in the sidebar
+          // it can be difficult to know what comments to show in the sidebar so we should open the commentary in the main panel.
           return false;
       }
       const book = Sefaria.index(parsedRef.index);


### PR DESCRIPTION
## Description
This problem was originally discovered because when one clicked on a Haggadah commentary on a topics page, the commentary didn't load properly in the side panel.  But it turned out to be a wider problem also affecting depth 2 Talmud commentaries.  This PR changes the way commentaries can be opened in the sidebar.  It only opens a commentary in the side panel if depth of commentary ref is >= 3 or the commentary ref is opened from book TOC.  The reasoning for this is as follows: If the commentary ref is opened from the book TOC, such as "Rashi on Genesis 1:2", we know exactly what ref to show in the main panel, Genesis 1:2, and we know what comments to show -- Rashi on Genesis 1:2.  In the case of opening a commentary ref from a search page or topic page where the commentary ref has a depth of 3, such as "Rashi on Genesis 1:1:1" it is also clear what to do -- show the "Rashi on Genesis 1:1" section in the main panel and the comments in the side panel.  However, if a depth 2 commentary ref such as "Rashi on Genesis 1:5" appeared on a topic page, we wouldn't want to show "Rashi on Genesis 1" in the main panel and all the comments for "Rashi on Genesis 1" as it would be too many comments to be useful.  So it's not clear what to do in that situation.  Complicating things are Talmud commentaries that are depth 2, instead of depth 3, where we have no way of knowing what comments to show for a given ref, since such Talmud commentaries are not one_to_one mappings of the depth 2 Talmud.  And complicating things further are complex texts like Haggadah commentaries where we don't even know what the depth of a given node is.  Therefore, it makes it simpler to require that a commentary ref be of at least depth 3 since then we know how to alter the ref to get to the base ref by simply going one level up.  If the user was on a book TOC for a commentary, we don't need to require depth 3 because we don't have to alter the ref. "Rashi on Genesis **1:6**" simply becomes "Genesis **1:6**".

## Code Changes
From the book TOC, I pass a variable, openCommentarySidePanel, to showBaseText, that ultimately gets processed in the Sefaria module's isCommentaryRefWithBaseText function with the simple check: if openCommentarySidePanel is false (i.e. we were not on the book TOC, but on a search or topic page), and the depth of the ref is < 3, return false so that the commentary ref will be rendered in the main panel.