### PR TITLE
fix new editor links addition, clikcking on and removal

### DIFF
--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -10207,6 +10207,7 @@ span.purim-emoji img{
   background-color: transparent;
   margin-inline-start: 50px;
 }
+
 .editorAddInterface:before {
   content: "";
   margin-inline-start:-46px;
@@ -10220,6 +10221,34 @@ span.purim-emoji img{
   background-size: 14px;
   border-radius: 50%;
   pointer-events:auto;
+  cursor: pointer;
+  background-repeat: no-repeat;
+  background-position: center;
+  box-sizing: border-box;
+  box-shadow: 0px 1px 3px 0px #00000040;
+}
+.editorAddLineButton {
+  position: relative;
+  background-color: transparent;
+  margin-inline-start: 50px;
+}
+.hidden.editorAddLineButton::before {
+    display: none;
+}
+
+.editorAddLineButton:before {
+  content: "";
+  margin-inline-start:-46px;
+  position: absolute;
+  width: 30px;
+  height: 30px;
+  transform: rotate(45deg);
+  background-color: white;
+  background-image: url("/static/icons/heavy-x-dark.svg");
+  border: 1px solid var(--light-grey);
+  background-size: 14px;
+  border-radius: 50%;
+  /*pointer-events:auto;*/
   cursor: pointer;
   background-repeat: no-repeat;
   background-position: center;

--- a/static/js/Editor.jsx
+++ b/static/js/Editor.jsx
@@ -2146,7 +2146,6 @@ const Link = ({ attributes, children, element }) => {
         className="element-link"
         onMouseEnter={(e) => onHover(e, element.url)}
         onMouseLeave={(e) => onBlur(e, element.url)}
-        style={{ position: 'relative', zIndex: 2 }}
     >
         <a
             href={element.url}

--- a/static/js/Editor.jsx
+++ b/static/js/Editor.jsx
@@ -180,11 +180,6 @@ const moveAnchorToEndOfClosestParagraph = (editor) => {
     }
   }
 };
-const insertNewLine = (editor) => {
-  // moveAnchorToEndOfCurrentNode(editor);
-  moveAnchorToEndOfClosestParagraph(editor);
-  editor.insertBreak();
-}
 const moveAnchorToEndOfCurrentNode = (editor) => {
   const { selection } = editor;
 
@@ -203,7 +198,10 @@ const moveAnchorToEndOfCurrentNode = (editor) => {
     }
   }
 };
-
+const insertNewLine = (editor) => {
+  moveAnchorToEndOfClosestParagraph(editor);
+  editor.insertBreak();
+}
 
 export const deserialize = el => {
     if (el.nodeType === 3) {
@@ -1247,15 +1245,14 @@ const Element = (props) => {
             editorAddLineButton: 1,
             };
             const handleClick = (event, editor) => {
-                 if (event.target.matches('.editorAddLineButton')) {
+                 // a way to check if the click was on the 'pseudo' ::before element or on the actual div
+                 if (event.target.matches('.editorAddLineButton')) { //if click was on ::before
                     insertNewLine(editor);
                   } else {
                     return;
                   }
-
-                // If the attribute is present, proceed with your logic
-                // insertNewLine(editor);
             };
+
             const pClasses = {center: element["text-align"] == "center" };
             return (
                 <div role="button" title={"paragraph"} contentEditable suppressContentEditableWarning

--- a/static/js/Editor.jsx
+++ b/static/js/Editor.jsx
@@ -1246,6 +1246,7 @@ const Element = (props) => {
             };
             const handleClick = (event, editor) => {
                  // a way to check if the click was on the 'pseudo' ::before element or on the actual div
+                //this relies on the event bubbling mechanism doing sth iffy, we should findd a more deterministic way to implement this check
                  if (event.target.matches('.editorAddLineButton')) { //if click was on ::before
                     insertNewLine(editor);
                   } else {


### PR DESCRIPTION
## Description
The last "plus button" feature added to new editor caused each text line to be 'insensitive' to clicks an hovers, disrupting creation and deletion of links within paragraph text. 

## Code Changes
I added a handleClick method to the addNewLine plus button which should distinguish between click on the actual div and the pseudo ::before element. Also, I added moveAnchorToEndOfClosestParagraph method so that new lines that are added via the button will be created at the end of the paragraph and not before the closest link.
