### PR TITLE
Bug/sc 29084/bug users can see other users sheet editor

### DIFF
--- a/static/js/UserProfile.jsx
+++ b/static/js/UserProfile.jsx
@@ -342,7 +342,7 @@ class UserProfile extends Component {
     return (
       <div key={this.props.profile.id} className="profile-page readerNavMenu">
         <div className="content noOverflowX">
-          {this.props.profile.show_editor_toggle ?  <EditorToggleHeader usesneweditor={this.props.profile.uses_new_editor} /> : null}
+          {this.props.profile.show_editor_toggle && this.props.profile === Sefaria._uid ? <EditorToggleHeader usesneweditor={this.props.profile.uses_new_editor} /> : null}
           <div className="contentInner">
             { !this.props.profile.id ? <LoadingMessage /> :
               <div>

--- a/static/js/UserProfile.jsx
+++ b/static/js/UserProfile.jsx
@@ -342,7 +342,7 @@ class UserProfile extends Component {
     return (
       <div key={this.props.profile.id} className="profile-page readerNavMenu">
         <div className="content noOverflowX">
-          {this.props.profile.show_editor_toggle && this.props.profile === Sefaria._uid ? <EditorToggleHeader usesneweditor={this.props.profile.uses_new_editor} /> : null}
+          {(this.props.profile.id === Sefaria._uid && this.props.profile.show_editor_toggle)  ? <EditorToggleHeader usesneweditor={this.props.profile.uses_new_editor} /> : null}
           <div className="contentInner">
             { !this.props.profile.id ? <LoadingMessage /> :
               <div>


### PR DESCRIPTION
## Description
Fixes an issue where one user coudl see the new/old sheet editor toggle of another user when viewing their profile.

## Code Changes
Added a check in the client code to check that the profile being viewed was the one also logged in, before rendering the toggle.

## Notes
We should really refactor the profile response object to not include that data from the backend at all in such a case