### PR TITLE
make English source text elements always be rendered LTR

### DIFF
--- a/sefaria/model/schema.py
+++ b/sefaria/model/schema.py
@@ -2646,7 +2646,7 @@ class AddressPerek(AddressInteger):
     }
     section_patterns = {
         "en": r"""(?:(?:[Cc]h(apters?|\.)|[Pp]erek|s\.)?\s*)""",  # the internal ? is a hack to allow a non match, even if 'strict'
-        "he": fr"""(?:\u05d1?{AddressType.reish_samekh_reg}\u05e4((?:"|\u05f4|''|'\s)|(?=[\u05d0-\u05ea]+(?:"|\u05f4|''|'\s)))   # Peh (for 'perek') maybe followed by a quote of some sort OR lookahead for some letters followed by a quote (e.g. פי״א for chapter 11)
+        "he": fr"""(?:\u05d1?{AddressType.reish_samekh_reg}\u05e4((?:"|\u05f4|''|'\s|\s)|(?=[\u05d0-\u05ea]+(?:"|\u05f4|''|'\s)))   # Peh (for 'perek') maybe followed by a quote of some sort OR lookahead for some letters followed by a quote (e.g. פי״א for chapter 11)
         |\u05e4\u05bc?\u05b6?\u05e8\u05b6?\u05e7(?:\u05d9\u05b4?\u05dd)?\s*                  # or 'perek(ym)' spelled out, followed by space
         )"""
     }

--- a/static/js/Editor.jsx
+++ b/static/js/Editor.jsx
@@ -765,7 +765,7 @@ const BoxedSheetElement = ({ attributes, children, element, divineName }) => {
       segment: 1,
       selected: isActive
   };
-  const heClasses = {he: 1, selected: isActive, editable: activeSourceLangContent == "he" ? true : false };
+  const heClasses = {he: 1, selected: isActive, editable: activeSourceLangContent == "he" ? true : false};
   const enClasses = {en: 1, selected: isActive, editable: activeSourceLangContent == "en" ? true : false };
   const dragStart = (e) => {
       const slateRange = ReactEditor.findEventRange(parentEditor, e)
@@ -809,6 +809,15 @@ const BoxedSheetElement = ({ attributes, children, element, divineName }) => {
       e.stopPropagation();
       parentEditor.dragging = false;
     }
+    const renderEnglishElement = ({attributes, children}) => {
+    //passed to the English source Editabe, to make it always! be rendered as 'ltr'
+        return (
+            <span {...attributes} dir="ltr">
+                {children}
+            </span>
+        )
+    }
+
 
   return (
       <div
@@ -833,7 +842,6 @@ const BoxedSheetElement = ({ attributes, children, element, divineName }) => {
               readOnly={!sourceActive}
               renderLeaf={props => <Leaf {...props} />}
               onKeyDown={(e) => onKeyDown(e, sheetSourceHeEditor)}
-
             />
           </Slate>
         </div>
@@ -841,12 +849,13 @@ const BoxedSheetElement = ({ attributes, children, element, divineName }) => {
       <div className={classNames(enClasses)} style={{ pointerEvents: (isActive) ? 'auto' : 'none'}}>
         {element.ref ? <div className="ref" contentEditable={false}><a style={{ userSelect: 'none', pointerEvents: 'auto' }} href={`/${element.ref}`}>{element.ref}</a></div> : null }
         <div className="sourceContentText">
-          <Slate editor={sheetSourceEnEditor} value={sheetEnSourceValue} onChange={value => onEnChange(value)}>
+          <Slate editor={sheetSourceEnEditor} value={sheetEnSourceValue} onChange={value => onEnChange(value)} dir={"ltr"}>
           {canUseDOM ? <HoverMenu buttons="basic"/> : null }
             <Editable
               readOnly={!sourceActive}
               renderLeaf={props => <Leaf {...props} />}
               onKeyDown={(e) => onKeyDown(e, sheetSourceEnEditor)}
+              renderElement={renderEnglishElement}
             />
           </Slate>
         </div>

--- a/static/js/Editor.jsx
+++ b/static/js/Editor.jsx
@@ -811,9 +811,8 @@ const BoxedSheetElement = ({ attributes, children, element, divineName }) => {
     }
     const renderEnglishElement = ({attributes, children}) => {
     //passed to the English source Editable, to make it always! be rendered as 'ltr'
-        attributes = {...attributes, 'dir':'ltr'}
         return (
-            <span {...attributes}>
+            <span {...attributes} dir='ltr'>
                 {children}
             </span>
         )

--- a/static/js/Editor.jsx
+++ b/static/js/Editor.jsx
@@ -810,9 +810,9 @@ const BoxedSheetElement = ({ attributes, children, element, divineName }) => {
       parentEditor.dragging = false;
     }
     const renderEnglishElement = ({attributes, children}) => {
-    //passed to the English source Editabe, to make it always! be rendered as 'ltr'
+    //passed to the English source Editable, to make it always! be rendered as 'ltr'
         return (
-            <span {...attributes} dir="ltr">
+            <span className=".int-en">
                 {children}
             </span>
         )

--- a/static/js/Editor.jsx
+++ b/static/js/Editor.jsx
@@ -849,7 +849,7 @@ const BoxedSheetElement = ({ attributes, children, element, divineName }) => {
       <div className={classNames(enClasses)} style={{ pointerEvents: (isActive) ? 'auto' : 'none'}}>
         {element.ref ? <div className="ref" contentEditable={false}><a style={{ userSelect: 'none', pointerEvents: 'auto' }} href={`/${element.ref}`}>{element.ref}</a></div> : null }
         <div className="sourceContentText">
-          <Slate editor={sheetSourceEnEditor} value={sheetEnSourceValue} onChange={value => onEnChange(value)} dir={"ltr"}>
+          <Slate editor={sheetSourceEnEditor} value={sheetEnSourceValue} onChange={value => onEnChange(value)}>
           {canUseDOM ? <HoverMenu buttons="basic"/> : null }
             <Editable
               readOnly={!sourceActive}

--- a/static/js/Editor.jsx
+++ b/static/js/Editor.jsx
@@ -811,8 +811,9 @@ const BoxedSheetElement = ({ attributes, children, element, divineName }) => {
     }
     const renderEnglishElement = ({attributes, children}) => {
     //passed to the English source Editable, to make it always! be rendered as 'ltr'
+        attributes = {...attributes, 'dir':'ltr'}
         return (
-            <span className=".int-en">
+            <span {...attributes}>
                 {children}
             </span>
         )


### PR DESCRIPTION
## Description
This PR defines a custom renderEnglishElement function to avoid rendering English source text as RTL when a Hebrew word is found within the text
## Code Changes
return value of BoxedSheetElement in Editor.jsx
