### PR TITLE
chore: refactor ModuleTitle so that h1 is always used

### DIFF
--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -1817,7 +1817,6 @@ div.interfaceLinks-row a {
   letter-spacing: 0em;
   text-decoration: underline;
 }
-.readerPanel .navSidebarModule h3,
 .readerPanel .navSidebarModule h1,
 .readerPanel .bookPage h3{
   margin: 0 0 20px;
@@ -1837,7 +1836,7 @@ div.interfaceLinks-row a {
 .singlePanel .navSidebarModule.blue {
   padding: 34px 15px 45px;
 }
-.readerPanel .navSidebarModule.blue h3 {
+.readerPanel .navSidebarModule.blue h1 {
   color: white;
 }
 .navSidebarIcon {
@@ -3071,7 +3070,7 @@ a.cardTitle:hover {
 .readerNavMenu.readerNavCategoryMenu .navTitle {
   margin-bottom: 40px;
 }
-.readerNavMenu.readerNavCategoryMenu h1 {
+.readerNavMenu.readerNavCategoryMenu .contentInner h1 {
   color: #000;
   text-transform: uppercase;
   font-size: 30px;

--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -3070,7 +3070,7 @@ a.cardTitle:hover {
 .readerNavMenu.readerNavCategoryMenu .navTitle {
   margin-bottom: 40px;
 }
-.readerNavMenu.readerNavCategoryMenu .contentInner h1 {
+.readerNavMenu.readerNavCategoryMenu .navTitle h1 {
   color: #000;
   text-transform: uppercase;
   font-size: 30px;

--- a/static/js/NavSidebar.jsx
+++ b/static/js/NavSidebar.jsx
@@ -68,14 +68,11 @@ const Module = ({children, blue, wide}) => {
 };
 
 
-const ModuleTitle = ({children, en, he, h1}) => {
+const ModuleTitle = ({children, en, he}) => {
   const content = children ?
     <InterfaceText>{children}</InterfaceText>
     : <InterfaceText text={{en, he}} />;
-
-  return h1 ?
-    <h1>{content}</h1>
-    : <h3>{content}</h3>
+  return <h1>{content}</h1>;
 };
 
 
@@ -137,7 +134,7 @@ const RecentlyViewed = ({toggleSignUpModal, mobile}) => {
    return <Module>
             <div className="recentlyViewed">
                 <div id="header">
-                  <ModuleTitle h1={true}>Recently Viewed</ModuleTitle>
+                  <ModuleTitle>Recently Viewed</ModuleTitle>
                   {!mobile && recentlyViewedList}
                   <a href="/texts/history" id="history" onClick={handleAllHistory}><InterfaceText>{allHistoryPhrase}</InterfaceText></a>
                 </div>
@@ -155,7 +152,7 @@ const Promo = () =>
 const AboutSefaria = ({hideTitle}) => (
   <Module>
     {!hideTitle ?
-    <ModuleTitle h1={true}>A Living Library of Torah</ModuleTitle> : null }
+    <ModuleTitle>A Living Library of Torah</ModuleTitle> : null }
     <InterfaceText>
       <EnglishText>
           Sefaria is home to 3,000 years of Jewish texts. We are a nonprofit organization offering free access to texts, translations,
@@ -214,7 +211,7 @@ const AboutTranslatedText = ({translationsSlug}) => {
   }
   return (
   <Module>
-    <ModuleTitle h1={true}>{translationLookup[translationsSlug] ?
+    <ModuleTitle>{translationLookup[translationsSlug] ?
           translationLookup[translationsSlug]["title"] : "A Living Library of Torah"}</ModuleTitle>
         { translationLookup[translationsSlug] ?
           translationLookup[translationsSlug]["body"] :
@@ -298,7 +295,7 @@ const AboutTextCategory = ({cats}) => {
 
   return (
     <Module>
-      <h3><InterfaceText text={{en: enTitle, he: heTitle}} /></h3>
+      <ModuleTitle><InterfaceText text={{en: enTitle, he: heTitle}} /></ModuleTitle>
       <InterfaceText markdown={{en: tocObject.enDesc, he: tocObject.heDesc}} />
     </Module>
   );
@@ -672,7 +669,7 @@ const StayConnected = () => { // TODO: remove? looks like we are not using this
 
 const AboutLearningSchedules = () => (
   <Module>
-    <ModuleTitle h1={true}>Learning Schedules</ModuleTitle>
+    <ModuleTitle>Learning Schedules</ModuleTitle>
     <InterfaceText>
         <EnglishText>
             Since biblical times, the Torah has been divided into sections which are read each week on a set yearly calendar.
@@ -690,7 +687,7 @@ const AboutLearningSchedules = () => (
 const AboutCollections = ({hideTitle}) => (
   <Module>
     {hideTitle ? null :
-    <ModuleTitle h1={true}>About Collections</ModuleTitle>}
+    <ModuleTitle>About Collections</ModuleTitle>}
     <InterfaceText>
         <EnglishText>Collections are user generated bundles of sheets which can be used privately, shared with friends, or made public on Sefaria.</EnglishText>
         <HebrewText>אסופות הן מקבצים של דפי מקורות שנוצרו על ידי משתמשי האתר. הן ניתנות לשימוש פרטי, לצורך שיתוף עם אחרים או לשימוש ציבורי באתר ספריא.</HebrewText>


### PR DESCRIPTION
## Description
We were confusingly using both h3 and h1 in Modules and then styling the h3 and h1 tags to look exactly the same.  This PR makes all ModuleTitles use h1s.

## Code Changes
1.  Re-factor `ModuleTitle` to not have h1 as a parameter
2. Change any uses of `ModuleTitle` that pass h1 to a prop to no longer pass h1
3. Change `AboutTextCategory` to use `ModuleTitle` instead of h3.
4. Change css to no longer style h3s to look like h1s.
5. Two special cases of CSS styling had to be dealt with here as well.  The "Support Sefaria" module was using an h3 previously and so its CSS styled an h3 tag.  It no longer is.  Also, text category pages have special styling for the name of the category to show the h1 header in all upper case letters.  I had to change the CSS and add ".contentInner" so that only the text category title gets modified by the relevant CSS and we do not also modify the NavSidebar h1s.  (This last case may have been part of why the strange lack of distinction between h3 and h1 existed in the code).