### PR TITLE
Fix a visual glitch on mobile-web nav

### DIFF
--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -4674,11 +4674,14 @@ body .ui-autocomplete.dictionary-toc-autocomplete .ui-menu-item a.ui-state-focus
   z-index: 2;
 }
 .singlePanel .autocomplete-dropdown {
-  width: 100vw;
+  width: 0;
   position: fixed;
   top: 120px;
   inset-inline-start: 0;
   padding-bottom: 10px;
+}
+.singlePanel .autocomplete-dropdown:has(*){
+  width: 100vw;
 }
 .search-group-suggestions{
   border-bottom: 0.766667px solid rgb(204, 204, 204);


### PR DESCRIPTION

## Description
This fixes a visual issue with the mobile web nav menu where you could see extra space and drop shadow that made the menu look broken

## Code Changes
Removed the width from the original css of the autocompleter placeholder and only added it under condition that it `:has()` children

## Notes
![image](https://github.com/user-attachments/assets/79ff56ca-5c60-4b6f-9864-29ce71df983d)
