### PR TITLE
Visual support for banners from Unbounce

### DIFF
--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -353,6 +353,25 @@ Legacy Style Guide Font Hierarchy -- the below should be refactored away in favo
   height: 100%;
   z-index: 1000;
 }
+
+/* Change styling when Unbounce banner is going to be placed on the page */
+div#s2:has(~ div.ub-emb-container) {
+  top: unset;
+}
+
+div#s2:has(~ div.ub-emb-container):not(:has(~ div#staticContentWrapper)) #footer {
+  margin-bottom: 120px;
+}
+
+/* Make some style changes on the static pages where the React node is in header only mode */
+div#staticContentWrapper:has(~ .ub-emb-container):has(.staticPage) {
+  padding-top: 60px;
+}
+
+div#staticContentWrapper:has(~ .ub-emb-container) .staticPage .staticPageHeader {
+  margin-top: unset;
+}
+
 #s2.headerOnly {
   z-index: 1000;
   height: 60px;

--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -359,8 +359,14 @@ div#s2:has(~ div.ub-emb-container) {
   top: unset;
 }
 
+/* Adjust margin on footer when banner is shown */
 div#s2:has(~ div.ub-emb-container):not(:has(~ div#staticContentWrapper)) #footer {
   margin-bottom: 120px;
+}
+
+/* Remove adjustment margin when banner is removed */
+div#s2:has(~ div.ub-emb-container div:only-child:empty):not(:has(~ div#staticContentWrapper)) #footer {
+  margin-bottom: 0;
 }
 
 /* Make some style changes on the static pages where the React node is in header only mode */

--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -4675,11 +4675,14 @@ body .ui-autocomplete.dictionary-toc-autocomplete .ui-menu-item a.ui-state-focus
   z-index: 2;
 }
 .singlePanel .autocomplete-dropdown {
-  width: 100vw;
+  width: 0;
   position: fixed;
   top: 120px;
   inset-inline-start: 0;
   padding-bottom: 10px;
+}
+.singlePanel .autocomplete-dropdown:has(*){
+  width: 100vw;
 }
 .search-group-suggestions{
   border-bottom: 0.766667px solid rgb(204, 204, 204);

--- a/static/css/unbounce-banner.css
+++ b/static/css/unbounce-banner.css
@@ -50,9 +50,13 @@ div#s2:has(~ div.ub-emb-container div:only-child:empty) .singlePanel div.mobileN
 }
 
 div#s2:has(~ div.ub-emb-container) .singlePanel .autocomplete-dropdown {
-  top: 240px
+  top: 45px;
+  left: -10px;
+  position: absolute;
 }
 
-div#s2:has(~ div.ub-emb-container div:only-child:empty) .singlePanel .autocomplete-dropdown {
-  top: 120px;
-}
+/* div#s2:has(~ div.ub-emb-container div:only-child:empty) .singlePanel .autocomplete-dropdown {
+  top: 45px;
+  position: absolute;
+  left: -10px;
+} */

--- a/static/css/unbounce-banner.css
+++ b/static/css/unbounce-banner.css
@@ -49,11 +49,11 @@ div#s2:has(~ div.ub-emb-container div:only-child:empty) .singlePanel div.mobileN
   top: 60px;
 }
 
-/* div#s2:has(~ div.ub-emb-container) .singlePanel .autocomplete-dropdown {
+div#s2:has(~ div.ub-emb-container) .singlePanel .autocomplete-dropdown {
   top: 45px;
   left: -10px;
   position: absolute;
-} */
+}
 
 /* div#s2:has(~ div.ub-emb-container div:only-child:empty) .singlePanel .autocomplete-dropdown {
   top: 45px;

--- a/static/css/unbounce-banner.css
+++ b/static/css/unbounce-banner.css
@@ -39,13 +39,13 @@ div#staticContentWrapper:has(~ .ub-emb-container) .staticPage .staticPageHeader 
 /*
   The mobile navigation menu needs to be shifted when displayed and the banner is displaying on mobile
 */
-div#s2:has(~ div.ub-emb-container) div.mobileNavMenu {
+/* div#s2:has(~ div.ub-emb-container) div.mobileNavMenu {
   padding-top: 120px;
 }
 
 div#s2:has(~ div.ub-emb-container div:only-child:empty) div.mobileNavMenu {
   padding-top: 0px;
-}
+} */
 
 /* div#s2:has(~ div.ub-emb-container) .singlePanel .autocomplete-dropdown {
   top: 240px
@@ -54,3 +54,15 @@ div#s2:has(~ div.ub-emb-container div:only-child:empty) div.mobileNavMenu {
 div#s2:has(~ div.ub-emb-container div:only-child:empty) .singlePanel .autocomplete-dropdown {
   top: 120px;
 } */
+
+div#s2:has(~ div.ub-emb-container) .singlePanel div.mobileNavMenu {
+  position: fixed;
+  height: calc(100vh - 180px);
+  top: 180px;
+}
+
+div#s2:has(~ div.ub-emb-container div:only-child:empty) .singlePanel div.mobileNavMenu {
+  position: fixed;
+  height: calc(100vh - 60px);
+  top: 60px;
+}

--- a/static/css/unbounce-banner.css
+++ b/static/css/unbounce-banner.css
@@ -49,11 +49,11 @@ div#s2:has(~ div.ub-emb-container div:only-child:empty) .singlePanel div.mobileN
   top: 60px;
 }
 
-div#s2:has(~ div.ub-emb-container) .singlePanel .autocomplete-dropdown {
+/* div#s2:has(~ div.ub-emb-container) .singlePanel .autocomplete-dropdown {
   top: 45px;
   left: -10px;
   position: absolute;
-}
+} */
 
 /* div#s2:has(~ div.ub-emb-container div:only-child:empty) .singlePanel .autocomplete-dropdown {
   top: 45px;

--- a/static/css/unbounce-banner.css
+++ b/static/css/unbounce-banner.css
@@ -44,6 +44,9 @@ div#s2:has(~ div.ub-emb-container) .singlePanel div.mobileNavMenu {
   top: 180px;
 }
 
+/*
+  Readjust the mobile navigation menu to its previous positioning after the banner is removed
+*/
 div#s2:has(~ div.ub-emb-container div:only-child:empty) .singlePanel div.mobileNavMenu {
   height: calc(100vh - 60px);
   top: 60px;
@@ -54,9 +57,3 @@ div#s2:has(~ div.ub-emb-container) .singlePanel .autocomplete-dropdown {
   left: -10px;
   position: absolute;
 }
-
-/* div#s2:has(~ div.ub-emb-container div:only-child:empty) .singlePanel .autocomplete-dropdown {
-  top: 45px;
-  position: absolute;
-  left: -10px;
-} */

--- a/static/css/unbounce-banner.css
+++ b/static/css/unbounce-banner.css
@@ -39,30 +39,20 @@ div#staticContentWrapper:has(~ .ub-emb-container) .staticPage .staticPageHeader 
 /*
   The mobile navigation menu needs to be shifted when displayed and the banner is displaying on mobile
 */
-/* div#s2:has(~ div.ub-emb-container) div.mobileNavMenu {
-  padding-top: 120px;
-}
-
-div#s2:has(~ div.ub-emb-container div:only-child:empty) div.mobileNavMenu {
-  padding-top: 0px;
-} */
-
-/* div#s2:has(~ div.ub-emb-container) .singlePanel .autocomplete-dropdown {
-  top: 240px
-}
-
-div#s2:has(~ div.ub-emb-container div:only-child:empty) .singlePanel .autocomplete-dropdown {
-  top: 120px;
-} */
-
 div#s2:has(~ div.ub-emb-container) .singlePanel div.mobileNavMenu {
-  position: fixed;
   height: calc(100vh - 180px);
   top: 180px;
 }
 
 div#s2:has(~ div.ub-emb-container div:only-child:empty) .singlePanel div.mobileNavMenu {
-  position: fixed;
   height: calc(100vh - 60px);
   top: 60px;
+}
+
+div#s2:has(~ div.ub-emb-container) .singlePanel .autocomplete-dropdown {
+  top: 240px
+}
+
+div#s2:has(~ div.ub-emb-container div:only-child:empty) .singlePanel .autocomplete-dropdown {
+  top: 120px;
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -152,7 +152,7 @@
     {% endif %}
 
     <!-- Unbounce Embed Code -->
-    <script src="https://fd810a0513c94a16a52ef4d0d9b9c6c8.js.ubembed.com" async></script>
+    <script src="https://fd810a0513c94a16a52ef4d0d9b9c6c8.js.ubembed.com" async></script> 
 </head>
 
 <body class="interface-{% if request.interfaceLang %}{{request.interfaceLang}}{% else %}english{% endif %}{% if EMBED %} embeded{% endif %} {% block bodyclasses %}{% endblock %}">

--- a/templates/base.html
+++ b/templates/base.html
@@ -153,18 +153,6 @@
 
     <!-- Unbounce Embed Code -->
     <script src="https://fd810a0513c94a16a52ef4d0d9b9c6c8.js.ubembed.com" async></script>
-
-    <script type="text/javascript">
-      document.addEventListener('DOMContentLoaded', () => {
-        window.addEventListener('message', (event) => {
-          if (event.data.type == 'unbounceFrameLoaded') {
-            document.getElementById('s2').style.top = 'auto';
-          }
-        });
-      });
-
-      
-    </script>
 </head>
 
 <body class="interface-{% if request.interfaceLang %}{{request.interfaceLang}}{% else %}english{% endif %}{% if EMBED %} embeded{% endif %} {% block bodyclasses %}{% endblock %}">

--- a/templates/base.html
+++ b/templates/base.html
@@ -153,6 +153,18 @@
 
     <!-- Unbounce Embed Code -->
     <script src="https://fd810a0513c94a16a52ef4d0d9b9c6c8.js.ubembed.com" async></script>
+
+    <script type="text/javascript">
+      document.addEventListener('DOMContentLoaded', () => {
+        window.addEventListener('message', (event) => {
+          if (event.data.type == 'unbounceFrameLoaded') {
+            document.getElementById('s2').style.top = 'auto';
+          }
+        });
+      });
+
+      
+    </script>
 </head>
 
 <body class="interface-{% if request.interfaceLang %}{{request.interfaceLang}}{% else %}english{% endif %}{% if EMBED %} embeded{% endif %} {% block bodyclasses %}{% endblock %}">


### PR DESCRIPTION
## Description
MarCom is evaluating using Unbounce for their modal and banner needs. Unbounce calls their banners "sticky bars". Unbounce by default does not provide the option for their sticky bars to have the desired behavior. Unbounce does not shift the page down when their sticky bars are shown. A solution using only CSS is provided to allow for Unbounce's sticky bars to mimic Sefaria's previous banners visually and behaviorally.

## Code Changes
A new CSS file is added `unbounce-banner.css` to readjust parts of the web application and static pages only if an Unbounce banner is present on the page to remove visual glitches.

## Notes

* The existing CSS is deployed to the following [cauldron](https://unbounce2.cauldron.sefaria.org)
* This depends on https://github.com/Sefaria/Sefaria-Project/pull/2033 and that should be approved and merged first
* This was tested on Firefox desktop (in mobile view too), Chrome desktop (in mobile view too), mobile Safari, and mobile Chrome on Android, so all major web browsing engines should be covered 😵‍💫