### PR TITLE
fix(topics_api): fixed typo that caused bug

### DIFF
--- a/sefaria/model/topic.py
+++ b/sefaria/model/topic.py
@@ -77,7 +77,7 @@ class AuthorCategoryAggregation(AuthorWorksAggregation):
 
     def get_title(self, lang):
         if self._collective_title_term is None:
-            cat_term = Term().load({"name": self.index_category.sharedTitle})
+            cat_term = Term().load({"name": self._index_category.sharedTitle})
             return cat_term.get_primary_title(lang)
         else:
             preposition = 'on' if lang != 'he' else 'על'


### PR DESCRIPTION
## Description
a recent refactor of the get_aggregated_urls_for_authors_indexes function in the Topic model has left a type that cuased a bug that prevented certain author topic pages from loading. This PR fixes the typo
