### PR TITLE
Fix various failing tests

### DIFF
--- a/sefaria/helper/llm/tests/topic_prompt_test.py
+++ b/sefaria/helper/llm/tests/topic_prompt_test.py
@@ -1,4 +1,5 @@
 import pytest
+from dataclasses import asdict
 from sefaria.helper.llm.topic_prompt import *
 from sefaria.helper.llm.topic_prompt import _lang_dict_by_func, _get_commentary_from_link_dict
 
@@ -37,7 +38,12 @@ def test_lang_dict_by_func(fn, expected):
     ]
 ])
 def test_get_commentary_from_link_dict(link_dict, expected):
-    assert _get_commentary_from_link_dict(link_dict) == expected
+    topic_prompt_commentary = _get_commentary_from_link_dict(link_dict)
+    try:
+        asdict(topic_prompt_commentary) == expected
+    except TypeError:
+        # None will fail as input to `asdict`
+        assert topic_prompt_commentary == expected
 
 
 @pytest.mark.parametrize(('ref_topic_links', 'ref__context_hints_by_lang'), [

--- a/sefaria/helper/tests/linker_test.py
+++ b/sefaria/helper/tests/linker_test.py
@@ -199,6 +199,7 @@ class TestFindRefsResponseLinkerV3:
             mock_linker = Mock()
             mock_get_linker.return_value = mock_linker
             mock_linker.link.return_value = LinkedDoc('', [], [])
+            mock_linker.link_by_paragraph.return_value = LinkedDoc('', [], [])
             yield mock_get_linker
 
     def test_make_find_refs_response_linker_v3(self, mock_get_linker: WSGIRequest,


### PR DESCRIPTION
## Description
This PR fixes 2 failing tests
- test_get_commentary_from_link_dict
- test_make_find_refs_response_linker_v3

## Code Changes
- test_get_commentary_from_link_dict: This test is one of the tests testing the interface between Sefaria-Project and the sefaria-llm-interface package. A return value had changed slightly and required `as_dict()` to convert it back to JSON.
- test_make_find_refs_response_linker_v3: This test only runs when the linker is enabled. It started failing because of the introduction of new function that wasn't mocked.
