### PR TITLE
feat(about and translations): show all translations that are not source on the translations box, and all primary versions on the about box

### DIFF
--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -9752,7 +9752,7 @@ body #keyboardInputMaster tbody tr td table tbody tr td.pressed{
 .aboutBox .currVersionSection, .aboutBox .alternateVersionsSection {
   padding-bottom: 30px;
 }
-.aboutBox .versionsBox .versionBlock:first-child{
+.aboutBox .versionsBox .language-block:first-child .versionBlock:first-child {
   border-top: none;
   padding-top: 10px;
 }

--- a/static/js/AboutBox.jsx
+++ b/static/js/AboutBox.jsx
@@ -11,9 +11,8 @@ import { Modules } from './NavSidebar';
 class AboutBox extends Component {
   constructor(props) {
     super(props);
-    this._includeOtherVersionsLangs = ["he"];
     this.state = {
-      versionLangMap: null,
+      versionLangMap: {},
       currentVersionsByActualLangs: Sefaria.transformVersionObjectsToByActualLanguageKeys(this.props.currObjectVersions),
       details: Sefaria.getIndexDetailsFromCache(props.title),
     }
@@ -56,8 +55,8 @@ class AboutBox extends Component {
     // then sort the current version to the top of its language list
     let versionsByLang = versions;
     let currentVersionsByActualLangs = Sefaria.transformVersionObjectsToByActualLanguageKeys(this.props.currObjectVersions);
-    for(let [lang,ver] of Object.entries(currentVersionsByActualLangs)){
-      if (this._includeOtherVersionsLangs.includes(lang)){ //remove current version if its "he"
+    for (let [lang,ver] of Object.entries(currentVersionsByActualLangs)){
+      if (versionsByLang[lang]){
         versionsByLang[lang] = versionsByLang[lang].filter((v) => v.versionTitle != ver.versionTitle);
       }
     }
@@ -210,7 +209,7 @@ class AboutBox extends Component {
           }
       </div> : null );
     const alternateSectionHe =
-      (this.state.versionLangMap?.he?.length > 0 ?
+      (Object.values(this.state.versionLangMap).some(array => array?.length) ?
           <div className="alternateVersionsSection">
             <h2 className="aboutHeader">
               <InterfaceText text={alternateVersionsSectionTitle} />

--- a/static/js/VersionBlock/VersionBlock.jsx
+++ b/static/js/VersionBlock/VersionBlock.jsx
@@ -382,7 +382,7 @@ class VersionsBlocksList extends Component{
   }
   render(){
       const sortedLanguages = this.sortVersions(this.props.sortPrioritizeLanugage);
-      if (this.props.versionsByLanguages === {}) {
+      if (!Object.keys(this.props.versionsByLanguages).length) {
         return (
           <div className="versionsBox">
             <LoadingMessage />

--- a/static/js/VersionBlock/VersionBlock.jsx
+++ b/static/js/VersionBlock/VersionBlock.jsx
@@ -382,7 +382,7 @@ class VersionsBlocksList extends Component{
   }
   render(){
       const sortedLanguages = this.sortVersions(this.props.sortPrioritizeLanugage);
-      if (!this.props.versionsByLanguages) {
+      if (this.props.versionsByLanguages === {}) {
         return (
           <div className="versionsBox">
             <LoadingMessage />

--- a/static/js/sefaria/sefaria.js
+++ b/static/js/sefaria/sefaria.js
@@ -731,7 +731,7 @@ Sefaria = extend(Sefaria, {
       /**
        * @versionsObj {object} whose keys are language codes ('he', 'en' etc.) and values are version objects (like the object that getVersions returns)
        * * @filterObj {object} keys are attribute of version objects and values are their values
-       * returns the versionsObj after filtering its version, and filtering languages withno matching versions
+       * returns the versionsObj after filtering its version, and filtering languages with no matching versions
        */
     return Object.fromEntries(
         Object.entries(versionsObj).reduce((acc, [lang, versions]) => {

--- a/static/js/sefaria/sefaria.js
+++ b/static/js/sefaria/sefaria.js
@@ -727,54 +727,36 @@ Sefaria = extend(Sefaria, {
       ]);
       return {status: "ok"};
   },
-  filterVersionsObjByLangs: function(versionsObj, langs, includeFilter) {
+  filterVersionsByAttr: function(versionsObj, filterObj) {
       /**
-       * @versionsObj {object} whode keys are language codes ('he', 'en' etc.) and values are version objects (like the object that getVersions returns)
-       * @langs {array} of string of language codes
-       * @includeFilter {boolean} true for returning the language in the langs param, false for returning other languages
+       * @versionsObj {object} whose keys are language codes ('he', 'en' etc.) and values are version objects (like the object that getVersions returns)
+       * * @filterObj {object} keys are attribute of version objects and values are their values
+       * returns the versionsObj after filtering its version, and filtering languages withno matching versions
        */
-    return Object.keys(versionsObj)
-        .filter(lang => {
-            return includeFilter === langs.includes(lang);
-        })
-        .reduce((obj, lang) => {
-            obj[lang] = versionsObj[lang];
-            return obj;
-          }, {});
-  },
-  filterVersionsArrayByAttr: function(versionsArray, filterObj) {
-      /**
-       * @versionsArray {array} of version objects
-       * @filterObj {object} keys are attribute of version objects and values are their values
-       * returns an array of versions from versionsArray that has all the attributes and their values as in filterObj
-       */
-    return versionsArray.filter(version => {
-        return Object.keys(filterObj).every(key => version?.[key] === filterObj[key])
-    });
+    return Object.fromEntries(
+        Object.entries(versionsObj).map(([lang, versions]) =>
+            [lang, versions.filter(version => Object.keys(filterObj).every(key => version?.[key] === filterObj[key]))]
+        ).filter(([lang, versions]) => versions.length)
+    );
   },
   getSourceVersions: async function(ref) {
     /**
-     * Gets Hebrew versions only
-     * @ref {string} ref
+     * Gets all versions that have isSource true
+     * * @ref {string} ref
      * @returns {string: [versions]} Versions by language
      */
     return Sefaria.getVersions(ref).then(versions => {
-        return Sefaria.filterVersionsObjByLangs(versions, ['he'], true);
+        return Sefaria.filterVersionsByAttr(versions, {isPrimary: true});
     });
   },
   getTranslations: async function(ref) {
     /**
-     * Gets all versions except Hebrew versions that have isSource true
+     * Gets all versions that have isSource false
      * @ref {string} ref
      * @returns {string: [versions]} Versions by language
      */
-    return Sefaria.getVersions(ref).then(result => {
-        let versions = Sefaria.filterVersionsObjByLangs(result, ['he'], false);
-        let heVersions = Sefaria.filterVersionsArrayByAttr(result?.he || [], {isSource: false});
-        if (heVersions.length) {
-            versions.he = heVersions;
-        }
-        return versions;
+    return Sefaria.getVersions(ref).then(versions => {
+        return Sefaria.filterVersionsByAttr(versions, {isSource: false});
     });
   },
   _makeVersions: function(versions, byLang){

--- a/static/js/sefaria/sefaria.js
+++ b/static/js/sefaria/sefaria.js
@@ -734,9 +734,15 @@ Sefaria = extend(Sefaria, {
        * returns the versionsObj after filtering its version, and filtering languages withno matching versions
        */
     return Object.fromEntries(
-        Object.entries(versionsObj).map(([lang, versions]) =>
-            [lang, versions.filter(version => Object.keys(filterObj).every(key => version?.[key] === filterObj[key]))]
-        ).filter(([lang, versions]) => versions.length)
+        Object.entries(versionsObj).reduce((acc, [lang, versions]) => {
+            const filteredVersions = versions.filter(version =>
+                Object.entries(filterObj).every(([key, value]) => version?.[key] === value)
+            );
+            if (filteredVersions.length) {
+              acc.push([lang, filteredVersions]);
+            }
+            return acc;
+        }, [])
     );
   },
   getSourceVersions: async function(ref) {


### PR DESCRIPTION

## Description
Show all primary versions in the about box (from different languages). Show all versions that are not source in translations box.
That also fixes 2 bugs:
1. hidden versions that were shown in neither boxes.
2. number of translations in the resources panel unfit to the number of shown translations

## Code Changes
Changes Sefaria functions  getSourceVersions and getTranslations for returning the right versions. That includes changing 2 functions they have used into one.
Changing the init value of versionLangMap in AboutBox to empty object rather than null, for consistency.
Removing the 'en' version from the source versions, for avoiding double VersionBlocks when it is a source version.
css change for selecting only the very first VersionBlock only if there are many languages.
