### PR TITLE
Disallow Sparse Translations in Translations Feature Page

### DIFF
--- a/reader/views.py
+++ b/reader/views.py
@@ -4132,9 +4132,7 @@ def translations_api(request, lang=None):
         "localField": "title",
         "foreignField": "title",
         "as": "vstate"
-    }}]
-    if lang == "en":
-        aggregation_query.append({"$match": {"vstate.flags.enComplete": True}})
+    }}, {"$match": {"vstate.flags.enComplete": True}}]
 
     aggregation_query.extend([{"$project": {"index.dependence": 1, "index.order": 1, "index.collective_title": 1,
                                             "index.title": 1, "index.order": 1,


### PR DESCRIPTION
Experimentally fix Translations API so it filters on completeness flag for every language, not just English.

This is attempting to fix an issue where really sparse non-English community translations misleadingly appear in the translations list component

## Description
The API for translations only matched against enCompleteness `vstate.flags.enComplete` when the requested lang was "en"

## Code Changes
Always match against the vstate flag above

## Notes
This may have been intentional so this PR may break unforeseen things? 