### PR TITLE
fix(test): category_test teardown order fix.

### DIFF
--- a/sefaria/model/tests/category_test.py
+++ b/sefaria/model/tests/category_test.py
@@ -10,7 +10,7 @@ import sefaria.model.category as c
 from sefaria.helper.category import update_order_of_category_children
 import datetime
 class Test_Category_Editor(object):
-    @pytest.fixture(autouse=True, scope='module')
+    @pytest.fixture(scope='function')
     def create_new_terms(self):
         terms = []
         for title in ["New Fake Category 1", "New Fake Category 2"]:


### PR DESCRIPTION
The error occurs during the teardown phase when the test tries to delete categories that reference terms that have already been deleted. Here's the relevant part of the error:

```
AttributeError: 'NoneType' object has no attribute 'title_group'
sefaria/model/schema.py:220: AttributeError
```

This suggests that library.get_term(self.sharedTitle) is returning None, and the code attempts to access term.title_group, resulting in an AttributeError.

The root cause is likely that the terms are being deleted before the categories that reference them during teardown. This can happen due to the order in which pytest tears down fixtures, especially when using scope='module' and autouse=True.

Change the scope to 'function' to ensure that it's torn down after create_new_cats.
