### PR TITLE
Add missing topics param

### DIFF
--- a/docs/openAPI.json
+++ b/docs/openAPI.json
@@ -4461,6 +4461,24 @@
         "tags": [
           "Topic"
         ],
+        "parameters": [
+          {
+              "examples": {
+                  "Return all topics": {
+                      "value": "limit=0"
+                  },
+                  "Return 20 topics": {
+                      "value": "limit=20"
+                  }
+              },
+              "name": "limit",
+              "description": "This parameter limits the number of topics returned. The default is `1000`. If `limit=0` then all topics will be returned.",
+              "schema": {
+                  "type": "integer"
+              },
+              "in": "query"
+          }
+      ],
         "responses": {
           "200": {
             "content": {


### PR DESCRIPTION
## Description
The `limit` parameter was missing from the documentation of the `api/topics` endpoint. (Known in the dev portal as [All Topics](https://developers.sefaria.org/reference/get_api-topics)). 

## Code Changes
The documentation of the parameter, with a description and two examples was added to `docs/openAPI.json`. 

