### PR TITLE
Bug/sc 29278/i clicked sign up to get updates on the https

### DIFF
--- a/sefaria/views.py
+++ b/sefaria/views.py
@@ -179,8 +179,10 @@ def generic_subscribe_to_newsletter_api(request, org, email):
         "steinsaltz": subscribe_steinsaltz,
     }
     body = json.loads(request.body)
-    first_name = body.get("firstName", None)
-    last_name = body.get("lastName", None)
+    if "firstName" not in body or "lastName" not in body:
+        return jsonResponse({"error": "You must provide first and last name."}, status=401)
+    first_name = body.get("firstName")
+    last_name = body.get("lastName")
     try:
         subscribe = org_subscribe_fn_map.get(org)
         if not subscribe:
@@ -190,7 +192,7 @@ def generic_subscribe_to_newsletter_api(request, org, email):
         else:
             logger.error(f"Failed to subscribe to list")
             return jsonResponse({"error": _("Sorry, there was an error.")})
-    except (TypeError, ValueError) as e:
+    except ValueError as e:
         logger.error(f"Failed to subscribe to list: {e}")
         return jsonResponse({"error": _("Sorry, there was an error.")})
 

--- a/sefaria/views.py
+++ b/sefaria/views.py
@@ -180,7 +180,7 @@ def generic_subscribe_to_newsletter_api(request, org, email):
     }
     body = json.loads(request.body)
     if "firstName" not in body or "lastName" not in body:
-        return jsonResponse({"error": "You must provide first and last name."}, status=401)
+        return jsonResponse({"error": "You must provide first and last name."})
     first_name = body.get("firstName")
     last_name = body.get("lastName")
     try:

--- a/sefaria/views.py
+++ b/sefaria/views.py
@@ -179,10 +179,10 @@ def generic_subscribe_to_newsletter_api(request, org, email):
         "steinsaltz": subscribe_steinsaltz,
     }
     body = json.loads(request.body)
-    if "firstName" not in body or "lastName" not in body:
-        return jsonResponse({"error": "You must provide first and last name."})
     first_name = body.get("firstName")
     last_name = body.get("lastName")
+    if not first_name or not last_name:
+        return jsonResponse({"error": "You must provide first and last name."})
     try:
         subscribe = org_subscribe_fn_map.get(org)
         if not subscribe:

--- a/sefaria/views.py
+++ b/sefaria/views.py
@@ -190,7 +190,7 @@ def generic_subscribe_to_newsletter_api(request, org, email):
         else:
             logger.error(f"Failed to subscribe to list")
             return jsonResponse({"error": _("Sorry, there was an error.")})
-    except ValueError as e:
+    except (TypeError, ValueError) as e:
         logger.error(f"Failed to subscribe to list: {e}")
         return jsonResponse({"error": _("Sorry, there was an error.")})
 

--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -9559,7 +9559,6 @@ body #keyboardInputMaster tbody tr td table tbody tr td.pressed{
 }
 .newsletterSignUpBox .subscribeMessage {
   margin: 4px 0 14px 0;
-  color: #333;
   font-size: 14px;
   font-family: "Roboto", "Helvetica Neue", "Helvetica", sans-serif;
   font-style: italic;

--- a/static/js/NewsletterSignUpForm.jsx
+++ b/static/js/NewsletterSignUpForm.jsx
@@ -28,7 +28,7 @@ export function NewsletterSignUpForm({
                     setSubscribeMessage("Subscribed! Welcome to our list.");
                     Sefaria.track.event("Newsletter", "Subscribe from " + contextName, "");
                 }).catch(error => {
-                    setSubscribeMessage(error?.error || "Sorry, there was an error.");
+                    setSubscribeMessage(error?.message || "Sorry, there was an error.");
                     setShowNameInputs(false);
                 });
             } else {

--- a/static/js/StaticPages.jsx
+++ b/static/js/StaticPages.jsx
@@ -2406,13 +2406,7 @@ const HeaderForEducatorsPage = () => {
           <span className="int-he">{heTitle}</span>
         </h1>
         <SimpleInterfaceBlock classes="staticPageHeaderText" he={heText} en={enText}/>
-        <SubscribeButton
-             enAction={"Sign up to get updates"}
-             heAction={"הירשמו לקבלת הניוזלטר"}
-             heLists={"Announcements_General_Hebrew|Announcements_Edu_Hebrew"}
-             enLists={"Announcements_General|Announcements_Edu"}
-             redirectURL={"/register?educator=true&next=/educators"}
-            />
+        <NewsletterSignUpForm contextName="educators" />
       </div>
     </div>
   </div>

--- a/static/js/StaticPages.jsx
+++ b/static/js/StaticPages.jsx
@@ -865,13 +865,7 @@ const EducatorsPage = () => (
     <div className="staticPageCallToActionFooter">
       <div className="staticPageBlockInner flexContainer">
         <SimpleInterfaceBlock classes="callToActionText" en="Sign up for our mailing list to get updates in your inbox" he="קבלו עדכונים והפניות למקורות מעניינים" />
-        <SubscribeButton
-                     enAction={"Sign up to get updates"}
-                     heAction={"הירשמו לקבלת הניוזלטר"}
-                     heLists={"Announcements_General_Hebrew|Announcements_Edu_Hebrew"}
-                     enLists={"Announcements_General|Announcements_Edu"}
-                     redirectURL={"/register?educator=true&next=/educators"}
-        />
+        <NewsletterSignUpForm contextName="educators" />
       </div>
     </div>
 

--- a/static/js/StaticPages.jsx
+++ b/static/js/StaticPages.jsx
@@ -2355,7 +2355,7 @@ const SubscribeButton = ({enAction, heAction, heLists, enLists, redirectURL}) =>
               method: 'POST',
               mode: 'same-origin',
               credentials: 'same-origin',
-              body: {"lists": lists},
+              body: JSON.stringify({"lists": lists}),
           }).then(response => {
               if (!response.ok) {
                   response.text().then(resp_text => {
@@ -2374,7 +2374,7 @@ const SubscribeButton = ({enAction, heAction, heLists, enLists, redirectURL}) =>
                   });
               }
           }).catch(error => {
-              setMessage(error.message);
+              setMessage(`Failed to subscribe ${email}.`);
           });
       }
   }


### PR DESCRIPTION
## Description
There were a few different problems with subscribing to the newsletter on the front-end and back-end.  On the back-end, there was an error because the only input to the subscription function provided was the user's e-mail, whereas our CRM requires first and last name also be provided.  Moreover, the error on the back-end was not handled properly causing the user to see the entire HTML error message that was generated by django.  

## Code Changes
1.  The back-end should catch the TypeError generated when no first name is provided so I changed the exception handler to `except (TypeError, ValueError) as e:`.
2. We can use the NewsletterSignUpForm component which is currently used in a few different places in the site which requires the user provide a first name and last name so that the error doesn't occur in the first place.
3.  Finally, the SubscribeButton, if we want to use it again, was broken, because it did not stringify the body of the request.  I changed this as well.