### PR TITLE
Prevent ibid for categories and books

### DIFF
--- a/sefaria/helper/linker.py
+++ b/sefaria/helper/linker.py
@@ -23,7 +23,7 @@ def load_spacy_model(path: str) -> spacy.Language:
 
     if path.startswith("gs://"):
         # file is located in Google Cloud
-        # file is expected to be a tar.gz of the model folder
+        # file is expected to be a tar.gz of the contents of the model folder (not the folder itself)
         match = re.match(r"gs://([^/]+)/(.+)$", path)
         bucket_name = match.group(1)
         blob_name = match.group(2)

--- a/sefaria/model/category.py
+++ b/sefaria/model/category.py
@@ -30,6 +30,7 @@ class Category(abstract.AbstractMongoRecord, schema.AbstractTitledOrTermedObject
         "isPrimary",
         "searchRoot",
         "order",
+        "match_templates",
     ]
 
     def __str__(self):

--- a/sefaria/model/category.py
+++ b/sefaria/model/category.py
@@ -9,9 +9,10 @@ from . import abstract as abstract
 from . import schema as schema
 from . import text as text
 from . import collection as collection
+from .linker.has_match_template import HasMatchTemplates
 
 
-class Category(abstract.AbstractMongoRecord, schema.AbstractTitledOrTermedObject):
+class Category(abstract.AbstractMongoRecord, schema.AbstractTitledOrTermedObject, HasMatchTemplates):
     collection = 'category'
     history_noun = "category"
 

--- a/sefaria/model/linker/category_resolver.py
+++ b/sefaria/model/linker/category_resolver.py
@@ -24,7 +24,7 @@ class CategoryMatcher:
         self._title_to_cat: dict[str, list[Category]] = defaultdict(list)
         for cat in category_registry:
             for title in cat.get_titles(lang):
-                self._title_to_cat[title.text] += [cat]
+                self._title_to_cat[title] += [cat]
 
     def match(self, raw_ref: RawRef) -> list[Category]:
         return self._title_to_cat[raw_ref.text]

--- a/sefaria/model/linker/category_resolver.py
+++ b/sefaria/model/linker/category_resolver.py
@@ -23,8 +23,10 @@ class CategoryMatcher:
     def __init__(self, lang: str, category_registry: list[Category]) -> None:
         self._title_to_cat: dict[str, list[Category]] = defaultdict(list)
         for cat in category_registry:
-            for title in cat.get_titles(lang):
-                self._title_to_cat[title] += [cat]
+            for match_template in cat.get_match_templates():
+                for term in match_template.get_terms():
+                    for title in term.get_titles(lang):
+                        self._title_to_cat[title] += [cat]
 
     def match(self, raw_ref: RawRef) -> list[Category]:
         return self._title_to_cat[raw_ref.text]

--- a/sefaria/model/linker/category_resolver.py
+++ b/sefaria/model/linker/category_resolver.py
@@ -1,0 +1,43 @@
+from collections import defaultdict
+from sefaria.model.category import Category
+from sefaria.model.linker.ref_part import RawRef
+
+
+class ResolvedCategory:
+
+    def __init__(self, raw_ref: RawRef, categories: list[Category]) -> None:
+        self.raw_entity = raw_ref
+        self.categories = categories
+
+    @property
+    def is_ambiguous(self):
+        return len(self.categories) != 1
+
+    @property
+    def resolution_failed(self):
+        return len(self.categories) == 0
+
+
+class CategoryMatcher:
+
+    def __init__(self, lang: str, category_registry: list[Category]) -> None:
+        self._title_to_cat: dict[str, list[Category]] = defaultdict(list)
+        for cat in category_registry:
+            for title in cat.get_titles(lang):
+                self._title_to_cat[title.text] += [cat]
+
+    def match(self, raw_ref: RawRef) -> list[Category]:
+        return self._title_to_cat[raw_ref.text]
+
+
+class CategoryResolver:
+
+    def __init__(self, category_matcher: CategoryMatcher) -> None:
+        self._matcher = category_matcher
+
+    def bulk_resolve(self, raw_refs: list[RawRef]) -> list[ResolvedCategory]:
+        resolved = []
+        for raw_ref in raw_refs:
+            matched_categories = self._matcher.match(raw_ref)
+            resolved += [ResolvedCategory(raw_ref, matched_categories)]
+        return resolved

--- a/sefaria/model/linker/has_match_template.py
+++ b/sefaria/model/linker/has_match_template.py
@@ -1,0 +1,19 @@
+class HasMatchTemplates:
+    MATCH_TEMPLATE_ALONE_SCOPES = {'any', 'alone'}
+
+    def get_match_templates(self):
+        from sefaria.model.linker.match_template import MatchTemplate
+        for raw_match_template in getattr(self, 'match_templates', []):
+            yield MatchTemplate(**raw_match_template)
+
+    def get_match_template_trie(self, lang: str):
+        from sefaria.model.linker.match_template import MatchTemplateTrie
+        return MatchTemplateTrie(lang, nodes=[self], scope='combined')
+
+    def has_scope_alone_match_template(self):
+        """
+        @return: True if `self` has any match template that has scope = "alone" OR scope = "any"
+        """
+        return any(template.scope in self.MATCH_TEMPLATE_ALONE_SCOPES for template in self.get_match_templates())
+
+

--- a/sefaria/model/linker/linker.py
+++ b/sefaria/model/linker/linker.py
@@ -86,7 +86,7 @@ class Linker:
         self._ner.map_normal_output_to_original_input(input_str, [x.raw_entity for x in doc.all_resolved])
         return doc
 
-    def link_by_paragraph(self, input_str: str, book_context_ref: Ref, *link_args, **link_kwargs) -> LinkedDoc:
+    def link_by_paragraph(self, input_str: str, book_context_ref: Optional[Ref] = None, *link_args, **link_kwargs) -> LinkedDoc:
         """
         Similar to `link()` except model is run on each paragraph individually (via a bulk operation)
         This better mimics the way the underlying ML models were trained and tends to lead to better results
@@ -142,8 +142,9 @@ class Linker:
         @param reset_ibids:
         @return:
         """
-        resolved_cats = self._cat_resolver.bulk_resolve(raw_refs)
-        unresolved_raw_refs = [r.raw_entity for r in filter(lambda r: r.resolution_failed, resolved_cats)]
+        possibly_resolved_cats = self._cat_resolver.bulk_resolve(raw_refs)
+        unresolved_raw_refs = [r.raw_entity for r in filter(lambda r: r.resolution_failed, possibly_resolved_cats)]
+        resolved_cats = list(filter(lambda r: not r.resolution_failed, possibly_resolved_cats))
         resolved_refs = self._ref_resolver.bulk_resolve(unresolved_raw_refs, book_context_ref, thoroughness, reset_ibids=reset_ibids)
         return resolved_refs, resolved_cats
 

--- a/sefaria/model/linker/linker.py
+++ b/sefaria/model/linker/linker.py
@@ -54,7 +54,7 @@ class Linker:
             if type_filter in {'all', 'citation'}:
                 resolved_refs, resolved_cats = self._bulk_resolve_refs_and_cats(raw_refs, book_context_ref, thoroughness, False)
             if type_filter in {'all', 'named entity'}:
-                resolved_named_entities = self._ne_resolver.bulk_resolve(named_entities, with_failures)
+                resolved_named_entities = self._ne_resolver.bulk_resolve(named_entities)
             if not with_failures:
                 resolved_refs, resolved_named_entities, resolved_cats = self._remove_failures(resolved_refs, resolved_named_entities, resolved_cats)
             docs += [LinkedDoc(input_str, resolved_refs, resolved_named_entities, resolved_cats)]

--- a/sefaria/model/linker/linker.py
+++ b/sefaria/model/linker/linker.py
@@ -145,6 +145,7 @@ class Linker:
         possibly_resolved_cats = self._cat_resolver.bulk_resolve(raw_refs)
         unresolved_raw_refs = [r.raw_entity for r in filter(lambda r: r.resolution_failed, possibly_resolved_cats)]
         resolved_cats = list(filter(lambda r: not r.resolution_failed, possibly_resolved_cats))
+        #try to resolve only unresolved categories (unresolved_raw_refs) as refs:
         resolved_refs = self._ref_resolver.bulk_resolve(unresolved_raw_refs, book_context_ref, thoroughness, reset_ibids=reset_ibids)
         return resolved_refs, resolved_cats
 

--- a/sefaria/model/linker/linker.py
+++ b/sefaria/model/linker/linker.py
@@ -6,6 +6,7 @@ from sefaria.model.linker.ref_part import RawRef, RawNamedEntity, span_inds
 from sefaria.model.linker.ref_resolver import RefResolver, ResolutionThoroughness, PossiblyAmbigResolvedRef
 from sefaria.model.linker.named_entity_resolver import NamedEntityResolver, ResolvedNamedEntity
 from sefaria.model.linker.named_entity_recognizer import NamedEntityRecognizer
+from sefaria.model.linker.category_resolver import CategoryResolver
 
 
 @dataclasses.dataclass
@@ -21,10 +22,11 @@ class LinkedDoc:
 
 class Linker:
 
-    def __init__(self, ner: NamedEntityRecognizer, ref_resolver: RefResolver, ne_resolver: NamedEntityResolver, ):
+    def __init__(self, ner: NamedEntityRecognizer, ref_resolver: RefResolver, ne_resolver: NamedEntityResolver, cat_resolver: CategoryResolver):
         self._ner = ner
         self._ref_resolver = ref_resolver
         self._ne_resolver = ne_resolver
+        self._cat_resolver = cat_resolver
 
     def bulk_link(self, inputs: List[str], book_context_refs: Optional[List[Optional[Ref]]] = None, with_failures=False,
                   verbose=False, thoroughness=ResolutionThoroughness.NORMAL, type_filter='all') -> List[LinkedDoc]:

--- a/sefaria/model/linker/linker.py
+++ b/sefaria/model/linker/linker.py
@@ -72,9 +72,12 @@ class Linker:
         raw_refs, named_entities = self._ner.recognize(input_str)
         resolved_refs, resolved_named_entities = [], []
         if type_filter in {'all', 'citation'}:
-            resolved_refs = self._ref_resolver.bulk_resolve(raw_refs, book_context_ref, with_failures, thoroughness)
+            resolved_refs = self._ref_resolver.bulk_resolve(raw_refs, book_context_ref, thoroughness)
         if type_filter in {'all', 'named entity'}:
-            resolved_named_entities = self._ne_resolver.bulk_resolve(named_entities, with_failures)
+            resolved_named_entities = self._ne_resolver.bulk_resolve(named_entities)
+        if not with_failures:
+            resolved_refs = list(filter(lambda r: not r.resolution_failed, resolved_refs))
+            resolved_named_entities = list(filter(lambda r: not r.resolution_failed, resolved_named_entities))
         doc = LinkedDoc(input_str, resolved_refs, resolved_named_entities)
         self._ner.map_normal_output_to_original_input(input_str, [x.raw_entity for x in doc.all_resolved])
         return doc

--- a/sefaria/model/linker/linker.py
+++ b/sefaria/model/linker/linker.py
@@ -103,11 +103,13 @@ class Linker:
         linked_docs = self.bulk_link(inputs, [book_context_ref]*len(inputs), *link_args, **link_kwargs)
         resolved_refs = []
         resolved_named_entities = []
+        resolved_categories = []
         full_spacy_doc = self._ner.named_entity_model.make_doc(input_str)
         offset = 0
         for curr_input, linked_doc in zip(inputs, linked_docs):
             resolved_refs += linked_doc.resolved_refs
             resolved_named_entities += linked_doc.resolved_named_entities
+            resolved_categories += linked_doc.resolved_categories
 
             for resolved in linked_doc.all_resolved:
                 named_entity = resolved.raw_entity
@@ -118,7 +120,7 @@ class Linker:
                     named_entity.align_parts_to_new_doc(full_spacy_doc, raw_ref_offset)
             curr_token_count = len(self._ner.named_entity_model.make_doc(curr_input))
             offset += curr_token_count+1  # +1 for newline token
-        return LinkedDoc(input_str, resolved_refs, resolved_named_entities)
+        return LinkedDoc(input_str, resolved_refs, resolved_named_entities, resolved_categories)
 
     def get_ner(self) -> NamedEntityRecognizer:
         return self._ner

--- a/sefaria/model/linker/match_template.py
+++ b/sefaria/model/linker/match_template.py
@@ -1,15 +1,12 @@
 from collections import defaultdict
-from typing import List, Optional, Iterable, Union
+from typing import List, Optional, Iterable
 from functools import reduce
 from sefaria.model import abstract as abst
 from sefaria.model import schema
-from sefaria.model.category import Category
 from .ref_part import TermContext, LEAF_TRIE_ENTRY
-from .referenceable_book_node import make_named_referenceable_book_node
+from .referenceable_book_node import NamedReferenceableBookNode
 import structlog
 
-
-TreeNodeOrCategory = Union[schema.TitledTreeNode, Category]
 logger = structlog.get_logger(__name__)
 
 
@@ -50,7 +47,7 @@ class MatchTemplateTrie:
     E.g. if there is match template with term slugs ["term1", "term2"], term1 has title "Term 1", term2 has title "Term 2"
     then an entry in the trie would be {"Term 1": {"Term 2": ...}}
     """
-    def __init__(self, lang: str, nodes: List[TreeNodeOrCategory] = None, sub_trie: dict = None, scope: str = None):
+    def __init__(self, lang: str, nodes: List[schema.TitledTreeNode] = None, sub_trie: dict = None, scope: str = None):
         """
         :param lang:
         :param nodes:
@@ -61,16 +58,16 @@ class MatchTemplateTrie:
         self.scope = scope
         self._trie = self.__init_trie(nodes, sub_trie)
 
-    def __init_trie(self, nodes: List[TreeNodeOrCategory], sub_trie: dict):
+    def __init_trie(self, nodes: List[schema.TitledTreeNode], sub_trie: dict):
         if nodes is None:
             return sub_trie
         return self.__init_trie_with_nodes(nodes)
 
-    def __init_trie_with_nodes(self, nodes: List[TreeNodeOrCategory]):
+    def __init_trie_with_nodes(self, nodes: List[schema.TitledTreeNode]):
         trie = {}
         for node in nodes:
             for match_template in node.get_match_templates():
-                if isinstance(node, schema.TitledTreeNode) and not node.is_root() and not match_template.matches_scope(self.scope):
+                if not node.is_root() and not match_template.matches_scope(self.scope):
                     continue
                 curr_dict_queue = [trie]
                 self.__add_all_term_titles_to_trie(match_template.terms, node, curr_dict_queue)
@@ -78,7 +75,7 @@ class MatchTemplateTrie:
         return trie
 
     @staticmethod
-    def __log_non_existent_term_warning(node: TreeNodeOrCategory):
+    def __log_non_existent_term_warning(node: schema.TitledTreeNode):
         try:
             node_ref = node.ref()
         except:
@@ -86,7 +83,7 @@ class MatchTemplateTrie:
         logger.warning(f"{node_ref} has match_templates that reference slugs that don't exist."
                        f"Check match_templates and fix.")
 
-    def __add_all_term_titles_to_trie(self, term_list: List[schema.NonUniqueTerm], node: TreeNodeOrCategory, curr_dict_queue: List[dict]):
+    def __add_all_term_titles_to_trie(self, term_list: List[schema.NonUniqueTerm], node: schema.TitledTreeNode, curr_dict_queue: List[dict]):
         for term in term_list:
             if term is None:
                 self.__log_non_existent_term_warning(node)
@@ -100,9 +97,9 @@ class MatchTemplateTrie:
             curr_dict_queue += self.__get_sub_tries_for_term(term, curr_dict)
 
     @staticmethod
-    def __add_nodes_to_leaves(node: TreeNodeOrCategory, curr_dict_queue: List[dict]):
+    def __add_nodes_to_leaves(node: schema.TitledTreeNode, curr_dict_queue: List[dict]):
         for curr_dict in curr_dict_queue:
-            leaf_node = make_named_referenceable_book_node(node.index if (isinstance(node, schema.TitledTreeNode) and node.is_root()) else node)
+            leaf_node = NamedReferenceableBookNode(node.index if node.is_root() else node)
             if LEAF_TRIE_ENTRY in curr_dict:
                 curr_dict[LEAF_TRIE_ENTRY] += [leaf_node]
             else:

--- a/sefaria/model/linker/match_template.py
+++ b/sefaria/model/linker/match_template.py
@@ -5,7 +5,7 @@ from sefaria.model import abstract as abst
 from sefaria.model import schema
 from sefaria.model.category import Category
 from .ref_part import TermContext, LEAF_TRIE_ENTRY
-from .referenceable_book_node import NamedReferenceableBookNode
+from .referenceable_book_node import make_named_referenceable_book_node
 import structlog
 
 
@@ -102,7 +102,7 @@ class MatchTemplateTrie:
     @staticmethod
     def __add_nodes_to_leaves(node: TreeNodeOrCategory, curr_dict_queue: List[dict]):
         for curr_dict in curr_dict_queue:
-            leaf_node = NamedReferenceableBookNode(node.index if (isinstance(node, schema.TitledTreeNode) and node.is_root()) else node)
+            leaf_node = make_named_referenceable_book_node(node.index if (isinstance(node, schema.TitledTreeNode) and node.is_root()) else node)
             if LEAF_TRIE_ENTRY in curr_dict:
                 curr_dict[LEAF_TRIE_ENTRY] += [leaf_node]
             else:

--- a/sefaria/model/linker/named_entity_resolver.py
+++ b/sefaria/model/linker/named_entity_resolver.py
@@ -26,6 +26,10 @@ class ResolvedNamedEntity:
     def is_ambiguous(self):
         return len(self.topics) != 1
 
+    @property
+    def resolution_failed(self):
+        return len(self.topics) == 0
+
 
 class TitleGenerator:
 
@@ -134,12 +138,11 @@ class NamedEntityResolver:
     def __init__(self, topic_matcher: TopicMatcher):
         self._topic_matcher = topic_matcher
 
-    def bulk_resolve(self, raw_named_entities: List[RawNamedEntity], with_failures=False) -> List[ResolvedNamedEntity]:
+    def bulk_resolve(self, raw_named_entities: List[RawNamedEntity]) -> List[ResolvedNamedEntity]:
         resolved = []
         for named_entity in raw_named_entities:
             matched_topics = self._topic_matcher.match(named_entity)
-            if len(matched_topics) > 0 or with_failures:
-                resolved += [ResolvedNamedEntity(named_entity, matched_topics)]
+            resolved += [ResolvedNamedEntity(named_entity, matched_topics)]
         return resolved
 
 

--- a/sefaria/model/linker/ref_resolver.py
+++ b/sefaria/model/linker/ref_resolver.py
@@ -498,7 +498,9 @@ class RefResolver:
 
             # combine
             if len(context_full_matches) > 0:
-                context_free_matches = list(filter(lambda x: x.ref.normal() not in refs_matched, context_free_matches))
+                # assumption is we don't want refs that used context at book level, then didn't get refined more when considering context free
+                # BUT did get refined more when considering context
+                context_free_matches = list(filter(lambda x: not (x.num_resolved(include={ContextPart}) > 0 and x.ref.normal() in refs_matched), context_free_matches))
             temp_matches += context_free_matches + context_full_matches
         return ResolvedRefPruner.prune_refined_ref_part_matches(self._thoroughness, temp_matches)
 

--- a/sefaria/model/linker/ref_resolver.py
+++ b/sefaria/model/linker/ref_resolver.py
@@ -364,7 +364,7 @@ class RefResolver:
             unrefined_matches = self.get_unrefined_ref_part_matches(book_context_ref, temp_raw_ref)
             if is_non_cts:
                 # filter unrefined matches to matches that resolved previously
-                resolved_titles = {r.ref.index.title for r in resolved_list}
+                resolved_titles = {r.ref.index.title for r in resolved_list if not r.is_ambiguous}
                 unrefined_matches = list(filter(lambda x: x.ref.index.title in resolved_titles, unrefined_matches))
                 # resolution will start at context_ref.sections - len(ref parts). rough heuristic
                 for match in unrefined_matches:

--- a/sefaria/model/linker/ref_resolver.py
+++ b/sefaria/model/linker/ref_resolver.py
@@ -1,6 +1,5 @@
 from collections import defaultdict
 from typing import List, Union, Dict, Optional, Tuple, Iterable, Set
-from functools import reduce
 from enum import IntEnum, Enum
 from sefaria.system.exceptions import InputError
 from sefaria.model import abstract as abst
@@ -228,23 +227,12 @@ class TermMatcher:
 
 class IbidHistory:
 
-    ignored_term_slugs = ['torah', 'talmud', 'gemara', 'mishnah', 'midrash']
-
     def __init__(self, last_n_titles: int = 3, last_n_refs: int = 3):
         self.last_n_titles = last_n_titles
         self.last_n_refs = last_n_refs
         self._last_refs: List[text.Ref] = []
         self._last_titles: List[str] = []
         self._title_ref_map: Dict[str, text.Ref] = {}
-        self._ignored_titles: Set[str] = self._get_ignored_titles()
-
-    @classmethod
-    def _get_ignored_titles(cls) -> Set[str]:
-        terms = [schema.NonUniqueTerm.init(slug) for slug in cls.ignored_term_slugs]
-        return reduce(lambda a, b: a | set(b), [term.get_titles() for term in terms], set())
-
-    def should_ignore_text(self, text) -> bool:
-        return text in self._ignored_titles
 
     def _get_last_refs(self) -> List[text.Ref]:
         return self._last_refs
@@ -311,8 +299,6 @@ class RefResolver:
         return temp_resolved
 
     def _update_ibid_history(self, raw_ref: RawRef, temp_resolved: List[PossiblyAmbigResolvedRef]):
-        if self._ibid_history.should_ignore_text(raw_ref.text):
-            return
         if len(temp_resolved) == 0:
             self.reset_ibid_history()
         elif any(r.is_ambiguous for r in temp_resolved):

--- a/sefaria/model/linker/ref_resolver.py
+++ b/sefaria/model/linker/ref_resolver.py
@@ -479,7 +479,7 @@ class RefResolver:
 
     def refine_ref_part_matches(self, book_context_ref: Optional[text.Ref], matches: List[ResolvedRef]) -> List[ResolvedRef]:
         temp_matches = []
-        refs_matched = {match.ref.normal() for match in matches}
+        refs_matched = {match.ref.normal() for match in matches if match.ref}
         for unrefined_match in matches:
             unused_parts = list(set(unrefined_match.raw_entity.parts_to_match) - set(unrefined_match.resolved_parts))
             context_free_matches = self._get_refined_ref_part_matches_recursive(unrefined_match, unused_parts)
@@ -612,7 +612,7 @@ class ResolvedRefPruner:
     def prune_unrefined_ref_part_matches(ref_part_matches: List[ResolvedRef]) -> List[ResolvedRef]:
         index_match_map = defaultdict(list)
         for match in ref_part_matches:
-            key = match.node.ref().normal()
+            key = match.node.unique_key()
             index_match_map[key] += [match]
         pruned_matches = []
         for match_list in index_match_map.values():

--- a/sefaria/model/linker/ref_resolver.py
+++ b/sefaria/model/linker/ref_resolver.py
@@ -301,9 +301,11 @@ class RefResolver:
     def _update_ibid_history(self, raw_ref: RawRef, temp_resolved: List[PossiblyAmbigResolvedRef]):
         if len(temp_resolved) == 0:
             self.reset_ibid_history()
-        elif any(r.is_ambiguous for r in temp_resolved):
+        elif any(r.is_ambiguous for r in temp_resolved) or temp_resolved[-1].ref is None:
             # can't be sure about future ibid inferences
             # TODO can probably salvage parts of history if matches are ambiguous within one book
+            # if ref is None, match is likely to AltStructNode
+            # TODO this node still has useful info. Try to salvage it.
             self.reset_ibid_history()
         else:
             self._ibid_history.last_refs = temp_resolved[-1].ref

--- a/sefaria/model/linker/ref_resolver.py
+++ b/sefaria/model/linker/ref_resolver.py
@@ -770,13 +770,8 @@ class ResolvedRefPruner:
             if resolved_ref.ref is None:
                 if resolved_ref.node is None:
                     return "N/A"
-                elif isinstance(resolved_ref.node._titled_tree_node, schema.AltStructNode):
-                    leaves = resolved_ref.node._titled_tree_node.get_leaf_nodes()
-                    # assume leaves are contiguous. If this is wrong, will be disproven later in the function
-                    if len(leaves) == 0:
-                        return "N/A"
-                    approx_ref = leaves[0].ref().to(leaves[-1].ref())
-                    return approx_ref.order_id()
+                elif hasattr(resolved_ref.node, "ref_order_id"):
+                    return resolved_ref.node.ref_order_id()
                 else:
                     return "N/A"
             else:

--- a/sefaria/model/linker/ref_resolver.py
+++ b/sefaria/model/linker/ref_resolver.py
@@ -188,6 +188,10 @@ class AmbiguousResolvedRef:
         # assumption is first resolved refs pretty_text is good enough
         return self.resolved_raw_refs[0].pretty_text
 
+    @property
+    def resolution_failed(self) -> bool:
+        return False
+
 
 PossiblyAmbigResolvedRef = Union[ResolvedRef, AmbiguousResolvedRef]
 

--- a/sefaria/model/linker/ref_resolver.py
+++ b/sefaria/model/linker/ref_resolver.py
@@ -479,7 +479,7 @@ class RefResolver:
 
     def refine_ref_part_matches(self, book_context_ref: Optional[text.Ref], matches: List[ResolvedRef]) -> List[ResolvedRef]:
         temp_matches = []
-        refs_matched = {match.ref.normal() for match in matches if match.ref}
+        refs_matched = {match.ref.normal() for match in matches}
         for unrefined_match in matches:
             unused_parts = list(set(unrefined_match.raw_entity.parts_to_match) - set(unrefined_match.resolved_parts))
             context_free_matches = self._get_refined_ref_part_matches_recursive(unrefined_match, unused_parts)

--- a/sefaria/model/linker/referenceable_book_node.py
+++ b/sefaria/model/linker/referenceable_book_node.py
@@ -1,12 +1,10 @@
 import dataclasses
-from abc import ABC, abstractmethod
 from typing import List, Union, Optional, Tuple, Dict
 import copy
 from typing import List, Union, Optional
 from sefaria.model import abstract as abst
 from sefaria.model import text
 from sefaria.model import schema
-from sefaria.model.category import Category
 from sefaria.system.exceptions import InputError
 from bisect import bisect_right
 
@@ -121,61 +119,7 @@ class ReferenceableBookNode:
         raise NotImplementedError
 
 
-def make_named_referenceable_book_node(object: Union[schema.TitledTreeNode, text.Index, Category]) -> 'AbstractNamedReferenceableBookNode':
-    if isinstance(object, Category):
-        return CategoryReferenceableBookNode(object)
-    return NamedReferenceableBookNode(object)
-
-
-class AbstractNamedReferenceableBookNode(ABC, ReferenceableBookNode):
-
-    @abstractmethod
-    def get_numeric_equivalent(self):
-        pass
-
-    @abstractmethod
-    def ref(self) -> text.Ref:
-        pass
-
-    @abstractmethod
-    def ref_order_id(self) -> str:
-        pass
-
-    @abstractmethod
-    def unique_key(self) -> str:
-        """
-        Key which uniquely identifies this node
-        @return:
-        """
-        pass
-
-    @abstractmethod
-    def ref_part_title_trie(self, *args, **kwargs):
-        pass
-
-
-class CategoryReferenceableBookNode(AbstractNamedReferenceableBookNode):
-
-    def __init__(self, category: Category):
-        self._category = category
-
-    def get_numeric_equivalent(self):
-        return None
-
-    def ref(self) -> text.Ref:
-        return None
-
-    def ref_order_id(self) -> str:
-        return "N/A"
-
-    def unique_key(self) -> str:
-        return '/'.join(self._category.path)
-
-    def ref_part_title_trie(self, *args, **kwargs):
-        pass
-
-
-class NamedReferenceableBookNode(AbstractNamedReferenceableBookNode):
+class NamedReferenceableBookNode(ReferenceableBookNode):
 
     def __init__(self, titled_tree_node_or_index: Union[schema.TitledTreeNode, text.Index]):
         self._titled_tree_node_or_index = titled_tree_node_or_index

--- a/sefaria/model/linker/referenceable_book_node.py
+++ b/sefaria/model/linker/referenceable_book_node.py
@@ -138,6 +138,10 @@ class AbstractNamedReferenceableBookNode(ABC, ReferenceableBookNode):
         pass
 
     @abstractmethod
+    def ref_order_id(self) -> str:
+        pass
+
+    @abstractmethod
     def ref_part_title_trie(self, *args, **kwargs):
         pass
 
@@ -180,6 +184,16 @@ class NamedReferenceableBookNode(AbstractNamedReferenceableBookNode):
 
     def ref(self) -> text.Ref:
         return self._titled_tree_node.ref()
+
+    def ref_order_id(self) -> str:
+        if isinstance(self._titled_tree_node, schema.AltStructNode):
+            leaves = self._titled_tree_node.get_leaf_nodes()
+            # assume leaves are contiguous. If this is wrong, will be disproven later in the function
+            if len(leaves) == 0:
+                return "N/A"
+            approx_ref = leaves[0].ref().to(leaves[-1].ref())
+            return approx_ref.order_id()
+        return self.ref().order_id()
 
     @staticmethod
     def _is_array_map_referenceable(node: schema.ArrayMapNode) -> bool:

--- a/sefaria/model/linker/referenceable_book_node.py
+++ b/sefaria/model/linker/referenceable_book_node.py
@@ -142,6 +142,14 @@ class AbstractNamedReferenceableBookNode(ABC, ReferenceableBookNode):
         pass
 
     @abstractmethod
+    def unique_key(self) -> str:
+        """
+        Key which uniquely identifies this node
+        @return:
+        """
+        pass
+
+    @abstractmethod
     def ref_part_title_trie(self, *args, **kwargs):
         pass
 
@@ -156,6 +164,12 @@ class CategoryReferenceableBookNode(AbstractNamedReferenceableBookNode):
 
     def ref(self) -> text.Ref:
         return None
+
+    def ref_order_id(self) -> str:
+        return "N/A"
+
+    def unique_key(self) -> str:
+        return '/'.join(self._category.path)
 
     def ref_part_title_trie(self, *args, **kwargs):
         pass
@@ -184,6 +198,9 @@ class NamedReferenceableBookNode(AbstractNamedReferenceableBookNode):
 
     def ref(self) -> text.Ref:
         return self._titled_tree_node.ref()
+
+    def unique_key(self) -> str:
+        return self.ref().normal()
 
     def ref_order_id(self) -> str:
         if isinstance(self._titled_tree_node, schema.AltStructNode):

--- a/sefaria/model/linker/referenceable_book_node.py
+++ b/sefaria/model/linker/referenceable_book_node.py
@@ -1,10 +1,12 @@
 import dataclasses
+from abc import ABC, abstractmethod
 from typing import List, Union, Optional, Tuple, Dict
 import copy
 from typing import List, Union, Optional
 from sefaria.model import abstract as abst
 from sefaria.model import text
 from sefaria.model import schema
+from sefaria.model.category import Category
 from sefaria.system.exceptions import InputError
 from bisect import bisect_right
 
@@ -119,7 +121,43 @@ class ReferenceableBookNode:
         raise NotImplementedError
 
 
-class NamedReferenceableBookNode(ReferenceableBookNode):
+def make_named_referenceable_book_node(object: Union[schema.TitledTreeNode, text.Index, Category]) -> 'AbstractNamedReferenceableBookNode':
+    if isinstance(object, Category):
+        return CategoryReferenceableBookNode(object)
+    return NamedReferenceableBookNode(object)
+
+
+class AbstractNamedReferenceableBookNode(ABC, ReferenceableBookNode):
+
+    @abstractmethod
+    def get_numeric_equivalent(self):
+        pass
+
+    @abstractmethod
+    def ref(self) -> text.Ref:
+        pass
+
+    @abstractmethod
+    def ref_part_title_trie(self, *args, **kwargs):
+        pass
+
+
+class CategoryReferenceableBookNode(AbstractNamedReferenceableBookNode):
+
+    def __init__(self, category: Category):
+        self._category = category
+
+    def get_numeric_equivalent(self):
+        return None
+
+    def ref(self) -> text.Ref:
+        return None
+
+    def ref_part_title_trie(self, *args, **kwargs):
+        pass
+
+
+class NamedReferenceableBookNode(AbstractNamedReferenceableBookNode):
 
     def __init__(self, titled_tree_node_or_index: Union[schema.TitledTreeNode, text.Index]):
         self._titled_tree_node_or_index = titled_tree_node_or_index

--- a/sefaria/model/linker/resolved_ref_refiner.py
+++ b/sefaria/model/linker/resolved_ref_refiner.py
@@ -76,7 +76,7 @@ class ResolvedRefRefinerForNumberedPart(ResolvedRefRefiner):
         return [self._clone_resolved_ref(resolved_parts=self._get_resolved_parts(), node=self.node, ref=refined_ref)]
 
     def __refine_context_free(self, lang: str, fromSections=None) -> List['ResolvedRef']:
-        if self.node is None:
+        if self.node is None or not isinstance(self.node, NumberedReferenceableBookNode):
             return []
         possible_subrefs, can_match_out_of_order_list = self.node.possible_subrefs(lang, self.resolved_ref.ref, self.part_to_match.text, fromSections)
         refined_refs = []

--- a/sefaria/model/linker/tests/category_matcher_test.py
+++ b/sefaria/model/linker/tests/category_matcher_test.py
@@ -1,0 +1,58 @@
+import pytest
+from unittest.mock import Mock
+from sefaria.model.category import Category
+from sefaria.model.linker.category_resolver import CategoryMatcher
+
+
+def make_title(text, lang):
+    return {"text": text, "lang": lang}
+
+
+@pytest.fixture
+def mock_category():
+    return Category({
+        "titles": [make_title("Title1", "en"), make_title("Title2", "en")]
+    })
+
+
+@pytest.fixture
+def mock_category_2():
+    return Category({
+        "titles": [make_title("Title1", "en"), make_title("Title4", "en")]
+    })
+
+
+@pytest.fixture
+def mock_raw_ref():
+    raw_ref = Mock()
+    raw_ref.text = "Title2"
+    return raw_ref
+
+
+@pytest.fixture
+def category_matcher(mock_category, mock_category_2):
+    return CategoryMatcher(lang="en", category_registry=[mock_category, mock_category_2])
+
+
+def test_match_single_title(category_matcher, mock_raw_ref, mock_category):
+    # Test matching for a valid title in mock_raw_ref
+    matched_categories = category_matcher.match(mock_raw_ref)
+    assert len(matched_categories) == 1
+    assert mock_category in matched_categories
+
+
+def test_match_no_match(category_matcher, mock_raw_ref):
+    # Test case where the raw_ref title does not match any category
+    mock_raw_ref.text = "NonexistentTitle"
+    matched_categories = category_matcher.match(mock_raw_ref)
+    assert matched_categories == []
+
+
+def test_match_multiple_titles(category_matcher, mock_raw_ref, mock_category, mock_category_2):
+    # Test case where multiple categories match the same title
+    mock_raw_ref.text = "Title1"
+
+    matched_categories = category_matcher.match(mock_raw_ref)
+    assert len(matched_categories) == 2
+    assert mock_category in matched_categories
+    assert mock_category_2 in matched_categories

--- a/sefaria/model/linker/tests/linker_test.py
+++ b/sefaria/model/linker/tests/linker_test.py
@@ -36,7 +36,6 @@ crrd = create_raw_ref_data
 
 
 @pytest.mark.parametrize(('resolver_data', 'expected_trefs'), [
-    [crrd(["@Torah"], lang='en'), tuple()],
     # Numbered JAs
     [crrd(["@Jerusalem", "@Talmud", "@Yoma", "#5a"], lang='en'), ("Jerusalem Talmud Yoma 1:1:20-25",)],
     [crrd(["@Babylonian", "@Talmud", "@Sukkah", "#49b"], lang='en'), ("Sukkah 49b",)],

--- a/sefaria/model/linker/tests/linker_test.py
+++ b/sefaria/model/linker/tests/linker_test.py
@@ -293,7 +293,7 @@ class TestResolveRawRef:
     pass
 
 @pytest.mark.parametrize(('context_tref', 'input_str', 'lang', 'expected_trefs', 'expected_pretty_texts'), [
-    ["Berakhot 2a", 'It says in the Talmud, "Don\'t steal" which implies it\'s bad to steal.', 'en', tuple(), tuple()],
+    ["Berakhot 2a", 'It says in the Talmud, "Don\'t steal" which implies it\'s bad to steal.', 'en', tuple(), tuple()],  # Don't match Talmud using Berakhot 2a as ibid context
     [None, 'It says in the Torah, "Don\'t steal" which implies it\'s bad to steal.', 'en', tuple(), tuple()],
     [None, """גמ' שמזונותן עליך. עיין ביצה (דף טו ע"ב רש"י ד"ה שמא יפשע:)""", 'he', ("Rashi on Beitzah 15b:8:1",), ['ביצה (דף טו ע"ב רש"י ד"ה שמא יפשע:)']],
     [None, """שם אלא ביתך ל"ל. ע' מנחות מד ע"א תד"ה טלית:""", 'he', ("Tosafot on Menachot 44a:12:1",), ['מנחות מד ע"א תד"ה טלית']],

--- a/sefaria/model/linker/tests/linker_test.py
+++ b/sefaria/model/linker/tests/linker_test.py
@@ -293,6 +293,8 @@ class TestResolveRawRef:
     pass
 
 @pytest.mark.parametrize(('context_tref', 'input_str', 'lang', 'expected_trefs', 'expected_pretty_texts'), [
+    ["Berakhot 2a", 'It says in the Talmud, "Don\'t steal" which implies it\'s bad to steal.', 'en', tuple(), tuple()],
+    [None, 'It says in the Torah, "Don\'t steal" which implies it\'s bad to steal.', 'en', tuple(), tuple()],
     [None, """גמ' שמזונותן עליך. עיין ביצה (דף טו ע"ב רש"י ד"ה שמא יפשע:)""", 'he', ("Rashi on Beitzah 15b:8:1",), ['ביצה (דף טו ע"ב רש"י ד"ה שמא יפשע:)']],
     [None, """שם אלא ביתך ל"ל. ע' מנחות מד ע"א תד"ה טלית:""", 'he', ("Tosafot on Menachot 44a:12:1",), ['מנחות מד ע"א תד"ה טלית']],
     [None, """גמ' במה מחנכין. עי' מנחות דף עח ע"א תוס' ד"ה אחת:""", 'he',("Tosafot on Menachot 78a:10:1",), ['''מנחות דף עח ע"א תוס' ד"ה אחת''']],

--- a/sefaria/model/linker/tests/linker_test.py
+++ b/sefaria/model/linker/tests/linker_test.py
@@ -36,6 +36,7 @@ crrd = create_raw_ref_data
 
 
 @pytest.mark.parametrize(('resolver_data', 'expected_trefs'), [
+    [crrd(["@Torah"], lang='en'), tuple()],
     # Numbered JAs
     [crrd(["@Jerusalem", "@Talmud", "@Yoma", "#5a"], lang='en'), ("Jerusalem Talmud Yoma 1:1:20-25",)],
     [crrd(["@Babylonian", "@Talmud", "@Sukkah", "#49b"], lang='en'), ("Sukkah 49b",)],

--- a/sefaria/model/linker/tests/linker_test.py
+++ b/sefaria/model/linker/tests/linker_test.py
@@ -293,6 +293,7 @@ class TestResolveRawRef:
 
     pass
 
+
 @pytest.mark.parametrize(('context_tref', 'input_str', 'lang', 'expected_trefs', 'expected_pretty_texts'), [
     ["Berakhot 2a", 'It says in the Talmud, "Don\'t steal" which implies it\'s bad to steal.', 'en', tuple(), tuple()],  # Don't match Talmud using Berakhot 2a as ibid context
     [None, 'It says in the Torah, "Don\'t steal" which implies it\'s bad to steal.', 'en', tuple(), tuple()],
@@ -301,6 +302,7 @@ class TestResolveRawRef:
     [None, """גמ' במה מחנכין. עי' מנחות דף עח ע"א תוס' ד"ה אחת:""", 'he',("Tosafot on Menachot 78a:10:1",), ['''מנחות דף עח ע"א תוס' ד"ה אחת''']],
     [None, """cf. Ex. 9:6,5""", 'en', ("Exodus 9:6", "Exodus 9:5"), ['Ex. 9:6', '5']],
     ["Gilyon HaShas on Berakhot 25b:1", 'רש"י תמורה כח ע"ב ד"ה נעבד שהוא מותר. זה רש"י מאוד יפה.', 'he', ("Rashi on Temurah 28b:4:2",), ['רש"י תמורה כח ע"ב ד"ה נעבד שהוא מותר']],
+    [None, "See Genesis 1:1. It says in the Torah, \"Don't steal\". It also says in 1:3 \"Let there be light\".", "en", ("Genesis 1:1", "Genesis 1:3"), ("Genesis 1:1", "1:3")],
 ])
 def test_full_pipeline_ref_resolver(context_tref, input_str, lang, expected_trefs, expected_pretty_texts):
     context_oref = context_tref and Ref(context_tref)

--- a/sefaria/model/linker/tests/linker_test.py
+++ b/sefaria/model/linker/tests/linker_test.py
@@ -141,6 +141,7 @@ crrd = create_raw_ref_data
     [crrd(['#פרק ז'], prev_trefs=["II Kings 17:31"]), ["II Kings 7"]],
     [crrd(['@ערוך השולחן', '#תצג'], prev_trefs=["Arukh HaShulchan, Orach Chaim 400"]), ["Arukh HaShulchan, Orach Chaim 493"]],  # ibid named part that's not root
     [crrd(['@רש"י', '&שם'], prev_trefs=["Genesis 25:9", "Rashi on Genesis 21:20"]), ["Rashi on Genesis 21:20", "Rashi on Genesis 25:9"]],  # ambiguous ibid
+    [crrd(["@Job"], lang='en', prev_trefs=['Job 1:1']), ("Job",)],  # don't use ibid context if there's a match that uses all input
 
     # Relative (e.g. Lekaman)
     [crrd(["@תוס'", "<לקמן", "#ד ע\"ב", "*ד\"ה דאר\"י"], "Gilyon HaShas on Berakhot 2a:2"), ("Tosafot on Berakhot 4b:6:1",)],  # likaman + abbrev in DH

--- a/sefaria/model/linker/tests/resolved_category_test.py
+++ b/sefaria/model/linker/tests/resolved_category_test.py
@@ -1,0 +1,37 @@
+import pytest
+from unittest.mock import Mock
+from sefaria.model.linker.category_resolver import ResolvedCategory
+
+
+@pytest.fixture
+def mock_raw_ref():
+    return Mock()
+
+
+@pytest.fixture
+def mock_category():
+    return Mock()
+
+
+def test_is_ambiguous_with_single_category(mock_raw_ref, mock_category):
+    # Test when there is exactly one category
+    resolved_category = ResolvedCategory(mock_raw_ref, [mock_category])
+    assert not resolved_category.is_ambiguous
+
+
+def test_is_ambiguous_with_multiple_categories(mock_raw_ref, mock_category):
+    # Test when there are multiple categories
+    resolved_category = ResolvedCategory(mock_raw_ref, [mock_category, mock_category])
+    assert resolved_category.is_ambiguous
+
+
+def test_resolution_failed_with_no_categories(mock_raw_ref):
+    # Test when there are no categories
+    resolved_category = ResolvedCategory(mock_raw_ref, [])
+    assert resolved_category.resolution_failed
+
+
+def test_resolution_not_failed_with_categories(mock_raw_ref, mock_category):
+    # Test when there are one or more categories
+    resolved_category = ResolvedCategory(mock_raw_ref, [mock_category])
+    assert not resolved_category.resolution_failed

--- a/sefaria/model/schema.py
+++ b/sefaria/model/schema.py
@@ -14,6 +14,7 @@ import regex
 from . import abstract as abst
 from sefaria.system.database import db
 from sefaria.model.lexicon import LexiconEntrySet
+from sefaria.model.linker.has_match_template import HasMatchTemplates
 from sefaria.system.exceptions import InputError, IndexSchemaError, DictionaryEntryNotFoundError, SheetNotFoundError
 from sefaria.utils.hebrew import decode_hebrew_numeral, encode_small_hebrew_numeral, encode_hebrew_numeral, encode_hebrew_daf, hebrew_term, sanitize
 from sefaria.utils.talmud import daf_to_section
@@ -671,7 +672,7 @@ class TreeNode(object):
         return self.all_children().index(child) + 1
 
 
-class TitledTreeNode(TreeNode, AbstractTitledOrTermedObject):
+class TitledTreeNode(TreeNode, AbstractTitledOrTermedObject, HasMatchTemplates):
     """
     A tree node that has a collection of titles - as contained in a TitleGroup instance.
     In this class, node titles, terms, 'default', and combined titles are handled.
@@ -680,7 +681,6 @@ class TitledTreeNode(TreeNode, AbstractTitledOrTermedObject):
     after_title_delimiter_re = r"(?:[,.:\s]|(?:to|\u05d5?\u05d1?(?:\u05e1\u05d5\u05e3|\u05e8\u05d9\u05e9)))+"  # should be an arg?  \r\n are for html matches
     after_address_delimiter_ref = r"[,.:\s]+"
     title_separators = [", "]
-    MATCH_TEMPLATE_ALONE_SCOPES = {'any', 'alone'}
 
     def __init__(self, serial=None, **kwargs):
         super(TitledTreeNode, self).__init__(serial, **kwargs)
@@ -840,10 +840,6 @@ class TitledTreeNode(TreeNode, AbstractTitledOrTermedObject):
         """
         return self.title_group.add_title(text, lang, primary, replace_primary, presentation)
 
-    def get_match_template_trie(self, lang: str):
-        from .linker.match_template import MatchTemplateTrie
-        return MatchTemplateTrie(lang, nodes=[self], scope='combined')
-
     def validate(self):
         super(TitledTreeNode, self).validate()
 
@@ -895,17 +891,6 @@ class TitledTreeNode(TreeNode, AbstractTitledOrTermedObject):
             d["title"] = self.title_group.primary_title("en")
             d["heTitle"] = self.title_group.primary_title("he")
         return d
-
-    def get_match_templates(self):
-        from .linker.match_template import MatchTemplate
-        for raw_match_template in getattr(self, 'match_templates', []):
-            yield MatchTemplate(**raw_match_template)
-
-    def has_scope_alone_match_template(self):
-        """
-        @return: True if `self` has any match template that has scope = "alone" OR scope = "any"
-        """
-        return any(template.scope in self.MATCH_TEMPLATE_ALONE_SCOPES for template in self.get_match_templates())
 
     def get_referenceable_alone_nodes(self):
         """

--- a/sefaria/model/text.py
+++ b/sefaria/model/text.py
@@ -5761,15 +5761,13 @@ class Library(object):
         from .linker.match_template import MatchTemplateTrie
         from .linker.ref_resolver import RefResolver, TermMatcher
         from sefaria.model.schema import NonUniqueTermSet
-        from sefaria.model.category import CategorySet, Category
 
         root_nodes = list(filter(lambda n: getattr(n, 'match_templates', None) is not None, self.get_index_forest()))
         alone_nodes = reduce(lambda a, b: a + b.index.get_referenceable_alone_nodes(), root_nodes, [])
-        categories: list[Category] = CategorySet({"match_templates": {"$exists": True}}).array()
         non_unique_terms = NonUniqueTermSet()
 
         return RefResolver(
-           lang, MatchTemplateTrie(lang, nodes=(root_nodes + alone_nodes + categories), scope='alone'),
+           lang, MatchTemplateTrie(lang, nodes=(root_nodes + alone_nodes), scope='alone'),
            TermMatcher(lang, non_unique_terms),
         )
 

--- a/sefaria/model/text.py
+++ b/sefaria/model/text.py
@@ -5761,13 +5761,15 @@ class Library(object):
         from .linker.match_template import MatchTemplateTrie
         from .linker.ref_resolver import RefResolver, TermMatcher
         from sefaria.model.schema import NonUniqueTermSet
+        from sefaria.model.category import CategorySet, Category
 
         root_nodes = list(filter(lambda n: getattr(n, 'match_templates', None) is not None, self.get_index_forest()))
         alone_nodes = reduce(lambda a, b: a + b.index.get_referenceable_alone_nodes(), root_nodes, [])
+        categories: list[Category] = CategorySet({"match_templates": {"$exists": True}}).array()
         non_unique_terms = NonUniqueTermSet()
 
         return RefResolver(
-           lang, MatchTemplateTrie(lang, nodes=(root_nodes + alone_nodes), scope='alone'),
+           lang, MatchTemplateTrie(lang, nodes=(root_nodes + alone_nodes + categories), scope='alone'),
            TermMatcher(lang, non_unique_terms),
         )
 

--- a/sefaria/model/text.py
+++ b/sefaria/model/text.py
@@ -5733,7 +5733,8 @@ class Library(object):
         named_entity_resolver = self._build_named_entity_resolver(lang)
         ref_resolver = self._build_ref_resolver(lang)
         named_entity_recognizer = self._build_named_entity_recognizer(lang)
-        self._linker_by_lang[lang] = Linker(named_entity_recognizer, ref_resolver, named_entity_resolver)
+        cat_resolver = self._build_category_resolver(lang)
+        self._linker_by_lang[lang] = Linker(named_entity_recognizer, ref_resolver, named_entity_resolver, cat_resolver)
         return self._linker_by_lang[lang]
 
     @staticmethod
@@ -5756,6 +5757,12 @@ class Library(object):
             load_spacy_model(RAW_REF_MODEL_BY_LANG_FILEPATH[lang]),
             load_spacy_model(RAW_REF_PART_MODEL_BY_LANG_FILEPATH[lang])
         )
+
+    def _build_category_resolver(self, lang: str):
+        from sefaria.model.category import CategorySet, Category
+        from .linker.category_resolver import CategoryResolver, CategoryMatcher
+        categories: list[Category] = CategorySet({"match_templates": {"$exists": True}}).array()
+        return CategoryResolver(CategoryMatcher(lang, categories))
 
     def _build_ref_resolver(self, lang: str):
         from .linker.match_template import MatchTemplateTrie


### PR DESCRIPTION
## Description
Prevents categories and books from being caught using ibid context

## Code Changes
- adds `match_templates` to categories so they can be caught independently
- add `CategoryResolver` class to match categories
- use `CategoryResolver` on `Linker` to first find categories and only then look for citations. 
- refactor out methods relating to match templates from `TitledTreeNode` into interface `HasMatchTemplates` so it can be reused for any object that has match templates
- pull out `with_failures` variable from `RefResolver` so all logic is in `Linker`. This helps `Linker` use failed categories to still search for refs.

## Notes
_Any additional notes go here_