### PR TITLE
chore: break down ProfileSummary into logical components

### DIFF
--- a/static/js/ReaderPanel.jsx
+++ b/static/js/ReaderPanel.jsx
@@ -24,7 +24,7 @@ import TopicsPage from './TopicsPage';
 import CollectionPage from "./CollectionPage"
 import { NotificationsPanel } from './NotificationsPanel';
 import UserHistoryPanel  from './UserHistoryPanel';
-import UserProfile  from './UserProfile';
+import {UserProfile}  from './UserProfile';
 import CommunityPage  from './CommunityPage';
 import CalendarsPage from './CalendarsPage'
 import UserStats  from './UserStats';

--- a/static/js/UserProfile.jsx
+++ b/static/js/UserProfile.jsx
@@ -552,109 +552,118 @@ const EditorToggleHeader = ({usesneweditor}) => {
 }
 
 
-const ProfileSummary = ({ profile:p, follow, openFollowers, openFollowing, toggleSignUpModal }) => {
-  // collect info about this profile in `infoList`
-  const social = ['facebook', 'twitter', 'youtube', 'linkedin'];
-  let infoList = [];
-  if (p.location) { infoList.push(p.location); }
-  infoList = infoList.concat(p.jewish_education);
-  if (p.website) {
-    infoList.push(<span><a href={p.website} target="_blank"><InterfaceText>Website</InterfaceText></a></span>);
-  }
-  const socialList = social.filter(s => !!p[s]);
-  if (socialList.length) {
-    infoList = infoList.concat(
-      // we only store twitter handles so twitter needs to be hardcoded
-      <span>
+const ProfileBio = ({profile: p}) => {
+    // used in ProfileSummary and in SheetContentSidebar, renders user education, organization, and location info
+    const social = ['facebook', 'twitter', 'youtube', 'linkedin'];
+    let infoList = [];
+    if (p.location) {
+        infoList.push(p.location);
+    }
+    infoList = infoList.concat(p.jewish_education);
+    if (p.website) {
+        infoList.push(<span><a href={p.website} target="_blank"><InterfaceText>Website</InterfaceText></a></span>);
+    }
+    const socialList = social.filter(s => !!p[s]);
+    if (socialList.length) {
+        infoList = infoList.concat(
+            // we only store twitter handles so twitter needs to be hardcoded
+            <span>
         {
-          socialList.map(s => (<a key={s} className="social-icon" target="_blank" href={(s == 'twitter' ? 'https://twitter.com/' : '') + p[s]}><img src={`/static/img/${s}.svg`} /></a>))
+            socialList.map(s => (<a key={s} className="social-icon" target="_blank"
+                                    href={(s == 'twitter' ? 'https://twitter.com/' : '') + p[s]}><img
+                src={`/static/img/${s}.svg`}/></a>))
         }
       </span>
-    );
-  }
-  return (
-    <div className="profile-summary sans-serif">
-      <div className="summary-column profile-summary-content start">
-        <div className="title pageTitle">
-          <span className="int-en">{p.full_name}</span>
-          <span className="int-he">{p.full_name}</span>
-        </div>
-        { p.position || p.organization ?
-          <div className="title sub-title">
-            <span>{p.position}</span>
-            { p.position && p.organization ? <span>{ Sefaria._(" at ") }</span> : null }
-            <span>{p.organization}</span>
-          </div> : null
-        }
-        { infoList.length ?
-          <div className="title sub-sub-title">
-            {
-              infoList.map((i, ii) => (
-                <span key={ii}>
-                  { ii !== 0 ? '\u2022' : null }
-                  <span className="small-margin">{i}</span>
-                </span>
-              ))
-            }
-          </div> : null
-        }
-        {
-          Sefaria._uid === p.id ? (
-          <div className="profile-actions">
-            <a href="/settings/profile" className="resourcesLink sans-serif">
-              <span className="int-en">Edit Profile</span>
-              <span className="int-he">עריכת פרופיל</span>
-            </a>
-            <a href="/settings/account" className="resourcesLink sans-serif profile-settings">
-              <img src="/static/icons/settings.svg" alt="Profile Settings" />
-              <span className="int-en">Settings</span>
-              <span className="int-he">הגדרות</span>
-            </a>
-            <a href="/logout" className="button transparent logoutLink">
-              <span className="int-en">Log Out</span>
-              <span className="int-he">ניתוק</span>
-            </a>
-          </div>) : (
-          <div className="profile-actions">
-            <FollowButton
-              large={true}
-              uid={p.id}
-              following={Sefaria.following.indexOf(p.id) > -1}
-              toggleSignUpModal={toggleSignUpModal}
+        );
+    }
+    const subTitle = <div className="title sub-title">
+        <span>{p.position}</span>
+        {p.position && p.organization ? <span>{Sefaria._(" at ")}</span> : null}
+        <span>{p.organization}</span>
+    </div>;
+    const infoListComponent = <div className="title sub-sub-title">
+                                        {
+                                            infoList.map((i, ii) => (
+                                                <span key={ii}>
+                                                        {ii !== 0 && '\u2022'}
+                                                    <span className="small-margin">{i}</span>
+                                                </span>
+                                            ))
+                                        }
+                                    </div>;
+
+    return <>{(p.position || p.organization) && subTitle}
+             {infoList.length > 0 && infoListComponent}
+           </>;
+}
+const ProfileSummary = ({
+                            profile: p,
+                            openFollowers,
+                            openFollowing,
+                            toggleSignUpModal,
+                        }) => {
+    const followInfo = <div className="follow">
+                                 <a href="" onClick={openFollowers}>
+                                    <InterfaceText>{String(p.followers.length)}</InterfaceText>&nbsp;
+                                    <InterfaceText>followers</InterfaceText>
+                                 </a>
+                                 <span className="follow-bull">&bull;</span>
+                                 <a href="" onClick={openFollowing}>
+                                    <InterfaceText>{String(p.followees.length)}</InterfaceText>&nbsp;
+                                    <InterfaceText>following</InterfaceText>
+                                 </a>
+                             </div>;
+    const profileButtons = Sefaria._uid === p.id ? (
+                                    <div className="profile-actions">
+                                        <a href="/settings/profile" className="resourcesLink sans-serif">
+                                            <span className="int-en">Edit Profile</span>
+                                            <span className="int-he">עריכת פרופיל</span>
+                                        </a>
+                                        <a href="/settings/account" className="resourcesLink sans-serif profile-settings">
+                                            <img src="/static/icons/settings.svg" alt="Profile Settings"/>
+                                            <span className="int-en">Settings</span>
+                                            <span className="int-he">הגדרות</span>
+                                        </a>
+                                        <a href="/logout" className="button transparent logoutLink">
+                                            <span className="int-en">Log Out</span>
+                                            <span className="int-he">ניתוק</span>
+                                        </a>
+                                    </div>) : (
+                                    <div className="profile-actions">
+                                        <FollowButton
+                                            large={true}
+                                            uid={p.id}
+                                            following={Sefaria.following.indexOf(p.id) > -1}
+                                            toggleSignUpModal={toggleSignUpModal}
+                                        />
+                                    </div>);
+    const profileName = <div className="title pageTitle">
+                                    <span className="int-en">{p.full_name}</span>
+                                    <span className="int-he">{p.full_name}</span>
+                                </div>;
+    return (
+        <div className="profile-summary sans-serif">
+            <div className="summary-column profile-summary-content start">
+                {profileName}
+                <ProfileBio profile={p}/>
+                {profileButtons}
+                {followInfo}
+            </div>
+            <ProfilePic
+                url={p.profile_pic_url}
+                name={p.full_name}
+                len={175}
+                hideOnDefault={Sefaria._uid !== p.id}
+                showButtons={Sefaria._uid === p.id}
             />
-          </div>)
-        }
-        <div className="follow">
-          <a href="" onClick={openFollowers}>
-            <InterfaceText>{String(p.followers.length)}</InterfaceText>&nbsp;
-            <InterfaceText>followers</InterfaceText>
-          </a>
-          <span className="follow-bull">&bull;</span>
-          <a href="" onClick={openFollowing}>
-            <InterfaceText>{String(p.followees.length)}</InterfaceText>&nbsp;
-            <InterfaceText>following</InterfaceText>
-          </a>
         </div>
-      </div>
-      <div className="summary-column end">
-        <ProfilePic
-          url={p.profile_pic_url}
-          name={p.full_name}
-          len={175}
-          hideOnDefault={Sefaria._uid !== p.id}
-          showButtons={Sefaria._uid === p.id}
-        />
-      </div>
-    </div>
-  );
+    );
 };
 ProfileSummary.propTypes = {
-  profile:       PropTypes.object.isRequired,
-  follow:        PropTypes.func.isRequired,
-  openFollowers: PropTypes.func.isRequired,
-  openFollowing: PropTypes.func.isRequired,
-  toggleSignUpModal: PropTypes.func.isRequired,
+    profile: PropTypes.object.isRequired,
+    openFollowers: PropTypes.func,
+    openFollowing: PropTypes.func,
+    toggleSignUpModal: PropTypes.func.isRequired,
 };
 
-
-export default UserProfile;
+export {UserProfile, ProfileBio};


### PR DESCRIPTION
## Description
A fair amount of ProfileSummary could be re-used by the new Sheet Viewer sidebar which displays profile data.  I broke down ProfileSummary into logical components and re-used one of them, ProfileBio.

## Code Changes
1. ProfileBio is re-usable as in both UserProfile and Sheets Viewer, we want to display user education, organization, and location info.
2. The existing ProfileSummary return statement is 50 lines long.  I found this difficult to read, and so even though I couldn't re-use every aspect of ProfileSummary for the sheets viewer, I re-factored ProfileSummary so that we now have 3 new constants -- profileName, profileButtons, and followInfo -- that allowed me to reduce considerably the size of the return statement in ProfileSummary.  I didn't make these constants into their own components because (1) profileName is too simple to be its own component and (2) profileButtons and followInfo do not conform to the spec for the sheets viewer profile.