### PR TITLE
Version with alt title

### DIFF
--- a/sefaria/export.py
+++ b/sefaria/export.py
@@ -726,7 +726,11 @@ def _import_versions_from_csv(rows, columns, user_id):
     from sefaria.tracker import modify_bulk_text
 
     index_title = rows[0][columns[0]]  # assume the same index title for all
-    index_node = Ref(index_title).index_node
+    index = Index().load({'title': index_title})
+    if index:
+        index_node = index.nodes
+    else:
+        raise InputError(f'No book with primary title "{index_title}"')
 
 
     action = "edit"

--- a/sefaria/model/text.py
+++ b/sefaria/model/text.py
@@ -1412,7 +1412,7 @@ class Version(AbstractTextRecord, abst.AbstractMongoRecord, AbstractSchemaConten
         pass
 
     def get_index(self):
-        return library.get_index(self.title)
+        return Index().load({'title': self.title})
 
     def first_section_ref(self):
         """


### PR DESCRIPTION
## Description
Versions should use only primary title of indexes and not alt titles (alts are not unique).

## Code Changes
1. Get the Index from Version by Index().load() rather than library.get_index
2. When saving version from a csv file, check for index with the primary title (rather than getting it by Ref), and if doesn't exist raise an InputError with clear message.