### PR TITLE
Fix topics analytics undefined index

### DIFF
--- a/build/linker/Dockerfile
+++ b/build/linker/Dockerfile
@@ -38,7 +38,7 @@ RUN apt-get update -qq \
  && rm -rf /var/lib/apt/lists/*
 
 # fix issues with shared objects
-RUN ls /usr/local/cuda-11.6/targets/x86_64-linux/lib/* | xargs -I{} ln -s {} /usr/lib/x86_64-linux-gnu/ \
+RUN ls /usr/local/cuda-11.4/targets/x86_64-linux/lib/* | xargs -I{} ln -s {} /usr/lib/x86_64-linux-gnu/ \
  && ln -s libcuda.so /usr/lib/x86_64-linux-gnu/libcuda.so.1 \
  && ln -s libnvidia-ml.so /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1
 

--- a/static/js/TopicPage.jsx
+++ b/static/js/TopicPage.jsx
@@ -168,7 +168,7 @@ const _extractAnalyticsDataFromRef = ref => {
     return {
         item_id: ref,
         content_id: title,
-        content_type: Sefaria.index(title).categories.join('|'),
+        content_type: Sefaria.index(title)?.categories?.join('|'),
     };
 };
 const refRenderWrapper = (toggleSignUpModal, topicData, topicTestVersion, langPref, isAdmin, displayDescription, hideLanguageMissingSources) => (item, index) => {


### PR DESCRIPTION
## Description
Currently analytics tracking on topics pages tries to extract the categories of each ref on the topics page. This causes the whole site to crash if a single ref has a parsing issue. Instead, we'll use optional chaining to avoid a hard crash in this case.