### PR TITLE
Change donation links to not use use short names

### DIFF
--- a/static/js/StaticPages.jsx
+++ b/static/js/StaticPages.jsx
@@ -1437,8 +1437,8 @@ const DonatePage = () => (
                 heText=""
                 enButtonText="Donate Now"
                 heButtonText=""
-                enButtonUrl="https://donate.sefaria.org/english?c_src=waystogive"
-                heButtonUrl="https://donate.sefaria.org/he?c_src=waystogive"
+                enButtonUrl="https://donate.sefaria.org/give/451346/#!/donation/checkout?c_src=ways-to-give"
+                heButtonUrl="https://donate.sefaria.org/give/468442/#!/donation/checkout?c_src=ways-to-give"
                 borderColor="#004E5F"
             />,
             <FeatureBox
@@ -1448,8 +1448,8 @@ const DonatePage = () => (
                 heText=""
                 enButtonText="Join the Sustainers"
                 heButtonText=""
-                enButtonUrl="https://donate.sefaria.org/sustainers?c_src=waystogive"
-                heButtonUrl="https://donate.sefaria.org/sustainershe?c_src=waystogive"
+                enButtonUrl="https://donate.sefaria.org/give/457760/#!/donation/checkout?c_src=waystogive"
+                heButtonUrl="https://donate.sefaria.org/give/478929/#!/donation/checkout?c_src=waystogive"
                 borderColor="#97B386"
             />,
             <FeatureBox
@@ -1459,8 +1459,8 @@ const DonatePage = () => (
                 heText=""
                 enButtonText="Sponsor a Day of Learning"
                 heButtonText=""
-                enButtonUrl="https://donate.sefaria.org/sponsor?c_src=waystogive"
-                heButtonUrl="https://donate.sefaria.org/sponsorhe?c_src=waystogive"
+                enButtonUrl="https://donate.sefaria.org/campaign/sponsor-a-day-of-learning/c460961?c_src=waystogive"
+                heButtonUrl="https://donate.sefaria.org/campaign/sponsor-a-day-of-learning-hebrew/c479003?c_src=waystogive"
                 borderColor="#4B71B7"
             />,
             <FeatureBox
@@ -1493,7 +1493,7 @@ const DonatePage = () => (
                 <HeaderWithColorAccentBlockAndText
                     enTitle="Donate Online"
                     heTitle=""
-                    enText="<p>Make a donation by <strong>credit card, PayPal, GooglePay, ApplePay, Venmo, or bank transfer</strong> on our <a href='http://donate.sefaria.org/english'>main donation page</a>.</p>"
+                    enText="<p>Make a donation by <strong>credit card, PayPal, GooglePay, ApplePay, Venmo, or bank transfer</strong> on our <a href='https://donate.sefaria.org/give/451346/#!/donation/checkout?c_src=waystogive'>main donation page</a>.</p>"
                     heText=""
                     colorBar="#AB4E66"
                 />,
@@ -1566,7 +1566,7 @@ const DonatePage = () => (
         <Accordian
             enTitle="Can I make a gift to support a specific program or initiative?"
             heTitle=""
-            enText="<p>Our online giving page does not support restricted gifts. You can sponsor a day of learning <a href='https://donate.sefaria.org/sponsor'>here</a>. If you would like to sponsor a text or support a specific Sefaria program, please email Samantha Shokin, Grant Writer and Development Associate, at <a href='mailto:samantha@sefaria.org'>samantha@sefaria.org</a> for more information.</p>"
+            enText="<p>Our online giving page does not support restricted gifts. You can sponsor a day of learning <a href='https://donate.sefaria.org/campaign/sponsor-a-day-of-learning/c460961?c_src=waystogive'>here</a>. If you would like to sponsor a text or support a specific Sefaria program, please email Samantha Shokin, Grant Writer and Development Associate, at <a href='mailto:samantha@sefaria.org'>samantha@sefaria.org</a> for more information.</p>"
             heText=""
             colorBar="#B8D4D3"
         />
@@ -1605,7 +1605,7 @@ const DonatePage = () => (
         <Accordian
             enTitle="Can I still donate from outside the USA?"
             heTitle=""
-            enText="<p>Yes! Donors outside of the USA may make a gift online  – via credit card, PayPal, GooglePay, ApplePay, Venmo, and bank transfer – <a href='https://donate.sefaria.org/english'>on this page</a> On this page you can modify your currency. You can also <a href='https://sefaria.formstack.com/forms/wire_request'>make a wire transfer</a>.</p>"
+            enText="<p>Yes! Donors outside of the USA may make a gift online  – via credit card, PayPal, GooglePay, ApplePay, Venmo, and bank transfer – <a href='https://donate.sefaria.org/give/451346/#!/donation/checkout?c_src=waystogive'>on this page</a> On this page you can modify your currency. You can also <a href='https://sefaria.formstack.com/forms/wire_request'>make a wire transfer</a>.</p>"
             heText=""
             colorBar="#7F85A9"
         />

--- a/templates/static/he/ways-to-give.html
+++ b/templates/static/he/ways-to-give.html
@@ -42,7 +42,7 @@
                 </span>
             </p>
             <div class="single-button center">
-                <a class="button big blue control-elem" role="button" href="https://donate.sefaria.org/he" target="_blank">
+                <a class="button big blue control-elem" role="button" href="https://donate.sefaria.org/give/468442/#!/donation/checkout?c_src=waystogive" target="_blank">
                     <span class="int-he">לתרומה</span>
                 </a>
             </div>
@@ -56,7 +56,7 @@
             <section>
                 <p>
                     <span class="int-he">
-                        הצטרפות <a href="https://donate.sefaria.org/sustainershe" target="_blank">לקהילת התומכים של ספריא על ידי תרומה חודשית</a>
+                        הצטרפות <a href="https://donate.sefaria.org/give/478929/#!/donation/checkout?c_src=waystogive" target="_blank">לקהילת התומכים של ספריא על ידי תרומה חודשית</a>
                      </span>
                 </p>
                 <p class="givingOpportunitiesDesc">
@@ -69,7 +69,7 @@
             <section>
                 <p>
                     <span class="int-he">
-                        <a href="https://donate.sefaria.org/sponsorhe" target="_blank">הקדשה אישית ליום, שבוע או חודש של לימוד</a>
+                        <a href="https://donate.sefaria.org/campaign/sponsor-a-day-of-learning-hebrew/c479003?c_src=waystogive" target="_blank">הקדשה אישית ליום, שבוע או חודש של לימוד</a>
                      </span>
                 </p>
                 <p class="givingOpportunitiesDesc">
@@ -92,7 +92,7 @@
                 </h3>
                 <p>
                     <span class="int-he">
-                        תרומה דרך <a href="https://donate.sefaria.org/he" target="_blank">עמוד התרומות הראשי שלנו</a> הפועל באמצעות <bdi>Stripe</bdi>.
+                        תרומה דרך <a href="https://donate.sefaria.org/give/468442/#!/donation/checkout?c_src=waystogive" target="_blank">עמוד התרומות הראשי שלנו</a> הפועל באמצעות <bdi>Stripe</bdi>.
                     </span>
                 </p>
             </section>


### PR DESCRIPTION
## Description
Using Classy's short name URLs prevents the the channel source codes from being parsed by Classy's tracking system. Classy URLs need to use the full form actual URLs instead of the short name aliases

## Code Changes
This changes all the URLs to use the actual URL instead of the short name alias with the channel source codes attached