### PR TITLE
Tests verifying basic topic page functionality

### DIFF
--- a/.github/workflows/integration-testing.yaml
+++ b/.github/workflows/integration-testing.yaml
@@ -193,7 +193,12 @@ jobs:
       
       - name: Run Playwright tests
         run: npx playwright test
-      
+        env:
+          PLAYWRIGHT_SUPERUSER_EMAIL: "${{ secrets.PLAYWRIGHT_SUPERUSER_EMAIL }}"
+          PLAYWRIGHT_SUPERUSER_PASSWORD: "${{ secrets.PLAYWRIGHT_SUPERUSER_PASSWORD }}"
+          PLAYWRIGHT_USER_EMAIL: "${{ secrets.PLAYWRIGHT_USER_EMAIL }}"
+          PLAYWRIGHT_USER_PASSWORD: "${{ secrets.PLAYWRIGHT_USER_PASSWORD }}"
+
       - name: Upload Playwright report
         uses: actions/upload-artifact@v3
         if: always()

--- a/e2e-tests/globals.ts
+++ b/e2e-tests/globals.ts
@@ -15,3 +15,8 @@ export const testUser = {
     email: 'test@example.com',
     password: 'test',
 }
+
+export const testAdminUser = {
+    email: process.env.ADMIN_EMAIL,
+    password: process.env.ADMIN_PASSWORD,
+};

--- a/e2e-tests/globals.ts
+++ b/e2e-tests/globals.ts
@@ -12,11 +12,11 @@ export const cookieObject = {
 }
 
 export const testUser = {
-    email: 'test@example.com',
-    password: 'test',
+    email: process.env.PLAYWRIGHT_USER_EMAIL,
+    password: process.env.PLAYWRIGHT_USER_PASSWORD,
 }
 
 export const testAdminUser = {
-    email: process.env.ADMIN_EMAIL,
-    password: process.env.ADMIN_PASSWORD,
+    email: process.env.PLAYWRIGHT_SUPERUSER_EMAIL,
+    password: process.env.PLAYWRIGHT_SUPERUSER_PASSWORD,
 };

--- a/e2e-tests/tests/topics.spec.ts
+++ b/e2e-tests/tests/topics.spec.ts
@@ -1,6 +1,7 @@
-import { test } from '@playwright/test';
-import {goToPageWithLang} from '../utils';
-import {LANGUAGES} from "../globals";
+import {expect, test} from '@playwright/test';
+import {goToPageWithLang, goToPageWithUser} from '../utils';
+import {LANGUAGES, testAdminUser} from "../globals";
+import * as assert from "node:assert";
 
 
 test('Go to topic page', async ({ context }) => {
@@ -15,6 +16,15 @@ test('Check source', async ({ context }) => {
   await page.getByRole('link', { name: 'Shabbat' }).first().click();
   await page.getByRole('link', { name: 'Notable Sources' }).first().isVisible();
   await page.getByRole('link', { name: 'All Sources' }).first().isVisible();
+});
+
+test('Check admin tab', async ({ context }) => {
+  const page = await goToPageWithUser(context, '/topics', testAdminUser);
+  await page.getByRole('link', { name: 'Jewish Calendar' }).click();
+  await page.getByRole('link', { name: 'Shabbat' }).first().click();
+  await page.getByRole('link', { name: 'Notable Sources' }).first().isVisible();
+  await page.getByRole('link', { name: 'All Sources' }).first().isVisible();
+  await page.getByRole('link', { name: 'Admin' }).first().isVisible();
 });
 
 test('Check sources he interface', async ({ context }) => {
@@ -32,8 +42,20 @@ test('Check author page', async ({ context }) => {
 
 test('Check redirection for sourcesless topic', async ({ context }) => {
   const page = await goToPageWithLang(context, '/topics/Monkey');
-  await page.waitForURL('https://example.com/target', { timeout: 5000 });
-  await page.getByRole('link', { name: 'Works on Sefaria' }).first().isVisible();
+  // await page.waitForURL('https://www.sefaria.org/search?q=Monkey&tab=sheet&tvar=1&tsort=relevance&stopics_enFilters=Monkey&svar=1&ssort=relevance', { timeout: 50000 });
+  const expectedUrl = 'https://www.sefaria.org/search?q=Monkey&tab=sheet&tvar=1&tsort=relevance&stopics_enFilters=Monkey&svar=1&ssort=relevance'
+  // await expect(page).toHaveURL(expectedUrl, { timeout: 90000 });
+  await page.waitForTimeout(10000)
+  expect(page.url()).toEqual(expectedUrl)
+  // await page.waitForURL(expectedUrl,  { timeout: 100000 });
+});
+
+test('Check no redirection when user is admin', async ({ context }) => {
+  const page = await goToPageWithUser(context, '/topics/Monkey', testAdminUser);
+  await page.waitForTimeout(2000)
+  await page.getByRole('link', { name: 'Admin' }).first().isVisible();
+
+
 });
 
 test('Filter topics', async ({ context }) => {

--- a/e2e-tests/tests/topics.spec.ts
+++ b/e2e-tests/tests/topics.spec.ts
@@ -42,20 +42,15 @@ test('Check author page', async ({ context }) => {
 
 test('Check redirection for sourcesless topic', async ({ context }) => {
   const page = await goToPageWithLang(context, '/topics/Monkey');
-  // await page.waitForURL('https://www.sefaria.org/search?q=Monkey&tab=sheet&tvar=1&tsort=relevance&stopics_enFilters=Monkey&svar=1&ssort=relevance', { timeout: 50000 });
   const expectedUrl = 'https://www.sefaria.org/search?q=Monkey&tab=sheet&tvar=1&tsort=relevance&stopics_enFilters=Monkey&svar=1&ssort=relevance'
-  // await expect(page).toHaveURL(expectedUrl, { timeout: 90000 });
   await page.waitForTimeout(10000)
   expect(page.url()).toEqual(expectedUrl)
-  // await page.waitForURL(expectedUrl,  { timeout: 100000 });
 });
 
 test('Check no redirection when user is admin', async ({ context }) => {
   const page = await goToPageWithUser(context, '/topics/Monkey', testAdminUser);
-  await page.waitForTimeout(2000)
+  await page.waitForTimeout(10000)
   await page.getByRole('link', { name: 'Admin' }).first().isVisible();
-
-
 });
 
 test('Filter topics', async ({ context }) => {

--- a/e2e-tests/tests/topics.spec.ts
+++ b/e2e-tests/tests/topics.spec.ts
@@ -40,7 +40,7 @@ test('Check author page', async ({ context }) => {
   await page.getByRole('link', { name: 'Works on Sefaria' }).first().isVisible();
 });
 
-test('Check redirection for sourcesless topic', async ({ context }) => {
+test('Check redirection for sourceless topic', async ({ context }) => {
   const page = await goToPageWithLang(context, '/topics/Monkey');
   const expectedUrl = 'https://www.sefaria.org/search?q=Monkey&tab=sheet&tvar=1&tsort=relevance&stopics_enFilters=Monkey&svar=1&ssort=relevance'
   await page.waitForTimeout(10000)

--- a/e2e-tests/tests/topics.spec.ts
+++ b/e2e-tests/tests/topics.spec.ts
@@ -1,5 +1,6 @@
 import { test } from '@playwright/test';
 import {goToPageWithLang} from '../utils';
+import {LANGUAGES} from "../globals";
 
 
 test('Go to topic page', async ({ context }) => {
@@ -8,6 +9,32 @@ test('Go to topic page', async ({ context }) => {
   await page.getByRole('link', { name: 'Rosh Hashanah' }).first().isVisible();
 });
 
+test('Check source', async ({ context }) => {
+  const page = await goToPageWithLang(context, '/topics');
+  await page.getByRole('link', { name: 'Jewish Calendar' }).click();
+  await page.getByRole('link', { name: 'Shabbat' }).first().click();
+  await page.getByRole('link', { name: 'Notable Sources' }).first().isVisible();
+  await page.getByRole('link', { name: 'All Sources' }).first().isVisible();
+});
+
+test('Check sources he interface', async ({ context }) => {
+  const page = await goToPageWithLang(context, '/topics', LANGUAGES.HE);
+  await page.getByRole('link', { name: 'מועדי השנה' }).click();
+  await page.getByRole('link', { name: 'שבת' }).first().click();
+  await page.getByRole('link', { name: 'מקורות מרכזיים' }).first().isVisible();
+  await page.getByRole('link', { name: 'כל המקורות' }).first().isVisible();
+});
+
+test('Check author page', async ({ context }) => {
+  const page = await goToPageWithLang(context, '/topics/jonathan-sacks');
+  await page.getByRole('link', { name: 'Works on Sefaria' }).first().isVisible();
+});
+
+test('Check redirection for sourcesless topic', async ({ context }) => {
+  const page = await goToPageWithLang(context, '/topics/Monkey');
+  await page.waitForURL('https://example.com/target', { timeout: 5000 });
+  await page.getByRole('link', { name: 'Works on Sefaria' }).first().isVisible();
+});
 
 test('Filter topics', async ({ context }) => {
   const page = await goToPageWithLang(context, '/topics/all/a');


### PR DESCRIPTION
## Description
Tests to verify the basic functionality of topic pages, ensuring that user information depends on environment variables and is not exposed.

## Code Changed
Added tests to e2e-tests/tests/topics.spec.ts simulating accessing topic pages as a normal and super user in en and he interfaces, vertifying that a redirect happens when a sourceless topic mage is visited in non-superuser mode.
In addition,  created testUser and testAdminUser objects in e2e-tests/globals.ts making them rely on env var data