### PR TITLE
Products Page: Fix Hebrew mobile typo

### DIFF
--- a/static/js/StaticPages.jsx
+++ b/static/js/StaticPages.jsx
@@ -3437,7 +3437,7 @@ const ProductsPage = memo(() => {
         <>
                 <h1 className="mobileAboutHeader">
                     <span className="int-en">Sefaria's Products</span>
-                    <span className="int-he">מוצרים של בספריא</span>
+                    <span className="int-he">המוצרים של ספריא</span>
                 </h1>
             <div className='productsFlexWrapper'>
                 {products && products.length > 0  ? (


### PR DESCRIPTION
## Description
The Hebrew mobile title displayed מוצרים של ספריא instead of המוצרים של ספריא. This code corrected the Hebrew copy. Web was unaffected, since no page title for the web display. 

## Code Changes
1. `static/js/StaticPages.jsx` - Fixed Hebrew copy