### PR TITLE
feat: [sc-29651] Remove numerals from Moreh Nevukhim

### DIFF
--- a/static/js/TextRange.jsx
+++ b/static/js/TextRange.jsx
@@ -309,8 +309,7 @@ class TextRange extends Component {
     }
     const formatEnAsPoetry = data && data.formatEnAsPoetry
     const formatHeAsPoetry = data && data.formatHeAsPoetry
-
-    const showNumberLabel =  data && data.categories &&
+    const showNumberLabel =  data && data.categories && !data.ref.startsWith("Guide for the Perplexed") &&
                               data.categories[0] !== "Liturgy" &&
                               data.categories[0] !== "Reference";
 


### PR DESCRIPTION
# Description
We want to add an exception for Guide for the Perplexed so that segment numbers don't show for the text.