### PR TITLE
fix(search): increase the amount of RAM the reindex elastic search cr…

### DIFF
--- a/helm-chart/sefaria-project/templates/cronjob/reindex-elasticsearch.yaml
+++ b/helm-chart/sefaria-project/templates/cronjob/reindex-elasticsearch.yaml
@@ -28,7 +28,7 @@ spec:
             image: "{{ .Values.web.containerImage.imageRegistry }}:{{ .Values.web.containerImage.tag }}"
             resources:
               limits:
-                memory: 9Gi
+                memory: 10Gi
               requests:
                 memory: 7Gi
             env:


### PR DESCRIPTION
…onjob needs so that it avoids an OOM error. The job slowly over time requires more RAM as we add more texts.