### PR TITLE
`bulktext` API Correct Handlings of 1/0 Booleans

### DIFF
--- a/sefaria/views.py
+++ b/sefaria/views.py
@@ -470,7 +470,7 @@ def bulktext_api(request, refs):
         g = lambda x: request.GET.get(x, None)
         min_char = int(g("minChar")) if g("minChar") else None
         max_char = int(g("maxChar")) if g("maxChar") else None
-        res = bundle_many_texts(refs, g("useTextFamily"), g("asSizedString"), min_char, max_char, g("transLangPref"), g("ven"), g("vhe"))
+        res = bundle_many_texts(refs, int(g("useTextFamily")), g("asSizedString"), min_char, max_char, g("transLangPref"), g("ven"), g("vhe"))
         resp = jsonResponse(res, cb)
         return resp
 


### PR DESCRIPTION
## Description
We had recently corrected a bug throughout the API which incorrectly handled boolean parameters being passed as 0s or 1s. They were handled as strings, and therefore constantly evaluating as `true` and causing unexpected behavior, we made an effort to make sure they were all properly being passed as ints. This PR fixes one instance that was missed in that initial sweep - based on user feedback. 

## Code Changes
1. `sefaria/views.py` - Cast the `useTextFamily` param results to an int. 

## Notes
- Tested locally and works. When set to `1`, the response includes the primary category of the text. 