### PR TITLE
Naming Clean Up

### DIFF
--- a/static/js/AboutBox.jsx
+++ b/static/js/AboutBox.jsx
@@ -5,7 +5,7 @@ import VersionBlock, {VersionsBlocksList} from './VersionBlock/VersionBlock';
 import Component             from 'react-class';
 import {InterfaceText} from "./Misc";
 import {ContentText} from "./ContentText";
-import { Modules } from './NavSidebar';
+import { SidebarModules } from './NavSidebar';
 
 
 class AboutBox extends Component {
@@ -232,8 +232,8 @@ class AboutBox extends Component {
           (<div>{versionSectionEn}{versionSectionHe}{alternateSectionHe}</div>) :
           (<div>{versionSectionHe}{versionSectionEn}{alternateSectionHe}</div>)
         }
-        <Modules type={"RelatedTopics"} props={{title: this.props.title}} />
-        { !isDictionary ? <Modules type={"DownloadVersions"} props={{sref: this.props.title}} /> : null}
+        <SidebarModules type={"RelatedTopics"} props={{title: this.props.title}} />
+        { !isDictionary ? <SidebarModules type={"DownloadVersions"} props={{sref: this.props.title}} /> : null}
       </section>
     );
   }

--- a/static/js/BookPage.jsx
+++ b/static/js/BookPage.jsx
@@ -19,7 +19,7 @@ import React, { useState, useRef }  from 'react';
 import ReactDOM  from 'react-dom';
 import $  from './sefaria/sefariaJquery';
 import Sefaria  from './sefaria/sefaria';
-import { NavSidebar, Modules } from './NavSidebar';
+import { NavSidebar, SidebarModules } from './NavSidebar';
 import DictionarySearch  from './DictionarySearch';
 import VersionBlock  from './VersionBlock/VersionBlock';
 import ExtendedNotes from './ExtendedNotes';
@@ -272,7 +272,7 @@ class BookPage extends Component {
 
                 {this.props.multiPanel ? null :
                 <div className="about">
-                  <Modules type={"AboutText"} props={{index: this.state.indexDetails, hideTitle: true}} />
+                  <SidebarModules type={"AboutText"} props={{index: this.state.indexDetails, hideTitle: true}} />
                 </div>}
 
                  <TabView
@@ -303,7 +303,7 @@ class BookPage extends Component {
               }
             </div>
             {this.isBookToc() && ! this.props.compare ? 
-            <NavSidebar modules={sidebarModules} /> : null}
+            <NavSidebar sidebarModules={sidebarModules} /> : null}
           </div>
           {this.isBookToc() && ! this.props.compare ?
           <Footer /> : null}

--- a/static/js/CalendarsPage.jsx
+++ b/static/js/CalendarsPage.jsx
@@ -6,7 +6,7 @@ import React, { useState } from 'react';
 import classNames  from 'classnames';
 import Sefaria  from './sefaria/sefaria';
 import $  from './sefaria/sefariaJquery';
-import { NavSidebar, Modules }from './NavSidebar';
+import { NavSidebar, SidebarModules }from './NavSidebar';
 import Footer  from './Footer';
 import Component from 'react-class';
 

--- a/static/js/CalendarsPage.jsx
+++ b/static/js/CalendarsPage.jsx
@@ -28,7 +28,7 @@ const CalendarsPage = ({multiPanel, initialWidth}) => {
   const weeklyListings  = makeListings(weeklyCalendars);
 
   const about = multiPanel ? null :
-    <Modules type={"AboutLearningSchedules"} />
+    <SidebarModules type={"AboutLearningSchedules"} />
 
   const sidebarModules = [
     multiPanel ? {type: "AboutLearningSchedules"} : {type: null},
@@ -56,7 +56,7 @@ const CalendarsPage = ({multiPanel, initialWidth}) => {
               <ResponsiveNBox content={weeklyListings} initialWidth={initialWidth} />
             </div>
           </div>
-          <NavSidebar modules={sidebarModules} />
+          <NavSidebar sidebarModules={sidebarModules} />
         </div>
         <Footer />
       </div>

--- a/static/js/CollectionPage.jsx
+++ b/static/js/CollectionPage.jsx
@@ -294,7 +294,7 @@ class CollectionPage extends Component {
             <div className="contentInner">
               {content}
             </div>
-            <NavSidebar modules={sidebarModules} />
+            <NavSidebar sidebarModules={sidebarModules} />
           </div>
           <Footer />
         </div>

--- a/static/js/CommunityPage.jsx
+++ b/static/js/CommunityPage.jsx
@@ -4,7 +4,7 @@ import $ from './sefaria/sefariaJquery';
 import Sefaria from './sefaria/sefaria';
 import PropTypes from 'prop-types';
 import classNames  from 'classnames';
-import { NavSidebar, Modules } from './NavSidebar';
+import { NavSidebar, SidebarModules } from './NavSidebar';
 import Footer from'./Footer';
 import {
   InterfaceText,
@@ -62,7 +62,7 @@ const CommunityPage = ({multiPanel, toggleSignUpModal, initialWidth}) => {
             <RecentlyPublished multiPanel={multiPanel} toggleSignUpModal={toggleSignUpModal} />
 
           </div>
-          <NavSidebar modules={sidebarModules} />
+          <NavSidebar sidebarModules={sidebarModules} />
         </div>
         <Footer />
       </div>
@@ -103,7 +103,7 @@ const RecentlyPublished = ({multiPanel, toggleSignUpModal}) => {
           recentSheets.map(s => <FeaturedSheet sheet={s} showDate={true} toggleSignUpModal={toggleSignUpModal} />);
   const joinTheConversation = (
     <div className="navBlock">
-      <Modules type={"JoinTheConversation"} props={{wide:multiPanel}} />
+      <SidebarModules type={"JoinTheConversation"} props={{wide:multiPanel}} />
     </div>
   );
   if (recentSheets) {

--- a/static/js/NavSidebar.jsx
+++ b/static/js/NavSidebar.jsx
@@ -7,10 +7,10 @@ import {InterfaceText, ProfileListing, Dropdown} from './Misc';
 import { Promotions } from './Promotions'
 import {SignUpModalKind} from "./sefaria/signupModalContent";
 
-const NavSidebar = ({modules}) => {
+const NavSidebar = ({sidebarModules}) => {
   return <div className="navSidebar sans-serif">
-    {modules.map((m, i) =>
-      <Modules
+    {sidebarModules.map((m, i) =>
+      <SidebarModules
         type={m.type}
         props={m.props || {}}
         key={i} />
@@ -19,7 +19,7 @@ const NavSidebar = ({modules}) => {
 };
 
 
-const Modules = ({type, props}) => {
+const SidebarModules = ({type, props}) => {
   // Choose the appropriate module component to render by `type`
   const moduleTypes = {
     "AboutSefaria":           AboutSefaria,
@@ -59,18 +59,18 @@ const Modules = ({type, props}) => {
     "StudyCompanion":        StudyCompanion,
   };
   if (!type) { return null; }
-  const ModuleType = moduleTypes[type];
-  return <ModuleType {...props} />
+  const SidebarModuleType = moduleTypes[type];
+  return <SidebarModuleType {...props} />
 };
 
 
-const Module = ({children, blue, wide}) => {
+const SidebarModule = ({children, blue, wide}) => {
   const classes = classNames({navSidebarModule: 1, "sans-serif": 1, blue, wide});
   return <div className={classes}>{children}</div>
 };
 
 
-const ModuleTitle = ({children, en, he, h1}) => {
+const SidebarModuleTitle = ({children, en, he, h1}) => {
   const content = children ?
     <InterfaceText>{children}</InterfaceText>
     : <InterfaceText text={{en, he}} />;
@@ -82,10 +82,10 @@ const ModuleTitle = ({children, en, he, h1}) => {
 
 
 const TitledText = ({enTitle, heTitle, enText, heText}) => {
-  return <Module>
-    <ModuleTitle en={enTitle} he={heTitle} />
+  return <SidebarModule>
+    <SidebarModuleTitle en={enTitle} he={heTitle} />
     <InterfaceText markdown={{en: enText, he: heText}} />
-  </Module>
+  </SidebarModule>
 };
 
 const RecentlyViewedItem = ({oref}) => {
@@ -136,27 +136,27 @@ const RecentlyViewed = ({toggleSignUpModal, mobile}) => {
    }
    const allHistoryPhrase = mobile ? "All History" : "All history ";
    const recentlyViewedList = <RecentlyViewedList items={recentlyViewedItems}/>;
-   return <Module>
+   return <SidebarModule>
             <div className="recentlyViewed">
                 <div id="header">
-                  <ModuleTitle h1={true}>Recently Viewed</ModuleTitle>
+                  <SidebarModuleTitle h1={true}>Recently Viewed</SidebarModuleTitle>
                   {!mobile && recentlyViewedList}
                   <a href="/texts/history" id="history" onClick={handleAllHistory}><InterfaceText>{allHistoryPhrase}</InterfaceText></a>
                 </div>
                 {mobile && recentlyViewedList}
             </div>
-          </Module>;
+          </SidebarModule>;
 }
 
 const Promo = () =>
-    <Module>
+    <SidebarModule>
         <Promotions adType="sidebar"/>
-    </Module>
+    </SidebarModule>
 ;
 
 const StudyCompanion = () => (
-    <Module>
-        <ModuleTitle>Study Companion</ModuleTitle>
+    <SidebarModule>
+        <SidebarModuleTitle>Study Companion</SidebarModuleTitle>
         <div><InterfaceText>Get the Weekly Parashah Study Companion in your inbox.</InterfaceText></div>
         <a className="button small"
            data-anl-event="select_promotion:click|view_promotion:scrollIntoView"
@@ -165,14 +165,14 @@ const StudyCompanion = () => (
             <img src="/static/icons/email-newsletter.svg" alt="Sign up for our weekly parashah study companion"/>
             <InterfaceText>Sign Up</InterfaceText>
         </a>
-    </Module>
+    </SidebarModule>
 )
 
 
 const AboutSefaria = ({hideTitle}) => (
-    <Module>
+    <SidebarModule>
         {!hideTitle ?
-            <ModuleTitle h1={true}>A Living Library of Torah</ModuleTitle> : null}
+            <SidebarModuleTitle h1={true}>A Living Library of Torah</SidebarModuleTitle> : null}
         <InterfaceText>
             <EnglishText>
                 Sefaria is home to 3,000 years of Jewish texts. We are a nonprofit organization offering free access to texts, translations,
@@ -209,7 +209,7 @@ const AboutSefaria = ({hideTitle}) => (
           </HebrewText>
       </InterfaceText>
     }
-  </Module>
+  </SidebarModule>
 );
 
 
@@ -230,9 +230,9 @@ const AboutTranslatedText = ({translationsSlug}) => {
     "yi": {title: "א לעבעדיקע ביבליאטעק פון תורה", body: "אין ספֿריאַ איז אַ היים פֿון 3,000 יאָר ייִדישע טעקסטן. מיר זענען אַ נאַן-נוץ אָרגאַניזאַציע וואָס אָפפערס פריי אַקסעס צו טעקסטן, איבערזעצונגען און קאָמענטאַרן אַזוי אַז אַלעמען קענען אָנטייל נעמען אין די אָנגאָינג פּראָצעס פון לערנען, ינטערפּריטיישאַן און שאפן תורה."}
   }
   return (
-  <Module>
-    <ModuleTitle h1={true}>{translationLookup[translationsSlug] ?
-          translationLookup[translationsSlug]["title"] : "A Living Library of Torah"}</ModuleTitle>
+  <SidebarModule>
+    <SidebarModuleTitle h1={true}>{translationLookup[translationsSlug] ?
+          translationLookup[translationsSlug]["title"] : "A Living Library of Torah"}</SidebarModuleTitle>
         { translationLookup[translationsSlug] ?
           translationLookup[translationsSlug]["body"] :
           <InterfaceText>
@@ -247,13 +247,13 @@ const AboutTranslatedText = ({translationsSlug}) => {
         </HebrewText>
         </InterfaceText>
         }
-  </Module>
+  </SidebarModule>
 );
 }
 
 
 const Resources = () => (
-  <Module>
+  <SidebarModule>
     <h3><InterfaceText context="ResourcesModule">Resources</InterfaceText></h3>
     <div className="linkList">
       <IconLink text="Mobile Apps" url="/mobile" icon="mobile.svg" />
@@ -264,42 +264,42 @@ const Resources = () => (
       <IconLink text="Torah Tab" url="/torah-tab" icon="torah-tab.svg" />
       <IconLink text="Help" url="/help" icon="help.svg" />
     </div>
-  </Module>
+  </SidebarModule>
 );
 
 
 const TheJewishLibrary = ({hideTitle}) => (
-  <Module>
+  <SidebarModule>
     {!hideTitle ?
-    <ModuleTitle>The Jewish Library</ModuleTitle> : null}
+    <SidebarModuleTitle>The Jewish Library</SidebarModuleTitle> : null}
     <InterfaceText>The tradition of Torah texts is a vast, interconnected network that forms a conversation across space and time. The five books of the Torah form its foundation, and each generation of later texts functions as a commentary on those that came before it.</InterfaceText>
-  </Module>
+  </SidebarModule>
 );
 
 
 const SupportSefaria = ({blue}) => (
-  <Module blue={blue}>
-    <ModuleTitle>Support Sefaria</ModuleTitle>
+  <SidebarModule blue={blue}>
+    <SidebarModuleTitle>Support Sefaria</SidebarModuleTitle>
     <InterfaceText>Sefaria is an open source, nonprofit project. Support us by making a tax-deductible donation.</InterfaceText>
     <br />
     <DonateLink classes={"button small" + (blue ? " white" : "")} source={"NavSidebar-SupportSefaria"}>
       <img src="/static/img/heart.png" alt="donation icon" />
       <InterfaceText>Make a Donation</InterfaceText>
     </DonateLink>
-  </Module>
+  </SidebarModule>
 );
 
 
 const SponsorADay = () => (
-  <Module>
-    <ModuleTitle>Sponsor A Day of Learning</ModuleTitle>
+  <SidebarModule>
+    <SidebarModuleTitle>Sponsor A Day of Learning</SidebarModuleTitle>
     <InterfaceText>With your help, we can add more texts and translations to the library, develop new tools for learning, and keep Sefaria accessible for Torah study anytime, anywhere.</InterfaceText>
     <br />
     <DonateLink classes={"button small"} link={"dayOfLearning"} source={"NavSidebar-SponsorADay"}>
       <img src="/static/img/heart.png" alt="donation icon" />
       <InterfaceText>Sponsor A Day</InterfaceText>
     </DonateLink>
-  </Module>
+  </SidebarModule>
 );
 
 
@@ -314,10 +314,10 @@ const AboutTextCategory = ({cats}) => {
   }
 
   return (
-    <Module>
+    <SidebarModule>
       <h3><InterfaceText text={{en: enTitle, he: heTitle}} /></h3>
       <InterfaceText markdown={{en: tocObject.enDesc, he: tocObject.heDesc}} />
-    </Module>
+    </SidebarModule>
   );
 };
 
@@ -343,9 +343,9 @@ const AboutText = ({index, hideTitle}) => {
   if (!authors.length && !composed && !description) { return null; }
 
   return (
-    <Module>
+    <SidebarModule>
       {hideTitle ? null :
-          <ModuleTitle>About This Text</ModuleTitle>}
+          <SidebarModuleTitle>About This Text</SidebarModuleTitle>}
       { composed || authors.length ?
       <div className="aboutTextMetadata">
 
@@ -371,7 +371,7 @@ const AboutText = ({index, hideTitle}) => {
       {description ?
       <InterfaceText markdown={{en: enDesc, he: heDesc}}/> : null}
 
-    </Module>
+    </SidebarModule>
   );
 };
 
@@ -431,8 +431,8 @@ const DafLink = () => {
 }
 
 const Translations = () => {
-  return (<Module>
-    <ModuleTitle>Translations</ModuleTitle>
+  return (<SidebarModule>
+    <SidebarModuleTitle>Translations</SidebarModuleTitle>
     <InterfaceText>
       <EnglishText>
         Access key works from the library in several languages.
@@ -442,14 +442,14 @@ const Translations = () => {
       </HebrewText>
     </InterfaceText>
     <TranslationLinks />
-  </Module>)
+  </SidebarModule>)
 }
 
 
 const LearningSchedules = () => {
   return (
-    <Module>
-      <ModuleTitle>Learning Schedules</ModuleTitle>
+    <SidebarModule>
+      <SidebarModuleTitle>Learning Schedules</SidebarModuleTitle>
       <div className="readingsSection">
         <span className="readingsSectionTitle">
           <InterfaceText>Weekly Torah Portion</InterfaceText>: <ParashahName />
@@ -474,15 +474,15 @@ const LearningSchedules = () => {
         <HebrewText>לוחות לימוד נוספים ›</HebrewText>
         </InterfaceText>
       </a>
-    </Module>
+    </SidebarModule>
   );
 };
 
 
 const WeeklyTorahPortion = () => {
   return (
-    <Module>
-      <ModuleTitle>Weekly Torah Portion</ModuleTitle>
+    <SidebarModule>
+      <SidebarModuleTitle>Weekly Torah Portion</SidebarModuleTitle>
       <div className="readingsSection">
         <span className="readingsSectionTitle">
           <ParashahName />
@@ -501,22 +501,22 @@ const WeeklyTorahPortion = () => {
         <HebrewText>פרשות השבוע ›</HebrewText>
         </InterfaceText>
       </a>
-    </Module>
+    </SidebarModule>
   );
 };
 
 
 const DafYomi = () => {
   return (
-    <Module>
-      <ModuleTitle>Daily Learning</ModuleTitle>
+    <SidebarModule>
+      <SidebarModuleTitle>Daily Learning</SidebarModuleTitle>
       <div className="readingsSection">
         <span className="readingsSectionTitle">
           <InterfaceText >Daf Yomi</InterfaceText>
         </span>
         <DafLink />
       </div>
-    </Module>
+    </SidebarModule>
   );
 };
 
@@ -551,8 +551,8 @@ const Visualizations = ({categories}) => {
   if (links.length == 0) { return null; }
 
   return (
-    <Module>
-      <ModuleTitle>Visualizations</ModuleTitle>
+    <SidebarModule>
+      <SidebarModuleTitle>Visualizations</SidebarModuleTitle>
       <InterfaceText>Explore interconnections among texts with our interactive visualizations.</InterfaceText>
       <div className="linkList">
         {links.map((link, i) =>
@@ -568,15 +568,15 @@ const Visualizations = ({categories}) => {
         <HebrewText>תרשימים גרפיים נוספים ›</HebrewText>
         </InterfaceText>
       </a>
-    </Module>
+    </SidebarModule>
   );
 };
 
 
 const AboutTopics = ({hideTitle}) => (
-  <Module>
+  <SidebarModule>
     {hideTitle ? null :
-    <ModuleTitle>About Topics</ModuleTitle> }
+    <SidebarModuleTitle>About Topics</SidebarModuleTitle> }
     <InterfaceText>
         <HebrewText>
 דפי הנושא מציגים מקורות נבחרים מארון הספרים היהודי עבור אלפי נושאים. ניתן לדפדף לפי קטגוריה או לחפש לפי נושא ספציפי, ובסרגל הצד מוצגים הנושאים הפופולריים ביותר ואלה הקשורים אליהם.  הקליקו ושוטטו בין הנושאים השונים כדי ללמוד עוד.
@@ -585,19 +585,19 @@ const AboutTopics = ({hideTitle}) => (
         Topics Pages present a curated selection of various genres of sources on thousands of chosen subjects. You can browse by category, search for something specific, or view the most popular topics — and related topics — on the sidebar. Explore and click through to learn more.
         </EnglishText>
     </InterfaceText>
-  </Module>
+  </SidebarModule>
 );
 
 
 const TrendingTopics = () => (
-  <Module>
-    <ModuleTitle>Trending Topics</ModuleTitle>
+  <SidebarModule>
+    <SidebarModuleTitle>Trending Topics</SidebarModuleTitle>
     {Sefaria.trendingTopics.map((topic, i) =>
       <div className="navSidebarLink ref serif" key={i}>
         <a href={"/topics/" + topic.slug}><InterfaceText text={{en: topic.en, he: topic.he}}/></a>
       </div>
     )}
-  </Module>
+  </SidebarModule>
 );
 
 
@@ -610,8 +610,8 @@ const RelatedTopics = ({title}) => {
         Sefaria.getIndexDetails(title).then(data => setTopics(data.relatedTopics));
   },[title]);
   return (topics.length ?
-    <Module>
-      <ModuleTitle>Related Topics</ModuleTitle>
+    <SidebarModule>
+      <SidebarModuleTitle>Related Topics</SidebarModuleTitle>
       {shownTopics.map((topic, i) =>
         <div className="navSidebarLink ref serif" key={i}>
           <a href={"/topics/" + topic.slug}><InterfaceText text={{en: topic.title.en, he: topic.title.he}}/></a>
@@ -621,7 +621,7 @@ const RelatedTopics = ({title}) => {
       <a className="moreLink" onClick={()=>{setShowMore(true);}}>
         <InterfaceText>More</InterfaceText>
       </a> : null}
-    </Module> : null
+    </SidebarModule> : null
   );
 };
 
@@ -630,9 +630,9 @@ const JoinTheConversation = ({wide}) => {
   if (!Sefaria.multiPanel) { return null; } // Don't advertise create sheets on mobile (yet)
 
   return (
-    <Module wide={wide}>
+    <SidebarModule wide={wide}>
       <div>
-        <ModuleTitle>Join the Conversation</ModuleTitle>
+        <SidebarModuleTitle>Join the Conversation</SidebarModuleTitle>
         <InterfaceText>Combine sources from our library with your own comments, questions, images, and videos.</InterfaceText>
       </div>
       <div>
@@ -641,16 +641,16 @@ const JoinTheConversation = ({wide}) => {
           <InterfaceText>Make a Sheet</InterfaceText>
         </a>
       </div>
-    </Module>
+    </SidebarModule>
   );
 };
 
 
 const JoinTheCommunity = ({wide}) => {
   return (
-    <Module wide={wide}>
+    <SidebarModule wide={wide}>
       <div>
-        <ModuleTitle>Join the Conversation</ModuleTitle>
+        <SidebarModuleTitle>Join the Conversation</SidebarModuleTitle>
         <InterfaceText>People around the world use Sefaria to create and share Torah resources. You're invited to add your voice.</InterfaceText>
       </div>
       <div>
@@ -659,14 +659,14 @@ const JoinTheCommunity = ({wide}) => {
           <InterfaceText>Explore the Community</InterfaceText>
         </a>
       </div>
-    </Module>
+    </SidebarModule>
   );
 };
 
 
 const GetTheApp = () => (
-  <Module>
-    <ModuleTitle>Get the Mobile App</ModuleTitle>
+  <SidebarModule>
+    <SidebarModuleTitle>Get the Mobile App</SidebarModuleTitle>
     <InterfaceText>Access the Jewish library anywhere and anytime with the</InterfaceText> <a href="/mobile" className="inTextLink"><InterfaceText>Sefaria mobile app.</InterfaceText></a>
     <br />
     <AppStoreButton
@@ -679,7 +679,7 @@ const GetTheApp = () => (
         platform='android'
         altText={Sefaria._("Sefaria app on Android")}
     />
-  </Module>
+  </SidebarModule>
 );
 
 
@@ -687,8 +687,8 @@ const StayConnected = () => { // TODO: remove? looks like we are not using this
   const fbURL = Sefaria.interfaceLang == "hebrew" ? "https://www.facebook.com/sefaria.org.il" : "https://www.facebook.com/sefaria.org";
 
   return (
-    <Module>
-      <ModuleTitle>Stay Connected</ModuleTitle>
+    <SidebarModule>
+      <SidebarModuleTitle>Stay Connected</SidebarModuleTitle>
       <InterfaceText>Get updates on new texts, learning resources, features, and more.</InterfaceText>
       <br />
       <NewsletterSignUpForm context="sidebar" />
@@ -703,14 +703,14 @@ const StayConnected = () => { // TODO: remove? looks like we are not using this
         <img src="/static/icons/youtube.svg" alt={Sefaria._("Sefaria on YouTube")} />
       </a>
 
-    </Module>
+    </SidebarModule>
   );
 };
 
 
 const AboutLearningSchedules = () => (
-  <Module>
-    <ModuleTitle h1={true}>Learning Schedules</ModuleTitle>
+  <SidebarModule>
+    <SidebarModuleTitle h1={true}>Learning Schedules</SidebarModuleTitle>
     <InterfaceText>
         <EnglishText>
             Since biblical times, the Torah has been divided into sections which are read each week on a set yearly calendar.
@@ -721,14 +721,14 @@ const AboutLearningSchedules = () => (
             בעקבות המנהג הזה התפתחו לאורך השנים סדרי לימוד תקופתיים רבים נוספים, ובעזרתם יכולות קהילות וקבוצות של לומדים ללמוד יחד טקסטים שלמים.
         </HebrewText>
     </InterfaceText>
-  </Module>
+  </SidebarModule>
 );
 
 
 const AboutCollections = ({hideTitle}) => (
-  <Module>
+  <SidebarModule>
     {hideTitle ? null :
-    <ModuleTitle h1={true}>About Collections</ModuleTitle>}
+    <SidebarModuleTitle h1={true}>About Collections</SidebarModuleTitle>}
     <InterfaceText>
         <EnglishText>Collections are user generated bundles of sheets which can be used privately, shared with friends, or made public on Sefaria.</EnglishText>
         <HebrewText>אסופות הן מקבצים של דפי מקורות שנוצרו על ידי משתמשי האתר. הן ניתנות לשימוש פרטי, לצורך שיתוף עם אחרים או לשימוש ציבורי באתר ספריא.</HebrewText>
@@ -740,13 +740,13 @@ const AboutCollections = ({hideTitle}) => (
         <InterfaceText>Create a Collection</InterfaceText>
       </a>
     </div>}
-  </Module>
+  </SidebarModule>
 );
 
 
 const ExploreCollections = () => (
-  <Module>
-    <ModuleTitle>Collections</ModuleTitle>
+  <SidebarModule>
+    <SidebarModuleTitle>Collections</SidebarModuleTitle>
     <InterfaceText>Organizations, communities and individuals around the world curate and share collections of sheets for you to explore.</InterfaceText>
     <div>
       <a className="button small white" href="/collections">
@@ -754,31 +754,31 @@ const ExploreCollections = () => (
         <InterfaceText>Explore Collections</InterfaceText>
       </a>
     </div>
-  </Module>
+  </SidebarModule>
 );
 
 
 const WhoToFollow = ({toggleSignUpModal}) => (
-  <Module>
-    <ModuleTitle>Who to Follow</ModuleTitle>
+  <SidebarModule>
+    <SidebarModuleTitle>Who to Follow</SidebarModuleTitle>
     {Sefaria.followRecommendations.map(user =>
     <ProfileListing {...user} key={user.uid} toggleSignUpModal={toggleSignUpModal} />)}
-  </Module>
+  </SidebarModule>
 );
 
 
 const Image = ({url}) => (
-  <Module>
+  <SidebarModule>
     <img className="imageModuleImage" src={url} />
-  </Module>
+  </SidebarModule>
 );
 
 
 const Wrapper = ({title, content}) => (
-  <Module>
-    {title ? <ModuleTitle>{title}</ModuleTitle> : null}
+  <SidebarModule>
+    {title ? <SidebarModuleTitle>{title}</SidebarModuleTitle> : null}
     {content}
-  </Module>
+  </SidebarModule>
 );
 
 
@@ -846,8 +846,8 @@ const DownloadVersions = ({sref}) => {
     }, [sref]);
 
     return(
-        <Module>
-          <ModuleTitle>Download Text</ModuleTitle>
+        <SidebarModule>
+          <SidebarModuleTitle>Download Text</SidebarModuleTitle>
           <div className="downloadTextModule sans-serif">
           <Dropdown
               name="dlVersionName"
@@ -878,51 +878,51 @@ const DownloadVersions = ({sref}) => {
           />
           <a className={`button fillWidth${isReady ? "" : " disabled"}`} onClick={handleClick} href={versionDlLink()} download>{Sefaria._("Download")}</a>
         </div>
-        </Module>
+        </SidebarModule>
     );
 };
 
 
 const PortalAbout = ({title, description, image_uri, image_caption}) => {
     return(
-        <Module>
-            <ModuleTitle en={title.en} he={title.he} />
+        <SidebarModule>
+            <SidebarModuleTitle en={title.en} he={title.he} />
             <div className="portalTopicImageWrapper">
                 <ImageWithCaption photoLink={image_uri} caption={image_caption} />
             </div>
             <InterfaceText markdown={{en: description.en, he: description.he}} />
-        </Module>
+        </SidebarModule>
     )
 };
 
 
 const PortalMobile = ({title, description, android_link, ios_link}) => {
     return(
-        <Module>
+        <SidebarModule>
             <div className="portalMobile">
-                <ModuleTitle en={title.en} he={title.he} />
+                <SidebarModuleTitle en={title.en} he={title.he} />
                 {description && <InterfaceText markdown={{en: description.en, he: description.he}} />}
                 <AppStoreButton href={ios_link} platform={'ios'} altText='Steinsaltz app on iOS' />
                 <AppStoreButton href={android_link} platform={'android'} altText='Steinsaltz app on Android' />
             </div>
-        </Module>
+        </SidebarModule>
     )
 };
 const PortalOrganization = ({title, description}) => {
     return(
-        <Module>
-                <ModuleTitle en={title.en} he={title.he} />
+        <SidebarModule>
+                <SidebarModuleTitle en={title.en} he={title.he} />
                 {description && <InterfaceText markdown={{en: description.en, he: description.he}} />}
-        </Module>
+        </SidebarModule>
     )
 };
 
 
 const PortalNewsletter = ({title, description}) => {
-    let titleElement = <ModuleTitle en={title.en} he={title.he} />;
+    let titleElement = <SidebarModuleTitle en={title.en} he={title.he} />;
 
     return(
-        <Module>
+        <SidebarModule>
             {titleElement}
             <InterfaceText markdown={{en: description.en, he: description.he}} />
             <NewsletterSignUpForm
@@ -930,13 +930,13 @@ const PortalNewsletter = ({title, description}) => {
                 emailPlaceholder={{en: "Email Address", he: "כתובת מייל"}}
                 subscribe={Sefaria.subscribeSefariaAndSteinsaltzNewsletter}
             />
-        </Module>
+        </SidebarModule>
     )
 };
 
 
 export {
   NavSidebar,
-  Modules,
+  SidebarModules,
   RecentlyViewed
 };

--- a/static/js/NotificationsPanel.jsx
+++ b/static/js/NotificationsPanel.jsx
@@ -90,7 +90,7 @@ class NotificationsPanel extends Component {
               notifications :
               <LoginPrompt fullPanel={true} /> }
             </div>
-            <NavSidebar modules={sidebarModules} />
+            <NavSidebar sidebarModules={sidebarModules} />
           </div>
           <Footer />
         </div>

--- a/static/js/PublicCollectionsPage.jsx
+++ b/static/js/PublicCollectionsPage.jsx
@@ -4,7 +4,7 @@ import classNames  from 'classnames';
 import Footer  from './Footer';
 import Sefaria  from './sefaria/sefaria';
 import Component from 'react-class';
-import { NavSidebar, Modules } from './NavSidebar';
+import { NavSidebar, SidebarModules } from './NavSidebar';
 import {
   InterfaceText,
   LoadingMessage,
@@ -70,7 +70,7 @@ const PublicCollectionsPage = ({multiPanel, initialWidth}) => {
             </h1>
 
             {multiPanel ? null :
-            <Modules type={"AboutCollections"} props={{hideTitle: true}} /> }
+            <SidebarModules type={"AboutCollections"} props={{hideTitle: true}} /> }
 
             <div className="collectionsList">
               { !!collectionsList ?
@@ -89,7 +89,7 @@ const PublicCollectionsPage = ({multiPanel, initialWidth}) => {
               : <LoadingMessage /> }
             </div>
           </div>
-          <NavSidebar modules={sidebarModules} />
+          <NavSidebar sidebarModules={sidebarModules} />
         </div>
         <Footer />
       </div>

--- a/static/js/TextCategoryPage.jsx
+++ b/static/js/TextCategoryPage.jsx
@@ -101,7 +101,7 @@ const TextCategoryPage = ({category, categories, setCategories, toggleLanguage,
               initialWidth={initialWidth}
               nestLevel={nestLevel} />
           </div>
-          {!compare ? <NavSidebar modules={sidebarModules} /> : null}
+          {!compare ? <NavSidebar sidebarModules={sidebarModules} /> : null}
         </div>
         {footer}
       </div>

--- a/static/js/TextsPage.jsx
+++ b/static/js/TextsPage.jsx
@@ -3,7 +3,7 @@ import PropTypes  from 'prop-types';
 import classNames  from 'classnames';
 import Sefaria  from './sefaria/sefaria';
 import $  from './sefaria/sefariaJquery';
-import { NavSidebar, Modules, RecentlyViewed } from './NavSidebar';
+import { NavSidebar, SidebarModules, RecentlyViewed } from './NavSidebar';
 import TextCategoryPage  from './TextCategoryPage';
 import Footer  from './Footer';
 import ComparePanelHeader from './ComparePanelHeader';
@@ -79,7 +79,7 @@ const TextsPage = ({categories, settings, setCategories, onCompareBack, openSear
     </div>
 
   const about = compare || multiPanel ? null :
-    <Modules type={"AboutSefaria"} props={{hideTitle: true}}/>;
+    <SidebarModules type={"AboutSefaria"} props={{hideTitle: true}}/>;
 
   const dedication = Sefaria._siteSettings.TORAH_SPECIFIC && !compare ? <Dedication /> : null;
 
@@ -112,7 +112,7 @@ const TextsPage = ({categories, settings, setCategories, onCompareBack, openSear
             { !multiPanel && <RecentlyViewed toggleSignUpModal={toggleSignUpModal} mobile={true}/>}
             { categoryListings }
           </div>
-          {!compare ? <NavSidebar modules={sidebarModules} /> : null}
+          {!compare ? <NavSidebar sidebarModules={sidebarModules} /> : null}
         </div>
         {footer}
       </div>

--- a/static/js/TopicPage.jsx
+++ b/static/js/TopicPage.jsx
@@ -285,7 +285,7 @@ const TopicCategory = ({topic, topicTitle, setTopic, setNavTopic, compare, initi
                         <ResponsiveNBox content={topicBlocks} initialWidth={initialWidth} />
                       </div>
                   </div>
-                  <NavSidebar modules={sidebarModules} />
+                  <NavSidebar sidebarModules={sidebarModules} />
                 </div>
                 <Footer />
             </div>
@@ -533,16 +533,16 @@ const PortalNavSideBar = ({portal, entriesToDisplayList}) => {
     "organization": "PortalOrganization",
     "newsletter": "PortalNewsletter"
     }
-    const modules = [];
+    const sidebarModules = [];
     for (let key of entriesToDisplayList) {
         if (!portal[key]) { continue; }
-        modules.push({
+        sidebarModules.push({
             type: portalModuleTypeMap[key],
             props: portal[key],
         });
     }
     return(
-        <NavSidebar modules={modules} />
+        <NavSidebar sidebarModules={sidebarModules} />
     )
 };
 

--- a/static/js/TopicPageAll.jsx
+++ b/static/js/TopicPageAll.jsx
@@ -119,7 +119,7 @@ class TopicPageAll extends Component {
                 }
               </div>
             </div>
-            <NavSidebar modules={sidebarModules} />
+            <NavSidebar sidebarModules={sidebarModules} />
           </div>
           <Footer />
         </div>

--- a/static/js/TopicsPage.jsx
+++ b/static/js/TopicsPage.jsx
@@ -7,7 +7,7 @@ import PropTypes  from 'prop-types';
 import classNames  from 'classnames';
 import Sefaria  from './sefaria/sefaria';
 import $  from './sefaria/sefariaJquery';
-import { NavSidebar, Modules } from './NavSidebar';
+import { NavSidebar, SidebarModules } from './NavSidebar';
 import Footer  from './Footer';
 import {CategoryHeader} from "./Misc";
 import Component from 'react-class';
@@ -45,7 +45,7 @@ const TopicsPage = ({setNavTopic, multiPanel, initialWidth}) => {
   );
 
   const about = multiPanel ? null :
-    <Modules type={"AboutTopics"} props={{hideTitle: true}} />;
+    <SidebarModules type={"AboutTopics"} props={{hideTitle: true}} />;
 
   const sidebarModules = [
     multiPanel ? {type: "AboutTopics"} : {type: null},
@@ -69,7 +69,7 @@ const TopicsPage = ({setNavTopic, multiPanel, initialWidth}) => {
               { about }
               { categoryListings }
           </div>
-          <NavSidebar modules={sidebarModules} />
+          <NavSidebar sidebarModules={sidebarModules} />
         </div>
         <Footer />
       </div>

--- a/static/js/TranslationsPage.jsx
+++ b/static/js/TranslationsPage.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from "react";
 import Sefaria from "./sefaria/sefaria";
 import classNames  from 'classnames';
 import {InterfaceText, TabView} from './Misc';
-import { NavSidebar, Modules } from './NavSidebar';
+import { NavSidebar, SidebarModules } from './NavSidebar';
 import Footer  from './Footer';
 
 
@@ -89,7 +89,7 @@ const TranslationsPage = ({translationsSlug}) => {
               </>
               </TabView>}
               </div>
-            <NavSidebar modules={sidebarModules} />
+            <NavSidebar sidebarModules={sidebarModules} />
           </div>
           <Footer />
         </div>

--- a/static/js/UserHistoryPanel.jsx
+++ b/static/js/UserHistoryPanel.jsx
@@ -64,7 +64,7 @@ const UserHistoryPanel = ({menuOpen, toggleLanguage, openDisplaySettings, openNa
               toggleSignUpModal={toggleSignUpModal}
               key={menuOpen}/>
           </div>
-          <NavSidebar modules={sidebarModules} />
+          <NavSidebar sidebarModules={sidebarModules} />
         </div>
         {footer}
       </div>


### PR DESCRIPTION
## Description
- The goal of this PR is to clean up the components `<Module/>`, `<Modules/>` and `<ModuleTitles/>` to be more specific in their naming, to all be prefaced with `Sidebar` since they are all related to the Sidebar. 
- The props for `<NavSidebar />` were also renamed from `modules` to `sidebarModules`

## Code Changes
- In all of the files there are changes, the aforementioned modules are renamed, and import statements are adjusted. 

## Notes
- This was tested extensively locally, however I'd appreciate if the reviewer was able to pull locally and check just to ensure nothing was missed accidentally. 