### PR TITLE
chore(linker): respond with validation errors when linker input is in…

### DIFF
--- a/api/api_errors.py
+++ b/api/api_errors.py
@@ -1,10 +1,16 @@
 """
 Classes for API errors
 """
+from sefaria.client.util import jsonResponse
 
 
 class APIInvalidInputException(Exception):
     """
     When data in an invalid format is passed to an API
     """
-    pass
+    def __init__(self, message):
+        super().__init__(message)
+        self.message = message
+
+    def to_json_response(self):
+        return jsonResponse({"invalid_input_error": self.message}, status=400)

--- a/api/api_errors.py
+++ b/api/api_errors.py
@@ -1,0 +1,10 @@
+"""
+Classes for API errors
+"""
+
+
+class APIInvalidInputException(Exception):
+    """
+    When data in an invalid format is passed to an API
+    """
+    pass

--- a/sefaria/helper/linker.py
+++ b/sefaria/helper/linker.py
@@ -13,7 +13,7 @@ from typing import List, Optional, Tuple
 
 logger = structlog.get_logger(__name__)
 
-FIND_REFS_POST_SCHEMA = schema = {
+FIND_REFS_POST_SCHEMA = {
     "text": {
         "type": "dict",
         "required": True,

--- a/sefaria/helper/linker.py
+++ b/sefaria/helper/linker.py
@@ -9,7 +9,7 @@ from sefaria.model import text, library
 from sefaria.model.webpage import WebPage
 from sefaria.system.cache import django_cache
 from sefaria.system.exceptions import APIInvalidInputException
-from typing import List, Union, Optional, Tuple
+from typing import List, Optional, Tuple
 
 logger = structlog.get_logger(__name__)
 
@@ -103,10 +103,6 @@ class _FindRefsText:
     title: str
     body: str
     lang: str
-
-    # def __post_init__(self):
-    #     from sefaria.utils.hebrew import is_mostly_hebrew
-    #     self.lang = 'he' if is_mostly_hebrew(self.body) else 'en'
 
 
 def _unpack_find_refs_request(request):

--- a/sefaria/helper/linker.py
+++ b/sefaria/helper/linker.py
@@ -8,7 +8,7 @@ from sefaria.model.linker.ref_resolver import PossiblyAmbigResolvedRef
 from sefaria.model import text, library
 from sefaria.model.webpage import WebPage
 from sefaria.system.cache import django_cache
-from sefaria.system.exceptions import APIInvalidInputException
+from api.api_errors import APIInvalidInputException
 from typing import List, Optional, Tuple
 
 logger = structlog.get_logger(__name__)

--- a/sefaria/helper/linker.py
+++ b/sefaria/helper/linker.py
@@ -2,14 +2,54 @@ import dataclasses
 import json
 import spacy
 import structlog
+from cerberus import Validator
 from sefaria.model.linker.ref_part import TermContext, RefPartType
 from sefaria.model.linker.ref_resolver import PossiblyAmbigResolvedRef
 from sefaria.model import text, library
 from sefaria.model.webpage import WebPage
 from sefaria.system.cache import django_cache
+from sefaria.system.exceptions import APIInvalidInputException
 from typing import List, Union, Optional, Tuple
 
 logger = structlog.get_logger(__name__)
+
+FIND_REFS_POST_SCHEMA = schema = {
+    "text": {
+        "type": "dict",
+        "required": True,
+        "schema": {
+            "title": {"type": "string", "required": True},
+            "body": {"type": "string", "required": True},
+        },
+    },
+    "metaDataForTracking": {
+        "type": "dict",
+        "required": False,
+        "schema": {
+            "url": {"type": "string", "required": False},
+            "description": {"type": "string", "required": False},
+            "title": {"type": "string", "required": False},
+        },
+    },
+    "lang": {
+        "type": "string",
+        "allowed": ["he", "en"],
+        "required": False,
+    },
+    "version_preferences_by_corpus": {
+        "type": "dict",
+        "required": False,
+        "keysrules": {"type": "string"},
+        "valuesrules": {
+            "type": "dict",
+            "schema": {
+                "type": "string",
+                "keysrules": {"type": "string"},
+                "valuesrules": {"type": "string"},
+            },
+        },
+    },
+}
 
 
 def load_spacy_model(path: str) -> spacy.Language:
@@ -70,7 +110,10 @@ class _FindRefsText:
 
 
 def _unpack_find_refs_request(request):
+    validator = Validator(FIND_REFS_POST_SCHEMA)
     post_body = json.loads(request.body)
+    if not validator.validate(post_body):
+        raise APIInvalidInputException(validator.errors)
     meta_data = post_body.get('metaDataForTracking')
     return _create_find_refs_text(post_body), _create_find_refs_options(request.GET, post_body), meta_data
 

--- a/sefaria/helper/tests/linker_test.py
+++ b/sefaria/helper/tests/linker_test.py
@@ -10,7 +10,7 @@ import io
 from sefaria.model.text import Ref, TextChunk
 from sefaria.model.webpage import WebPage
 from sefaria.settings import ENABLE_LINKER
-from sefaria.system.exceptions import APIInvalidInputException
+from api.api_errors import APIInvalidInputException
 
 if not ENABLE_LINKER:
     pytest.skip("Linker not enabled", allow_module_level=True)

--- a/sefaria/helper/tests/linker_test.py
+++ b/sefaria/helper/tests/linker_test.py
@@ -198,8 +198,8 @@ class TestFindRefsResponseLinkerV3:
         with patch.object(library, 'get_linker') as mock_get_linker:
             mock_linker = Mock()
             mock_get_linker.return_value = mock_linker
-            mock_linker.link.return_value = LinkedDoc('', [], [])
-            mock_linker.link_by_paragraph.return_value = LinkedDoc('', [], [])
+            mock_linker.link.return_value = LinkedDoc('', [], [], [])
+            mock_linker.link_by_paragraph.return_value = LinkedDoc('', [], [], [])
             yield mock_get_linker
 
     def test_make_find_refs_response_linker_v3(self, mock_get_linker: WSGIRequest,

--- a/sefaria/helper/tests/linker_test.py
+++ b/sefaria/helper/tests/linker_test.py
@@ -10,6 +10,7 @@ import io
 from sefaria.model.text import Ref, TextChunk
 from sefaria.model.webpage import WebPage
 from sefaria.settings import ENABLE_LINKER
+from sefaria.system.exceptions import APIInvalidInputException
 
 if not ENABLE_LINKER:
     pytest.skip("Linker not enabled", allow_module_level=True)
@@ -80,6 +81,12 @@ def mock_request_post_data_without_meta_data(mock_request_post_data: dict) -> di
     return mock_request_post_data
 
 
+@pytest.fixture
+def mock_request_invalid_post_data(mock_request_post_data: dict) -> dict:
+    mock_request_post_data['text'] = 'plain text'
+    return mock_request_post_data
+
+
 def make_mock_request(post_data: dict) -> WSGIRequest:
     factory = RequestFactory()
     request = factory.post('/api/find-refs', data=json.dumps(post_data), content_type='application/json')
@@ -107,6 +114,11 @@ def mock_find_refs_options(mock_request: WSGIRequest) -> linker._FindRefsTextOpt
 @pytest.fixture
 def mock_request_without_meta_data(mock_request_post_data_without_meta_data: dict) -> WSGIRequest:
     return make_mock_request(mock_request_post_data_without_meta_data)
+
+
+@pytest.fixture
+def mock_request_invalid(mock_request_invalid_post_data: dict) -> WSGIRequest:
+    return make_mock_request(mock_request_invalid_post_data)
 
 
 @pytest.fixture
@@ -161,6 +173,13 @@ class TestMakeFindRefsResponse:
         response = linker.make_find_refs_response(mock_request_without_meta_data)
         mock_webpage.add_hit.assert_not_called()
         mock_webpage.save.assert_not_called()
+
+    def test_make_find_refs_response_invalid_post_data(self, mock_request_invalid: dict,
+                                                       mock_webpage: Mock):
+        with pytest.raises(APIInvalidInputException) as exc_info:
+            response = linker.make_find_refs_response(mock_request_invalid)
+        # assert that the 'text' field had a validation error
+        assert 'text' in exc_info.value.args[0]
 
 
 class TestUnpackFindRefsRequest:

--- a/sefaria/system/exceptions.py
+++ b/sefaria/system/exceptions.py
@@ -99,3 +99,7 @@ class InvalidHTTPMethodException(Exception):
         self.method = method
         self.message = f"'{method}' is not a valid HTTP API method."
         super().__init__(self.message)
+
+
+class APIInvalidInputException(Exception):
+    pass

--- a/sefaria/system/exceptions.py
+++ b/sefaria/system/exceptions.py
@@ -99,7 +99,3 @@ class InvalidHTTPMethodException(Exception):
         self.method = method
         self.message = f"'{method}' is not a valid HTTP API method."
         super().__init__(self.message)
-
-
-class APIInvalidInputException(Exception):
-    pass

--- a/sefaria/views.py
+++ b/sefaria/views.py
@@ -46,7 +46,7 @@ from sefaria.model.notification import process_sheet_deletion_in_notifications
 from sefaria.export import export_all as start_export_all
 from sefaria.datatype.jagged_array import JaggedTextArray
 # noinspection PyUnresolvedReferences
-from sefaria.system.exceptions import InputError, NoVersionFoundError
+from sefaria.system.exceptions import InputError, NoVersionFoundError, APIInvalidInputException
 from sefaria.system.database import db
 from sefaria.system.decorators import catch_error_as_http
 from sefaria.utils.hebrew import has_hebrew, strip_nikkud
@@ -339,7 +339,10 @@ def find_refs_report_api(request):
 @api_view(["POST"])
 def find_refs_api(request):
     from sefaria.helper.linker import make_find_refs_response
-    return jsonResponse(make_find_refs_response(request))
+    try:
+        return jsonResponse(make_find_refs_response(request))
+    except APIInvalidInputException as e:
+        return jsonResponse({"error": str(e)}, status=400)
 
 
 @api_view(["GET"])

--- a/sefaria/views.py
+++ b/sefaria/views.py
@@ -46,7 +46,8 @@ from sefaria.model.notification import process_sheet_deletion_in_notifications
 from sefaria.export import export_all as start_export_all
 from sefaria.datatype.jagged_array import JaggedTextArray
 # noinspection PyUnresolvedReferences
-from sefaria.system.exceptions import InputError, NoVersionFoundError, APIInvalidInputException
+from sefaria.system.exceptions import InputError, NoVersionFoundError
+from api.api_errors import APIInvalidInputException
 from sefaria.system.database import db
 from sefaria.system.decorators import catch_error_as_http
 from sefaria.utils.hebrew import has_hebrew, strip_nikkud

--- a/sefaria/views.py
+++ b/sefaria/views.py
@@ -343,7 +343,7 @@ def find_refs_api(request):
     try:
         return jsonResponse(make_find_refs_response(request))
     except APIInvalidInputException as e:
-        return jsonResponse({"error": str(e)}, status=400)
+        return e.to_json_response()
 
 
 @api_view(["GET"])

--- a/static/js/linker.v3/main.js
+++ b/static/js/linker.v3/main.js
@@ -441,7 +441,8 @@ import {LinkExcluder} from "./excluder";
         return new Promise((resolve, reject) => {
             fetch(getFindRefsUrl(), {
                 method: 'POST',
-                body: JSON.stringify(postData)
+                body: JSON.stringify(postData),
+                headers: {'Content-Type': 'application/json'},
             })
                 .then(handleApiResponse)
                 .then(resp => resolve(resp));


### PR DESCRIPTION
…valid

## Description
Until now the find-refs API endpoint would respond with a 500 error if the input to the API was invalid. Now we respond with 400 and a list of validation errors.

## Code Changes
We rely on a Cerberus schema of the valid find-refs input to validate the input and respond with appropriate validation errors.