### PR TITLE
fix(onSidebarSearchClick): prevent converting of commentary ref to base ref

### DIFF
--- a/static/js/ReaderApp.jsx
+++ b/static/js/ReaderApp.jsx
@@ -1010,7 +1010,7 @@ toggleSignUpModal(modalContentKind = SignUpModalKind.Default) {
                       showHighlight: true,
                       currentlyVisibleRef: refs,
                     }
-    this.replacePanel(n-1, ref, currVersions, new_opts);
+    this.replacePanel(n-1, ref, currVersions, new_opts, false);
 }
   getHTMLLinkParentOfEventTarget(event){
     //get the lowest level parent element of an event target that is an HTML link tag. Or Null.
@@ -1547,9 +1547,9 @@ toggleSignUpModal(modalContentKind = SignUpModalKind.Default) {
   openPanelAtEnd(ref, currVersions) {
     this.openPanelAt(this.state.panels.length+1, ref, currVersions);
   }
-  replacePanel(n, ref, currVersions, options) {
+  replacePanel(n, ref, currVersions, options, convertCommentaryRefToBaseRef=true) {
     // Opens a text in in place of the panel currently open at `n`.
-    this.openPanelAt(n, ref, currVersions, options, true);
+    this.openPanelAt(n, ref, currVersions, options, true, convertCommentaryRefToBaseRef);
   }
   openComparePanel(n, connectAfter) {
     const comparePanel = this.makePanelState({


### PR DESCRIPTION
prevent converting of commentary ref to base refwhen clicking a search result from side bar.

## Code Changes
ReaderApp.jsx
add `convertCommentaryRefToBaseRef` param to `replacePanel`, and set it to false when calling from `handleSidebarSearchClick`