### PR TITLE
fix(linker): allow version preferences to be null for find refs api

### DIFF
--- a/sefaria/helper/linker.py
+++ b/sefaria/helper/linker.py
@@ -39,6 +39,7 @@ FIND_REFS_POST_SCHEMA = {
     "version_preferences_by_corpus": {
         "type": "dict",
         "required": False,
+        "nullable": True,
         "keysrules": {"type": "string"},
         "valuesrules": {
             "type": "dict",


### PR DESCRIPTION
/api/find-refs takes a POST parameter called `version_preferences_by_corpus`. This parameter allows specifying the user's preference for specific versions to be returned. This parameter is optional but passing null would cause the API to return a validation error. 

This PR allows null to be passed for this param.