### PR TITLE
Reusable ImageCropper Component

### DIFF
--- a/static/js/AboutSheet.jsx
+++ b/static/js/AboutSheet.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
-import {SheetAuthorStatement, InterfaceText, ProfilePic, EnglishText, HebrewText} from "./Misc";
+import {SheetAuthorStatement, InterfaceText, EnglishText, HebrewText} from "./Misc";
+import {ProfilePic} from "./ProfilePic";
 import Sefaria from "./sefaria/sefaria";
 import ReactTags from 'react-tag-autocomplete'
 import { useDebounce } from "./Hooks";

--- a/static/js/CollectionPage.jsx
+++ b/static/js/CollectionPage.jsx
@@ -15,12 +15,12 @@ import {
   InterfaceText,
   LanguageToggleButton,
   LoadingMessage,
-  ProfilePic,
   ResponsiveNBox,
   SheetListing,
   TabView,
   TwoOrThreeBox,
 } from './Misc';
+import {ProfilePic} from "./ProfilePic";
 import {ContentText} from "./ContentText";
 
 

--- a/static/js/ConnectionsPanel.jsx
+++ b/static/js/ConnectionsPanel.jsx
@@ -8,7 +8,6 @@ import {
   SheetListing,
   Note,
   FeedbackBox,
-  ProfilePic,
   DivineNameReplacer,
   ToolTipped, InterfaceText, EnglishText, HebrewText,
 } from './Misc';

--- a/static/js/Editor.jsx
+++ b/static/js/Editor.jsx
@@ -13,10 +13,10 @@ import {
     SheetAuthorStatement,
     SheetTitle,
     CollectionStatement,
-    ProfilePic,
     InterfaceText,
     Autocompleter,
 } from './Misc';
+import {ProfilePic} from "./ProfilePic";
 
 import classNames from 'classnames';
 import $ from "./sefaria/sefariaJquery";

--- a/static/js/Header.jsx
+++ b/static/js/Header.jsx
@@ -8,12 +8,12 @@ import Sefaria  from './sefaria/sefaria';
 import {
   SearchButton,
   GlobalWarningMessage,
-  ProfilePic,
   InterfaceLanguageMenu,
   InterfaceText,
   LanguageToggleButton,
   DonateLink
 } from './Misc';
+import {ProfilePic} from "./ProfilePic";
 import {Autocomplete} from './Autocomplete'
 
 class Header extends Component {

--- a/static/js/ImageCropper.jsx
+++ b/static/js/ImageCropper.jsx
@@ -1,0 +1,117 @@
+import React, {useState, useRef} from 'react';
+import Sefaria from './sefaria/sefaria';
+import ReactCrop from 'react-image-crop';
+import {LoadingRing} from "./Misc";
+import 'react-image-crop/dist/ReactCrop.css';
+
+export const ImageCropper = ({loading, error, src, onClose, onSave}) => {
+    const imageRef = useRef(null);
+    const [isFirstCropChange, setIsFirstCropChange] = useState(true);
+    const [crop, setCrop] = useState({unit: "px", width: 250, aspect: 1});
+    const [croppedImageBlob, setCroppedImageBlob] = useState(null);
+    const onImageLoaded = (image) => {imageRef.current = image};
+    const onCropComplete = (crop) => {
+        makeClientCrop(crop);
+    }
+    const onCropChange = (crop, percentCrop) => {
+        if (isFirstCropChange) {
+            const { clientWidth:width, clientHeight:height } = imageRef.current;
+            crop.width = Math.min(width, height);
+            crop.height = crop.width;
+            crop.x = (imageRef.current.width/2) - (crop.width/2);
+            crop.y = (imageRef.current.height/2) - (crop.width/2);
+            setCrop(crop);
+            setIsFirstCropChange(false);
+        } else {
+            setCrop(crop);
+        }
+    }
+    const makeClientCrop = async (crop) => {
+        if (imageRef.current && crop.width && crop.height) {
+            const croppedImageBlob = await getCroppedImg(
+                imageRef.current,
+                crop,
+                "newFile.jpeg"
+            );
+            setCroppedImageBlob(croppedImageBlob);
+        }
+    }
+    const getCroppedImg = (image, crop, fileName) => {
+        const canvas = document.createElement("canvas");
+        const scaleX = image.naturalWidth / image.width;
+        const scaleY = image.naturalHeight / image.height;
+        canvas.width = crop.width * scaleX;
+        canvas.height = crop.height * scaleY;
+        const ctx = canvas.getContext("2d");
+        ctx.drawImage(
+            image,
+            crop.x * scaleX,
+            crop.y * scaleY,
+            crop.width * scaleX,
+            crop.height * scaleY,
+            0,
+            0,
+            crop.width * scaleX,
+            crop.height * scaleY
+        );
+
+        return new Promise((resolve, reject) => {
+            canvas.toBlob(blob => {
+                if (!blob) {
+                    console.error("Canvas is empty");
+                    return;
+                }
+                blob.name = fileName;
+                resolve(blob);
+            }, "image/jpeg");
+        });
+    }
+    const closePopup = () => {
+        setCrop({unit: "px", width: 250, aspect: 1});
+        setIsFirstCropChange(true);
+        setCroppedImageBlob(null);
+        onClose();
+    }
+    return (<>
+        { (src || !!error) && (
+            <div id="interruptingMessageBox" className="sefariaModalBox">
+                <div id="interruptingMessageOverlay" onClick={closePopup}></div>
+                <div id="interruptingMessage" className="profile-pic-cropper-modal">
+                    <div className="sefariaModalContent profile-pic-cropper-modal-inner">
+                        { src ?
+                            (<ReactCrop
+                                src={src}
+                                crop={crop}
+                                className="profile-pic-cropper"
+                                keepSelection
+                                onImageLoaded={onImageLoaded}
+                                onComplete={onCropComplete}
+                                onChange={onCropChange}
+                            />) : (<div className="profile-pic-cropper-error">{ error }</div>)
+                        }
+                    </div>
+                    { (loading || isFirstCropChange) ? (<div className="profile-pic-loading"><LoadingRing /></div>) : (
+                        <div>
+                            <div className="smallText profile-pic-cropper-desc">
+                                <span className="int-en">Drag corners to crop image</span>
+                                <span className="int-he">לחיתוך התמונה, גרור את הפינות</span>
+                            </div>
+                            <div className="profile-pic-cropper-button-row">
+                                <a href="#" className="resourcesLink profile-pic-cropper-button" onClick={closePopup}>
+                                    <span className="int-en">Cancel</span>
+                                    <span className="int-he">בטל</span>
+                                </a>
+                                <a href="#" className="resourcesLink blue profile-pic-cropper-button" onClick={onSave}>
+                                    <span className="int-en">Save</span>
+                                    <span className="int-he">שמור</span>
+                                </a>
+                            </div>
+                        </div>
+                    )
+                    }
+                </div>
+            </div>
+        )
+        }
+    </>);
+};

--- a/static/js/Misc.jsx
+++ b/static/js/Misc.jsx
@@ -9,11 +9,10 @@ import PropTypes from 'prop-types';
 import Component from 'react-class';
 import { usePaginatedDisplay } from './Hooks';
 import {ContentLanguageContext, AdContext, StrapiDataContext} from './context';
-import ReactCrop from 'react-image-crop';
-import 'react-image-crop/dist/ReactCrop.css';
 import {ContentText} from "./ContentText";
 import ReactTags from "react-tag-autocomplete";
 import {AdminEditorButton, useEditToggle} from "./AdminEditor";
+import {ProfilePic} from "./ProfilePic";
 import {CategoryEditor, ReorderEditor} from "./CategoryEditor";
 import {refSort} from "./TopicPage";
 import {TopicEditor} from "./TopicEditor";
@@ -141,226 +140,6 @@ const DonateLink = ({children, classes, source, link}) => {
   );
 };
 
-/* flexible profile picture that overrides the default image of gravatar with text with the user's initials */
-class ProfilePic extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      showDefault: !this.props.url || this.props.url.startsWith("https://www.gravatar"), // We can't know in advance if a gravatar image exists of not, so start with the default beforing trying to load image
-      src: null,
-      isFirstCropChange: true,
-      crop: {unit: "px", width: 250, aspect: 1},
-      croppedImageBlob: null,
-      error: null,
-    };
-    this.imgFile = React.createRef();
-  }
-  setShowDefault() { /* console.log("error"); */ this.setState({showDefault: true});  }
-  setShowImage() { /* console.log("load"); */ this.setState({showDefault: false});  }
-  componentDidMount() {
-    if (this.didImageLoad()) {
-      this.setShowImage();
-    } else {
-      this.setShowDefault();
-    }
-  }
-  didImageLoad(){
-    // When using React Hydrate, the onLoad event of the profile image will return before
-    // react code runs, so we check after mount as well to look replace bad images, or to
-    // swap in a gravatar image that we now know is valid.
-    const img = this.imgFile.current;
-    return (img && img.complete && img.naturalWidth !== 0);
-  }
-  onSelectFile(e) {
-    if (e.target.files && e.target.files.length > 0) {
-      if (!e.target.files[0].type.startsWith('image/')) {
-        this.setState({ error: "Error: Please upload an image with the correct file extension (e.g. jpg, png)"});
-        return;
-      }
-      const reader = new FileReader();
-      reader.addEventListener("load", () =>
-        this.setState({ src: reader.result })
-      );
-      console.log("FILE", e.target.files[0]);
-      reader.readAsDataURL(e.target.files[0]);
-    }
-  }
-  onImageLoaded(image) {
-    this.imageRef = image;
-  }
-  onCropComplete(crop) {
-    this.makeClientCrop(crop);
-  }
-  onCropChange(crop, percentCrop) {
-    // You could also use percentCrop:
-    // this.setState({ crop: percentCrop });
-    if (this.state.isFirstCropChange) {
-      const { clientWidth:width, clientHeight:height } = this.imageRef;
-      crop.width = Math.min(width, height);
-      crop.height = crop.width;
-      crop.x = (this.imageRef.width/2) - (crop.width/2);
-      crop.y = (this.imageRef.height/2) - (crop.width/2);
-      this.setState({ crop, isFirstCropChange: false });
-    } else {
-      this.setState({ crop });
-    }
-  }
-  async makeClientCrop(crop) {
-    if (this.imageRef && crop.width && crop.height) {
-      const croppedImageBlob = await this.getCroppedImg(
-        this.imageRef,
-        crop,
-        "newFile.jpeg"
-      );
-      //console.log(croppedImageUrl);
-      this.setState({ croppedImageBlob });
-    }
-  }
-  getCroppedImg(image, crop, fileName) {
-    const canvas = document.createElement("canvas");
-    const scaleX = image.naturalWidth / image.width;
-    const scaleY = image.naturalHeight / image.height;
-    canvas.width = crop.width * scaleX;
-    canvas.height = crop.height * scaleY;
-    const ctx = canvas.getContext("2d");
-    ctx.drawImage(
-      image,
-      crop.x * scaleX,
-      crop.y * scaleY,
-      crop.width * scaleX,
-      crop.height * scaleY,
-      0,
-      0,
-      crop.width * scaleX,
-      crop.height * scaleY
-    );
-
-    return new Promise((resolve, reject) => {
-      canvas.toBlob(blob => {
-        if (!blob) {
-          console.error("Canvas is empty");
-          return;
-        }
-        blob.name = fileName;
-        resolve(blob);
-      }, "image/jpeg");
-    });
-  }
-  closePopup({ cb }) {
-    this.setState({
-      src: null,
-      crop: {unit: "px", width: 250, aspect: 1},
-      isFirstCropChange: true,
-      croppedImageBlob: null,
-      error: null,
-    }, cb);
-  }
-  async upload() {
-    const formData = new FormData();
-    formData.append('file', this.state.croppedImageBlob);
-    this.setState({ uploading: true });
-    let errored = false;
-    try {
-      const response = await Sefaria.uploadProfilePhoto(formData);
-      if (response.error) {
-        throw new Error(response.error);
-      } else {
-        this.closePopup({ cb: () => {
-          window.location = "/profile/" + Sefaria.slug; // reload to get update
-          return;
-        }});
-      }
-    } catch (e) {
-      errored = true;
-      console.log(e);
-    }
-    this.setState({ uploading: false, errored });
-  }
-  render() {
-    const { name, url, len, hideOnDefault, showButtons, outerStyle } = this.props;
-    const { showDefault, src, crop, error, uploading, isFirstCropChange } = this.state;
-    const nameArray = !!name.trim() ? name.trim().split(/\s/) : [];
-    const initials = nameArray.length > 0 ? (nameArray.length === 1 ? nameArray[0][0] : nameArray[0][0] + nameArray[nameArray.length-1][0]) : "";
-    const defaultViz = showDefault ? 'flex' : 'none';
-    const profileViz = showDefault ? 'none' : 'block';
-    const imageSrc = url.replace("profile-default.png", 'profile-default-404.png');  // replace default with non-existant image to force onLoad to fail
-
-    return (
-      <div style={outerStyle} className="profile-pic">
-        <div className={classNames({'default-profile-img': 1, noselect: 1, invisible: hideOnDefault})}
-          style={{display: defaultViz,  width: len, height: len, fontSize: len/2}}>
-          { showButtons ? null : `${initials}` }
-        </div>
-        <img
-          className="img-circle profile-img"
-          style={{display: profileViz, width: len, height: len, fontSize: len/2}}
-          src={imageSrc}
-          alt="User Profile Picture"
-          ref={this.imgFile}
-          onLoad={this.setShowImage}
-          onError={this.setShowDefault}
-        />
-        {this.props.children ? this.props.children : null /*required for slate.js*/}
-        { showButtons ? /* cant style file input directly. see: https://stackoverflow.com/questions/572768/styling-an-input-type-file-button */
-            (<div className={classNames({"profile-pic-button-visible": showDefault !== null, "profile-pic-hover-button": !showDefault, "profile-pic-button": 1})}>
-              <input type="file" className="profile-pic-input-file" id="profile-pic-input-file" onChange={this.onSelectFile} onClick={(event)=> { event.target.value = null}}/>
-              <label htmlFor="profile-pic-input-file" className={classNames({resourcesLink: 1, blue: showDefault})}>
-                <span className="int-en">{ showDefault ? "Add Picture" : "Upload New" }</span>
-                <span className="int-he">{ showDefault ? "הוספת תמונה" : "עדכון תמונה" }</span>
-              </label>
-            </div>) : null
-          }
-          { (src || !!error) && (
-            <div id="interruptingMessageBox" className="sefariaModalBox">
-              <div id="interruptingMessageOverlay" onClick={this.closePopup}></div>
-              <div id="interruptingMessage" className="profile-pic-cropper-modal">
-                <div className="sefariaModalContent profile-pic-cropper-modal-inner">
-                  { src ?
-                    (<ReactCrop
-                      src={src}
-                      crop={crop}
-                      className="profile-pic-cropper"
-                      keepSelection
-                      onImageLoaded={this.onImageLoaded}
-                      onComplete={this.onCropComplete}
-                      onChange={this.onCropChange}
-                    />) : (<div className="profile-pic-cropper-error">{ error }</div>)
-                  }
-              </div>
-              { (uploading || isFirstCropChange) ? (<div className="profile-pic-loading"><LoadingRing /></div>) : (
-                <div>
-                  <div className="smallText profile-pic-cropper-desc">
-                    <span className="int-en">Drag corners to crop image</span>
-                    <span className="int-he">לחיתוך התמונה, גרור את הפינות</span>
-                  </div>
-                  <div className="profile-pic-cropper-button-row">
-                    <a href="#" className="resourcesLink profile-pic-cropper-button" onClick={this.closePopup}>
-                      <span className="int-en">Cancel</span>
-                      <span className="int-he">בטל</span>
-                    </a>
-                    <a href="#" className="resourcesLink blue profile-pic-cropper-button" onClick={this.upload}>
-                      <span className="int-en">Save</span>
-                      <span className="int-he">שמור</span>
-                    </a>
-                  </div>
-                </div>
-                )
-              }
-            </div>
-          </div>
-          )
-        }
-      </div>
-    );
-  }
-}
-ProfilePic.propTypes = {
-  url:           PropTypes.string,
-  name:          PropTypes.string,
-  len:           PropTypes.number,
-  hideOnDefault: PropTypes.bool,  // hide profile pic if you have are displaying default pic
-  showButtons:   PropTypes.bool,  // show profile pic action buttons
-};
 
 
 /**
@@ -3507,7 +3286,6 @@ export {
   NBox,
   Note,
   ProfileListing,
-  ProfilePic,
   ReaderMessage,
   CloseButton,
   DisplaySettingsButton,

--- a/static/js/ProfilePic.jsx
+++ b/static/js/ProfilePic.jsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import classNames from 'classnames';
+import PropTypes from 'prop-types';
+import Component from 'react-class';
+import {ImageCropper} from "./ImageCropper";
+
+/* flexible profile picture that overrides the default image of gravatar with text with the user's initials */
+export class ProfilePic extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            showDefault: !this.props.url || this.props.url.startsWith("https://www.gravatar"), // We can't know in advance if a gravatar image exists of not, so start with the default beforing trying to load image
+            fileToCropSrc: null,
+            uploadError: null,
+            uploading: false,
+        };
+        this.imgFile = React.createRef();
+    }
+    setShowDefault() { /* console.log("error"); */ this.setState({showDefault: true});  }
+    setShowImage() { /* console.log("load"); */ this.setState({showDefault: false});  }
+    componentDidMount() {
+        if (this.didImageLoad()) {
+            this.setShowImage();
+        } else {
+            this.setShowDefault();
+        }
+    }
+    didImageLoad(){
+        // When using React Hydrate, the onLoad event of the profile image will return before
+        // react code runs, so we check after mount as well to look replace bad images, or to
+        // swap in a gravatar image that we now know is valid.
+        const img = this.imgFile.current;
+        return (img && img.complete && img.naturalWidth !== 0);
+    }
+    onSelectFile(e) {
+        if (e.target.files && e.target.files.length > 0) {
+            if (!e.target.files[0].type.startsWith('image/')) {
+                this.setState({uploadError: "Error: Please upload an image with the correct file extension (e.g. jpg, png)"})
+                return;
+            }
+            const reader = new FileReader();
+            reader.addEventListener("load", () => this.setState({fileToCropSrc: reader.result}));
+            console.log("FILE", e.target.files[0]);
+            reader.readAsDataURL(e.target.files[0]);
+        }
+    }
+    onCloseCropper() {
+        this.setState({fileToCropSrc: null, uploadError: null, uploading: false});
+    }
+    async upload(croppedImageBlob) {
+        const formData = new FormData();
+        formData.append('file', croppedImageBlob);
+        this.setState({ uploading: true });
+        console.log("uploading")
+        try {
+            const response = await Sefaria.uploadProfilePhoto(formData);
+            console.log('responsse', response)
+            if (response.error) {
+                throw new Error(response.error);
+            } else {
+                window.location = "/profile/" + Sefaria.slug; // reload to get update
+                return;
+            }
+        } catch (e) {
+            this.setState({fileToCropSrc: null, uploadError: "Upload Error. Please contact hello@sefaria.org for assistance."})
+        }
+        this.setState({ uploading: false });
+    }
+    render() {
+        const { name, url, len, hideOnDefault, showButtons, outerStyle } = this.props;
+        const { showDefault} = this.state;
+        const nameArray = !!name.trim() ? name.trim().split(/\s/) : [];
+        const initials = nameArray.length > 0 ? (nameArray.length === 1 ? nameArray[0][0] : nameArray[0][0] + nameArray[nameArray.length-1][0]) : "";
+        const defaultViz = showDefault ? 'flex' : 'none';
+        const profileViz = showDefault ? 'none' : 'block';
+        const imageSrc = url.replace("profile-default.png", 'profile-default-404.png');  // replace default with non-existant image to force onLoad to fail
+
+        return (
+            <div style={outerStyle} className="profile-pic">
+                <div className={classNames({'default-profile-img': 1, noselect: 1, invisible: hideOnDefault})}
+                     style={{display: defaultViz,  width: len, height: len, fontSize: len/2}}>
+                    { showButtons ? null : `${initials}` }
+                </div>
+                <img
+                    className="img-circle profile-img"
+                    style={{display: profileViz, width: len, height: len, fontSize: len/2}}
+                    src={imageSrc}
+                    alt="User Profile Picture"
+                    ref={this.imgFile}
+                    onLoad={this.setShowImage}
+                    onError={this.setShowDefault}
+                />
+                {this.props.children ? this.props.children : null /*required for slate.js*/}
+                { showButtons ? /* cant style file input directly. see: https://stackoverflow.com/questions/572768/styling-an-input-type-file-button */
+                    (<div className={classNames({"profile-pic-button-visible": showDefault !== null, "profile-pic-hover-button": !showDefault, "profile-pic-button": 1})}>
+                        <input type="file" className="profile-pic-input-file" id="profile-pic-input-file" onChange={this.onSelectFile} onClick={(event)=> { event.target.value = null}}/>
+                        <label htmlFor="profile-pic-input-file" className={classNames({resourcesLink: 1, blue: showDefault})}>
+                            <span className="int-en">{ showDefault ? "Add Picture" : "Upload New" }</span>
+                            <span className="int-he">{ showDefault ? "הוספת תמונה" : "עדכון תמונה" }</span>
+                        </label>
+                    </div>) : null
+                }
+                <ImageCropper
+                    loading={this.state.uploading}
+                    error={this.state.uploadError}
+                    src={this.state.fileToCropSrc}
+                    onClose={this.onCloseCropper}
+                    onSave={this.upload}
+                />
+            </div>
+        );
+    }
+}
+ProfilePic.propTypes = {
+    url:           PropTypes.string,
+    name:          PropTypes.string,
+    len:           PropTypes.number,
+    hideOnDefault: PropTypes.bool,  // hide profile pic if you have are displaying default pic
+    showButtons:   PropTypes.bool,  // show profile pic action buttons
+};

--- a/static/js/SearchSheetResult.jsx
+++ b/static/js/SearchSheetResult.jsx
@@ -6,8 +6,8 @@ import PropTypes  from 'prop-types';
 import Component      from 'react-class';
 import {
     ColorBarBox, InterfaceText,
-    ProfilePic,
 } from './Misc';
+import {ProfilePic} from "./ProfilePic";
 
 
 class SearchSheetResult extends Component {

--- a/static/js/Sheet.jsx
+++ b/static/js/Sheet.jsx
@@ -15,8 +15,8 @@ import {
   SheetAuthorStatement,
   SheetTitle,
   CollectionStatement,
-  ProfilePic,
 } from './Misc';
+import {ProfilePic} from "./ProfilePic";
 
 
 class Sheet extends Component {

--- a/static/js/SheetMetadata.jsx
+++ b/static/js/SheetMetadata.jsx
@@ -7,9 +7,8 @@ import {
   LoadingMessage,
   LoginPrompt,
   SheetAuthorStatement,
-  ProfilePic,
-
 } from './Misc';
+import {ProfilePic} from "./ProfilePic";
 import { CollectionsModal } from './CollectionsWidget'
 import React  from 'react';
 import ReactDOM  from 'react-dom';

--- a/static/js/UserProfile.jsx
+++ b/static/js/UserProfile.jsx
@@ -11,10 +11,10 @@ import {
   TabView,
   SheetListing,
   ProfileListing,
-  ProfilePic,
   FollowButton,
   InterfaceText,
 } from './Misc';
+import {ProfilePic} from "./ProfilePic";
 import { SignUpModalKind } from './sefaria/signupModalContent';
 
 class UserProfile extends Component {


### PR DESCRIPTION
## Description
Pulled out ImageCropper code from ProfilePic to make ImageCropper a reusable component. This makes ProfilePic a much simpler component and allows for reusing ImageCropper in other places.

## Code Changes
- Moved ImageCropper out of ProfilePic
- Moved ProfilePic out of Misc.jsx. This became necessary to avoid circular dependencies since ImageCropper relies on other code in Misc.jsx. As a side benefit, ProfilePic is a large enough component that it warrants its own file.

## Notes
This change is in preparation for allowing image cropping for other admin tools, such as on the topics admin page.