### PR TITLE
Update subscribe endpoint for multiple newsletter subscriptions

### DIFF
--- a/sefaria/helper/crm/crm_mediator.py
+++ b/sefaria/helper/crm/crm_mediator.py
@@ -20,7 +20,7 @@ class CrmMediator:
         except:
             return False
 
-    def subscribe_to_lists(self, email, first_name, last_name, educator=False, lang="en", mailing_lists=[]):
+    def subscribe_to_lists(self, email, first_name, last_name, educator=False, lang="en", mailing_lists=None):
         return self._crm_connection.subscribe_to_lists(email, first_name, last_name, educator, lang, mailing_lists)
 
     def sync_sustainers(self):

--- a/sefaria/helper/crm/crm_mediator.py
+++ b/sefaria/helper/crm/crm_mediator.py
@@ -20,8 +20,8 @@ class CrmMediator:
         except:
             return False
 
-    def subscribe_to_lists(self, email, first_name, last_name, educator=False, lang="en"):
-        return self._crm_connection.subscribe_to_lists(email, first_name, last_name, educator, lang)
+    def subscribe_to_lists(self, email, first_name, last_name, educator=False, lang="en", mailing_lists=[]):
+        return self._crm_connection.subscribe_to_lists(email, first_name, last_name, educator, lang, mailing_lists)
 
     def sync_sustainers(self):
         current_sustainers = CrmInfoStore.get_current_sustainers()
@@ -71,3 +71,6 @@ class CrmMediator:
             CrmInfoStore.save_crm_id(crm_id, email)
         else:
             return False
+
+    def get_available_lists(self):
+        return self._crm_connection.get_available_lists()

--- a/sefaria/helper/crm/salesforce.py
+++ b/sefaria/helper/crm/salesforce.py
@@ -168,5 +168,5 @@ class SalesforceConnectionManager(CrmConnectionManager):
             response = self.get(endpoint + "?q=SELECT+Subscriptions__c+FROM+AC_to_SF_List_Mapping__mdt")
             records = response.json()["records"]
             return [record["Subscriptions__c"] for record in records]
-        except (requests.RequestException, KeyError, json.JSONDecodeError):
+        except (requests.RequestException, KeyError, json.JSONDecodeError, AttributeError):
             raise SalesforceNewsletterListRetrievalError("Unable to retrieve newsletter mailing lists from Salesforce CRM")

--- a/sefaria/helper/crm/salesforce.py
+++ b/sefaria/helper/crm/salesforce.py
@@ -6,6 +6,11 @@ import json
 from sefaria.helper.crm.crm_connection_manager import CrmConnectionManager
 from sefaria import settings as sls
 
+from typing import Any, Optional, List
+from pprint import pprint
+import traceback
+
+
 class SalesforceConnectionManager(CrmConnectionManager):
     def __init__(self):
         CrmConnectionManager.__init__(self, sls.SALESFORCE_BASE_URL)
@@ -13,6 +18,7 @@ class SalesforceConnectionManager(CrmConnectionManager):
         self.resource_prefix = f"services/data/v{self.version}/sobjects/"
 
     def create_endpoint(self, *args):
+        print(f"{sls.SALESFORCE_BASE_URL}/{self.resource_prefix}{'/'.join(args)}")
         return f"{sls.SALESFORCE_BASE_URL}/{self.resource_prefix}{'/'.join(args)}"
 
     def make_request(self, request, **kwargs):
@@ -25,7 +31,7 @@ class SalesforceConnectionManager(CrmConnectionManager):
 
     def get(self, endpoint):
         headers = {'Content-type': 'application/json', 'Accept': 'application/json'}
-        return self.session.get(endpoint, headers)
+        return self.session.get(endpoint, headers=headers)
 
     def post(self, endpoint, **kwargs):
         headers = {'Content-type': 'application/json', 'Accept': 'application/json'}
@@ -120,8 +126,18 @@ class SalesforceConnectionManager(CrmConnectionManager):
         except:
             return False
 
-    def subscribe_to_lists(self, email, first_name=None, last_name=None, lang="en", educator=False):
-        # TODO: Implement once endpoint exists
+    def subscribe_to_lists(
+        self, 
+        email: str, 
+        first_name: Optional[str] = None, 
+        last_name: Optional[str] = None, 
+        lang: str = "en", 
+        educator: bool = False,
+        mailing_lists: Optional[List[str]] = None) -> Any:
+
+        if mailing_lists is None:
+            mailing_lists = []
+
         CrmConnectionManager.subscribe_to_lists(self, email, first_name, last_name, lang, educator)
         if lang == "he":
             language = "Hebrew"
@@ -134,7 +150,8 @@ class SalesforceConnectionManager(CrmConnectionManager):
                       "Last_Name__c": last_name,
                       "Sefaria_App_Email__c": email,
                       "Hebrew_English__c": language,
-                      "Educator__c": educator
+                      "Educator__c": educator,
+                      "Newsletter_Names__c": mailing_lists
                   })
         res = self.post(self.create_endpoint("Sefaria_App_Data__c"),
                         json={
@@ -145,3 +162,23 @@ class SalesforceConnectionManager(CrmConnectionManager):
         except:
             return False
         return res
+
+    def get_available_lists(self) -> List[str]:
+        print("reaching here")
+        try:
+            resource_prefix = f"services/data/v{self.version}/query"
+            endpoint = f"{sls.SALESFORCE_BASE_URL}/{resource_prefix}/"
+            response = self.get(endpoint + "?q=SELECT+Subscriptions__c+FROM+AC_to_SF_List_Mapping__mdt")
+            pprint(response)
+            pprint(response.json())
+            records = response.json()["records"]
+            return [record["Subscriptions__c"] for record in records]
+        except Exception as e:
+            print("An unexpected error occurred:")
+            pprint({
+                "type": type(e).__name__,
+                "message": str(e),
+                "args": e.args,
+                "traceback": traceback.format_exc()
+            })
+            return []

--- a/sefaria/helper/crm/salesforce.py
+++ b/sefaria/helper/crm/salesforce.py
@@ -7,8 +7,6 @@ from sefaria.helper.crm.crm_connection_manager import CrmConnectionManager
 from sefaria import settings as sls
 
 from typing import Any, Optional, List
-from pprint import pprint
-import traceback
 
 
 class SalesforceConnectionManager(CrmConnectionManager):
@@ -18,7 +16,6 @@ class SalesforceConnectionManager(CrmConnectionManager):
         self.resource_prefix = f"services/data/v{self.version}/sobjects/"
 
     def create_endpoint(self, *args):
-        print(f"{sls.SALESFORCE_BASE_URL}/{self.resource_prefix}{'/'.join(args)}")
         return f"{sls.SALESFORCE_BASE_URL}/{self.resource_prefix}{'/'.join(args)}"
 
     def make_request(self, request, **kwargs):
@@ -164,21 +161,12 @@ class SalesforceConnectionManager(CrmConnectionManager):
         return res
 
     def get_available_lists(self) -> List[str]:
-        print("reaching here")
         try:
             resource_prefix = f"services/data/v{self.version}/query"
             endpoint = f"{sls.SALESFORCE_BASE_URL}/{resource_prefix}/"
             response = self.get(endpoint + "?q=SELECT+Subscriptions__c+FROM+AC_to_SF_List_Mapping__mdt")
-            pprint(response)
-            pprint(response.json())
             records = response.json()["records"]
             return [record["Subscriptions__c"] for record in records]
-        except Exception as e:
-            print("An unexpected error occurred:")
-            pprint({
-                "type": type(e).__name__,
-                "message": str(e),
-                "args": e.args,
-                "traceback": traceback.format_exc()
-            })
+        except:
+            print("Unable to retrieve newsletter mailing lists from Salesforce CRM")
             return []

--- a/sefaria/urls.py
+++ b/sefaria/urls.py
@@ -396,10 +396,11 @@ urlpatterns += [
     url(r'^api/send_feedback$', sefaria_views.generate_feedback),
 ]
 
-# Email Subscribe
+# Email Newsletter Subscriptions
 urlpatterns += [
     url(r'^api/subscribe/(?P<org>.+)/(?P<email>.+)$', sefaria_views.generic_subscribe_to_newsletter_api),
     url(r'^api/subscribe/(?P<email>.+)$', sefaria_views.subscribe_sefaria_newsletter_view),
+    url(r'^api/newsletter_mailing_lists/?$', sefaria_views.get_available_newsletter_mailing_lists),
 ]
 
 # Admin

--- a/sefaria/views.py
+++ b/sefaria/views.py
@@ -36,6 +36,7 @@ from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
 import sefaria.model as model
 import sefaria.system.cache as scache
 from sefaria.helper.crm.crm_mediator import CrmMediator
+from sefaria.helper.crm.salesforce import SalesforceNewsletterListRetrievalError
 from sefaria.system.cache import in_memory_cache
 from sefaria.client.util import jsonResponse, send_email, read_webpack_bundle
 from sefaria.forms import SefariaNewUserForm, SefariaNewUserFormAPI, SefariaDeleteUserForm, SefariaDeleteSheet
@@ -203,9 +204,11 @@ def subscribe_sefaria_newsletter_view(request, email):
 
 def subscribe_sefaria_newsletter(request, email, first_name, last_name):
     """
-    API for subscribing to mailing lists, in `lists` url param.
-    Currently active lists are:
-    "Announcements_General", "Announcements_General_Hebrew", "Announcements_Edu", "Announcements_Edu_Hebrew"
+    API for subscribing to mailing lists
+    * By default, the user's email address is subscribed to the default lists: "Master," "General Updates" (or the one for Hebrew), and "Educator Updates" (if the user is an educator).
+    * If the user's email address already exists, the email address to those lists is not resubscribed to those lists
+    * When you provide additional newsletter mailing lists, the email address will be subscribed to those lists, along with the default ones, if the email address does not already exist.
+    * However, if we pass the email address with any of those default newsletter lists as additional ones, Salesforce will resubscribe the email address to those lists.
     """
     body = json.loads(request.body)
     language = body.get("language", "")
@@ -214,8 +217,14 @@ def subscribe_sefaria_newsletter(request, email, first_name, last_name):
     crm_mediator = CrmMediator()
     return crm_mediator.subscribe_to_lists(email, first_name, last_name, educator=educator, lang=language, mailing_lists=mailing_lists)
 
+@csrf_exempt
 def get_available_newsletter_mailing_lists(request):
-    return jsonResponse({"newsletter_mailing_lists": CrmMediator().get_available_lists()})
+    try:
+        return jsonResponse({"newsletter_mailing_lists": CrmMediator().get_available_lists()})
+    except SalesforceNewsletterListRetrievalError as e:
+        return jsonResponse({"error": e.message}, status=502)
+    except:
+        return jsonResponse({"error": "Unknown error occurred"}, status=500)
 
 def subscribe_steinsaltz(request, email, first_name, last_name):
     """

--- a/sefaria/views.py
+++ b/sefaria/views.py
@@ -222,7 +222,7 @@ def get_available_newsletter_mailing_lists(request):
     try:
         return jsonResponse({"newsletter_mailing_lists": CrmMediator().get_available_lists()})
     except SalesforceNewsletterListRetrievalError as e:
-        return jsonResponse({"error": e.message}, status=502)
+        return jsonResponse({"error": str(e)}, status=502)
     except:
         return jsonResponse({"error": "Unknown error occurred"}, status=500)
 

--- a/sefaria/views.py
+++ b/sefaria/views.py
@@ -210,9 +210,12 @@ def subscribe_sefaria_newsletter(request, email, first_name, last_name):
     body = json.loads(request.body)
     language = body.get("language", "")
     educator = body.get("educator", False)
+    mailing_lists = body.get("lists", [])
     crm_mediator = CrmMediator()
-    return crm_mediator.subscribe_to_lists(email, first_name, last_name, educator=educator, lang=language)
+    return crm_mediator.subscribe_to_lists(email, first_name, last_name, educator=educator, lang=language, mailing_lists=mailing_lists)
 
+def get_available_newsletter_mailing_lists(request):
+    return jsonResponse({"newsletter_mailing_lists": CrmMediator().get_available_lists()})
 
 def subscribe_steinsaltz(request, email, first_name, last_name):
     """


### PR DESCRIPTION
## Description
Sefaria currently provides a backend API for subscribing to newsletters. The API does not currently support subscribing to multiple and different newsletter lists that Sefaria provides. This PR gives that ability. A code update to Salesforce will also be necessary to support allowing multiple newsletter.

## Code Changes
* Adds a new payload item as a list of strings for the `api/subscribe` endpoint to take other newsletter lists besides the default included for every user. Either none or multiple newsletters can be sent. Duplicates and invalid mailing lists are ignored.
* Adds a new `api/newsletter_mailing_lists` endpoint to show the available newsletter mailing lists a user can be susbscribed to. The management of these lists are done through Salesforce/ActiveCampaign. The endpoint will be used by Sefaria's CMS to sync available lists so specific lists can be chosen and for engineers to get specific values for lists

## Further considerations
* Making API requests to Salesforce can take a long time. Those API requests may be better served asynchronously through a job queue or some other method, since the user does not need to be totally aware of the status for the subscription process and they do not need to be subscribed immediately.