### PR TITLE
Secondary topic image

### DIFF
--- a/reader/views.py
+++ b/reader/views.py
@@ -3658,7 +3658,7 @@ def topic_upload_photo(request, slug, secondary=False):
         if old_filename:
             old_filename = f"topics/{old_filename.split('/')[-1]}"
 
-        img_url = GoogleStorageManager.upload_file(request.FILES.get('file'), f"topics/{request.user.id}-{uuid.uuid1()}.gif",
+        img_url = GoogleStorageManager.upload_file(request.FILES.get('file'), f"topics/{slug}-{uuid.uuid1()}.png",
                                                     GoogleStorageManager.TOPICS_BUCKET, old_filename=old_filename)
         if secondary:
             add_secondary_image_to_topic(slug, img_url)

--- a/reader/views.py
+++ b/reader/views.py
@@ -3658,8 +3658,8 @@ def topic_upload_photo(request, slug, secondary=False):
         if old_filename:
             old_filename = f"topics/{old_filename.split('/')[-1]}"
 
-        img_url = GoogleStorageManager.upload_file(request.FILES.get('file'), f"topics/{slug}-{uuid.uuid1()}.png",
-                                                    GoogleStorageManager.TOPICS_BUCKET, old_filename=old_filename)
+        to_filename = f"topics/{slug}-{'secondary-' if secondary else ''}{uuid.uuid1()}.png"
+        img_url = GoogleStorageManager.upload_file(request.FILES.get('file'), to_filename, GoogleStorageManager.TOPICS_BUCKET, old_filename=old_filename)
         if secondary:
             add_secondary_image_to_topic(slug, img_url)
         else:

--- a/reader/views.py
+++ b/reader/views.py
@@ -3638,7 +3638,7 @@ def profile_follow_api(request, ftype, slug):
     return jsonResponse({"error": "Unsupported HTTP method."})
 
 @staff_member_required
-def topic_upload_photo(request, topic):
+def topic_upload_photo(request, slug):
     from io import BytesIO
     import uuid
     import base64
@@ -3648,7 +3648,7 @@ def topic_upload_photo(request, topic):
             return jsonResponse({"error": "You cannot remove an image as you haven't selected one yet."})
         old_filename = f"topics/{old_filename.split('/')[-1]}"
         GoogleStorageManager.delete_filename(old_filename, GoogleStorageManager.TOPICS_BUCKET)
-        topic = Topic.init(topic)
+        topic = Topic.init(slug)
         if hasattr(topic, "image"):
             del topic.image
             topic.save()
@@ -3661,7 +3661,7 @@ def topic_upload_photo(request, topic):
         img_file_in_mem = BytesIO(base64.b64decode(file))
         img_url = GoogleStorageManager.upload_file(img_file_in_mem, f"topics/{request.user.id}-{uuid.uuid1()}.gif",
                                                     GoogleStorageManager.TOPICS_BUCKET, old_filename=old_filename)
-        topic = Topic.init(topic)
+        topic = Topic.init(slug)
         if not hasattr(topic, "image"):
             topic.image = {"image_uri": img_url, "image_caption": {"en": "", "he": ""}}
         else:

--- a/reader/views.py
+++ b/reader/views.py
@@ -3640,10 +3640,8 @@ def profile_follow_api(request, ftype, slug):
 
 @staff_member_required
 def topic_upload_photo(request, slug, secondary=False):
-    from io import BytesIO
     from sefaria.helper.topic import add_image_to_topic, delete_image_from_topic, add_secondary_image_to_topic, delete_secondary_image_from_topic
     import uuid
-    import base64
     if request.method == "DELETE":
         old_filename = request.GET.get("old_filename")
         if old_filename is None:
@@ -3656,12 +3654,11 @@ def topic_upload_photo(request, slug, secondary=False):
             delete_image_from_topic(slug)
         return jsonResponse({"success": "You have successfully removed the image."})
     elif request.method == "POST":
-        file = request.POST.get('file')
         old_filename = request.POST.get('old_filename')  # delete file from google storage if there is one there
         if old_filename:
             old_filename = f"topics/{old_filename.split('/')[-1]}"
-        img_file_in_mem = BytesIO(base64.b64decode(file))
-        img_url = GoogleStorageManager.upload_file(img_file_in_mem, f"topics/{request.user.id}-{uuid.uuid1()}.gif",
+
+        img_url = GoogleStorageManager.upload_file(request.FILES.get('file'), f"topics/{request.user.id}-{uuid.uuid1()}.gif",
                                                     GoogleStorageManager.TOPICS_BUCKET, old_filename=old_filename)
         if secondary:
             add_secondary_image_to_topic(slug, img_url)

--- a/sefaria/helper/topic.py
+++ b/sefaria/helper/topic.py
@@ -1328,7 +1328,7 @@ def delete_ref_topic_link(tref, to_topic, link_type, lang):
             return {"error": f"Cannot delete link between {tref} and {to_topic}."}
 
 
-def add_image_to_topic(topic_slug, image_uri, en_caption, he_caption):
+def add_image_to_topic(topic_slug: str, image_uri: str, en_caption: str = "", he_caption: str =""):
     """
     A function to add an image to a Topic in the database. Helper for data migration.
     This function queries the desired Topic, adds the image data, and then saves.
@@ -1339,9 +1339,32 @@ def add_image_to_topic(topic_slug, image_uri, en_caption, he_caption):
     :param he_caption String: The Hebrew caption for a Topic image
     """
     topic = Topic.init(topic_slug)
-    topic.image = {"image_uri": image_uri,
-                   "image_caption": {
-                       "en": en_caption,
-                       "he": he_caption
-                   }}
+    if not hasattr(topic, "image"):
+        topic.image = {"image_uri": image_uri, "image_caption": {"en": en_caption, "he": he_caption}}
+    else:
+        topic.image["image_uri"] = image_uri
+        if en_caption:
+            topic.image["image_caption"]["en"] = en_caption
+        if he_caption:
+            topic.image["image_caption"]["he"] = he_caption
     topic.save()
+
+
+def add_secondary_image_to_topic(topic_slug: str, image_uri: str):
+    topic = Topic.init(topic_slug)
+    topic.secondary_image = image_uri
+    topic.save()
+
+
+def delete_image_from_topic(topic_slug: str):
+    topic = Topic.init(topic_slug)
+    if hasattr(topic, "image"):
+        del topic.image
+        topic.save()
+
+
+def delete_secondary_image_from_topic(topic_slug: str):
+    topic = Topic.init(topic_slug)
+    if hasattr(topic, "secondary_image"):
+        del topic.secondary_image
+        topic.save()

--- a/sefaria/helper/topic.py
+++ b/sefaria/helper/topic.py
@@ -1352,7 +1352,7 @@ def add_image_to_topic(topic_slug: str, image_uri: str, en_caption: str = "", he
 
 def add_secondary_image_to_topic(topic_slug: str, image_uri: str):
     topic = Topic.init(topic_slug)
-    topic.secondary_image = image_uri
+    topic.secondary_image_uri = image_uri
     topic.save()
 
 
@@ -1365,6 +1365,6 @@ def delete_image_from_topic(topic_slug: str):
 
 def delete_secondary_image_from_topic(topic_slug: str):
     topic = Topic.init(topic_slug)
-    if hasattr(topic, "secondary_image"):
-        del topic.secondary_image
+    if hasattr(topic, "secondary_image_uri"):
+        del topic.secondary_image_uri
         topic.save()

--- a/sefaria/model/topic.py
+++ b/sefaria/model/topic.py
@@ -153,7 +153,7 @@ class Topic(abst.SluggedAbstractMongoRecord, AbstractTitledObject):
         'isAmbiguous',  # True if topic primary title can refer to multiple other topics
         "data_source",  #any topic edited manually should display automatically in the TOC and this flag ensures this
         'image',
-        'secondary_image',
+        'secondary_image_uri',
         "portal_slug",  # slug to relevant Portal object
     ]
 

--- a/sefaria/model/topic.py
+++ b/sefaria/model/topic.py
@@ -153,6 +153,7 @@ class Topic(abst.SluggedAbstractMongoRecord, AbstractTitledObject):
         'isAmbiguous',  # True if topic primary title can refer to multiple other topics
         "data_source",  #any topic edited manually should display automatically in the TOC and this flag ensures this
         'image',
+        'secondary_image',
         "portal_slug",  # slug to relevant Portal object
     ]
 

--- a/sefaria/urls.py
+++ b/sefaria/urls.py
@@ -103,7 +103,8 @@ urlpatterns += [
     url(r'^topics/b/(?P<topic>.+)$', reader_views.topic_page_b),
     url(r'^topics/(?P<topic>.+)$', reader_views.topic_page),
     url(r'^api/topic/completion/(?P<topic>.+)', reader_views.topic_completion_api),
-    url(r'^api/topics/images/(?P<topic>.+)$', reader_views.topic_upload_photo)
+    url(r'^_api/topics/images/secondary/(?P<slug>.+)$', reader_views.topic_upload_photo, {"secondary": True}),
+    url(r'^_api/topics/images/(?P<slug>.+)$', reader_views.topic_upload_photo)
 
 ]
 

--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -7631,10 +7631,10 @@ But not to use a display block directive that might break continuous mode for ot
 }
 .profile-pic-cropper {
 }
-.profile-page .profile-pic .profile-pic-cropper-modal .profile-pic-cropper-button {
+#interruptingMessage.profile-pic-cropper-modal .profile-pic-cropper-button {
   display: inline-flex;
 }
-.profile-page .profile-pic .profile-pic-cropper-desc {
+.profile-pic-cropper-desc {
   margin-top: 9px;
   margin-bottom: 18px;
 }
@@ -11561,7 +11561,8 @@ cursor: pointer;
 .profile-page .follow-header .follow-count {
   color: #999;
 }
-.profile-page .resourcesLink  {
+.profile-page .resourcesLink,
+.profile-pic-cropper-button.resourcesLink {
   min-height: 46px;
   height: 46px;
   overflow: visible;
@@ -11584,7 +11585,8 @@ cursor: pointer;
   line-height: 1.5;
 }
 .profile-page .profile-summary .resourcesLink + .resourcesLink,
-.profile-page .profile-summary .largeFollowButton + .resourcesLink {
+.profile-page .profile-summary .largeFollowButton + .resourcesLink,
+#interruptingMessage.profile-pic-cropper-modal .resourcesLink + .resourcesLink {
   margin: 0 0 0 10px;
 }
 .interface-hebrew .profile-page .profile-summary .largeFollowButton + .resourcesLink,

--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -7619,8 +7619,10 @@ But not to use a display block directive that might break continuous mode for ot
   margin-top: 17px;
 }
 .profile-pic-cropper-modal .ReactCrop__crop-selection {
-  border-radius: 50%;
   box-shadow: 0 0 0 9999em rgba(255, 255, 255, 0.6);
+}
+.profile-page .profile-pic-cropper-modal .ReactCrop__crop-selection {
+  border-radius: 50%;
 }
 .profile-pic-cropper-modal .ReactCrop__image {
   max-width: 50vw;

--- a/static/js/AdminEditor.jsx
+++ b/static/js/AdminEditor.jsx
@@ -123,7 +123,7 @@ const validateMarkdownLinks = async (input) => {
     return true;
 }
 
-const AdminEditor = ({title, data, close, catMenu, pictureUploader, updateData, savingStatus,
+const AdminEditor = ({title, data, close, catMenu, pictureUploader, secondaryPictureCropper, updateData, savingStatus,
                              validate, deleteObj, items = [], isNew = true,
                              extras = [], path = []}) => {
     const [validatingLinks, setValidatingLinks] = useState(false);
@@ -213,6 +213,8 @@ const AdminEditor = ({title, data, close, catMenu, pictureUploader, updateData, 
                             return catMenu;
                         } else if (x === "Picture Uploader") {
                             return pictureUploader;
+                        } else if (x === "Secondary Picture Cropper") {
+                            return secondaryPictureCropper;
                         }
                         else {
                             return item({...options_for_form[x]});

--- a/static/js/ImageCropper.jsx
+++ b/static/js/ImageCropper.jsx
@@ -95,6 +95,7 @@ export const ImageCropper = ({loading, error, src, onClose, onSave}) => {
                                 onImageLoaded={onImageLoaded}
                                 onComplete={onCropComplete}
                                 onChange={onCropChange}
+                                crossorigin={"anonymous"}
                             />) : (<div className="profile-pic-cropper-error">{ error }</div>)
                         }
                     </div>

--- a/static/js/ImageCropper.jsx
+++ b/static/js/ImageCropper.jsx
@@ -4,7 +4,7 @@ import ReactCrop from 'react-image-crop';
 import {LoadingRing} from "./Misc";
 import 'react-image-crop/dist/ReactCrop.css';
 
-export const ImageCropper = ({loading, error, src, onClose, onSave}) => {
+export const ImageCropper = ({loading, error, src, onClose, onSave, widthHeightRatio}) => {
     /**
      * loading - bool, is the image cropper loading data
      * error - str, error message
@@ -15,7 +15,7 @@ export const ImageCropper = ({loading, error, src, onClose, onSave}) => {
      */
     const imageRef = useRef(null);
     const [isFirstCropChange, setIsFirstCropChange] = useState(true);
-    const [crop, setCrop] = useState({unit: "px", width: 250, aspect: 1});
+    const [crop, setCrop] = useState({unit: "px", width: 250, aspect: widthHeightRatio});
     const [croppedImageBlob, setCroppedImageBlob] = useState(null);
     const onImageLoaded = (image) => {imageRef.current = image};
     const onCropComplete = (crop) => {
@@ -25,7 +25,7 @@ export const ImageCropper = ({loading, error, src, onClose, onSave}) => {
         if (isFirstCropChange) {
             const { clientWidth:width, clientHeight:height } = imageRef.current;
             crop.width = Math.min(width, height);
-            crop.height = crop.width;
+            crop.height = crop.width/widthHeightRatio;
             crop.x = (imageRef.current.width/2) - (crop.width/2);
             crop.y = (imageRef.current.height/2) - (crop.width/2);
             setCrop(crop);

--- a/static/js/ImageCropper.jsx
+++ b/static/js/ImageCropper.jsx
@@ -24,13 +24,11 @@ export const ImageCropper = ({loading, error, src, onClose, onSave, widthHeightR
     const onCropChange = (crop, percentCrop) => {
         if (isFirstCropChange) {
             const { clientWidth:width, clientHeight:height } = imageRef.current;
-            setCrop({
-                ...crop,
-                width: Math.min(width, height),
-                height: crop.width/widthHeightRatio,
-                x: (imageRef.current.width/2) - (crop.width/2),
-                y: (imageRef.current.height/2) - (crop.width/2),
-            });
+            crop.width = Math.min(width, height);
+            crop.height = crop.width/widthHeightRatio;
+            crop.x = (imageRef.current.width/2) - (crop.width/2);
+            crop.y = (imageRef.current.height/2) - (crop.width/2);
+            setCrop(crop);
             setIsFirstCropChange(false);
         } else {
             setCrop(crop);

--- a/static/js/ImageCropper.jsx
+++ b/static/js/ImageCropper.jsx
@@ -17,6 +17,7 @@ export const ImageCropper = ({loading, error, src, onClose, onSave, widthHeightR
     const [isFirstCropChange, setIsFirstCropChange] = useState(true);
     const [crop, setCrop] = useState({unit: "px", width: 250, aspect: widthHeightRatio});
     const [croppedImageBlob, setCroppedImageBlob] = useState(null);
+    const [internalError, setInternalError] = useState(null);
     const onImageLoaded = (image) => {imageRef.current = image};
     const onCropComplete = (crop) => {
         makeClientCrop(crop);
@@ -50,6 +51,13 @@ export const ImageCropper = ({loading, error, src, onClose, onSave, widthHeightR
         const scaleY = image.naturalHeight / image.height;
         canvas.width = crop.width * scaleX;
         canvas.height = crop.height * scaleY;
+
+        const actualAspectRatio = canvas.width / canvas.height;
+        if (Math.abs(actualAspectRatio - widthHeightRatio) > 0.01) {
+            // in rare circumstances ReactCrop doesn't enforce aspect ratio properly
+            // catch these cases and inform user
+            setInternalError("Aspect ratio of image doesn't match allowed value. When this happens, refresh the page and try again.");
+        }
         const ctx = canvas.getContext("2d");
         ctx.drawImage(
             image,
@@ -78,15 +86,17 @@ export const ImageCropper = ({loading, error, src, onClose, onSave, widthHeightR
         setCrop({unit: "px", width: 250, aspect: 1});
         setIsFirstCropChange(true);
         setCroppedImageBlob(null);
+        setInternalError(null);
         onClose();
     }
+    const displayError = error || internalError;
     return (<>
-        { (src || !!error) && (
+        { (src || displayError) && (
             <div id="interruptingMessageBox" className="sefariaModalBox">
                 <div id="interruptingMessageOverlay" onClick={closePopup}></div>
                 <div id="interruptingMessage" className="profile-pic-cropper-modal">
                     <div className="sefariaModalContent profile-pic-cropper-modal-inner">
-                        { src ?
+                        { displayError ? (<div className="profile-pic-cropper-error">{ displayError }</div>) :
                             (<ReactCrop
                                 src={src}
                                 crop={crop}
@@ -96,7 +106,7 @@ export const ImageCropper = ({loading, error, src, onClose, onSave, widthHeightR
                                 onComplete={onCropComplete}
                                 onChange={onCropChange}
                                 crossorigin={"anonymous"}
-                            />) : (<div className="profile-pic-cropper-error">{ error }</div>)
+                            />)
                         }
                     </div>
                     { (loading || isFirstCropChange) ? (<div className="profile-pic-loading"><LoadingRing /></div>) : (
@@ -105,16 +115,18 @@ export const ImageCropper = ({loading, error, src, onClose, onSave, widthHeightR
                                 <span className="int-en">Drag corners to crop image</span>
                                 <span className="int-he">לחיתוך התמונה, גרור את הפינות</span>
                             </div>
-                            <div className="profile-pic-cropper-button-row">
-                                <a href="#" className="resourcesLink profile-pic-cropper-button" onClick={closePopup}>
-                                    <span className="int-en">Cancel</span>
-                                    <span className="int-he">בטל</span>
-                                </a>
-                                <a href="#" className="resourcesLink blue profile-pic-cropper-button" onClick={()=>onSave(croppedImageBlob)}>
-                                    <span className="int-en">Save</span>
-                                    <span className="int-he">שמור</span>
-                                </a>
-                            </div>
+                            { !displayError ? (
+                                <div className="profile-pic-cropper-button-row">
+                                    <a href="#" className="resourcesLink profile-pic-cropper-button" onClick={closePopup}>
+                                        <span className="int-en">Cancel</span>
+                                        <span className="int-he">בטל</span>
+                                    </a>
+                                    <a href="#" className="resourcesLink blue profile-pic-cropper-button" onClick={()=>onSave(croppedImageBlob)}>
+                                        <span className="int-en">Save</span>
+                                        <span className="int-he">שמור</span>
+                                    </a>
+                                </div>
+                            ) : null}
                         </div>
                     )
                     }

--- a/static/js/ImageCropper.jsx
+++ b/static/js/ImageCropper.jsx
@@ -5,6 +5,14 @@ import {LoadingRing} from "./Misc";
 import 'react-image-crop/dist/ReactCrop.css';
 
 export const ImageCropper = ({loading, error, src, onClose, onSave}) => {
+    /**
+     * loading - bool, is the image cropper loading data
+     * error - str, error message
+     * src
+     * onClose - fn, called when ImageCropper is closed
+     * onSave - fn, called when "Save" is pressed
+     * @type {React.MutableRefObject<null>}
+     */
     const imageRef = useRef(null);
     const [isFirstCropChange, setIsFirstCropChange] = useState(true);
     const [crop, setCrop] = useState({unit: "px", width: 250, aspect: 1});

--- a/static/js/ImageCropper.jsx
+++ b/static/js/ImageCropper.jsx
@@ -24,11 +24,13 @@ export const ImageCropper = ({loading, error, src, onClose, onSave, widthHeightR
     const onCropChange = (crop, percentCrop) => {
         if (isFirstCropChange) {
             const { clientWidth:width, clientHeight:height } = imageRef.current;
-            crop.width = Math.min(width, height);
-            crop.height = crop.width/widthHeightRatio;
-            crop.x = (imageRef.current.width/2) - (crop.width/2);
-            crop.y = (imageRef.current.height/2) - (crop.width/2);
-            setCrop(crop);
+            setCrop({
+                ...crop,
+                width: Math.min(width, height),
+                height: crop.width/widthHeightRatio,
+                x: (imageRef.current.width/2) - (crop.width/2),
+                y: (imageRef.current.height/2) - (crop.width/2),
+            });
             setIsFirstCropChange(false);
         } else {
             setCrop(crop);

--- a/static/js/Misc.jsx
+++ b/static/js/Misc.jsx
@@ -1021,7 +1021,7 @@ const EditorForExistingTopic = ({ toggle, data }) => {
     origDeathYear: data?.properties?.deathYear?.value,
     origEra: data?.properties?.era?.value,
     origImage: data?.image,
-
+    origSecondaryImageUri: data?.secondary_image_uri,
   };
 
   const origWasCat = "displays-above" in data?.links;

--- a/static/js/Misc.jsx
+++ b/static/js/Misc.jsx
@@ -1432,7 +1432,15 @@ FollowButton.propTypes = {
 
 };
 
-const TopicPictureUploader = ({slug, callback, old_filename, caption}) => {
+const SmallBlueButton = ({onClick, tabIndex, text}) => {
+  return (
+      <div onClick={onClick} className="button extraSmall blue control-elem" tabIndex={tabIndex} role="button">
+        <InterfaceText>{text}</InterfaceText>
+      </div>
+  );
+};
+
+const TopicPictureUploader = ({title, slug, callback, old_filename, caption}) => {
     /*
     `old_filename` is passed to API so that if it exists, it is deleted
      */
@@ -1500,16 +1508,14 @@ const TopicPictureUploader = ({slug, callback, old_filename, caption}) => {
             </label>
             <div role="button" title={Sefaria._("Add an image")} aria-label="Add an image" contentEditable={false} onClick={(e) => e.stopPropagation()} id="addImageButton">
               <label htmlFor="addImageFileSelector">
-                <div className="button extraSmall blue control-elem" tabIndex="0" role="button">
-                      <InterfaceText>Upload Picture</InterfaceText>
-                    </div>
+                <SmallBlueButton tabIndex="0" text="Upload Picture" />
               </label>
               </div><input style={{display: "none"}} id="addImageFileSelector" type="file" onChange={onFileSelect} ref={fileInput} />
               {old_filename !== "" && <div style={{"max-width": "420px"}}>
                     <br/><ImageWithCaption photoLink={old_filename} caption={caption}/>
-                    <br/><div onClick={deleteImage} className="button extraSmall blue control-elem" tabIndex="1" role="button">
-                      <InterfaceText>Remove Picture</InterfaceText>
-                    </div></div>
+                    <br/>
+                    <SmallBlueButton tabIndex="1" text="Remove Picture" onClick={deleteImage} />
+              </div>
               }
           </div>
     }

--- a/static/js/Misc.jsx
+++ b/static/js/Misc.jsx
@@ -18,7 +18,6 @@ import {refSort} from "./TopicPage";
 import {TopicEditor} from "./TopicEditor";
 import {generateContentForModal, SignUpModalKind} from './sefaria/signupModalContent';
 import {SourceEditor} from "./SourceEditor";
-import Cookies from "js-cookie";
 import {EditTextInfo} from "./BookPage";
 import ReactMarkdown from 'react-markdown';
 import TrackG4 from "./sefaria/trackG4";

--- a/static/js/Misc.jsx
+++ b/static/js/Misc.jsx
@@ -1440,85 +1440,6 @@ const SmallBlueButton = ({onClick, tabIndex, text}) => {
   );
 };
 
-const TopicPictureUploader = ({title, slug, callback, old_filename, caption}) => {
-    /*
-    `old_filename` is passed to API so that if it exists, it is deleted
-     */
-    const fileInput = useRef(null);
-
-    const uploadImage = function(imageData, type="POST") {
-      const formData = new FormData();
-      formData.append('file', imageData.replace(/data:image\/(jpe?g|png|gif);base64,/, ""));
-      if (old_filename !== "") {
-        formData.append('old_filename', old_filename);
-      }
-      const request = new Request(
-        `${Sefaria.apiHost}/api/topics/images/${slug}`,
-        {headers: {'X-CSRFToken': Cookies.get('csrftoken')}}
-      );
-      fetch(request, {
-          method: 'POST',
-          mode: 'same-origin',
-          credentials: 'same-origin',
-          body: formData
-      }).then(response => {
-        if (!response.ok) {
-            response.text().then(resp_text=> {
-                alert(resp_text);
-            })
-        }else{
-            response.json().then(resp_json=>{
-                callback(resp_json.url);
-            });
-        }
-    }).catch(error => {
-        alert(error);
-    })};
-    const onFileSelect = (e) => {
-          const file = fileInput.current.files[0];
-          if (file == null)
-          return;
-          if (/\.(jpe?g|png|gif)$/i.test(file.name)) {
-              const reader = new FileReader();
-
-              reader.addEventListener("load", function() {
-                uploadImage(reader.result);
-              }, false);
-
-              reader.addEventListener("onerror", function() {
-                alert(reader.error);
-              }, false);
-
-              reader.readAsDataURL(file);
-          } else {
-            alert('The file is not an image');
-          }
-    }
-    const deleteImage = () => {
-        const old_filename_wout_url = old_filename.split("/").slice(-1);
-        const url = `${Sefaria.apiHost}/api/topics/images/${slug}?old_filename=${old_filename_wout_url}`;
-        Sefaria.adminEditorApiRequest(url, null, null, "DELETE").then(() => alert("Deleted image."));
-        callback("");
-        fileInput.current.value = "";
-    }
-    return <div className="section">
-            <label><InterfaceText>Picture</InterfaceText></label>
-            <label>
-              <span className="optional"><InterfaceText>Please use horizontal, square, or only-slightly-vertical images for best results.</InterfaceText></span>
-            </label>
-            <div role="button" title={Sefaria._("Add an image")} aria-label="Add an image" contentEditable={false} onClick={(e) => e.stopPropagation()} id="addImageButton">
-              <label htmlFor="addImageFileSelector">
-                <SmallBlueButton tabIndex="0" text="Upload Picture" />
-              </label>
-              </div><input style={{display: "none"}} id="addImageFileSelector" type="file" onChange={onFileSelect} ref={fileInput} />
-              {old_filename !== "" && <div style={{"max-width": "420px"}}>
-                    <br/><ImageWithCaption photoLink={old_filename} caption={caption}/>
-                    <br/>
-                    <SmallBlueButton tabIndex="1" text="Remove Picture" onClick={deleteImage} />
-              </div>
-              }
-          </div>
-    }
 
 const CategoryColorLine = ({category}) =>
   <div className="categoryColorLine" style={{background: Sefaria.palette.categoryColor(category)}}/>;
@@ -3320,9 +3241,9 @@ export {
   CategoryChooser,
   TitleVariants,
   OnInView,
-  TopicPictureUploader,
   ImageWithCaption,
   handleAnalyticsOnMarkdown,
   LangSelectInterface,
-  PencilSourceEditor
+  PencilSourceEditor,
+  SmallBlueButton,
 };

--- a/static/js/ProfilePic.jsx
+++ b/static/js/ProfilePic.jsx
@@ -40,7 +40,6 @@ export class ProfilePic extends Component {
             }
             const reader = new FileReader();
             reader.addEventListener("load", () => this.setState({fileToCropSrc: reader.result}));
-            console.log("FILE", e.target.files[0]);
             reader.readAsDataURL(e.target.files[0]);
         }
     }
@@ -51,10 +50,8 @@ export class ProfilePic extends Component {
         const formData = new FormData();
         formData.append('file', croppedImageBlob);
         this.setState({ uploading: true });
-        console.log("uploading")
         try {
             const response = await Sefaria.uploadProfilePhoto(formData);
-            console.log('responsse', response)
             if (response.error) {
                 throw new Error(response.error);
             } else {

--- a/static/js/ProfilePic.jsx
+++ b/static/js/ProfilePic.jsx
@@ -106,6 +106,7 @@ export class ProfilePic extends Component {
                     src={this.state.fileToCropSrc}
                     onClose={this.onCloseCropper}
                     onSave={this.upload}
+                    widthHeightRatio={1}
                 />
             </div>
         );

--- a/static/js/TopicEditor.jsx
+++ b/static/js/TopicEditor.jsx
@@ -1,14 +1,101 @@
 import Sefaria from "./sefaria/sefaria";
-import {InterfaceText, TopicPictureUploader} from "./Misc";
+import {InterfaceText, SmallBlueButton, ImageWithCaption} from "./Misc";
 import $ from "./sefaria/sefariaJquery";
 import {AdminEditor} from "./AdminEditor";
 import {Reorder} from "./CategoryEditor";
 import {ImageCropper} from "./ImageCropper";
-import React, {useState, useEffect} from "react";
+import React, {useState, useRef} from "react";
 
 
-const TopicPictureCropper = ({}) => {
-    return (<div>hello</div>);
+const TopicPictureUploader = ({slug, callback, old_filename, caption}) => {
+    /*
+    `old_filename` is passed to API so that if it exists, it is deleted
+     */
+    const fileInput = useRef(null);
+
+    const uploadImage = function(imageData, type="POST") {
+        const formData = new FormData();
+        formData.append('file', imageData.replace(/data:image\/(jpe?g|png|gif);base64,/, ""));
+        if (old_filename !== "") {
+            formData.append('old_filename', old_filename);
+        }
+        const request = new Request(
+            `${Sefaria.apiHost}/api/topics/images/${slug}`,
+            {headers: {'X-CSRFToken': Cookies.get('csrftoken')}}
+        );
+        fetch(request, {
+            method: 'POST',
+            mode: 'same-origin',
+            credentials: 'same-origin',
+            body: formData
+        }).then(response => {
+            if (!response.ok) {
+                response.text().then(resp_text=> {
+                    alert(resp_text);
+                })
+            }else{
+                response.json().then(resp_json=>{
+                    callback(resp_json.url);
+                });
+            }
+        }).catch(error => {
+            alert(error);
+        })};
+    const onFileSelect = (e) => {
+        const file = fileInput.current.files[0];
+        if (file == null)
+            return;
+        if (/\.(jpe?g|png|gif)$/i.test(file.name)) {
+            const reader = new FileReader();
+
+            reader.addEventListener("load", function() {
+                uploadImage(reader.result);
+            }, false);
+
+            reader.addEventListener("onerror", function() {
+                alert(reader.error);
+            }, false);
+
+            reader.readAsDataURL(file);
+        } else {
+            alert('The file is not an image');
+        }
+    }
+    const deleteImage = () => {
+        const old_filename_wout_url = old_filename.split("/").slice(-1);
+        const url = `${Sefaria.apiHost}/api/topics/images/${slug}?old_filename=${old_filename_wout_url}`;
+        Sefaria.adminEditorApiRequest(url, null, null, "DELETE").then(() => alert("Deleted image."));
+        callback("");
+        fileInput.current.value = "";
+    }
+    return <div className="section">
+        <label><InterfaceText>Picture</InterfaceText></label>
+        <label>
+            <span className="optional"><InterfaceText>Please use horizontal, square, or only-slightly-vertical images for best results.</InterfaceText></span>
+        </label>
+        <div role="button" title={Sefaria._("Add an image")} aria-label="Add an image" contentEditable={false} onClick={(e) => e.stopPropagation()} id="addImageButton">
+            <label htmlFor="addImageFileSelector">
+                <SmallBlueButton tabIndex="0" text="Upload Picture" />
+            </label>
+        </div><input style={{display: "none"}} id="addImageFileSelector" type="file" onChange={onFileSelect} ref={fileInput} />
+        {old_filename !== "" && <div style={{"max-width": "420px"}}>
+            <br/><ImageWithCaption photoLink={old_filename} caption={caption}/>
+            <br/>
+            <SmallBlueButton tabIndex="1" text="Remove Picture" onClick={deleteImage} />
+        </div>
+        }
+    </div>
+}
+
+
+const TopicPictureCropper = ({image_uri}) => {
+    const [imageToCrop, setImageToCrop] = useState(null);
+    return (
+        <div>
+            <SmallBlueButton tabIndex="0" onClick={() => setImageToCrop(image_uri)} text="Upload Secondary Picture" />
+            <ImageCropper src={imageToCrop} onClose={() => setImageToCrop(null)}/>
+        </div>
+    );
 }
 
 
@@ -246,7 +333,7 @@ const TopicEditor = ({origData, onCreateSuccess, close, origWasCat}) => {
                         validate={validate} deleteObj={deleteObj} updateData={updateData} isNew={isNew} items={items}
                         pictureUploader={<TopicPictureUploader slug={data.origSlug} callback={handlePictureChange} old_filename={data.image_uri}
                                                                caption={{en: data.enImgCaption, he: data.heImgCaption}}/>}
-                        secondaryPictureCropper={<TopicPictureCropper />}
+                        secondaryPictureCropper={<TopicPictureCropper image_uri={data.image_uri}/>}
                         extras={
                               [isNew ? null :
                                 <Reorder subcategoriesAndBooks={sortedSubtopics}

--- a/static/js/TopicEditor.jsx
+++ b/static/js/TopicEditor.jsx
@@ -3,7 +3,13 @@ import {InterfaceText, TopicPictureUploader} from "./Misc";
 import $ from "./sefaria/sefariaJquery";
 import {AdminEditor} from "./AdminEditor";
 import {Reorder} from "./CategoryEditor";
+import {ImageCropper} from "./ImageCropper";
 import React, {useState, useEffect} from "react";
+
+
+const TopicPictureCropper = ({}) => {
+    return (<div>hello</div>);
+}
 
 
 const TopicEditor = ({origData, onCreateSuccess, close, origWasCat}) => {
@@ -235,10 +241,12 @@ const TopicEditor = ({origData, onCreateSuccess, close, origWasCat}) => {
     items.push("Picture Uploader");
     items.push("English Caption");
     items.push("Hebrew Caption");
+    items.push("Secondary Picture Cropper")
     return <AdminEditor title="Topic Editor" close={closeTopicEditor} catMenu={catMenu} data={data} savingStatus={savingStatus}
                         validate={validate} deleteObj={deleteObj} updateData={updateData} isNew={isNew} items={items}
                         pictureUploader={<TopicPictureUploader slug={data.origSlug} callback={handlePictureChange} old_filename={data.image_uri}
                                                                caption={{en: data.enImgCaption, he: data.heImgCaption}}/>}
+                        secondaryPictureCropper={<TopicPictureCropper />}
                         extras={
                               [isNew ? null :
                                 <Reorder subcategoriesAndBooks={sortedSubtopics}

--- a/static/js/TopicEditor.jsx
+++ b/static/js/TopicEditor.jsx
@@ -129,7 +129,7 @@ const TopicPictureCropper = ({slug, callback, old_filename, image_uri}) => {
     return (
         <div>
             <label><InterfaceText>Secondary Picture</InterfaceText></label>
-            <InterfaceText>This version of the topic's image will be shown on Topics Landing.</InterfaceText>
+            <div><InterfaceText>This version of the topic's image will be shown on Topics Landing.</InterfaceText></div>
             <SmallBlueButton tabIndex="0" onClick={() => setImageToCrop(image_uri)} text="Edit Secondary Picture" />
             <ImageCropper
                 loading={loading}

--- a/static/js/TopicEditor.jsx
+++ b/static/js/TopicEditor.jsx
@@ -129,7 +129,8 @@ const TopicPictureCropper = ({slug, callback, old_filename, image_uri}) => {
     return (
         <div>
             <label><InterfaceText>Secondary Picture</InterfaceText></label>
-            <SmallBlueButton tabIndex="0" onClick={() => setImageToCrop(image_uri)} text="Upload Secondary Picture" />
+            <InterfaceText>This version of the topic's image will be shown on Topics Landing.</InterfaceText>
+            <SmallBlueButton tabIndex="0" onClick={() => setImageToCrop(image_uri)} text="Edit Secondary Picture" />
             <ImageCropper
                 loading={loading}
                 src={imageToCrop}

--- a/static/js/TopicEditor.jsx
+++ b/static/js/TopicEditor.jsx
@@ -52,7 +52,7 @@ const CurrImageThumbnail = ({image_src, caption, deleteImage, removeButtonText})
     return (
         <div style={{"max-width": "420px"}}>
             <br/>
-            <ImageWithCaption photoLink={image_src} caption={caption}/>
+            <ImageWithCaption photoLink={image_src} caption={caption || {en: "", he: ""}}/>
             <br/>
             <SmallBlueButton tabIndex="1" text={removeButtonText} onClick={deleteImage} />
         </div>
@@ -153,7 +153,7 @@ const TopicEditor = ({origData, onCreateSuccess, close, origWasCat}) => {
                                 enImgCaption: origData?.origImage?.image_caption?.en || "",
                                 heImgCaption: origData?.origImage?.image_caption?.he || "",
                                 image_uri: origData?.origImage?.image_uri || "",
-                                secondary_image_uri: origData?.secondary_image_uri || "",
+                                secondary_image_uri: origData?.origSecondaryImageUri || "",
                                 });
     const isNew = !('origSlug' in origData);
     const [savingStatus, setSavingStatus] = useState(false);

--- a/static/js/TopicEditor.jsx
+++ b/static/js/TopicEditor.jsx
@@ -105,6 +105,11 @@ const TopicPictureCropper = ({slug, callback, old_filename, image_uri}) => {
     const [imageToCrop, setImageToCrop] = useState(null);
     const [loading, setLoading] = useState(false);
 
+    if (!image_uri) {
+        // no primary image so nothing to crop
+        return null;
+    }
+
     const onSave = (croppedImageBlob) => {
         setLoading(true);
         uploadTopicImage(croppedImageBlob, old_filename, `_api/topics/images/secondary/${slug}`)

--- a/static/js/TopicEditor.jsx
+++ b/static/js/TopicEditor.jsx
@@ -92,6 +92,7 @@ const TopicPictureCropper = ({image_uri}) => {
     const [imageToCrop, setImageToCrop] = useState(null);
     return (
         <div>
+            <label><InterfaceText>Secondary Picture</InterfaceText></label>
             <SmallBlueButton tabIndex="0" onClick={() => setImageToCrop(image_uri)} text="Upload Secondary Picture" />
             <ImageCropper src={imageToCrop} onClose={() => setImageToCrop(null)}/>
         </div>

--- a/static/js/TopicEditor.jsx
+++ b/static/js/TopicEditor.jsx
@@ -86,11 +86,14 @@ const TopicPictureUploader = ({slug, callback, old_filename, caption}) => {
 
 const TopicPictureCropper = ({image_uri, slug, old_filename}) => {
     const [imageToCrop, setImageToCrop] = useState(null);
+    const [loading, setLoading] = useState(false);
     const onSave = (croppedImageBlob) => {
+        setLoading(true);
         uploadTopicImage(croppedImageBlob, old_filename, `_api/topics/images/secondary/${slug}`)
             .then((new_image_uri) => {
                 //TODO propagate new_image_uri to TopicEditor
                 setImageToCrop(null);
+                setLoading(false);
             });
     }
     return (
@@ -98,8 +101,10 @@ const TopicPictureCropper = ({image_uri, slug, old_filename}) => {
             <label><InterfaceText>Secondary Picture</InterfaceText></label>
             <SmallBlueButton tabIndex="0" onClick={() => setImageToCrop(image_uri)} text="Upload Secondary Picture" />
             <ImageCropper
+                loading={loading}
                 src={imageToCrop}
                 onClose={() => setImageToCrop(null)}
+                widthHeightRatio={4/3}
                 onSave={onSave}/>
         </div>
     );


### PR DESCRIPTION
## Description
Adds ability to upload secondary topic images through the topic admin editor

## Code Changes
- add `_api/topics/images/secondary` API for uploading and deleting secondary topic images.
- refactor existing topic image API so that it handles files in a more standard way (using the file object that's uploaded as opposed to using the base64 string)
- Pull topic editor code from Misc.jsx into TopicEditor.jsx where it belongs
- Allow ImageCropper to take a widthHeightRatio prop to control the ratio of the cropping square.