### PR TITLE
Fix display of Strapi banners on static pages

### DIFF
--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -385,6 +385,9 @@ body.hasBannerMessage {
   transition: padding-top .3s;
   padding-top: 120px;
 }
+body.hasBannerMessage:not(:has(#bannerMessage)) {
+  padding-top: 0;
+}
 body.hasBannerMessage #s2.headerOnly {
   height: 180px;
 }


### PR DESCRIPTION
This is a temporary fix for the display of Strapi banners to fix the spacing in the header when the banners are closed. The `setContainerMode` code for adjusting the class on `<body>` used to work, but is currently not working. That code will need to be refactored in the future.