### PR TITLE
fix: [sc-30750] bug with Otzar Midrashim

### DIFF
--- a/sefaria/model/text.py
+++ b/sefaria/model/text.py
@@ -3542,7 +3542,12 @@ class Ref(object, metaclass=RefCacheType):
                             return None
                     if next_leaf:
                         next_node_ref = next_leaf.ref() #get a ref so we can do the next lines
-                        potential_next = next_node_ref._iter_text_section(depth_up=0 if next_leaf.depth == 1 else 1, vstate=vstate)
+                        if next_leaf.depth == 1:
+                            potential_next = next_node_ref._iter_text_section(depth_up=0, vstate=vstate)
+                            if potential_next:
+                                potential_next = potential_next.as_ranged_segment_ref()
+                        else:
+                            potential_next = next_node_ref._iter_text_section(depth_up=1, vstate=vstate)
                         if potential_next:
                             self._next = potential_next
                             break

--- a/sefaria/model/text.py
+++ b/sefaria/model/text.py
@@ -3544,7 +3544,9 @@ class Ref(object, metaclass=RefCacheType):
                         next_node_ref = next_leaf.ref() #get a ref so we can do the next lines
                         if next_leaf.depth == 1:
                             potential_next = next_node_ref._iter_text_section(depth_up=0, vstate=vstate)
-                            if potential_next:
+                            if potential_next and next_leaf.is_default():
+                                # edge case: when a depth 1 node is a default node, there's no way to
+                                # distinguish it from its parent node unless we convert it to a ranged ref
                                 potential_next = potential_next.as_ranged_segment_ref()
                         else:
                             potential_next = next_node_ref._iter_text_section(depth_up=1, vstate=vstate)


### PR DESCRIPTION
## Description
We noticed a bunch of infinite "Loading..." bugs on Otzar Midrashim.  I discovered this bug exists on a few other indices as well -- because each of these indices has a depth 1 default node.  The texts API for a ref returns next and previous section refs.  The problem occurs when the next section is a default node.  Most default nodes are depth 2, so when we return the next section ref, we return "{default node} 1", but when a default node is depth 2, we just return the name of the default node, which means we have no way of distinguishing it from its parent.  The texts API then gets a request for the next section ref, which in this case comes _before_ the current ref causing the client to get confused and to keep trying to hit the API.


## Code Changes
When the texts API returns the next section ref, it calls next_section_ref, which simply needs special casing.  In case we are dealing with a depth 1 default node, we convert the default node ref into a ranged segment ref so that it is not the identical string as the default node's parent.