### PR TITLE
Fix topic test dec 2024

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -69,7 +69,7 @@ undecorated==0.3.0
 unicodecsv==0.14.1
 unidecode==1.1.1
 user-agents==2.2.0
-
+pytest-django==4.9.*
 
 #opentelemetry-distro
 #opentelemetry-exporter-otlp

--- a/sefaria/model/tests/topic_test.py
+++ b/sefaria/model/tests/topic_test.py
@@ -7,8 +7,20 @@ from sefaria.system.exceptions import SluggedMongoRecordMissingError
 from django_topics.models import Topic as DjangoTopic, TopicPool
 from django_topics.models.pool import PoolType
 
+TEST_SLUG_PREFIX = 'this-is-a-test-slug-'
 
-def make_topic(slug):
+
+def _ms(slug_suffix):
+    """
+    ms = make slug. makes full test slug.
+    @param slug_suffix:
+    @return:
+    """
+    return TEST_SLUG_PREFIX+slug_suffix
+
+
+def make_topic(slug_suffix):
+    slug = _ms(slug_suffix)
     ts = TopicSet({'slug': slug})
     if ts.count() > 0:
         ts.delete()
@@ -18,13 +30,13 @@ def make_topic(slug):
 
 
 def make_it_link(a, b, type):
-    l = IntraTopicLink({'fromTopic': a, 'toTopic': b, 'linkType': type, 'dataSource': 'sefaria'})
+    l = IntraTopicLink({'fromTopic': _ms(a), 'toTopic': _ms(b), 'linkType': type, 'dataSource': 'sefaria'})
     l.save()
     return l
 
 
 def make_rt_link(a, tref):
-    l = RefTopicLink({'toTopic': a, 'ref': tref, 'linkType': 'about', 'dataSource': 'sefaria'})
+    l = RefTopicLink({'toTopic': _ms(a), 'ref': tref, 'linkType': 'about', 'dataSource': 'sefaria'})
     l.save()
     return l
 
@@ -35,11 +47,11 @@ def clean_links(a):
     :param a:
     :return:
     """
-    ls = RefTopicLinkSet({'toTopic': a})
+    ls = RefTopicLinkSet({'toTopic': _ms(a)})
     if ls.count() > 0:
         ls.delete()
 
-    ls = IntraTopicLinkSet({"$or": [{"fromTopic": a}, {"toTopic": a}]})
+    ls = IntraTopicLinkSet({"$or": [{"fromTopic": _ms(a)}, {"toTopic": _ms(a)}]})
     if ls.count() > 0:
         ls.delete()
 
@@ -99,10 +111,10 @@ def topic_graph_to_merge(db):
     mongo_db.sheets.insert_one({
         "id": 1234567890,
         "topics": [
-            {"slug": '20', 'asTyped': 'twenty'},
-            {"slug": '40', 'asTyped': '4d'},
-            {"slug": '20', 'asTyped': 'twent-e'},
-            {"slug": '30', 'asTyped': 'thirty'}
+            {"slug": _ms('20'), 'asTyped': 'twenty'},
+            {"slug": _ms('40'), 'asTyped': '4d'},
+            {"slug": _ms('20'), 'asTyped': 'twent-e'},
+            {"slug": _ms('30'), 'asTyped': 'thirty'}
         ]
     })
     
@@ -114,8 +126,8 @@ def topic_graph_to_merge(db):
     mongo_db.sheets.delete_one({"id": 1234567890})
 
 
-@pytest.fixture(scope='module')
-def topic_pool():
+@pytest.fixture()
+def topic_pool(db):
     pool = TopicPool.objects.create(name='test-pool')
     yield pool
     pool.delete()
@@ -126,24 +138,24 @@ class TestTopics(object):
     @pytest.mark.django_db
     def test_graph_funcs(self, topic_graph):
         ts = topic_graph['topics']
-        assert ts['1'].get_types() == {'1', '2', '3', '4', '5'}
-        assert ts['2'].get_types() == {'2', '3', '4', '5'}
-        assert ts['5'].get_types() == {'5'}
+        assert ts['1'].get_types() == {_ms(x) for x in {'1', '2', '3', '4', '5'}}
+        assert ts['2'].get_types() == {_ms(x) for x in {'2', '3', '4', '5'}}
+        assert ts['5'].get_types() == {_ms('5')}
 
-        assert ts['1'].has_types({'3', '8'})
-        assert not ts['2'].has_types({'6'})
+        assert ts['1'].has_types({_ms('3'), _ms('8')})
+        assert not ts['2'].has_types({_ms('6')})
 
-        assert {t.slug for t in ts['5'].topics_by_link_type_recursively(linkType='is-a', only_leaves=True)} == {'1', '6'}
+        assert {t.slug for t in ts['5'].topics_by_link_type_recursively(linkType='is-a', only_leaves=True)} == {_ms('1'), _ms('6')}
         assert ts['1'].topics_by_link_type_recursively(linkType='is-a', only_leaves=True) == [ts['1']]
 
     def test_link_set(self, topic_graph):
         ts = topic_graph['topics']
         ls = ts['1'].link_set(_class='intraTopic')
-        assert list(ls)[0].topic == '2'
+        assert list(ls)[0].topic == _ms('2')
         assert ls.count() == 1
 
         ls = ts['4'].link_set(_class='intraTopic')
-        assert {l.topic for l in ls} == {'2', '5'}
+        assert {l.topic for l in ls} == {_ms('2'), _ms('5')}
 
         trefs = {r.normal() for r in Ref('Genesis 1:1-10').range_list()}
 
@@ -151,33 +163,33 @@ class TestTopics(object):
         assert {l.ref for l in ls} == trefs
 
         ls = ts['1'].link_set(_class=None)
-        assert {getattr(l, 'ref', getattr(l, 'topic', None)) for l in ls} == (trefs | {'2'})
+        assert {getattr(l, 'ref', getattr(l, 'topic', None)) for l in ls} == (trefs | {_ms('2')})
 
     @pytest.mark.django_db
     def test_merge(self, topic_graph_to_merge):
         ts = topic_graph_to_merge['topics']
         ts['20'].merge(ts['40'])
 
-        t20 = Topic.init('20')
-        assert t20.slug == '20'
+        t20 = Topic.init(_ms('20'))
+        assert t20.slug == _ms('20')
         assert len(t20.titles) == 2
-        assert t20.get_primary_title('en') == '20'
+        assert t20.get_primary_title('en') == _ms('20')
         ls = t20.link_set(_class='intraTopic')
-        assert {l.topic for l in ls} == {'10', '30', '50'}
+        assert {l.topic for l in ls} == {_ms(x) for x in {'10', '30', '50'}}
 
-        s = db.sheets.find_one({"id": 1234567890})
+        s = mongo_db.sheets.find_one({"id": 1234567890})
         assert s['topics'] == [
-            {"slug": '20', 'asTyped': 'twenty'},
-            {"slug": '20', 'asTyped': '4d'},
-            {"slug": '20', 'asTyped': 'twent-e'},
-            {"slug": '30', 'asTyped': 'thirty'}
+            {"slug": _ms('20'), 'asTyped': 'twenty'},
+            {"slug": _ms('20'), 'asTyped': '4d'},
+            {"slug": _ms('20'), 'asTyped': 'twent-e'},
+            {"slug": _ms('30'), 'asTyped': 'thirty'}
         ]
 
-        t40 = Topic.init('40')
+        t40 = Topic.init(_ms('40'))
         assert t40 is None
-        DjangoTopic.objects.get(slug='20')
+        DjangoTopic.objects.get(slug=_ms('20'))
         with pytest.raises(DjangoTopic.DoesNotExist):
-            DjangoTopic.objects.get(slug='40')
+            DjangoTopic.objects.get(slug=_ms('40'))
 
     def test_change_title(self, topic_graph):
         ts = topic_graph['topics']
@@ -192,18 +204,17 @@ class TestTopics(object):
     def test_pools(self, topic_graph, topic_pool):
         ts = topic_graph['topics']
         t1 = ts['1']
-        assert len(t1.get_pools()) == 0
         t1.add_pool(topic_pool.name)
-        assert t1.get_pools() == [topic_pool.name]
+        assert topic_pool.name in t1.get_pools()
 
         # dont add duplicates
         t1.add_pool(topic_pool.name)
-        assert t1.get_pools() == [topic_pool.name]
+        assert t1.get_pools().count(topic_pool.name) == 1
 
         assert t1.has_pool(topic_pool.name)
         t1.remove_pool(topic_pool.name)
-        assert len(t1.get_pools()) == 0
-        # dont error when removing non-existant pool
+        assert topic_pool.name not in t1.get_pools()
+        # dont error when removing non-existent pool
         t1.remove_pool(topic_pool.name)
 
     def test_sanitize(self):
@@ -223,8 +234,8 @@ class TestTopics(object):
 class TestTopicLinkHelper(object):
 
     def test_init_by_class(self, topic_graph):
-        l1 = db.topic_links.find_one({'fromTopic': '1', 'toTopic': '2', 'linkType': 'is-a'})
-        l2 = db.topic_links.find_one({'toTopic': '1', 'ref': 'Genesis 1:1'})
+        l1 = mongo_db.topic_links.find_one({'fromTopic': _ms('1'), 'toTopic': _ms('2'), 'linkType': 'is-a'})
+        l2 = mongo_db.topic_links.find_one({'toTopic': _ms('1'), 'ref': 'Genesis 1:1'})
 
         obj = TopicLinkHelper.init_by_class(l1)
         assert isinstance(obj, IntraTopicLink)
@@ -232,12 +243,12 @@ class TestTopicLinkHelper(object):
         obj = TopicLinkHelper.init_by_class(l2)
         assert isinstance(obj, RefTopicLink)
 
-        obj = TopicLinkHelper.init_by_class(l1, context_slug='2')
-        assert obj.topic == '1'
+        obj = TopicLinkHelper.init_by_class(l1, context_slug=_ms('2'))
+        assert obj.topic == _ms('1')
         assert obj.is_inverse
 
-        obj = TopicLinkHelper.init_by_class(l1, context_slug='1')
-        assert obj.topic == '2'
+        obj = TopicLinkHelper.init_by_class(l1, context_slug=_ms('1'))
+        assert obj.topic == _ms('2')
 
 
 class TestIntraTopicLink(object):
@@ -246,8 +257,8 @@ class TestIntraTopicLink(object):
         from sefaria.system.exceptions import DuplicateRecordError, InputError
 
         attrs = {
-            'fromTopic': '1',
-            'toTopic': '6',
+            'fromTopic': _ms('1'),
+            'toTopic': _ms('6'),
             'linkType': 'is-a',
             'dataSource': 'sefaria'
         }
@@ -257,8 +268,8 @@ class TestIntraTopicLink(object):
         l.delete()
 
         attrs = {
-            'fromTopic': '1',
-            'toTopic': '2',
+            'fromTopic': _ms('1'),
+            'toTopic': _ms('2'),
             'linkType': 'is-a',
             'dataSource': 'sefaria'
         }
@@ -266,10 +277,10 @@ class TestIntraTopicLink(object):
         with pytest.raises(DuplicateRecordError):
             l.save()
 
-        # non-existant datasource
+        # non-existent datasource
         attrs = {
-            'fromTopic': '1',
-            'toTopic': '2',
+            'fromTopic': _ms('1'),
+            'toTopic': _ms('2'),
             'linkType': 'is-a',
             'dataSource': 'blahblah'
         }
@@ -277,10 +288,10 @@ class TestIntraTopicLink(object):
         with pytest.raises(SluggedMongoRecordMissingError):
             l.save()
 
-        # non-existant toTopic
+        # non-existent toTopic
         attrs = {
-            'fromTopic': '1',
-            'toTopic': '2222',
+            'fromTopic': _ms('1'),
+            'toTopic': _ms('2222'),
             'linkType': 'is-a',
             'dataSource': 'sefaria'
         }
@@ -288,10 +299,10 @@ class TestIntraTopicLink(object):
         with pytest.raises(SluggedMongoRecordMissingError):
             l.save()
 
-        # non-existant fromTopic
+        # non-existent fromTopic
         attrs = {
-            'fromTopic': '11111',
-            'toTopic': '2',
+            'fromTopic': _ms('11111'),
+            'toTopic': _ms('2'),
             'linkType': 'is-a',
             'dataSource': 'sefaria'
         }
@@ -299,10 +310,10 @@ class TestIntraTopicLink(object):
         with pytest.raises(SluggedMongoRecordMissingError):
             l.save()
 
-        # non-existant linkType
+        # non-existent linkType
         attrs = {
-            'fromTopic': '11111',
-            'toTopic': '2',
+            'fromTopic': _ms('11111'),
+            'toTopic': _ms('2'),
             'linkType': 'is-aaaaaa',
             'dataSource': 'sefaria'
         }
@@ -312,15 +323,15 @@ class TestIntraTopicLink(object):
 
         # duplicate for symmetric linkType
         attrs = {
-            'fromTopic': '1',
-            'toTopic': '2',
+            'fromTopic': _ms('1'),
+            'toTopic': _ms('2'),
             'linkType': 'related-to',
             'dataSource': 'sefaria'
         }
         l1 = IntraTopicLink(attrs)
         l1.save()
-        attrs['fromTopic'] = '2'
-        attrs['toTopic'] = '1'
+        attrs['fromTopic'] = _ms('2')
+        attrs['toTopic'] = _ms('1')
         l2 = IntraTopicLink(attrs)
         with pytest.raises(DuplicateRecordError):
             l2.save()
@@ -332,7 +343,7 @@ class TestRefTopicLink(object):
     def test_add_expanded_refs(self, topic_graph):
         attrs = {
             'ref': 'Genesis 1:1',
-            'toTopic': '6',
+            'toTopic': _ms('6'),
             'linkType': 'about',
             'dataSource': 'sefaria'
         }
@@ -344,7 +355,7 @@ class TestRefTopicLink(object):
 
         attrs = {
             'ref': 'Genesis 1:1-3',
-            'toTopic': '6',
+            'toTopic': _ms('6'),
             'linkType': 'about',
             'dataSource': 'sefaria'
         }
@@ -355,7 +366,7 @@ class TestRefTopicLink(object):
 
         attrs = {
             'ref': 'Genesis 1-2',
-            'toTopic': '6',
+            'toTopic': _ms('6'),
             'linkType': 'about',
             'dataSource': 'sefaria'
         }
@@ -370,7 +381,7 @@ class TestRefTopicLink(object):
 
         attrs = {
             'ref': 'Genesis 1:1',
-            'toTopic': '6',
+            'toTopic': _ms('6'),
             'linkType': 'about',
             'dataSource': 'sefaria'
         }


### PR DESCRIPTION
## Description
Fixes failing topic tests. The tests were failing because Django by default doesn't allow tests to access the database (i.e. the django database, not mongo). In order to allow access, you can either use Django's built-in test system or use `pytest-django`. `pytest-django` more naturally fits into how we are already running tests.

## Code Changes
- add pytest-django pip module
- use pytest-django to allow access to db for fixtures that need it
- create unique test slugs using custom `_ms()` function so that there aren't any conflicts with existing slugs
- fix some typos

## Notes
_Any additional notes go here_