### PR TITLE
Fix a missed module rename

### DIFF
--- a/static/js/NavSidebar.jsx
+++ b/static/js/NavSidebar.jsx
@@ -344,7 +344,7 @@ const AboutTextCategory = ({cats}) => {
 
   return (
     <SidebarModule>
-      <ModuleTitle><InterfaceText text={{en: enTitle, he: heTitle}} /></ModuleTitle>
+      <SidebarModuleTitle><InterfaceText text={{en: enTitle, he: heTitle}} /></SidebarModuleTitle>
       <InterfaceText markdown={{en: tocObject.enDesc, he: tocObject.heDesc}} />
     </SidebarModule>
   );


### PR DESCRIPTION
## Description
There was a `<ModuleTitle/>` in `NavSidebar` that was missed when we renamed to `<SidebarModuleTitle/>`

## Code Changes
In `static/js/NavSidebar.jsx` component renamed as described above. 

## Notes
Checked branch for any other breaking instances of `<ModuleTitle/>`. None found. 