### PR TITLE
fix: Short circuit Ref.contains() and avoid call to as_ranged_segment_ref ...

### DIFF
--- a/sefaria/model/text.py
+++ b/sefaria/model/text.py
@@ -4243,9 +4243,9 @@ class Ref(object, metaclass=RefCacheType):
             return self.index_node.is_ancestor_of(other.index_node)
 
         if len(self.sections) > len(other.sections): # other is less specific than self
-            if len(other.sections) == 0:  # other is a whole book
-                if any([x != 1 for x in self.sections]):  # self is not a whole book
-                    return False  # performance optimization to avoid call to as_ranged_segment_ref
+            additional_depth = len(self.sections) - len(other.sections)
+            if any([x != 1 for x in self.sections[-additional_depth:]]):  # self is not whole at some depth
+                return False  # performance optimization to avoid call to as_ranged_segment_ref
             # we need to get the true extent of other
             other = other.as_ranged_segment_ref()
 


### PR DESCRIPTION
even in cases where other is not a whole book.

For example:
`assert not Ref("Exodus 6:2").contains(Ref("Exodus 6"))` Can be solved without finding the true extent of the second ref.

## Description
In Ref.contains(), short circuit and avoid call to as_ranged_segment_ref even in cases where other is not a whole book.

## Notes
For example:
`assert not Ref("Exodus 6:2").contains(Ref("Exodus 6"))` Can be solved without finding the true extent of the second ref.