### PR TITLE
Trending Topics for Topic Landing Page

### DIFF
--- a/django_topics/admin.py
+++ b/django_topics/admin.py
@@ -1,6 +1,8 @@
 from django.contrib import admin, messages
 from django_topics.models import Topic, TopicPool, FeaturedTopicEnglish, FeaturedTopicHebrew, SeasonalTopicEnglish, SeasonalTopicHebrew
 from django_topics.models.pool import PoolType
+from django.utils.html import format_html
+
 
 
 def create_add_to_pool_action(pool_name):

--- a/reader/views.py
+++ b/reader/views.py
@@ -3279,14 +3279,17 @@ def trending_topics_api(request):
     from sefaria.helper.topic import get_trending_topics
     n = int(request.GET.get("n"))
     pool_name = request.GET.get("pool", None)
+
     trending_slugs = get_trending_topics(n * n)
-    trending_topics = []
-    for slug in trending_slugs:
-        topic = Topic.init(slug)
-        if not topic:
-            continue
-        if not pool_name or pool_name in topic.pools:
-            trending_topics.append(topic.contents())
+    #Bulk loading of topics (for better performance) then sorting them:
+    loaded_topics = TopicSet({"slug": {"$in": trending_slugs}}).array()
+    trending_order_map = {slug: index for index, slug in enumerate(trending_slugs)}
+    sorted_loaded_topics = sorted(loaded_topics, key=lambda x: trending_order_map.get(x.slug, float('inf')))
+    trending_topics = [
+        topic.contents()
+        for topic in sorted_loaded_topics
+        if topic and (not pool_name or pool_name in topic.pools)
+    ]
     return jsonResponse(trending_topics[:n])
 
 

--- a/reader/views.py
+++ b/reader/views.py
@@ -3278,8 +3278,17 @@ def featured_topic_api(request):
 
 def trending_topics_api(request):
     from sefaria.helper.topic import get_trending_topics
-    response = get_trending_topics()
-    return jsonResponse(response)
+    n = int(request.GET.get("n"))
+    pool_name = request.GET.get("pool", None)
+    trending_slugs = get_trending_topics(n * n)
+    trending_topics = []
+    for slug in trending_slugs:
+        topic = Topic.init(slug)
+        if not topic:
+            continue
+        if not pool_name or pool_name in topic.pools:
+            trending_topics.append(topic.contents())
+    return jsonResponse(trending_topics)
 
 
 @staff_member_required

--- a/reader/views.py
+++ b/reader/views.py
@@ -3288,7 +3288,7 @@ def trending_topics_api(request):
             continue
         if not pool_name or pool_name in topic.pools:
             trending_topics.append(topic.contents())
-    return jsonResponse(trending_topics)
+    return jsonResponse(trending_topics[:n])
 
 
 @staff_member_required

--- a/reader/views.py
+++ b/reader/views.py
@@ -33,7 +33,6 @@ from django.utils import timezone
 from django.utils.html import strip_tags
 from bson.objectid import ObjectId
 
-from scripts.update_parashah_descriptions import response
 from sefaria.model import *
 from sefaria.google_storage_manager import GoogleStorageManager
 from sefaria.model.user_profile import UserProfile, user_link, public_user_data, UserWrapper

--- a/reader/views.py
+++ b/reader/views.py
@@ -33,6 +33,7 @@ from django.utils import timezone
 from django.utils.html import strip_tags
 from bson.objectid import ObjectId
 
+from scripts.update_parashah_descriptions import response
 from sefaria.model import *
 from sefaria.google_storage_manager import GoogleStorageManager
 from sefaria.model.user_profile import UserProfile, user_link, public_user_data, UserWrapper
@@ -3273,6 +3274,11 @@ def featured_topic_api(request):
         return jsonResponse({'error': f'No featured topic found for lang "{lang}"'}, status=404)
     mongo_topic = Topic.init(featured_topic.topic.slug)
     response = {'topic': mongo_topic.contents(), 'date': featured_topic.start_date.isoformat()}
+    return jsonResponse(response)
+
+def trending_topics_api(request):
+    from sefaria.helper.topic import get_trending_topics
+    response = get_trending_topics()
     return jsonResponse(response)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ elasticsearch==8.8.2
 geojson==2.5.0
 geopy==2.3.0
 gevent==20.12.0; sys_platform != 'darwin'
-google-analytics-data
+google-analytics-data==0.18.16
 git+https://github.com/Sefaria/LLM@v1.0.3#egg=sefaria_llm_interface&subdirectory=app/llm_interface
 git+https://github.com/Sefaria/elasticsearch-dsl-py@v8.0.0#egg=elasticsearch-dsl
 google-api-python-client==1.12.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,7 @@ elasticsearch==8.8.2
 geojson==2.5.0
 geopy==2.3.0
 gevent==20.12.0; sys_platform != 'darwin'
+google-analytics-data
 git+https://github.com/Sefaria/LLM@v1.0.3#egg=sefaria_llm_interface&subdirectory=app/llm_interface
 git+https://github.com/Sefaria/elasticsearch-dsl-py@v8.0.0#egg=elasticsearch-dsl
 google-api-python-client==1.12.5

--- a/sefaria/helper/topic.py
+++ b/sefaria/helper/topic.py
@@ -384,10 +384,10 @@ def get_trending_topics(num_topics=10):
     )
     from sefaria.settings import GOOGLE_APPLICATION_CREDENTIALS_FILEPATH
     import urllib.parse
-    """Fetches the top trending topics from Google Analytics."""
+    PROPERTY_ID = 397824505
     client = BetaAnalyticsDataClient.from_service_account_file(GOOGLE_APPLICATION_CREDENTIALS_FILEPATH)
     request = RunReportRequest(
-        property="properties/397824505",
+        property=f"properties/{PROPERTY_ID}",
         date_ranges=[DateRange(start_date="7daysAgo", end_date="yesterday")],
         dimensions=[Dimension(name="pagePath")],
         metrics=[Metric(name="screenPageViews")],

--- a/sefaria/helper/topic.py
+++ b/sefaria/helper/topic.py
@@ -371,7 +371,7 @@ def get_topics_for_ref(tref, lang="english", annotate=False):
     serialized.sort(key=cmp_to_key(partial(sort_refs_by_relevance, lang=lang)))
     return serialized
 
-@django_cache(timeout=24 * 60 * 60)
+# @django_cache(timeout=24 * 60 * 60)
 def get_trending_topics(num_topics=10):
     from google.analytics.data_v1beta import BetaAnalyticsDataClient
     from google.analytics.data_v1beta.types import (
@@ -385,11 +385,11 @@ def get_trending_topics(num_topics=10):
     )
     from sefaria.settings import GOOGLE_APPLICATION_CREDENTIALS_FILEPATH
     import urllib.parse
-    PROPERTY_ID = 397824505
+    PROPERTY_ID = 204095655
     client = BetaAnalyticsDataClient.from_service_account_file(GOOGLE_APPLICATION_CREDENTIALS_FILEPATH)
     request = RunReportRequest(
         property=f"properties/{PROPERTY_ID}",
-        date_ranges=[DateRange(start_date="7daysAgo", end_date="yesterday")],
+        date_ranges=[DateRange(start_date="28daysAgo", end_date="yesterday")],
         dimensions=[Dimension(name="pagePath")],
         metrics=[Metric(name="screenPageViews")],
         dimension_filter=FilterExpression(
@@ -406,6 +406,7 @@ def get_trending_topics(num_topics=10):
     )
     response = client.run_report(request)
     slugs = [urllib.parse.unquote(row.dimension_values[0].value.removeprefix("/topics/")) for row in response.rows]
+    print(slugs)
     slugs = [slug for slug in slugs if not slug.startswith("category/")]
     return slugs
 

--- a/sefaria/helper/topic.py
+++ b/sefaria/helper/topic.py
@@ -371,7 +371,7 @@ def get_topics_for_ref(tref, lang="english", annotate=False):
     serialized.sort(key=cmp_to_key(partial(sort_refs_by_relevance, lang=lang)))
     return serialized
 
-def get_trending_topics():
+def get_trending_topics(num_topics=10):
     from google.analytics.data_v1beta import BetaAnalyticsDataClient
     from google.analytics.data_v1beta.types import (
         DateRange,
@@ -383,15 +383,11 @@ def get_trending_topics():
         OrderBy,
     )
     from sefaria.settings import GOOGLE_APPLICATION_CREDENTIALS_FILEPATH
-    # GA4 property ID
-    PROPERTY_ID = "397824505"
-
-    # Initialize the client
+    import urllib.parse
+    """Fetches the top trending topics from Google Analytics."""
     client = BetaAnalyticsDataClient.from_service_account_file(GOOGLE_APPLICATION_CREDENTIALS_FILEPATH)
-
-    # Create a request to fetch data
     request = RunReportRequest(
-        property=f"properties/{PROPERTY_ID}",
+        property="properties/397824505",
         date_ranges=[DateRange(start_date="7daysAgo", end_date="yesterday")],
         dimensions=[Dimension(name="pagePath")],
         metrics=[Metric(name="screenPageViews")],
@@ -404,24 +400,13 @@ def get_trending_topics():
                 )
             )
         ),
-        order_bys=[
-            OrderBy(
-                metric=OrderBy.MetricOrderBy(metric_name="screenPageViews"),
-                desc=True
-            )
-        ],
-        limit=10,
+        order_bys=[OrderBy(metric=OrderBy.MetricOrderBy(metric_name="screenPageViews"), desc=True)],
+        limit=num_topics,
     )
-
-    # Run the report
     response = client.run_report(request)
-
-    # Print the results
-    result = []
-    for row in response.rows:
-        # print(f"URL: {row.dimension_values[0].value}, Views: {row.metric_values[0].value}")
-        result.append(row.dimension_values[0].value)
-    return result
+    slugs = [urllib.parse.unquote(row.dimension_values[0].value.removeprefix("/topics/")) for row in response.rows]
+    slugs = [slug for slug in slugs if not slug.startswith("category/")]
+    return slugs
 
 @django_cache(timeout=24 * 60 * 60, cache_prefix="get_topics_for_book")
 def get_topics_for_book(title: str, annotate=False, n=18) -> list:

--- a/sefaria/helper/topic.py
+++ b/sefaria/helper/topic.py
@@ -406,7 +406,6 @@ def get_trending_topics(num_topics=10):
     )
     response = client.run_report(request)
     slugs = [urllib.parse.unquote(row.dimension_values[0].value.removeprefix("/topics/")) for row in response.rows]
-    print(slugs)
     slugs = [slug for slug in slugs if not slug.startswith("category/")]
     return slugs
 

--- a/sefaria/helper/topic.py
+++ b/sefaria/helper/topic.py
@@ -371,6 +371,7 @@ def get_topics_for_ref(tref, lang="english", annotate=False):
     serialized.sort(key=cmp_to_key(partial(sort_refs_by_relevance, lang=lang)))
     return serialized
 
+@django_cache(timeout=24 * 60 * 60)
 def get_trending_topics(num_topics=10):
     from google.analytics.data_v1beta import BetaAnalyticsDataClient
     from google.analytics.data_v1beta.types import (

--- a/sefaria/helper/topic.py
+++ b/sefaria/helper/topic.py
@@ -371,21 +371,14 @@ def get_topics_for_ref(tref, lang="english", annotate=False):
     serialized.sort(key=cmp_to_key(partial(sort_refs_by_relevance, lang=lang)))
     return serialized
 
-# @django_cache(timeout=24 * 60 * 60)
+@django_cache(timeout=24 * 60 * 60)
 def get_trending_topics(num_topics=10):
     from google.analytics.data_v1beta import BetaAnalyticsDataClient
-    from google.analytics.data_v1beta.types import (
-        DateRange,
-        Metric,
-        Dimension,
-        RunReportRequest,
-        FilterExpression,
-        Filter,
-        OrderBy,
-    )
+    from google.analytics.data_v1beta.types import DateRange, Metric, Dimension, RunReportRequest, FilterExpression, Filter, OrderBy
     from sefaria.settings import GOOGLE_APPLICATION_CREDENTIALS_FILEPATH
     import urllib.parse
-    PROPERTY_ID = 204095655
+    sefaria_analytics_mobile_and_web_property_id = 204095655
+    PROPERTY_ID = sefaria_analytics_mobile_and_web_property_id
     client = BetaAnalyticsDataClient.from_service_account_file(GOOGLE_APPLICATION_CREDENTIALS_FILEPATH)
     request = RunReportRequest(
         property=f"properties/{PROPERTY_ID}",
@@ -406,8 +399,8 @@ def get_trending_topics(num_topics=10):
     )
     response = client.run_report(request)
     slugs = [urllib.parse.unquote(row.dimension_values[0].value.removeprefix("/topics/")) for row in response.rows]
-    slugs = [slug for slug in slugs if not slug.startswith("category/")]
-    return slugs
+    filtered_slugs = [slug for slug in slugs if not slug.startswith("category/")]
+    return filtered_slugs
 
 @django_cache(timeout=24 * 60 * 60, cache_prefix="get_topics_for_book")
 def get_topics_for_book(title: str, annotate=False, n=18) -> list:

--- a/sefaria/urls.py
+++ b/sefaria/urls.py
@@ -269,6 +269,7 @@ urlpatterns += [
     url(r'^_api/topics/seasonal-topic/?$', reader_views.seasonal_topic_api),
     url(r'^api/topics/pools/(?P<pool_name>.+)$', reader_views.topic_pool_api),
     url(r'^_api/topics/featured-topic/?$', reader_views.featured_topic_api),
+    url(r'^api/topics/trending/?$', reader_views.trending_topics_api),
     url(r'^api/ref-topic-links/bulk$', reader_views.topic_ref_bulk_api),
     url(r'^api/ref-topic-links/(?P<tref>.+)$', reader_views.topic_ref_api),
     url(r'^api/v2/topics/(?P<topic>.+)$', reader_views.topics_api, {'v2': True}),

--- a/static/js/NavSidebar.jsx
+++ b/static/js/NavSidebar.jsx
@@ -36,6 +36,7 @@ const SidebarModules = ({type, props}) => {
     "DafYomi":                DafYomi,
     "AboutTopics":            AboutTopics,
     "TrendingTopics":         TrendingTopics,
+    "TopicLandingTrendingTopics": TopicLandingTrendingTopics,
     "RelatedTopics":          RelatedTopics,
     "TitledText":             TitledText,
     "Visualizations":         Visualizations,
@@ -607,6 +608,32 @@ const TrendingTopics = () => (
         </SidebarModule>
     </div>
 );
+const TopicLandingTrendingTopics = () => {
+    let [trendingTopics, setTrendingTopics] = useState(null);
+    useEffect(() => {
+        Sefaria.getTrendingTopics().then(result => setTrendingTopics(result));
+    }, []);
+
+    if (!trendingTopics) { return null; }
+    console.log(trendingTopics);
+    return(
+    <div data-anl-feature_name="Trending" data-anl-link_type="topic">
+        <SidebarModule>
+            <SidebarModuleTitle>Trending Topics</SidebarModuleTitle>
+            {trendingTopics.map((topic, i) =>
+                <div className="navSidebarLink ref serif" key={i}>
+                    <a
+                        href={"/topics/" + topic.slug}
+                        data-anl-event="navto_topic:click"
+                        data-anl-text={topic.primaryTitle.en}
+                    >
+                        <InterfaceText text={{en: topic.primaryTitle.en, he: topic.primaryTitle.he}}/>
+                    </a>
+                </div>
+            )}
+        </SidebarModule>
+    </div>)
+};
 
 
 const RelatedTopics = ({title}) => {
@@ -947,5 +974,5 @@ export {
   NavSidebar,
   SidebarModules,
   RecentlyViewed,
-  ParashahLink
+  ParashahLink,
 };

--- a/static/js/NavSidebar.jsx
+++ b/static/js/NavSidebar.jsx
@@ -615,7 +615,6 @@ const TopicLandingTrendingTopics = () => {
     }, []);
 
     if (!trendingTopics) { return null; }
-    console.log(trendingTopics);
     return(
     <div data-anl-feature_name="Trending" data-anl-link_type="topic">
         <SidebarModule>

--- a/static/js/TopicLandingPage/TopicsLandingPage.jsx
+++ b/static/js/TopicLandingPage/TopicsLandingPage.jsx
@@ -12,6 +12,7 @@ import Sefaria from "../sefaria/sefaria";
 
 export const TopicsLandingPage = ({openTopic}) => {
     const sidebarModules = [
+        {type: "TopicLandingTrendingTopics"}
     ];
     return (
         <div className="readerNavMenu" key="0">

--- a/static/js/sefaria/sefaria.js
+++ b/static/js/sefaria/sefaria.js
@@ -2798,6 +2798,14 @@ _media: {},
         store: this._seasonalTopic,
     });
   },
+  trendingTopics: {},
+  getTrendingTopics: function() {
+      return this._cachedApiPromise({
+        url: `${Sefaria.apiHost}/api/topics/trending?n=10&pool=general_${Sefaria.interfaceLang.slice(0, 2)}`,
+        key: (new Date()).toLocaleDateString(),
+        store: this.trendingTopics,
+    });
+  },
   _topicSlugsToTitles: null,
   slugsToTitles: function() {
     //initializes _topicSlugsToTitles for Topic Editor tool and adds necessary "Choose a Category" and "Main Menu" for


### PR DESCRIPTION
## Description
This pull request introduces a new trending topics API and related frontend components. The backend has been updated to handle caching, filtering, and returning a configurable number of trending topics based on data from google analytics. The frontend now includes a new "Trending Topics" sidebar module to display the fetched topics.
## Code Changes
Django Backend:
Added a trending_topics_api endpoint that returns a filtered list of topics.
Modified the get_trending_topics helper function to accept a variable n and handle topic filtering.
Added caching decorators to the get_trending_topics function for improved performance.
Frontend:
Introduced a TrendingTopics sidebar module to display trending topics dynamically.
Added logic in sefaria.js to fetch and cache trending topics from the API.
Updated the TopicLandingPage component to include the new TrendingTopics sidebar module.

## Notes
_Any additional notes go here_