### PR TITLE
fix(Links): safely fall back when keyerror is returned

### DIFF
--- a/sefaria/model/tests/library_test.py
+++ b/sefaria/model/tests/library_test.py
@@ -301,6 +301,14 @@ class Test_he_get_refs_in_text(object):
         st = "(סוכה מ\' א\' – ב\')"
         wrapped = library.get_wrapped_refs_string(st, lang="he", citing_only=True)
 
+    def test_bad_refs(self):
+        trefs = ["סנהדרין ב, ב ו-ג, ב"]
+        orefs = [Ref(tref) for tref in trefs]
+        st = reduce(lambda a, b: a + "({}) בלה בלה ".format(b), trefs, "")
+        res = reduce(lambda a, b: a + '(<a class ="refLink" href="/{}" data-ref="{}">{}</a>) בלה בלה '.format(b[0].url(), b[0].normal(), b[1]), list(zip(orefs, trefs)), "")
+        wrapped = library.get_wrapped_refs_string(st, lang="he", citing_only=True)
+        assert wrapped != res and wrapped == st
+
 
 class Test_get_titles_in_text(object):
 

--- a/sefaria/model/tests/library_test.py
+++ b/sefaria/model/tests/library_test.py
@@ -302,6 +302,7 @@ class Test_he_get_refs_in_text(object):
         wrapped = library.get_wrapped_refs_string(st, lang="he", citing_only=True)
 
     def test_bad_refs(self):
+        # We want to make sure that bad refs don't get wrapped in a tags nor error out
         trefs = ["סנהדרין ב, ב ו-ג, ב"]
         orefs = [Ref(tref) for tref in trefs]
         st = reduce(lambda a, b: a + "({}) בלה בלה ".format(b), trefs, "")

--- a/sefaria/model/text.py
+++ b/sefaria/model/text.py
@@ -6249,7 +6249,7 @@ class Library(object):
             if replacement is None:
                 return match.group(0)
             return replacement
-        except InputError as e:
+        except (InputError, KeyError) as e:
             logger.warning("Wrap Ref Warning: Ref:({}) {}".format(match.group(0), str(e)))
             return match.group(0)
 


### PR DESCRIPTION
## Description
Badly formatted citations were generating a KeyError and preventing loading of segment in Rashba on Megillah

## Code Changes
We are now handling the KeyError.  The segment loads properly.  The badly formatted citation simply appears as regular text and is not picked up as a link.