### PR TITLE
feat(analytics): traffic_type for internal users

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -259,7 +259,8 @@
             function gtag(){dataLayer.push(arguments);}
             gtag('js', new Date());
             gtag('config', '{{ GOOGLE_GTAG }}', {
-              'user_id': DJANGO_VARS.props ? DJANGO_VARS.props._uid : null
+              'user_id': DJANGO_VARS.props ? DJANGO_VARS.props._uid : null,
+              'traffic_type': DJANGO_VARS.props && DJANGO_VARS.props._email.includes('sefaria.org') ? 'sefariaemail' : null
             });
 
             <!-- attach analyticsEventTracker -->


### PR DESCRIPTION
## Description
Analytics parameter traffic_type to be sent with every event from internal Sefaria team so that to exclude their data from our user data. 

## Code Changes
a addition to all events sent thorough gtag, the change is in templates/base.html

## Notes
This is a change needed to be implemented asap so we can gather accurate data for topic pages.