### PR TITLE
hide unpublished sources in topic page

### DIFF
--- a/static/js/TopicPage.jsx
+++ b/static/js/TopicPage.jsx
@@ -344,6 +344,8 @@ const TopicSponsorship = ({topic_slug}) => {
 }
 
 const isLinkPublished = (lang, link) => link.descriptions?.[lang]?.published !== false;
+const isLinkReviewed= (lang, link) => link.descriptions?.[lang]?.review_state !== "not reviewed";
+
 
 const doesLinkHaveAiContent = (lang, link) => link.descriptions?.[lang]?.ai_title?.length > 0 && isLinkPublished(lang, link);
 
@@ -362,7 +364,7 @@ const getLinksToGenerate = (refTopicLinks = []) => {
 const getLinksToPublish = (refTopicLinks = []) => {
     const lang = Sefaria.interfaceLang === "english" ? 'en' : 'he';
     return refTopicLinks.filter(link => {
-        return !isLinkPublished(lang, link);
+        return !isLinkPublished(lang, link) && isLinkReviewed(lang, link);
     });
 };
 

--- a/static/js/sefaria/sefaria.js
+++ b/static/js/sefaria/sefaria.js
@@ -2699,7 +2699,7 @@ _media: {},
         if (refObj.is_sheet) { continue; }
         let tabKey = linkTypeSlug;
         if (tabKey === 'about') {
-            tabKey = (refObj.descriptions?.[lang]?.title || refObj.descriptions?.[lang]?.prompt) ? 'notable-sources' : 'sources';
+            tabKey = (refObj.descriptions?.[lang]?.title || refObj.descriptions?.[lang]?.prompt) && refObj.descriptions?.[lang]?.published ? 'notable-sources' : 'sources';
         }
         if (!tabs[tabKey]) {
           let { title } = linkTypeObj;


### PR DESCRIPTION
## Description
This PR ensures that unpublished sources are no longer displayed on the topic page. Also, when now hitting the "Publish" button, not-reviewed prompts are not published.

## Code Changes
_The following changes were made to the files below_

## Notes
_Any additional notes go here_