### PR TITLE
Feature/sc 31547/metrics webpage

### DIFF
--- a/scripts/scheduled/metrics.py
+++ b/scripts/scheduled/metrics.py
@@ -21,10 +21,10 @@ contributors = contributors.union(set(db.sheets.find({"status": "public"}).disti
 contributors = len(contributors)
 
 # Number of Links
-links = db.links.count_documents()
+links = db.links.count_documents({})
 
 # Number of Source sheets
-sheets = db.sheets.count_documents()
+sheets = db.sheets.count_documents({})
 
 metrics = {
     "timestamp": datetime.datetime.now().replace(hour=0, minute=0, second=0, microsecond=0),

--- a/scripts/scheduled/metrics.py
+++ b/scripts/scheduled/metrics.py
@@ -21,10 +21,10 @@ contributors = contributors.union(set(db.sheets.find({"status": "public"}).disti
 contributors = len(contributors)
 
 # Number of Links
-links = db.links.count()
+links = db.links.count_documents()
 
 # Number of Source sheets
-sheets = db.sheets.count()
+sheets = db.sheets.count_documents()
 
 metrics = {
     "timestamp": datetime.datetime.now().replace(hour=0, minute=0, second=0, microsecond=0),
@@ -37,6 +37,6 @@ metrics = {
 }
 
 try:
-    db.metrics.save(metrics)
+    db.metrics.insert_one(metrics)
 except DuplicateKeyError:
     pass

--- a/sefaria/model/text.py
+++ b/sefaria/model/text.py
@@ -1029,7 +1029,11 @@ class AbstractTextRecord(object):
 
     def word_count(self):
         """ Returns the number of words in this text """
-        return self.ja(remove_html=True).word_count()
+        try:
+            wc = self.ja(remove_html=True).word_count()
+        except AttributeError:
+            wc = 0
+        return wc
 
     def char_count(self):
         """ Returns the number of characters in this text """


### PR DESCRIPTION
## Description
Fixing a non graceful error with word_count in text that created some old schedule scripts to fail

## Code Changes
text.py try catch in the word_count function. and in the metrics.py script mongodb api function names changes. save -> insert_one and count -> count_documents. 
