### PR TITLE
fix(errors): Update URL to match new devportal slug

### DIFF
--- a/sefaria/system/exceptions.py
+++ b/sefaria/system/exceptions.py
@@ -108,5 +108,5 @@ class ComplexBookLevelRefError(InputError):
                         f"'{book_ref}' is a \'complex\' book-level ref. We only support book-level "
                         f"refs in cases of texts with a 'simple' structure. To learn more about the "
                         f"structure of a text on Sefaria, "
-                        f"see: https://developers.sefaria.org/docs/the-schema-of-a-simple-text")
+                        f"see: https://developers.sefaria.org/docs/the-structure-of-a-simple-text")
         super().__init__(self.message)


### PR DESCRIPTION
## Description
We recently updated the slugs for the pages in the Readme docs. This PR catches the instance of the "old" slug, and updates it to match the new one. 

## Code Changes
1. In `sefaria/system/exceptions.py` - Slug of URL was updated, the word `structure` was swapped for `schema`. 