### PR TITLE
fix(Texts API): check for default child ref

### DIFF
--- a/sefaria/model/text_reuqest_adapter.py
+++ b/sefaria/model/text_reuqest_adapter.py
@@ -193,6 +193,7 @@ class TextRequestAdapter:
             version['text'] = ja.modify_by_function(composite_func)
 
     def get_versions_for_query(self) -> dict:
+        self.oref = self.oref.default_child_ref()
         for lang, vtitle in self.versions_params:
             self._append_required_versions(lang, vtitle)
         self._add_ref_data_to_return_obj()


### PR DESCRIPTION
## Description
Infinite loading bug found in "On Providence".  The reason turned out to be that there was an edge case not previously considered -- a default child with depth 1.

## Code Changes
The /api/v3/texts/ needs to check if the ref has a default child ref.  "On Providence" should yield "On Providence<d>".  This also solves an existing bug with Otzar Midrashim where there are default nodes with depth 1.
