### PR TITLE
fix(Connections Panel): derive section ref if not cached yet

### DIFF
--- a/static/js/TextList.jsx
+++ b/static/js/TextList.jsx
@@ -50,7 +50,7 @@ class TextList extends Component {
   }
   getSectionRef() {
     var ref = this.props.srefs[0]; // TODO account for selections spanning sections
-    var sectionRef = Sefaria.sectionRef(ref) || ref;
+    var sectionRef = Sefaria.sectionRef(ref, true) || ref;
     return sectionRef;
   }
   loadConnections() {


### PR DESCRIPTION
## Description
When loading "Rashi on Genesis 1:2:1", we should load "Genesis 1:2" in the main panel with Rashi's links in the side panel.  Sometimes, due to a seeming race condition, it wouldn't load the Rashi links.  When the links didn't load, it's because there was no section "Genesis 1" in the ref cache and so this call below to this.getSectionRef() was evaluating to "Genesis 1:2" instead of "Genesis 1".  The links at this point have loaded for "Genesis 1" but not yet for "Genesis 1:2".  It would then try to load the links from the link cache for "Genesis 1:2" which it couldn't find.  

See this code from TextList.jsx.
```
preloadSingleCommentaryText(filter) {
    //console.log('preloading single commentary')
    // Preload commentary for an entire section of text.
    this.setState({textLoaded: false});
    var commentator       = filter[0];
    var basetext          = this.getSectionRef();
    var commentarySection = Sefaria.commentarySectionRef(commentator, basetext);
    if (!commentarySection) {
      this.setState({waitForText: false});
      return;
    }
    this.setState({waitForText: true});
    Sefaria.text(commentarySection, {}, function() {
      if (this._isMounted) {
        this.setState({textLoaded: true});
      }
    }.bind(this));
  }
```


## Code Changes
_The following changes were made to the files below_
Sefaria.sectionRef has a parameter deriveIfNotFound, so I set that parameter to true when calling it from TextList.jsx.
