### PR TITLE
Fix edit text

### DIFF
--- a/static/js/ConnectionsPanel.jsx
+++ b/static/js/ConnectionsPanel.jsx
@@ -1269,17 +1269,18 @@ WebPagesList.propTypes = {
 const AdvancedToolsList = ({srefs, canEditText, currVersions, setConnectionsMode, masterPanelLanguage, toggleSignUpModal}) => {
     const {textsData} = useContext(ReaderPanelContext);
     const editText = canEditText && textsData ? function () {
-      const {primaryLang, translationLang} = textsData;
       let refString = srefs[0];
-      let currentPath = Sefaria.util.currentPath();
-      const language =  (masterPanelLanguage === 'english') ? translationLang : primaryLang;
-      const langCode = language.slice(0, 2);
-      const currVersionsLangCode = masterPanelLanguage.slice(0, 2);
+      const {primaryDirection, translationDirection} = textsData;
+      const currVersionsLangCode = masterPanelLanguage.slice(0,2);
       const versionTitle = currVersions[currVersionsLangCode]?.versionTitle;
+      const direction = (masterPanelLanguage === 'english') ? translationDirection : primaryDirection;
+      const langCode = direction === 'rtl' ? 'he': 'en';
       if (versionTitle) {
         refString += "/" + encodeURIComponent(langCode) + "/" + encodeURIComponent(versionTitle);
       }
+
       let path = "/edit/" + refString;
+      let currentPath = Sefaria.util.currentPath();
       let nextParam = "?next=" + encodeURIComponent(currentPath);
       path += nextParam;
       //console.log(path);


### PR DESCRIPTION
Edit text works with old dichotomy he/en.
So the language code that sent to the server should be en for ltr and he for rtl.
But in the client side editText function, we should get the versionTitle from currVersions by the master panel language (which is en for translation and he for primary).
This PR fixes the function to the right languages.