### PR TITLE
Add Topic Category List and A-Z Topics Link to Sidebar

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ elasticsearch==8.8.2
 geojson==2.5.0
 geopy==2.3.0
 gevent==20.12.0; sys_platform != 'darwin'
-google-analytics-data==0.18.16
+google-analytics-data
 git+https://github.com/Sefaria/LLM@v1.0.3#egg=sefaria_llm_interface&subdirectory=app/llm_interface
 git+https://github.com/Sefaria/elasticsearch-dsl-py@v8.0.0#egg=elasticsearch-dsl
 google-api-python-client==1.12.5

--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -4954,6 +4954,11 @@ h1.topic-landing-header {
 .topic-landing-search-suggestion.highlighted{
   background-color: #EDEDEC;
 }
+.topic-landing-sidebar-list{
+  font-size: 18px;
+  font-weight: 400;
+  line-height: 21px
+}
 
 .topic-landing-search-dropdown{
   background: #FFFFFF;

--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -4957,7 +4957,7 @@ h1.topic-landing-header {
 .topic-landing-sidebar-list{
   font-size: 18px;
   font-weight: 400;
-  line-height: 21px
+  line-height: 20px
 }
 
 .topic-landing-search-dropdown{

--- a/static/js/NavSidebar.jsx
+++ b/static/js/NavSidebar.jsx
@@ -642,7 +642,7 @@ const TopicLandingTopicCatList = () => {
             <SidebarModuleTitle>Browse Topics</SidebarModuleTitle>
           {topicCats.map((topic, i) =>
             <div className="navSidebarLink ref serif" key={i}>
-              <a href={"/topics/" + topic.slug}><InterfaceText text={{en: topic.en, he: topic.he}}/></a>
+              <a href={"/topics/category/" + topic.slug}><InterfaceText text={{en: topic.en, he: topic.he}}/></a>
             </div>
           )}
         </SidebarModule>

--- a/static/js/NavSidebar.jsx
+++ b/static/js/NavSidebar.jsx
@@ -37,7 +37,8 @@ const SidebarModules = ({type, props}) => {
     "AboutTopics":            AboutTopics,
     "TrendingTopics":         TrendingTopics,
     "TopicLandingTrendingTopics": TopicLandingTrendingTopics,
-    "TopicLandingTopicCatList": TopicLandingTopicCatList,
+    "TopicLandingTopicCatList":  TopicLandingTopicCatList,
+    "AZTopicsLink":           AZTopicsLink,
     "RelatedTopics":          RelatedTopics,
     "TitledText":             TitledText,
     "Visualizations":         Visualizations,
@@ -644,6 +645,15 @@ const TopicLandingTopicCatList = () => {
               <a href={"/topics/" + topic.slug}><InterfaceText text={{en: topic.en, he: topic.he}}/></a>
             </div>
           )}
+        </SidebarModule>
+    )
+};
+const AZTopicsLink = () => {
+    return(
+        <SidebarModule>
+            <a href={'/topics/all/a'}>
+            <SidebarModuleTitle>All Topics A-Z ›</SidebarModuleTitle>
+            </a>
         </SidebarModule>
     )
 };

--- a/static/js/NavSidebar.jsx
+++ b/static/js/NavSidebar.jsx
@@ -37,6 +37,7 @@ const SidebarModules = ({type, props}) => {
     "AboutTopics":            AboutTopics,
     "TrendingTopics":         TrendingTopics,
     "TopicLandingTrendingTopics": TopicLandingTrendingTopics,
+    "TopicLandingTopicCatList": TopicLandingTopicCatList,
     "RelatedTopics":          RelatedTopics,
     "TitledText":             TitledText,
     "Visualizations":         Visualizations,
@@ -632,6 +633,19 @@ const TopicLandingTrendingTopics = () => {
             )}
         </SidebarModule>
     </div>)
+};
+const TopicLandingTopicCatList = () => {
+    const topicCats = Sefaria.topicTocPage();
+    return(
+        <SidebarModule>
+            <SidebarModuleTitle>Browse Topics</SidebarModuleTitle>
+          {topicCats.map((topic, i) =>
+            <div className="navSidebarLink ref serif" key={i}>
+              <a href={"/topics/" + topic.slug}><InterfaceText text={{en: topic.en, he: topic.he}}/></a>
+            </div>
+          )}
+        </SidebarModule>
+    )
 };
 
 

--- a/static/js/NavSidebar.jsx
+++ b/static/js/NavSidebar.jsx
@@ -621,6 +621,7 @@ const TopicLandingTrendingTopics = () => {
     <div data-anl-feature_name="Trending" data-anl-link_type="topic">
         <SidebarModule>
             <SidebarModuleTitle>Trending Topics</SidebarModuleTitle>
+            <div className="topic-landing-sidebar-list">
             {trendingTopics.map((topic, i) =>
                 <div className="navSidebarLink ref serif" key={i}>
                     <a
@@ -632,6 +633,7 @@ const TopicLandingTrendingTopics = () => {
                     </a>
                 </div>
             )}
+            </div>
         </SidebarModule>
     </div>)
 };
@@ -640,16 +642,18 @@ const TopicLandingTopicCatList = () => {
     return(
         <SidebarModule>
             <SidebarModuleTitle>Browse Topics</SidebarModuleTitle>
-          {topicCats.map((topic, i) =>
-            <div className="navSidebarLink ref serif" key={i}>
-              <a href={"/topics/category/" + topic.slug}><InterfaceText text={{en: topic.en, he: topic.he}}/></a>
+            <div className="topic-landing-sidebar-list">
+                {topicCats.map((topic, i) =>
+                    <div className="navSidebarLink ref serif" key={i}>
+                        <a href={"/topics/category/" + topic.slug}><InterfaceText text={{en: topic.en, he: topic.he}}/></a>
+                    </div>
+                )}
             </div>
-          )}
         </SidebarModule>
     )
 };
 const AZTopicsLink = () => {
-    return(
+    return (
         <SidebarModule>
             <a href={'/topics/all/a'}>
             <SidebarModuleTitle>All Topics A-Z ›</SidebarModuleTitle>

--- a/static/js/TopicLandingPage/TopicsLandingPage.jsx
+++ b/static/js/TopicLandingPage/TopicsLandingPage.jsx
@@ -13,7 +13,8 @@ import Sefaria from "../sefaria/sefaria";
 
 export const TopicsLandingPage = ({openTopic}) => {
     const sidebarModules = [
-        {type: "TopicLandingTrendingTopics"}
+        {type: "TopicLandingTopicCatList"},
+        {type: "TopicLandingTrendingTopics"},
     ];
     return (
         <div className="readerNavMenu" key="0">

--- a/static/js/TopicLandingPage/TopicsLandingPage.jsx
+++ b/static/js/TopicLandingPage/TopicsLandingPage.jsx
@@ -15,6 +15,7 @@ export const TopicsLandingPage = ({openTopic}) => {
     const sidebarModules = [
         {type: "TopicLandingTopicCatList"},
         {type: "TopicLandingTrendingTopics"},
+        {type: "AZTopicsLink"},
     ];
     return (
         <div className="readerNavMenu" key="0">


### PR DESCRIPTION
## Description
This PR introduces two new sidebar components for the Topic Landing Page:

1. Topic Category List: Displays a categorized list of topics with links to their respective pages.
2. A-Z Topics Link: Adds a link to the all topics a-z page.

## Code Changes
_The following changes were made to the files below_

## Notes
_Any additional notes go here_