### PR TITLE
Show (publish) Manual Descriptions for Sources on Topic Pages

### DIFF
--- a/static/js/sefaria/sefaria.js
+++ b/static/js/sefaria/sefaria.js
@@ -2700,7 +2700,7 @@ _media: {},
         if (refObj.is_sheet) { continue; }
         let tabKey = linkTypeSlug;
         if (tabKey === 'about') {
-            tabKey = (refObj.descriptions?.[lang]?.title || refObj.descriptions?.[lang]?.prompt) && refObj.descriptions?.[lang]?.published ? 'notable-sources' : 'sources';
+            tabKey = (refObj.descriptions?.[lang]?.title || refObj.descriptions?.[lang]?.prompt) && refObj.descriptions?.[lang]?.published != false ? 'notable-sources' : 'sources';
         }
         if (!tabs[tabKey]) {
           let { title } = linkTypeObj;

--- a/static/js/sefaria/sefaria.js
+++ b/static/js/sefaria/sefaria.js
@@ -2700,6 +2700,7 @@ _media: {},
         if (refObj.is_sheet) { continue; }
         let tabKey = linkTypeSlug;
         if (tabKey === 'about') {
+            // Mark as notable if it has a prompt, title, and isn't explicitly unpublished (happens when returns from LLM pod);
             tabKey = (refObj.descriptions?.[lang]?.title || refObj.descriptions?.[lang]?.prompt) && refObj.descriptions?.[lang]?.published != false ? 'notable-sources' : 'sources';
         }
         if (!tabs[tabKey]) {


### PR DESCRIPTION
## Description
This PR ensures that manual descriptions for topics on the topic page are displayed when available. It fixes an issue where certain descriptions were not appearing


## Code Changes
_The following changes were made to the files below_

## Notes
_Any additional notes go here_