### PR TITLE
chore: pass highlightedRefsInSheet from SheetsWithRefPage

### DIFF
--- a/static/js/ReaderPanel.jsx
+++ b/static/js/ReaderPanel.jsx
@@ -263,9 +263,10 @@ class ReaderPanel extends Component {
     e.preventDefault();
     this.conditionalSetState({
       mode: "Sheet",
-      sheetID: sheet.id,
+      sheetID: typeof sheet === 'object' ? sheet.id : sheet, // latter case is for when 'sheet' passed is ID
       highlightedNode,
-      highlightedRefsInSheet
+      highlightedRefsInSheet,
+      menuOpen: null,
     });
   }
   setPreviousSettings(backButtonSettings) {
@@ -866,7 +867,7 @@ class ReaderPanel extends Component {
                                  updateAppliedOptionSort={this.props.updateSearchOptionSort}
                                  registerAvailableFilters={this.props.registerAvailableFilters}
                                  resetSearchFilters={this.props.resetSearchFilters}
-                                 onResultClick={this.props.onSearchResultClick}/>);
+                                 onResultClick={this.handleSheetClick}/>);
     } else if (this.state.menuOpen === "sheet meta") {
       menu = (<SheetMetadata
                     mode={this.state.menuOpen}

--- a/static/js/SearchSheetResult.jsx
+++ b/static/js/SearchSheetResult.jsx
@@ -4,18 +4,23 @@ import Sefaria  from './sefaria/sefaria';
 import classNames  from 'classnames';
 import PropTypes  from 'prop-types';
 import Component      from 'react-class';
-import {
-    ColorBarBox, InterfaceText,
-} from './Misc';
-import {ProfilePic} from "./ProfilePic";
+import { ProfilePic } from "./ProfilePic";
 
 
 class SearchSheetResult extends Component {
     handleSheetClick(e) {
       const s = this.props.metadata;
       if (this.props.onResultClick) {
-        e.preventDefault()
-        this.props.onResultClick("Sheet " + s.sheetId);
+        const queryIsRef = !Sefaria.parseRef(this.props.query)?.error;
+        if (queryIsRef) {
+          // called from SheetsWithRefPage which has a ref query.  in this case, onResultClick is handleSheetClick in ReaderPanel.jsx
+          this.props.onResultClick(e, s.sheetId, null, [this.props.query]);
+        }
+        else {
+          // called from ElasticSearchQuerier which has a text query. in this case, onResultClick is the panel's onSearchResultClick
+          e.preventDefault();
+          this.props.onResultClick(`Sheet ${s.sheetId}`);
+        }
       }
       Sefaria.track.event("Search", "Search Result Sheet Click", `${this.props.query} - ${s.sheetId}`);
     }

--- a/static/js/SearchSheetResult.jsx
+++ b/static/js/SearchSheetResult.jsx
@@ -12,13 +12,13 @@ class SearchSheetResult extends Component {
       const s = this.props.metadata;
       if (this.props.onResultClick) {
         const queryIsRef = !Sefaria.parseRef(this.props.query)?.error;
+        e.preventDefault();
         if (queryIsRef) {
-          // called from SheetsWithRefPage which has a ref query.  in this case, onResultClick is handleSheetClick in ReaderPanel.jsx
+          // This is called from SheetsWithRefPage which has a ref query.  In this case, onResultClick is handleSheetClick in ReaderPanel.jsx
           this.props.onResultClick(e, s.sheetId, null, [this.props.query]);
         }
         else {
-          // called from ElasticSearchQuerier which has a text query. in this case, onResultClick is the panel's onSearchResultClick
-          e.preventDefault();
+          // This is called from ElasticSearchQuerier which has a text query. In this case, onResultClick is the panel's onSearchResultClick
           this.props.onResultClick(`Sheet ${s.sheetId}`);
         }
       }


### PR DESCRIPTION
## Description
We have a feature in production that was not implemented when we created the Sheets With Ref Page this summer.  The feature is that if a user has "Exodus 7:1" open in the reader and opens a sheet from the sidebar, the sheet will scroll to highlight the source "Exodus 7:1" in the sheet.  In modularization, when a user tries to open a sheet from the reader, they are taken to a new page, the Sheets With Ref Page which displays all the sheets for the given ref with appropriate topic filters (like the Search Page).  However, previously in the modularization branch, when a user would click one of these sheets, the sheet would not scroll to "Exodus 7:1" and highlight it.  This PR corrects this.

## Code Changes
There's a function in ReaderPanel, handleSheetClick, which is used in production to implement this feature.  I used the same function, by passing it to the SheetsWithRefPage component, which ultimately passes it all the way to SearchSheetResult.  I had to slightly modify handleSheetClick in ReaderPanel and slightly modify the click handler in SearchSheetResult, which is confusingly also called handleSheetClick.  The substantive difference in the SearchSheetResult click handler is that I need to check if the query passed is a search query (i.e. plain text) in which case we should use the this.props.onResultClick handler that was already being used before, OR if the query passed is in the form of a valid Sefaria ref, in which case we know that the function passed down as this.props.onResultClick is really the ReaderPanel's handleSheetClick.
