### PR TITLE
fix(TextRange): use sectionRef for key only if the ref is cached, oth…

### DIFF
--- a/static/js/TextColumn.jsx
+++ b/static/js/TextColumn.jsx
@@ -395,7 +395,7 @@ class TextColumn extends Component {
         unsetTextHighlight={this.props.unsetTextHighlight}
         navigatePanel={this.props.navigatePanel}
         translationLanguagePreference={this.props.translationLanguagePreference}
-        key={oref.sectionRef} />);
+        key={sref || oref.sectionRef} />);
     });
 
     let pre, post, bookTitle;


### PR DESCRIPTION
use sectionRef for TextRange key if the ref is cached, for preventing re-creating of TextRange; otherwise, use sref.