### PR TITLE
Fix link in dropdown

### DIFF
--- a/static/js/Header.jsx
+++ b/static/js/Header.jsx
@@ -113,7 +113,7 @@ const LoggedInDropdown = () => {
                   </DropdownMenuItem>
               </div>
               <DropdownMenuSeparator/>
-              <DropdownMenuItem url={'/notifications'}>
+              <DropdownMenuItem url={'/updates'}>
                   <InterfaceText text={{'en': 'New Additions', 'he': 'חידושים בארון הספרים של ספריא'}}/>
               </DropdownMenuItem>
               <DropdownMenuItem preventClose={true} url={'/help'}>


### PR DESCRIPTION
## Description
The `New Additions` link in the dropdown was linking to notifications, this moves it to link to `/updates`/ 

## Code Changes
In `static/js/Header.jsx` changed the URL. 