### PR TITLE
Add language toggle to sidebar in Hebrew UI

### DIFF
--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -5099,10 +5099,10 @@ body .ui-autocomplete.dictionary-toc-autocomplete .ui-menu-item a.ui-state-focus
   align-items: center;
  }
  .leftButtons {
-   text-align: start;
+  text-align: start;
  }
  .rightButtons {
-   text-align: end;
+  text-align: end;
  }
 /* icons need a little nudge in flipped hebrew mode */
 .interface-hebrew .rightButtons {

--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -5092,19 +5092,18 @@ body .ui-autocomplete.dictionary-toc-autocomplete .ui-menu-item a.ui-state-focus
 .readerControls .readerTextToc .categoryAttribution .he {
   font-style: normal;
 }
-.interface-english .leftButtons,
-.interface-hebrew .rightButtons {
+ .leftButtons,
+ .rightButtons {
   display: flex;
   flex-direction: row;
-  text-align: left;
-}
-.interface-english .rightButtons,
-.interface-hebrew .leftButtons {
-  display: flex;
-  flex-direction: row;
-  text-align: right;
   align-items: center;
-}
+ }
+ .leftButtons {
+   text-align: start;
+ }
+ .rightButtons {
+   text-align: end;
+ }
 /* icons need a little nudge in flipped hebrew mode */
 .interface-hebrew .rightButtons {
   margin-left: -3px;

--- a/static/js/ConnectionsPanelHeader.jsx
+++ b/static/js/ConnectionsPanelHeader.jsx
@@ -117,7 +117,7 @@ class ConnectionsPanelHeader extends Component {
       const toggleLang = Sefaria.util.getUrlVars()["lang2"] === "en" ? "he" : "en";
       const langUrl = Sefaria.util.replaceUrlParam("lang2", toggleLang);
       const closeUrl = Sefaria.util.removeUrlParam("with");
-      const showOneLanguage = !Sefaria._siteSettings.TORAH_SPECIFIC || Sefaria.interfaceLang === "hebrew";
+      const showOneLanguage = !Sefaria._siteSettings.TORAH_SPECIFIC;
       const toggleButton =  (showOneLanguage) ? null : (this.props.connectionsMode === 'TextList') ?
           <DropdownMenu buttonContent={<DisplaySettingsButton/>} context={ReaderPanelContext}><ReaderDisplayOptionsMenu/></DropdownMenu> :
             <LanguageToggleButton toggleLanguage={this.props.toggleLanguage} url={langUrl} />;

--- a/static/js/ReaderPanel.jsx
+++ b/static/js/ReaderPanel.jsx
@@ -150,8 +150,8 @@ class ReaderPanel extends Component {
       contentLangOverride = (Sefaria.interfaceLang === "english") ? "bilingual" : "hebrew";
 
     } else if ((mode === "Connections" && connectionsMode !== 'TextList') || !!menuOpen){
-      // Always Hebrew for Hebrew interface, treat bilingual as English for English interface
-      contentLangOverride = (Sefaria.interfaceLang === "hebrew") ? "hebrew" : ((originalLanguage === "bilingual") ? "english" : originalLanguage);
+      // Default bilingual to interface language
+      contentLangOverride = (originalLanguage === "bilingual") ? Sefaria.interfaceLang : originalLanguage;
     }
     return contentLangOverride;
   }


### PR DESCRIPTION
changes:
ConnectionsPanelHeader - remove Hebrew UI from showOneLanguage
ReaderControls - do not default ConnectionsPanel language to Hebrew.
CSS - align buttons to center.