### PR TITLE
Fix for intermittent unexplained Node errors

### DIFF
--- a/node/server.js
+++ b/node/server.js
@@ -130,6 +130,8 @@ router.post('/ReaderApp/:cachekey', function(req, res) {
       res.end(resphtml);
     } catch (render_e){
       logger.error(render_e);
+      // Return an HTTP 500 for the client
+      return res.status(500).end('Error rendering ReaderApp: ' + render_e.message);
     }
   }).catch(error => {
     res.status(500).end('Data required for render is missing:  ' + error.message);


### PR DESCRIPTION
## Description
Tries to address some node server responses hanging from Djangos perspective

## Code Changes
Adds explicit 500 response when a render error gets caught in node SSR while attempting to render ReaderApp

## Notes
This doesnt really fix any errors it just allows node and django to interact more informatively when a rendering error occurs