### PR TITLE
Clean up Header Icons

### DIFF
--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -791,13 +791,19 @@ div:has(#bannerMessage) + .readerApp.singlePanel .mobileNavMenu {
 .accountLinks.anon .help {
   margin-top: 6px;
 }
-.header .interfaceLinks {
-  display: block;
+.headerLinksSection .help {
+  display: flex;
+  justify-content: center;
   align-items: center;
-  margin-top: 2px;
+  height: 100%;
+  margin-top: 4px;
+}
+.header .interfaceLinks {
+  display: flex;
+  justify-content: center;
+  align-items: center;
   color: #666;
   cursor: pointer;
-  position: relative;
   -webkit-margin-start: 20px;
   -moz-margin-start: 20px;
   margin-inline-start: 10px;
@@ -807,6 +813,11 @@ div:has(#bannerMessage) + .readerApp.singlePanel .mobileNavMenu {
   width: 18px;
   vertical-align: middle;
   margin-inline-end: 2px;
+}
+.header .interfaceLinks a.interfaceLinks-button{
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 .header .interfaceLinks a.interfaceLinks-button::after {
   display: inline-block;
@@ -4772,6 +4783,7 @@ body .ui-autocomplete.dictionary-toc-autocomplete .ui-menu-item a.ui-state-focus
 }
 .search-container{
   position: relative;
+  padding-right: 10px;
 }
 .autocomplete-dropdown{
   background: #FFFFFF;

--- a/static/js/Header.jsx
+++ b/static/js/Header.jsx
@@ -202,13 +202,11 @@ class Header extends Component {
 
         { Sefaria._siteSettings.TORAH_SPECIFIC ? <HelpButton /> : null}
 
-
         { !Sefaria._uid && Sefaria._siteSettings.TORAH_SPECIFIC ?
               <InterfaceLanguageMenu
                 currentLang={Sefaria.interfaceLang}
                 translationLanguagePreference={this.props.translationLanguagePreference}
                 setTranslationLanguagePreference={this.props.setTranslationLanguagePreference} /> : null}
-
 
           <ModuleSwitcher /> 
 

--- a/static/js/Header.jsx
+++ b/static/js/Header.jsx
@@ -200,6 +200,9 @@ class Header extends Component {
             openURL={this.props.openURL}
         />
 
+        { Sefaria._siteSettings.TORAH_SPECIFIC ? <HelpButton /> : null}
+
+
         { !Sefaria._uid && Sefaria._siteSettings.TORAH_SPECIFIC ?
               <InterfaceLanguageMenu
                 currentLang={Sefaria.interfaceLang}
@@ -308,7 +311,7 @@ const LoggedOutButtons = ({mobile, loginOnly}) => {
           <InterfaceText>Log in</InterfaceText>
         </a>
       </span>}
-      {/* { Sefaria._siteSettings.TORAH_SPECIFIC ? <HelpButton /> : null} */}
+      
     </div>
   );
 }


### PR DESCRIPTION
## Description
- The header icons were not vertically aligned, this PR cleans it up with CSS
- The help button was mistakenly removed, this PR reinserts it and centers it properly

## Code Changes
1. `static/css/s2.css` - Adjusting some margins, mostly just making sure each div wrapping each icon svg was displaying its contents as centered. 
2. `static/js/Header.jsx` - Adding the help button

## Notes
- Right now, the help button seems to disappear in mobile-web, is this by design?