### PR TITLE
Disable tooltip in ReaderControls on Mobile-Web 

### DIFF
--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -11682,12 +11682,16 @@ cursor: pointer;
   }
 }
 
+.tooltip-toggle {
+  position: relative; /* Ensure positioning context for absolute pseudo-element */
+}
 .tooltip-toggle::before {
+  content: attr(aria-label);
   color: #000;
   font-family: "Roboto", "Helvetica Neue", "Helvetica", sans-serif;
   font-size: 13px;
   opacity: 0;
-  pointer-events: none;
+  /*pointer-events: none;*/
   text-align: center;
   position: absolute;
   top: 30px;
@@ -11696,17 +11700,32 @@ cursor: pointer;
   background-color: #fff;
   box-shadow: 0 1px 3px rgba(0,0,0,.2);
   border-radius: 5px;
-  content: attr(aria-label);
   text-transform: none;
-  transition: all 0.5s ease;
+  transition: opacity 0.5s ease;
   width: 140px;
   z-index: 1;
+  visibility: hidden; /* Hide completely when not shown */
 }
-/*Triggering the transition*/
-.tooltip-toggle:hover::before, .tooltip-toggle:hover::after {
-  opacity: 1;
-  transition: all 0.75s ease;
+/* Combine hover and focus for better accessibility */
+@media (hover: hover) and (pointer: fine) {
+  .tooltip-toggle:hover::before,
+  .tooltip-toggle:focus::before {
+    opacity: 1;
+    visibility: visible;
+    transition: opacity 0.75s ease;
+  }
 }
+@media (pointer: coarse) {
+  .tooltip-toggle::before {
+    /* Mobile-specific styles */
+    display: none; /* or alternative mobile-friendly behavior */
+  }
+}
+/* Ensure the button itself can receive focus */
+.tooltip-toggle {
+  outline: none; /* Optional: removes default focus outline */
+}
+
 .largeFollowButton {
   display: inline-flex;
   min-height: 46px;


### PR DESCRIPTION
## Description
Disables the ability to hover over a tooltip in mobile web settings

## Code Changes
Use explicit touch/mouse css declarations to disable inconsistent tool tip behavior on mobile browsers
Adds media queries to check for hover implementation and pointer granularity (coarse on touch devices) to make sure only mouse enabled environments respond to hover

## Notes
This is due to an inconsistent implementation of touch to pseudo states like hover in different browser engines that makes it impossible to use correctly in mobile browsers. So in Firefox it simply would not show anyway and in Chrome the tooltip would show on touch instead of hover but then get stuck because there is no parallel off "not hover" 