### PR TITLE
fix: Check for window before referencing it

### DIFF
--- a/static/js/Misc.jsx
+++ b/static/js/Misc.jsx
@@ -2258,7 +2258,11 @@ TwoOrThreeBox.defaultProps = {
 const ResponsiveNBox = ({content, stretch, initialWidth, threshold2=500, threshold3=1500, gap=0}) => {
   //above threshold2, there will be 2 columns
   //above threshold3, there will be 3 columns
-  initialWidth = initialWidth || (window ? window.innerWidth : 1000);
+  initialWidth = initialWidth || (
+    typeof window !== 'undefined' && window.innerWidth
+    ? window.innerWidth
+    : 1000
+  );
   const [width, setWidth] = useState(initialWidth);
   const ref = useRef(null);
 


### PR DESCRIPTION
## Description
Node was erroring out periodically because of this reference to the undefined `window` var. 