### PR TITLE
Pool Cache on Django's TopicManager

### DIFF
--- a/django_topics/admin.py
+++ b/django_topics/admin.py
@@ -71,6 +71,10 @@ class TopicAdmin(admin.ModelAdmin):
         create_remove_from_pool_action('general_he'),
         create_remove_from_pool_action(PoolType.TORAH_TAB.value),
     ]
+    def save_related(self, request, form, formsets, change):
+        super().save_related(request, form, formsets, change)
+        Topic.objects.build_slug_to_pools_cache(rebuild=True)
+
 
     def has_add_permission(self, request):
         return False

--- a/django_topics/models/topic.py
+++ b/django_topics/models/topic.py
@@ -2,9 +2,12 @@ from django.db import models
 from django.db.models.query import QuerySet
 import random
 from django_topics.models.pool import TopicPool
+from collections import defaultdict
 
 
 class TopicManager(models.Manager):
+    slug_to_pools = defaultdict(list)
+
     def sample_topic_slugs(self, order, pool: str = None, limit=10) -> list[str]:
         if pool:
             topics = self.get_topic_slugs_by_pool(pool)
@@ -16,11 +19,21 @@ class TopicManager(models.Manager):
             raise Exception("Invalid order: '{}'".format(order))
 
     def get_pools_by_topic_slug(self, topic_slug: str) -> QuerySet:
-        return self.filter(slug=topic_slug).values_list("pools__name", flat=True)
+        if not self.slug_to_pools:
+            self.build_slug_to_pools_cache()
+        return self.slug_to_pools.get(topic_slug, [])
 
     def get_topic_slugs_by_pool(self, pool: str) -> QuerySet:
         return self.filter(pools__name=pool).values_list("slug", flat=True)
 
+    def build_slug_to_pools_cache(self):
+        """
+        Refreshes the slug_to_pools cache if it hasn't been initialized yet.
+        """
+        topics = self.model.objects.values_list('slug', 'pools__name')
+        for slug, pool_name in topics:
+            if pool_name:
+                self.slug_to_pools[slug].append(pool_name)
 
 class Topic(models.Model):
     slug = models.CharField(max_length=255, primary_key=True)

--- a/django_topics/models/topic.py
+++ b/django_topics/models/topic.py
@@ -26,14 +26,13 @@ class TopicManager(models.Manager):
     def get_topic_slugs_by_pool(self, pool: str) -> QuerySet:
         return self.filter(pools__name=pool).values_list("slug", flat=True)
 
-    def build_slug_to_pools_cache(self):
-        """
-        Refreshes the slug_to_pools cache if it hasn't been initialized yet.
-        """
-        topics = self.model.objects.values_list('slug', 'pools__name')
-        for slug, pool_name in topics:
-            if pool_name:
-                self.slug_to_pools[slug].append(pool_name)
+    def build_slug_to_pools_cache(self, rebuild=False):
+        if rebuild or not self.slug_to_pools:
+            self.slug_to_pools.clear()
+            topics = self.model.objects.values_list('slug', 'pools__name')
+            for slug, pool_name in topics:
+                if pool_name:
+                    self.slug_to_pools[slug].append(pool_name)
 
 class Topic(models.Model):
     slug = models.CharField(max_length=255, primary_key=True)

--- a/sefaria/model/autospell.py
+++ b/sefaria/model/autospell.py
@@ -547,7 +547,7 @@ class TitleTrie(datrie.Trie):
                     "key": tuple(key) if isinstance(key, list) else key,
                     "is_primary": True,
                     "order": base_order + sub_order,
-                    "topic_pools": obj.get_pools() if isinstance(obj, Topic) else []
+                    "topic_pools": obj.pools if isinstance(obj, Topic) else []
                 }
 
             titles = getattr(obj, all_names_method)(self.lang)
@@ -562,7 +562,7 @@ class TitleTrie(datrie.Trie):
                     "key": tuple(key) if isinstance(key, list) else key,
                     "is_primary": False,
                     "order": base_order + sub_order,
-                    "topic_pools": obj.get_pools() if isinstance(obj, Topic) else []
+                    "topic_pools": obj.pools if isinstance(obj, Topic) else []
                 }
 
 


### PR DESCRIPTION
## Description
A simpler cahce mecahnism for the retrievel of pools per slug - implemented as part of the Django TopicManager
The cahce is  created only after first call to get_pools_by_topic_slug ("lazy"), I tried to create it upon first initialization of of the topic manager but it's somewhat complicated, since the actual models (schemas) are not yet created at this point, so it's  not possible to get the data from the tables at this stage.

## Code Changes
_The following changes were made to the files below_

## Notes
_Any additional notes go here_