### PR TITLE
"Explore All Topics" prompt for mobile, Initialize Topic Pools Cache on Server Start

### DIFF
--- a/django_topics/models/topic.py
+++ b/django_topics/models/topic.py
@@ -6,7 +6,8 @@ from collections import defaultdict
 
 
 class TopicManager(models.Manager):
-    slug_to_pools = defaultdict(list)
+    slug_to_pools = {}
+
 
     def sample_topic_slugs(self, order, pool: str = None, limit=10) -> list[str]:
         if pool:
@@ -28,11 +29,12 @@ class TopicManager(models.Manager):
 
     def build_slug_to_pools_cache(self, rebuild=False):
         if rebuild or not self.slug_to_pools:
-            self.slug_to_pools.clear()
+            new_slug_to_pools = defaultdict(list)
             topics = self.model.objects.values_list('slug', 'pools__name')
             for slug, pool_name in topics:
                 if pool_name:
-                    self.slug_to_pools[slug].append(pool_name)
+                    new_slug_to_pools[slug].append(pool_name)
+            self.slug_to_pools = new_slug_to_pools
 
 class Topic(models.Model):
     slug = models.CharField(max_length=255, primary_key=True)

--- a/reader/startup.py
+++ b/reader/startup.py
@@ -1,4 +1,4 @@
-
+from django_topics.models import Topic as DjangoTopic
 
 def init_library_cache():
     import django
@@ -9,6 +9,8 @@ def init_library_cache():
     from sefaria.model.text import library
     from sefaria.system.multiserver.coordinator import server_coordinator
     from django.conf import settings
+    logger.info("Initializing topic pools cache")
+    DjangoTopic.objects.build_slug_to_pools_cache()
     logger.info("Initializing library objects.")
     logger.info("Initializing TOC Tree")
     library.get_toc_tree()

--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -5019,6 +5019,20 @@ h1.topic-landing-header {
   top: 6px;
   padding-inline-start: 11px;
 }
+.explore-all-topics-prompt{
+  display: none;
+}
+.singlePanel .explore-all-topics-prompt{
+  display: block;
+  color: var(--darkest-grey);
+  --english-font: var(--english-sans-serif-font-family);
+  font-size: 14px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 18px;
+  text-align: center;
+  margin-top: 15px
+}
 .featuredTopic {
   display: flex;
   flex-direction: column;

--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -4911,6 +4911,9 @@ h1.topic-landing-header {
 .singlePanel .topic-landing-page-content .topic-landing-section.first-section {
   margin-top: 18px;
 }
+.singlePanel .topic-landing-page-content .topic-landing-section.following-search-section {
+  margin-top: 18px;
+}
 
 .interface-hebrew .topic-landing-page-wrapper{
   direction: rtl;

--- a/static/js/NavSidebar.jsx
+++ b/static/js/NavSidebar.jsx
@@ -643,7 +643,9 @@ const TopicLandingTopicCatList = () => {
     const topicCats = Sefaria.topicTocPage();
     return(
         <SidebarModule>
-            <span id="browseTopics"><SidebarModuleTitle>Browse Topics</SidebarModuleTitle></span>
+            <SidebarModuleTitle>
+                <span id="browseTopics">Browse Topics</span>
+            </SidebarModuleTitle>
             <div className="topic-landing-sidebar-list">
                 {topicCats.map((topic, i) =>
                     <div className="navSidebarLink ref serif" key={i}>

--- a/static/js/NavSidebar.jsx
+++ b/static/js/NavSidebar.jsx
@@ -643,7 +643,7 @@ const TopicLandingTopicCatList = () => {
     const topicCats = Sefaria.topicTocPage();
     return(
         <SidebarModule>
-            <SidebarModuleTitle>Browse Topics</SidebarModuleTitle>
+            <span id="browseTopics"><SidebarModuleTitle>Browse Topics</SidebarModuleTitle></span>
             <div className="topic-landing-sidebar-list">
                 {topicCats.map((topic, i) =>
                     <div className="navSidebarLink ref serif" key={i}>

--- a/static/js/TopicLandingPage/TopicLandingSearch.jsx
+++ b/static/js/TopicLandingPage/TopicLandingSearch.jsx
@@ -116,8 +116,7 @@ const renderInput = (openTopic, numOfTopics, highlightedIndex, highlightedSugges
 }
 
 const scrollBrowseTopicsIntoView = (e) =>{
-    console.log("click")
-    document.getElementById("browseTopics")?.scrollIntoView({ behavior: "smooth" });
+    document.getElementById("browseTopics")?.scrollIntoView({block: 'center', inline: 'center', behavior: 'auto'});
 }
 
 export const TopicLandingSearch = ({openTopic, numOfTopics}) => {
@@ -135,7 +134,7 @@ export const TopicLandingSearch = ({openTopic, numOfTopics}) => {
             />
         </div>
     <div className="explore-all-topics-prompt" onClick={scrollBrowseTopicsIntoView}>
-        <InterfaceText>Explore all topics></InterfaceText>
+        <InterfaceText>Explore all topics ›</InterfaceText>
     </div>
             </>
     );

--- a/static/js/TopicLandingPage/TopicLandingSearch.jsx
+++ b/static/js/TopicLandingPage/TopicLandingSearch.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import classNames  from 'classnames';
 import {GeneralAutocomplete} from "../GeneralAutocomplete";
 import Sefaria from "../sefaria/sefaria";
-import {SearchButton} from "../Misc";
+import {InterfaceText, SearchButton} from "../Misc";
 
 const getSuggestions = async (input) => {
     if (input.length <=1) {
@@ -115,9 +115,15 @@ const renderInput = (openTopic, numOfTopics, highlightedIndex, highlightedSugges
     )
 }
 
+const scrollBrowseTopicsIntoView = (e) =>{
+    console.log("click")
+    document.getElementById("browseTopics")?.scrollIntoView({ behavior: "smooth" });
+}
+
 export const TopicLandingSearch = ({openTopic, numOfTopics}) => {
 
     return (
+        <>
         <div className="topic-landing-search-wrapper">
             <GeneralAutocomplete
                 getSuggestions={getSuggestions}
@@ -128,5 +134,9 @@ export const TopicLandingSearch = ({openTopic, numOfTopics}) => {
                 // shouldDisplaySuggestions={()=>true}
             />
         </div>
+    <div className="explore-all-topics-prompt" onClick={scrollBrowseTopicsIntoView}>
+        <InterfaceText>Explore all topics></InterfaceText>
+    </div>
+            </>
     );
 };

--- a/static/js/TopicLandingPage/TopicLandingSearch.jsx
+++ b/static/js/TopicLandingPage/TopicLandingSearch.jsx
@@ -115,8 +115,17 @@ const renderInput = (openTopic, numOfTopics, highlightedIndex, highlightedSugges
     )
 }
 
+function _scrollTo(element, scrollableParent=window, yOffset = 0){
+  const y = element.getBoundingClientRect().top + window.pageYOffset + yOffset;
+  scrollableParent.scrollTo({top: y, behavior: 'smooth'});
+}
+
 const scrollBrowseTopicsIntoView = (e) =>{
-    document.getElementById("browseTopics")?.scrollIntoView({block: 'center', inline: 'center', behavior: 'auto'});
+    const scrollToElement = document.querySelector("#browseTopics");
+    const scrollableParent = document.querySelector('.content');
+    const headerInner = document.querySelector('.headerInner');
+    const height = headerInner.offsetHeight;
+    _scrollTo(scrollToElement, scrollableParent,  -height)
 }
 
 export const TopicLandingSearch = ({openTopic, numOfTopics}) => {

--- a/static/js/TopicLandingPage/TopicsLandingPage.jsx
+++ b/static/js/TopicLandingPage/TopicsLandingPage.jsx
@@ -29,7 +29,7 @@ export const TopicsLandingPage = ({openTopic}) => {
                         <div className="topic-landing-section first-section">
                             <TopicLandingSearch openTopic={openTopic} numOfTopics={Sefaria.numLibraryTopics}/>
                         </div>
-                        <div className="topic-landing-section">
+                        <div className="topic-landing-section following-search-section">
                             <TopicSalad/>
                         </div>
                         <div className="topic-landing-section">


### PR DESCRIPTION
## Description
Added an "Explore All Topics" prompt for mobile users on the Topic Landing Page. The prompt smoothly scrolls to the Browse Topics section when clicked.
Make slug_to_pool cache map initialize on server start

## Code Changes
_The following changes were made to the files below_

## Notes
_Any additional notes go here_