### PR TITLE
Fix visualization in Hebrew

### DIFF
--- a/static/js/explore.js
+++ b/static/js/explore.js
@@ -120,6 +120,7 @@ function buildFrame() {
     svg = d3.select("#linkExplorerPage").insert("svg", "#svgBefore")
         .attr("width", w + margin[1] + margin[3] - 16)
         .attr("height", h + margin[0] + margin[2])
+        .style("direction", "ltr")
       .append("g")
         .attr("transform", "translate(" + margin[3] + "," + margin[0] + ")");
 


### PR DESCRIPTION
## Description
Explicitly add direction ltr to the svg element.
This svg building is based on the assumption of rtl also for the Hebrew interface.
This fixes the location of Hebrew strings to be within the text boxes, and of the Hebrew book titles not to be over the horizontal bars.

## Notes
We can solve the first problem (text out of its box) by changing the text-anchor, but changing the other problem seems much more complcated. It seems that the text-anchor: end is there from the first place due this.