### PR TITLE
fix(topics): [sc-32232] "Source+Transaltion mode" in the Hebrew UI on topic pages seems to be non-functional

### DIFF
--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -11948,6 +11948,10 @@ body .homeFeedWrapper .content {
   box-shadow: 0px 1px 3px rgba(0, 0, 0, 0.25);
 }
 
+.topicTabContents .story.topicPassageStory .contentSpan {
+  display: block;
+}
+
 .story.topicPassageStory .storyBody {
   padding-inline-end: 20px;
   padding-top: 20px;

--- a/static/js/TopicPage.jsx
+++ b/static/js/TopicPage.jsx
@@ -724,7 +724,7 @@ const TopicPage = ({
     const handleLangSelectInterfaceChange = (selection) => {
       if (selection === "source") {setLangPref("hebrew")}
       else if (selection === "translation") {setLangPref("english")}
-      else setLangPref(null);
+      else setLangPref("bilingual");
     }
 
     const getCurrentLang = () => {


### PR DESCRIPTION
## Description
For topic pages, bilingual mode doesn't work

## Code Changes
Very simple issue.  We simply weren't setting "bilingual" mode.  I changed one line and a little CSS: