### PR TITLE
Optimize topic sampling with queryset slicing

### DIFF
--- a/django_topics/models/topic.py
+++ b/django_topics/models/topic.py
@@ -10,14 +10,11 @@ class TopicManager(models.Manager):
 
 
     def sample_topic_slugs(self, order, pool: str = None, limit=10) -> list[str]:
-        if pool:
-            topics = self.get_topic_slugs_by_pool(pool)
-        else:
-            topics = self.all().values_list('slug', flat=True)
+        queryset = self.get_topic_slugs_by_pool(pool) if pool else self.all().values_list('slug', flat=True)
         if order == 'random':
-            return random.sample(list(topics), min(limit, len(topics)))
+            return list(queryset.order_by("?")[:limit])  # Uses database-level random ordering
         else:
-            raise Exception("Invalid order: '{}'".format(order))
+            raise ValueError(f"Invalid order: '{order}'")
 
     def get_pools_by_topic_slug(self, topic_slug: str) -> QuerySet:
         if not self.slug_to_pools:


### PR DESCRIPTION
## Description
Refactors sample_topic_slugs to use queryset-level slicing for improved efficiency. Replaces in-memory random.sample with database-level random ordering. Cleans up exception handling.
## Code Changes
_The following changes were made to the files below_

## Notes
_Any additional notes go here_