### PR TITLE
Contains a POC of the POM strategy for organizing e2e tests

### DIFF
--- a/e2e-tests/pages/banner.ts
+++ b/e2e-tests/pages/banner.ts
@@ -1,0 +1,90 @@
+import { Page, expect } from "@playwright/test"
+import { LANGUAGES } from '../globals'
+import { getPathAndParams } from "../utils"
+
+export class Banner{
+    private page: Page
+    private language: string
+
+    constructor(page: Page, language: string){
+        this.page = page
+        this.language = language
+    }
+
+    async toggleLanguage(newLanguage: string){
+        this.language = newLanguage
+    }
+
+    async textsPageFromLogo(){
+        await this.page.getByRole('link', { name: 'Sefaria Logo' }).click();
+        
+        expect(getPathAndParams(this.page.url())).toEqual("/texts")
+    }
+
+    async textsPageFromLink(){
+        if(this.language == LANGUAGES.EN){
+            await this.page.getByRole('banner').getByRole('link', { name: 'Texts' }).click();
+        }
+        else{
+            await this.page.getByRole('banner').getByRole('link', { name: 'מקורות' }).click();
+        }
+        
+        expect(getPathAndParams(this.page.url())).toEqual("/texts")
+    }
+
+    async topicsPage(){
+        if(this.language == LANGUAGES.EN){
+            await this.page.getByRole('banner').getByRole('link', { name: 'Topics' }).click();
+        }
+        else{
+            await this.page.getByRole('banner').getByRole('link', { name: 'נושאים' }).click();
+        }
+        
+        expect(getPathAndParams(this.page.url())).toBe("/topics")
+    }
+
+    async communityPage(){
+        if(this.language == LANGUAGES.EN){
+            await this.page.getByRole('banner').getByRole('link', { name: 'Community' }).click();
+        }
+        else{
+            await this.page.getByRole('banner').getByRole('link', { name: 'קהילה' }).click();
+        }
+
+        expect(getPathAndParams(this.page.url())).toEqual("/community")
+    }
+
+    async donatePage(): Promise<Page>{
+        const donatePagePromise = this.page.waitForEvent('popup')
+
+        if(this.language == LANGUAGES.EN){
+            await this.page.getByRole('banner').getByRole('link', { name: 'Donate' }).click();
+        }
+        else{
+            await this.page.getByRole('banner').getByRole('link', { name: 'תרומה' }).click();
+        }
+
+        const donatePage = await donatePagePromise
+        
+        expect(donatePage.url()).toContain("https://donate.sefaria.org/")
+
+        return donatePage
+    }
+
+    async helpPage(){
+        if(this.language == LANGUAGES.EN){
+            await this.page.getByRole('banner').getByRole('link', { name: 'Help' }).click();
+        }
+        else{
+            await this.page.getByRole('banner').getByRole('link', { name: 'עזרה' }).click();
+        }
+        
+        expect(getPathAndParams(this.page.url())).toContain("/collections/")
+    }
+
+    async loginPage(){
+        
+    }
+
+    
+}

--- a/e2e-tests/pages/communityPage.ts
+++ b/e2e-tests/pages/communityPage.ts
@@ -1,0 +1,21 @@
+import { Page, expect } from "@playwright/test"
+import { LANGUAGES } from "../globals"
+import { HelperBase } from "./helperBase"
+
+export class CommunityPage extends HelperBase{
+    constructor(page: Page, language: string){
+        super(page, language)
+    }
+
+    async validateCommunityPageLayout(){
+        if(this.language == LANGUAGES.HE){
+            await expect(this.page.locator('.contentInner')).toContainText('היום בספריא')
+            await expect(this.page.locator('.navSidebar')).toContainText('קחו חלק בשיח')
+        }
+        else{
+            await expect(this.page.locator('.contentInner')).toContainText('Today on Sefaria')
+            await expect(this.page.locator('.navSidebar')).toContainText('Join the Conversation')
+        }
+    }
+
+}

--- a/e2e-tests/pages/donatePage.ts
+++ b/e2e-tests/pages/donatePage.ts
@@ -1,0 +1,15 @@
+import { Page, expect } from "@playwright/test"
+import { LANGUAGES } from "../globals"
+import { HelperBase } from "./helperBase"
+
+export class DonatePage extends HelperBase{
+    constructor(page: Page, language: string){
+        super(page, language)
+    }
+
+    async selectDonationFrequencyAndAmount(frequency: 'One-time'|'Monthly'|'פעם אחת'|'פעם בחודש', amount='180'){
+        await this.page.getByRole('radio', {name: frequency}).click()
+        await this.page.getByRole('radio', {name: amount}).click()
+    }
+    
+}

--- a/e2e-tests/pages/helperBase.ts
+++ b/e2e-tests/pages/helperBase.ts
@@ -1,0 +1,23 @@
+import { Page } from "@playwright/test"
+
+
+export class HelperBase{
+    readonly page : Page
+    language: string
+
+    constructor(page : Page, language: string){
+        this.page = page
+        this.language = language
+    }
+
+    toggleLanguage(newLanguage: string){
+        this.language = newLanguage
+    }
+
+    getPathAndParams(){
+        const urlObj = new URL(this.page.url());
+        console.log(urlObj.pathname)
+        console.log(urlObj.search)
+        return urlObj.pathname + urlObj.search;
+    }
+}

--- a/e2e-tests/pages/loginPage.ts
+++ b/e2e-tests/pages/loginPage.ts
@@ -1,0 +1,27 @@
+import { Page, expect } from "@playwright/test"
+import { LANGUAGES } from "../globals"
+import { HelperBase } from "./helperBase"
+
+export class LoginPage extends HelperBase{
+    constructor(page: Page, language: string){
+        super(page, language)
+    }
+
+    // Maybe we should go about this a better way, like with a config file that is saved to each dev's machine, rather than hard coded in test files
+    // Also, this code is a refactor of utils.ts: loginUser, just with using the POM structure
+    async loginAs(email: string, password: string){
+        if(this.language == LANGUAGES.HE){
+            await this.page.getByPlaceholder('כתובת').fill(email)
+            await this.page.getByPlaceholder('סיסמא').fill(password)
+            await this.page.getByRole('button', {name: 'התחברות'}).click()
+            //await this.page.getByRole('link', { name: 'See My Saved Texts' }).isVisible();
+        }
+        else{
+            await this.page.getByRole('textbox', {name: 'Email'}).fill(email)
+            await this.page.getByRole('textbox', {name: 'Password'}).fill(password)
+            await this.page.getByRole('button', { name: 'Login' }).click();
+            await this.page.getByRole('link', { name: 'See My Saved Texts' }).isVisible();
+        }
+        
+    }
+}

--- a/e2e-tests/pages/pageManager.ts
+++ b/e2e-tests/pages/pageManager.ts
@@ -1,0 +1,88 @@
+import { Page } from "@playwright/test"
+import {changeLanguage} from "../utils"
+import {LANGUAGES} from '../globals'
+import { Banner } from "./banner"
+import { TextsPage } from "./textsPage"
+import { TopicsPage } from "./topicsPage"
+import { CommunityPage } from "./communityPage"
+import { DonatePage } from "./donatePage"
+import { LoginPage } from "./loginPage"
+import { SignUpPage } from "./signupPage"
+import { SearchPage } from "./searchPage"
+import { UserMenu } from "./userMenu"
+import { SourceTextPage } from "./sourceTextPage"
+
+export class PageManager{
+    private readonly page: Page
+    private readonly banner: Banner
+    private readonly textsPage: TextsPage
+    private readonly topicsPage: TopicsPage
+    private readonly communityPage: CommunityPage
+    private readonly donatePage: DonatePage
+    private readonly loginPage: LoginPage
+    private readonly signupPage: SignUpPage
+    private readonly searchPage: SearchPage
+    private readonly userMenu: UserMenu
+    private readonly sourceTextPage: SourceTextPage
+    
+
+    constructor(page: Page, language: string){
+        this.page = page
+        this.banner = new Banner(page, language)
+        this.textsPage = new TextsPage(page, language)
+        this.topicsPage = new TopicsPage(page, language)
+        this.communityPage = new CommunityPage(page, language)
+        this.donatePage = new DonatePage(page, language)
+        this.loginPage = new LoginPage(page, language)
+        this.signupPage = new SignUpPage(page, language)
+        this.searchPage = new SearchPage(page, language)
+        this.userMenu = new UserMenu(page, language)
+        this.sourceTextPage = new SourceTextPage(page, language)
+    }
+
+    async toggleLanguage(newLanguage: string){
+        await changeLanguage(this.page, LANGUAGES.HE)
+        this.banner.toggleLanguage(newLanguage)
+        this.textsPage.toggleLanguage(newLanguage)
+    }
+
+    navigateTo(){
+        return this.banner
+    }
+
+    onTextsPage(){
+        return this.textsPage
+    }
+
+    onTopicsPage(){
+        return this.topicsPage
+    }
+
+    onCommunityPage(){
+        return this.communityPage
+    }
+
+    onDonatePage(){
+        return this.donatePage
+    }
+
+    onLoginPage(){
+        return this.loginPage
+    }
+
+    onSignUpPage(){
+        return this.signupPage
+    }
+
+    onSearchPage(){
+        return this.searchPage
+    }
+
+    onUserMenu(){
+        return this.userMenu
+    }
+
+    onSourceTextPage(){
+        return this.sourceTextPage
+    }
+}

--- a/e2e-tests/pages/searchPage.ts
+++ b/e2e-tests/pages/searchPage.ts
@@ -1,0 +1,34 @@
+import { Page, expect } from "@playwright/test"
+import { LANGUAGES } from "../globals"
+import { HelperBase } from "./helperBase"
+
+export class SearchPage extends HelperBase{
+    constructor(page: Page, language: string){
+        super(page, language)
+    }
+
+    async searchFor(criteria: string){
+
+        const searchBox = this.page.getByRole('banner').getByRole('combobox')
+
+        await searchBox.click()
+        await searchBox.fill(criteria)
+        await searchBox.press('Enter')
+        
+        if(this.language == LANGUAGES.HE){
+            await this.page.getByText('תוצאות עבור').click();
+        }
+        else{
+            await this.page.getByPlaceholder('Search').click();
+        }
+
+        await expect(this.page.getByRole('heading').first()).toContainText(criteria)
+    }
+
+    async validateVirtualKeyboardForEnglish(character: string){
+        await this.page.getByRole('banner').getByRole('combobox').click()
+        await this.page.getByRole('img', { name: 'Display virtual keyboard' }).click();    
+        await this.page.getByRole('cell', { name: character, exact: true }).click();
+        await expect(this.page.getByRole('banner').getByRole('combobox')).toHaveValue(character)
+    }
+}

--- a/e2e-tests/pages/signupPage.ts
+++ b/e2e-tests/pages/signupPage.ts
@@ -1,0 +1,26 @@
+import { Page, expect } from "@playwright/test"
+import { LANGUAGES } from "../globals"
+import { HelperBase } from "./helperBase"
+
+export class SignUpPage extends HelperBase{
+    constructor(page: Page, language: string){
+        super(page, language)
+    }
+
+    // This class will be good to validate error messages associated with sign-up
+    async fillNewUser(email: string, password: string, firstName: string, lastName: string, isEducator: boolean){
+        await this.page.getByRole('textbox', {name: 'Email'}).fill(email)
+        await this.page.getByRole('textbox', {name: 'Password'}).fill(password)
+        await this.page.getByRole('textbox', {name: 'First Name'}).fill(firstName)
+        await this.page.getByRole('textbox', {name: 'Last Name'}).fill(lastName)
+
+        if(isEducator){
+            if(this.language == LANGUAGES.HE){
+                await this.page.getByRole('checkbox', {name: 'אני מחנך/ מחנכת'}).check()
+            }
+            else{
+                await this.page.getByRole('checkbox', {name: 'I am an educator'}).check()
+            }
+        }
+    }
+}

--- a/e2e-tests/pages/sourceTextPage.ts
+++ b/e2e-tests/pages/sourceTextPage.ts
@@ -1,0 +1,26 @@
+import { Page, expect } from "@playwright/test"
+import { LANGUAGES } from "../globals"
+import { HelperBase } from "./helperBase"
+
+export class SourceTextPage extends HelperBase{
+    constructor(page: Page, language: string){
+        super(page, language)
+    }
+
+    // Refactored from utils.ts: changeLanguageOfText
+    async changeTextLanguage(sourceLanguage: RegExp){
+        // Clicking on the Source Language toggle
+        await this.page.getByAltText('Toggle Reader Menu Display Settings').click()
+    
+        // Selecting Source Language
+        await this.page.locator('div').filter({ hasText: sourceLanguage }).click()
+    }
+
+    async validateFirstLineOfContent(text: string){
+        await expect(this.page.locator('div.segmentNumber').first().locator('..').locator('p')).toContainText(`${text}`)
+    }
+
+    async validateLinkExistsBanner(text: string){
+        await expect(this.page.getByRole('banner')).toContainText(text)
+    }
+}

--- a/e2e-tests/pages/textsPage.ts
+++ b/e2e-tests/pages/textsPage.ts
@@ -1,0 +1,21 @@
+import { Page, expect } from "@playwright/test"
+import { LANGUAGES } from "../globals"
+import { HelperBase } from "./helperBase"
+
+export class TextsPage extends HelperBase{
+
+    constructor(page: Page, language){
+        super(page, language)
+    }
+
+    async clickTanakh(){
+        if(this.language == LANGUAGES.HE){
+            await this.page.getByRole('link', {name: 'תנ"ך'}).click()
+        }
+        else{
+            await this.page.getByRole('link', {name: 'Tanakh'}).click()
+        }
+
+        expect(this.getPathAndParams()).toContain('/Tanakh')
+    }
+}

--- a/e2e-tests/pages/topicsPage.ts
+++ b/e2e-tests/pages/topicsPage.ts
@@ -1,0 +1,22 @@
+import { Page, expect } from "@playwright/test"
+import { LANGUAGES } from "../globals"
+import { HelperBase } from "./helperBase"
+
+export class TopicsPage extends HelperBase{
+    constructor(page: Page, language: string){
+        super(page, language)
+    }
+
+    async validateTopicsPageLayout(){
+        if(this.language == LANGUAGES.HE){
+            await expect(this.page.locator('.contentInner')).toContainText('למדו לפי נושא')
+            await expect(this.page.locator('.navSidebar')).toContainText('אודות "נושאים')
+        }
+        else{
+            await expect(this.page.locator('.contentInner')).toContainText('Explore By Topic')
+            await expect(this.page.locator('.navSidebar')).toContainText('About Topics')
+        }
+
+    }
+
+}

--- a/e2e-tests/pages/userMenu.ts
+++ b/e2e-tests/pages/userMenu.ts
@@ -1,0 +1,69 @@
+import { Page, expect } from "@playwright/test"
+import { LANGUAGES } from "../globals"
+import { HelperBase } from "./helperBase"
+
+export class UserMenu extends HelperBase{
+    constructor(page: Page, language: string){
+        super(page, language)
+    }
+
+    async clickUserMenu(userInitials: string){
+        await this.page.getByRole('link', {name: userInitials}).click()
+    }
+
+    async clickProfile(){
+        if(this.language == LANGUAGES.HE){
+            await this.page.getByRole('link', {name: 'פרופיל'}).click()
+        }
+        else{
+            await this.page.getByRole('link', {name: 'Profile'}).click()
+        }
+    }
+
+    async clickCreateNewSheet(){
+        if(this.language == LANGUAGES.HE){
+            await this.page.getByRole('link', {name: 'יצירת דף מקורות'}).click()
+        }
+        else{
+            await this.page.getByRole('link', {name: 'Create a New Sheet'}).click()
+        }
+    }
+
+    async accountSettings(){
+        if(this.language == LANGUAGES.HE){
+            await this.page.getByRole('link', {name: 'הגדרות'}).click()
+        }
+        else{
+            await this.page.getByRole('link', {name: 'Account Settings'}).click()
+        }
+    }
+
+    async clickLanguage(language: string){
+        if(language == LANGUAGES.EN){
+            await this.page.getByRole('link', {name: 'English'}).click()
+        }
+        else{
+            await this.page.getByRole('link', {name: 'עברית'}).click()
+        }
+        
+    }
+
+    async clickHelp(){
+        if(this.language == LANGUAGES.HE){
+            await this.page.getByRole('link', {name: 'עזרה'}).click()
+        }
+        else{
+            await this.page.getByRole('link', {name: 'Help'}).click()
+        }
+    }
+
+    async clickLogout(){
+        if(this.language == LANGUAGES.HE){
+            await this.page.getByRole('link', {name: 'ניתוק'}).click()
+        }
+        else{
+            await this.page.getByRole('link', {name: 'Logout'}).click()
+        }
+    }
+
+}

--- a/e2e-tests/tests/banner.spec.ts
+++ b/e2e-tests/tests/banner.spec.ts
@@ -5,11 +5,68 @@
 */
 
 import {test, expect} from '@playwright/test';
-import {goToPageWithLang, getPathAndParams} from "../utils";
-import {LANGUAGES} from '../globals'
+import {goToPageWithLang, getPathAndParams, isIsraelIp} from "../utils";
+import {LANGUAGES} from '../globals';
+import { PageManager } from '../pages/pageManager';
 
-test('Banner links exist - English', async ({ context }) => {
+/***** NEW TESTS *****/
+const testLanguageConfigs = [
+    {testLanguage: "English", interfaceLanguage: LANGUAGES.EN},
+    {testLanguage: "Hebrew", interfaceLanguage: LANGUAGES.HE}
+]
+
+testLanguageConfigs.forEach(({testLanguage, interfaceLanguage}) => {
+    test(`Banner links with PageManager - ${testLanguage}`, async({ context }) =>{
+        const page = await goToPageWithLang(context,'/texts', interfaceLanguage)
+        
+        const pm = new PageManager(page, interfaceLanguage)
+
+        await pm.navigateTo().textsPageFromLogo()
+
+        await pm.navigateTo().textsPageFromLink()
+
+        await pm.navigateTo().topicsPage()
+
+        await pm.navigateTo().communityPage()
+
+        const donatePage = await pm.navigateTo().donatePage()
+        await donatePage.close()
+
+    })
+})
+
+testLanguageConfigs.forEach(({testLanguage, interfaceLanguage}) => {
+    test(`Search Functionality from Banner with PageManager - ${testLanguage}`, async({ context }) => {
+        const page = await goToPageWithLang(context,'/texts', interfaceLanguage)
+        
+        const pm = new PageManager(page, LANGUAGES.EN)
+
+        if(interfaceLanguage == LANGUAGES.HE){
+            await pm.onSearchPage().searchFor('אהבה')
+        }
+        else{
+            await pm.onSearchPage().searchFor('Love')
+            await pm.onSearchPage().validateVirtualKeyboardForEnglish('א')
+        }
+    })
+})
+
+test('Toggle Language Based on Locale with PageManager', async({ context }) => {
+    const page = await goToPageWithLang(context,'/texts', LANGUAGES.HE)
+    const pm = new PageManager(page, LANGUAGES.HE)
     
+    const inIsrael = await isIsraelIp(page)
+
+    if(inIsrael){
+        await pm.toggleLanguage(LANGUAGES.EN)
+    }
+})
+
+
+/***** OLD TESTS *****/
+test('Banner links exist - English', async ({ context }) => {
+    console.log(await context.cookies())
+
     const page = await goToPageWithLang(context,'/texts',LANGUAGES.EN);
 
     // Testing Sefaria logo

--- a/e2e-tests/tests/interface-language-is-sticky.spec.ts
+++ b/e2e-tests/tests/interface-language-is-sticky.spec.ts
@@ -1,11 +1,12 @@
 import {test, expect} from '@playwright/test';
 import {changeLanguageOfText, goToPageWithLang, isIsraelIp} from "../utils";
 import {LANGUAGES, SOURCE_LANGUAGES} from '../globals'
+import { PageManager } from '../pages/pageManager';
 
 const interfaceTextHE = 'מקורות';
 const interfaceTextEN = 'Texts';
 
-[
+const languageInterfaceAndSourceConfig = [
     // Hebrew Interface and English Source
     {interfaceLanguage: 'Hebrew', interfaceLanguageToggle: LANGUAGES.HE, 
         sourceLanguage: 'English', sourceLanguageToggle: SOURCE_LANGUAGES.EN, 
@@ -37,7 +38,28 @@ const interfaceTextEN = 'Texts';
         sourceLanguage: 'Hebrew', sourceLanguageToggle: SOURCE_LANGUAGES.HE, 
         expectedSourceText: 'רֵאשִׁ֖ית בָּרָ֣א אֱלֹהִ֑ים אֵ֥ת הַשָּׁמַ֖יִם וְאֵ֥ת הָאָֽרֶץ׃', expectedBilingualText: '', expectedInterfaceText: interfaceTextEN }
 
-].forEach(({interfaceLanguage, interfaceLanguageToggle, sourceLanguage, sourceLanguageToggle, expectedSourceText, expectedBilingualText, expectedInterfaceText}) => {
+]
+
+/***** NEW TESTS *****/
+languageInterfaceAndSourceConfig.forEach(({interfaceLanguage, interfaceLanguageToggle, sourceLanguage, sourceLanguageToggle, expectedSourceText, expectedBilingualText, expectedInterfaceText}) => {
+    test(`${interfaceLanguage} Interface Language with ${sourceLanguage} Source with PageManager`, async ({ context }) => {
+
+        // Navigating to Bereshit with selected Interface Language, Hebrew or English
+        const page = await goToPageWithLang(context,'/Genesis.1',`${interfaceLanguageToggle}`)
+        
+        const pm = new PageManager(page, `${interfaceLanguageToggle}`)
+        
+        await pm.onSourceTextPage().changeTextLanguage(sourceLanguageToggle)
+        
+        await pm.onSourceTextPage().validateFirstLineOfContent(expectedSourceText)
+
+        // Validate Hebrew interface language is still toggled
+        await pm.onSourceTextPage().validateLinkExistsBanner(expectedInterfaceText)
+    })
+})
+
+/***** OLD TESTS *****/
+languageInterfaceAndSourceConfig.forEach(({interfaceLanguage, interfaceLanguageToggle, sourceLanguage, sourceLanguageToggle, expectedSourceText, expectedBilingualText, expectedInterfaceText}) => {
     test(`${interfaceLanguage} Interface Language with ${sourceLanguage} Source`, async ({ context }) => {
 
         // Navigating to Bereshit with selected Interface Language, Hebrew or English


### PR DESCRIPTION


banner.spec.ts and interface-language-is-stickey.spec.ts contain refactorizations of previous tests (and also keep the old ones).

## Description
Page-Object-Models consist of each page as an object, centralized in a Page Manager, with tests containing abstractions of commands.

## Code Changes
* New Pages folder under e2e tests, containing some example pages as objects
  * Each page inherits the Helper Base class, containing common methods for each of the pages.   
  * Each page has multilingual support
* Page Manager to organize the pages, so we only need to call one object for all pages.  Page Manager also toggles language changes for all pages. 
* Refactorization of Banner and Interface-Language-Is-Sticky tests
  * Old tests are still available in the files
* Improvements/Refactors for utils.ts functions: 
  * goToPageWithLang: Starting a test no longer spawns multiple tabs
  *  changeLanguageOfText: Added to sourceTextPage.ts as a method, the only place where it will be used
  * loginUser: loginPage.ts might replace this
  * getPathAndParams: abstracted into HelperBase, as many pages will use it.

## Notes
### Architecture
Pages
* Parent Class: HelperBase
* Child Classes:  Page classes
* Separate Interface Navigation Class: banner.ts
* Separate Page Manager class: PageManager.ts

Tests
* Spec files