### PR TITLE
Fix Venice Daf Calculation

### DIFF
--- a/sefaria/model/linker/tests/linker_test.py
+++ b/sefaria/model/linker/tests/linker_test.py
@@ -37,6 +37,8 @@ crrd = create_raw_ref_data
 
 @pytest.mark.parametrize(('resolver_data', 'expected_trefs'), [
     # Numbered JAs
+    [crrd(["@ירושלמי", "@ברכות", "#יג ע״א"]), ("Jerusalem Talmud Berakhot 9:1:11-19", "Jerusalem Talmud Berakhot 2:1:14-19")],  # ambig venice or vilna yerushalmi daf
+    [crrd(["@ירושלמי", "@ברכות", "#יג ע״ג"]), ("Jerusalem Talmud Berakhot 9:1:31-2:9",)],  # venice yerushalmi daf
     [crrd(["@Jerusalem", "@Talmud", "@Yoma", "#5a"], lang='en'), ("Jerusalem Talmud Yoma 1:1:20-25",)],
     [crrd(["@Babylonian", "@Talmud", "@Sukkah", "#49b"], lang='en'), ("Sukkah 49b",)],
     [crrd(["@בבלי", "@ברכות", "#דף ב"]), ("Berakhot 2",)],   # amud-less talmud

--- a/sefaria/model/schema.py
+++ b/sefaria/model/schema.py
@@ -2470,7 +2470,7 @@ class AddressFolio(AddressType):
             reg += r"\d+[abcdᵃᵇᶜᵈ]?)"
         elif lang == "he":
             # todo: How do these references look in Hebrew?
-            reg += self.hebrew_number_regex() + r'''([.:]|[,\s]+(?:\u05e2(?:"|\u05f4|''))?[\u05d0\u05d1])?)'''
+            reg += self.hebrew_number_regex() + r'''([.:]|[,\s]+(?:\u05e2(?:"|\u05f4|''))?[\u05d0-\u05d3])?)'''
 
         return reg
 
@@ -2506,7 +2506,7 @@ class AddressFolio(AddressType):
             # check for each amud letter in reverse order (dalet, gimmel, bet, alef)
             # if the amud matches that amud letter, subtract the appropriate offset
             for amud_offset, amud_letter in enumerate(("\u05d3", "\u05d2", "\u05d1", "\u05d0")):
-                if re.search(fr"^(?::|,?\s?(?:{amud_letter}|\\u05e2(?:''|\"|\\u05f4){amud_letter}))$", rest):
+                if re.search(fr"^(?::|,?\s?(?:{amud_letter}|ע(?:''|\"|״){amud_letter}))$", rest):
                     return daf - amud_offset
             # if no match, guess it's amud alef
             logger.warn(f"Couldn't parse folio amud from {s}. Assuming it's amud alef.")

--- a/sefaria/model/schema.py
+++ b/sefaria/model/schema.py
@@ -2128,7 +2128,7 @@ class AddressType(object):
                 if addr.is_special_case(curr_s):
                     section_str = curr_s
                 else:
-                    strict = SuperClass not in {AddressAmud, AddressTalmud}  # HACK: AddressTalmud doesn't inherit from AddressInteger so it relies on flexibility of not matching "Daf"
+                    strict = SuperClass not in {AddressAmud, AddressTalmud, AddressFolio}  # HACK: AddressTalmud doesn't inherit from AddressInteger so it relies on flexibility of not matching "Daf"
                     regex_str = addr.regex(lang, strict=strict, group_id='section', with_roman_numerals=True) + "$"  # must match entire string
                     if regex_str is None: continue
                     reg = regex.compile(regex_str, regex.VERBOSE)
@@ -2499,21 +2499,19 @@ class AddressFolio(AddressType):
                 indx -= 1
             return indx
         elif lang == "he":
-            # todo: This needs work
             num = re.split(r"[.:,\s]", s)[0]
-            daf = decode_hebrew_numeral(num) * 2
-            if s[-1] == ":" or (
-                    s[-1] == "\u05d1"    #bet
-                        and
-                    ((len(s) > 2 and s[-2] in ", ")  # simple bet
-                     or (len(s) > 4 and s[-3] == '\u05e2')  # ayin"bet
-                     or (len(s) > 5 and s[-4] == "\u05e2")  # ayin''bet
-                    )
-            ):
-                return daf  # amud B
-            return daf - 1
+            daf = decode_hebrew_numeral(num) * 4
+            rest = s[len(num):]
 
-            #if s[-1] == "." or (s[-1] == u"\u05d0" and len(s) > 2 and s[-2] in ",\s"):
+            # check for each amud letter in reverse order (dalet, gimmel, bet, alef)
+            # if the amud matches that amud letter, subtract the appropriate offset
+            for amud_offset, amud_letter in enumerate(("\u05d3", "\u05d2", "\u05d1", "\u05d0")):
+                if re.search(fr"^(?::|,?\s?(?:{amud_letter}|\\u05e2(?:''|\"|\\u05f4){amud_letter}))$", rest):
+                    return daf - amud_offset
+            # if no match, guess it's amud alef
+            logger.warn(f"Couldn't parse folio amud from {s}. Assuming it's amud alef.")
+            return daf - 3
+
 
     @classmethod
     def toStr(cls, lang, i, **kwargs):


### PR DESCRIPTION
## Description
Possibly since AddressFolio was created, the regex's and calculation of numeric form of folio was never handled properly. This PR fixes these issues and adds tests.

## Code Changes
- Correct AddressFolio.toNumber() so it handles all amudim
- Correct AddressFolio regex so it searches for all amudim
- Make AddressFolio another exception for using non-strict regex. This is required because AddressFolio (along with AddressAmud and AddressTalmud) don't inherit from AddressInteger. This means they need to have internal flexibilty to not match the initial word (Daf, Amud etc.) as opposed to relying on parent class to do this (as is the case with all other address types)
