### PR TITLE
filter out existing notable sources from sources refs

### DIFF
--- a/static/js/sefaria/sefaria.js
+++ b/static/js/sefaria/sefaria.js
@@ -2900,6 +2900,10 @@ _media: {},
           tabs.sources = {refMap: {}, shouldDisplay: true, refs: []};
       }
       tabs.sources.title = {en: 'All Sources', he: Sefaria.translation('hebrew', 'All Sources')};
+      // Filter out refs in tabs.sources.refs that are already in tabs["notable-sources"].refs
+     tabs.sources.refs = tabs.sources.refs.filter(sourceRef => {
+     return !tabs["notable-sources"].refs.some(notableRef => notableRef.ref === sourceRef.ref);
+     });
       //turn "sources" tab into 'super-set', containing all refs from all tabs:
       const allRefs = [...tabs["notable-sources"].refs, ...tabs.sources.refs];
       tabs.sources.refs = allRefs;


### PR DESCRIPTION

This pull request includes a significant change to the `static/js/sefaria/sefaria.js` file, specifically in the handling of sources in the `tabs.sources` object. The main update involves filtering out references in `tabs.sources.refs` that are already present in `tabs["notable-sources"].refs`.

### Improvements to sources handling:

* [`static/js/sefaria/sefaria.js`](diffhunk://#diff-2f1b7852161a95e253017883a3aa2a5d372103e32b61cfd95ff57edc7ffaaf43R2903-R2906): Added a filter to remove references in `tabs.sources.refs` that are already included in `tabs["notable-sources"].refs`. This ensures that the `sources` tab does not duplicate references from the `notable-sources` tab.