### PR TITLE
Remove "Mark All As Read" button

### DIFF
--- a/static/js/Header.jsx
+++ b/static/js/Header.jsx
@@ -81,12 +81,10 @@ const LoggedInDropdown = () => {
   }
 
   return (
-      <DropdownMenu positioningClass="headerDropdownMenu" buttonComponent={<ProfilePic
-          url={Sefaria.profile_pic_url}
-          name={Sefaria.full_name}
-          len={25}
-      />
-      }>
+      <DropdownMenu positioningClass="headerDropdownMenu" 
+                    buttonComponent={<ProfilePic url={Sefaria.profile_pic_url}
+                                                 name={Sefaria.full_name}
+                                                 len={25}/>}>
           <div className='dropdownLinks-options'>
               <DropdownMenuItem preventClose={true}>
                   <strong>{Sefaria.full_name}</strong>

--- a/static/js/NotificationsPanel.jsx
+++ b/static/js/NotificationsPanel.jsx
@@ -38,11 +38,6 @@ class NotificationsPanel extends Component {
       this.getMoreNotifications();
     }
   }
-  markAllAsRead() {
-    $.post("/api/notifications/read", {notifications: "all"}, function(data) {
-      this.props.setUnreadNotificationsCount(data.unreadCount);
-    }.bind(this));
-  }
   markAsRead() {
     // Marks each notification that is loaded into the page as read via API call
     var ids = [];
@@ -86,13 +81,6 @@ class NotificationsPanel extends Component {
                     <img className="notificationsTitleIcon" src="/static/icons/notification.svg" alt="Notification icon"/>
                     <InterfaceText>Notifications</InterfaceText>
                   </h1>
-                  <>
-                    {Sefaria.notificationCount > 0 ? (
-                      <button className="button small white" onClick={this.markAllAsRead} aria-label="Mark all as Read">
-                        <InterfaceText en={"Mark all as Read"} he={"סימון כל ההודעות כהודעות שנקראו"} />
-                      </button>
-                    ) : null}
-                  </>
                 </div>
                 {(Sefaria._uid) ? (
                      Sefaria.notificationCount > 0 && notifications


### PR DESCRIPTION
## Description
Removes the "Mark All As Read" button from the notifications page, while ensuring that the current behavior of the notifications are marked as read on scroll is retained. 

## Code Changes
1. `static/js/NotificationsPanel.jsx` - Removed the button and underlying `all` function. Note, the `markAsRead` function and marking as read on scroll are retained. 
2. `static/js/Header.jsx` - Slight code cleanup for readability