### PR TITLE
chore(docs): Updated Name API documentation

### DIFF
--- a/docs/openAPI.json
+++ b/docs/openAPI.json
@@ -5242,12 +5242,11 @@
             "in": "query"
           },
           {
-            "name": "ref_only",
-            "description": "By default `0` the Name API returns `Ref`s, book titles, authors, topics, and collections. If true, the response will only contain text references.",
+            "name": "type",
+            "description": "By default the Name API returns `Ref`s, book titles, authors, topics, and collections. If `type=ref`, the response will only contain text references.",
             "schema": {
               "enum": [
-                "0",
-                "1"
+                "ref"
               ],
               "type": "string"
             },
@@ -5611,9 +5610,9 @@
             ],
             "type": "string"
           },
-          "is_ref": {
-            "description": "Returns `true` if the submitted text is a valid Sefaria textual reference",
-            "type": "boolean"
+          "type": {
+            "description": "By default the Name API returns `Ref`s, book titles, authors, topics, and collections. If `type=ref`, the response will only contain text references.",
+            "type": "string"
           },
           "completions": {
             "description": "A list of autocompletion responses for the submitted text.",
@@ -5679,15 +5678,15 @@
             "type": "string"
           },
           "ref": {
-            "description": "If `is_ref` is `true`, this returns the cannonical ref for the submitted text.",
+            "description": "If `type=ref`, this returns the cannonical ref for the submitted text.",
             "type": "string"
           },
           "url": {
-            "description": "If `is_ref` is `true`, this returns the URL path to link to the submitted text on [Sefaria.org](sefaria.org)",
+            "description": "If `type=ref`, this returns the URL path to link to the submitted text on [Sefaria.org](sefaria.org)",
             "type": "string"
           },
           "index": {
-            "description": "If `is_ref` is `true`, this returns the cannonical name of the `index` of the submitted text.",
+            "description": "If `type=ref`, this returns the cannonical name of the `index` of the submitted text.",
             "type": "string"
           },
           "book": {
@@ -5755,7 +5754,7 @@
         },
         "example": {
           "lang": "en",
-          "is_ref": true,
+          "type": "ref",
           "completions": [
             "Job",
             "Rashi on Job",

--- a/docs/openAPI.json
+++ b/docs/openAPI.json
@@ -5243,10 +5243,15 @@
           },
           {
             "name": "type",
-            "description": "By default the Name API returns `Ref`s, book titles, authors, topics, and collections. If `type=ref`, the response will only contain text references.",
+            "description": "By default the Name API returns `Ref`s, book titles, authors, topics, and collections. If the `type` is set, the response will only contain items of that type. Note: `Topic` includes authors, topics and people without differentiation.",
             "schema": {
               "enum": [
-                "ref"
+                "ref", 
+                "Collection", 
+                "Topic", 
+                "TocCategory",
+                "Term", 
+                "User"
               ],
               "type": "string"
             },
@@ -5611,7 +5616,7 @@
             "type": "string"
           },
           "type": {
-            "description": "By default the Name API returns `Ref`s, book titles, authors, topics, and collections. If `type=ref`, the response will only contain text references.",
+            "description": "By default the Name API returns `Ref`s, book titles, authors, topics, and collections. If `type` is set, the response will only contain items of that type.",
             "type": "string"
           },
           "completions": {

--- a/docs/openAPI.json
+++ b/docs/openAPI.json
@@ -5678,7 +5678,7 @@
             "type": "string"
           },
           "ref": {
-            "description": "If `type=ref`, this returns the cannonical ref for the submitted text.",
+            "description": "If `type=ref`, this returns the canonical ref for the submitted text.",
             "type": "string"
           },
           "url": {
@@ -5686,7 +5686,7 @@
             "type": "string"
           },
           "index": {
-            "description": "If `type=ref`, this returns the cannonical name of the `index` of the submitted text.",
+            "description": "If `type=ref`, this returns the canonical name of the `index` of the submitted text.",
             "type": "string"
           },
           "book": {
@@ -7377,7 +7377,7 @@
                     "type": "object",
                     "properties": {
                       "heRef": {
-                        "description": "The Hebrew equivalent of the cannonical ref",
+                        "description": "The Hebrew equivalent of the canonical ref",
                         "type": "string"
                       },
                       "url": {
@@ -7437,7 +7437,7 @@
                     "type": "object",
                     "properties": {
                       "heRef": {
-                        "description": "The Hebrew equivalent of the cannonical ref",
+                        "description": "The Hebrew equivalent of the canonical ref",
                         "type": "string"
                       },
                       "url": {
@@ -9552,7 +9552,7 @@
             "type": "string"
           },
           "index_title": {
-            "description": "The cannonical title of the text in the Sefaria library.",
+            "description": "The canonical title of the text in the Sefaria library.",
             "type": "string"
           },
           "category": {


### PR DESCRIPTION
## Description
Updates the documentation of the Name API to account for a shift in parameters. The boolean `is_ref` has now become `type` which expects a String `ref` to indicate it should return refs only. 

## Code Changes
1. In `docs/openAPI.json` - updated the path documentation and the data schema, corrected any other references to the old boolean param. 

## Notes
1. This has been successfully tested with ReadMe, and makes the expected changes. 