### PR TITLE
fix(translations): Handle case where translation is missing in side

### DIFF
--- a/static/js/VersionsTextList.jsx
+++ b/static/js/VersionsTextList.jsx
@@ -55,7 +55,25 @@ export const VersionsTextList = ({
         return <LoadingMessage/>;
     }
 
-    const {languageFamilyName, versionTitle, language, isPrimary} = getVersion()
+    const recentFilters = <RecentFilterSet
+        srefs={srefs}
+        asHeader={false}
+        filter={vFilter}
+        recentFilters={recentVFilters}
+        setFilter={setFilter}
+    />
+
+    const version = getVersion();
+    if (!version) {
+        // If no version is found, display the recent filters and return
+        // TODO: handle this case better
+        return (
+        <div className="versionsTextList">
+            {recentFilters}
+        </div>
+        ) 
+    }
+    const {languageFamilyName, versionTitle, language, isPrimary} = version;
     const pseudoLanguage = (isPrimary) ? 'he' : 'en';
     const currSelectedVersions = {[pseudoLanguage]: {versionTitle, languageFamilyName}};
     const handleRangeClick = (sref) => {
@@ -64,13 +82,7 @@ export const VersionsTextList = ({
 
     return (
         <div className="versionsTextList">
-            <RecentFilterSet
-                srefs={srefs}
-                asHeader={false}
-                filter={vFilter}
-                recentFilters={recentVFilters}
-                setFilter={setFilter}
-            />
+            {recentFilters}
             <TextRange
                 sref={Sefaria.humanRef(srefs)}
                 currVersions={currSelectedVersions}


### PR DESCRIPTION
This pull request includes changes to the `VersionsTextList` component in `static/js/VersionsTextList.jsx` to improve how recent filters are displayed when no version is found. The most important changes include adding a `recentFilters` constant and updating the return logic to handle cases where no version is found.

Improvements to recent filters display:

* Added a `recentFilters` constant that initializes a `RecentFilterSet` component with the necessary props.
* Updated the return logic to display the `recentFilters` when no version is found, with a TODO comment to handle this case better in the future.
* Modified the JSX to use the `recentFilters` constant instead of directly rendering the `RecentFilterSet` component.

Corresponding ticket:  https://app.shortcut.com/sefaria/story/32923/whitescreen-when-scrolling-through-text