### PR TITLE
Refactor Language Toggle

### DIFF
--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -949,7 +949,7 @@ div.interfaceLinks-row a {
 .header .profile-menu-he {
   color: #666666;
 }
-.header .interfaceLinks .interfaceLinks-option::before {
+.header .interfaceLinks-option::before {
   content: "";
   font-family: FontAwesome;
   color: #999;
@@ -958,10 +958,10 @@ div.interfaceLinks-row a {
   font-style: normal;
   padding: 0 15px;
 }
-.header .interfaceLinks .interfaceLinks-option.active {
+.header  .interfaceLinks-option.active {
   order: -1;
 }
-.header .interfaceLinks .interfaceLinks-option.active::before {
+.header .interfaceLinks-option.active::before {
   content: "\f00c";
   padding: 0 8px;
 }
@@ -15124,7 +15124,12 @@ span.ref-link-color-3 {color: blue}
   text-align: start;
 }
 
-.emptyNoticationPage{
+.emptyNotificationPage{
+  display: flex;
+  flex-direction: column;
+}
+
+.languageFlex {
   display: flex;
   flex-direction: column;
 }

--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -15132,6 +15132,11 @@ span.ref-link-color-3 {color: blue}
 .languageFlex {
   display: flex;
   flex-direction: column;
+  gap: 10px;
+  padding: 10px;
+}
+.languageHeader {
+  padding: 10px;
 }
 
 @-webkit-keyframes load5 {

--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -15134,10 +15134,9 @@ span.ref-link-color-3 {color: blue}
   flex-direction: column;
   gap: 10px;
   padding: 10px;
+  direction:ltr;
 }
-.languageHeader {
-  padding: 10px;
-}
+
 
 @-webkit-keyframes load5 {
 0%,100%{box-shadow:0 -2.6em 0 0 #ffffff,1.8em -1.8em 0 0 rgba(0,0,0,0.2),2.5em 0 0 0 rgba(0,0,0,0.2),1.75em 1.75em 0 0 rgba(0,0,0,0.2),0 2.5em 0 0 rgba(0,0,0,0.2),-1.8em 1.8em 0 0 rgba(0,0,0,0.2),-2.6em 0 0 0 rgba(0,0,0,0.5),-1.8em -1.8em 0 0 rgba(0,0,0,0.7)}

--- a/static/js/Misc.jsx
+++ b/static/js/Misc.jsx
@@ -1170,10 +1170,8 @@ DisplaySettingsButton.propTypes = {
 
 
 function InterfaceLanguageMenu({currentLang, translationLanguagePreference, setTranslationLanguagePreference}){
-  // TODO:
-  // Fix the CSS (more spacing between elements, the spacing of the checkmark ::before class)
+
   const [isOpen, setIsOpen] = useState(false);
-  const [curLang, setCurLang] = useState(currentLang);
 
   const getCurrentPage = () => {
     return isOpen ? (encodeURIComponent(Sefaria.util.currentPath())) : "/";
@@ -1192,10 +1190,10 @@ function InterfaceLanguageMenu({currentLang, translationLanguagePreference, setT
         </div>
         <DropdownMenuSeparator />
         <div className='languageFlex'>
-          <DropdownMenuItem  url={`/interface/hebrew?next=${getCurrentPage()}`} onClick={() => setCurLang("hebrew")} customCSS={`interfaceLinks-option int-bi ${(curLang === 'hebrew') ? 'active':''}`}>
+          <DropdownMenuItem  url={`/interface/hebrew?next=${getCurrentPage()}`} customCSS={`interfaceLinks-option int-bi ${(currentLang === 'hebrew') ? 'active':''}`}>
             עברית
           </DropdownMenuItem>
-          <DropdownMenuItem url={`/interface/english?next=${getCurrentPage()}`} onClick={() => setCurLang("english")} customCSS={`interfaceLinks-option int-bi ${(curLang === 'english') ? 'active' : ''}`}>
+          <DropdownMenuItem url={`/interface/english?next=${getCurrentPage()}`} customCSS={`interfaceLinks-option int-bi ${(currentLang === 'english') ? 'active' : ''}`}>
             English
           </DropdownMenuItem>
         </div>

--- a/static/js/Misc.jsx
+++ b/static/js/Misc.jsx
@@ -23,7 +23,7 @@ import {SourceEditor} from "./SourceEditor";
 import {EditTextInfo} from "./BookPage";
 import ReactMarkdown from 'react-markdown';
 import TrackG4 from "./sefaria/trackG4";
-import {DropdownMenu, DropdownMenuItem, DropdownMenuItemWithCallback, DropdownMenuItemWithIcon, DropdownMenuSeparator} from "./common/DropdownMenu";
+import {DropdownMenu, DropdownMenuItem, DropdownMenuItemWithIcon, DropdownMenuSeparator} from "./common/DropdownMenu";
 
 /**
  * Component meant to simply denote a language specific string to go inside an InterfaceText element

--- a/static/js/Misc.jsx
+++ b/static/js/Misc.jsx
@@ -1172,47 +1172,17 @@ DisplaySettingsButton.propTypes = {
 function InterfaceLanguageMenu({currentLang, translationLanguagePreference, setTranslationLanguagePreference}){
   // TODO:
   // Fix the CSS (more spacing between elements, the spacing of the checkmark ::before class)
-
   const [isOpen, setIsOpen] = useState(false);
   const [curLang, setCurLang] = useState(currentLang);
-  const wrapperRef = useRef(null);
 
   const getCurrentPage = () => {
     return isOpen ? (encodeURIComponent(Sefaria.util.currentPath())) : "/";
   }
-  const handleClick = (e) => {
-    e.stopPropagation();
-    setIsOpen(isOpen => !isOpen);
-  }
-  const saveLangPref = (lang) => {
-    setCurLang(lang);
-  }
+
   const handleTransPrefResetClick = (e) => {
     e.stopPropagation();
     setTranslationLanguagePreference(null);
   };
-  const handleHideDropdown = (event) => {
-      if (event.key === 'Escape') {
-          setIsOpen(false);
-      }
-  };
-  const handleClickOutside = (event) => {
-      if (
-          wrapperRef.current &&
-          !wrapperRef.current.contains(event.target)
-      ) {
-          setIsOpen(false);
-      }
-  };
-
-  useEffect(() => {
-      document.addEventListener('keydown', handleHideDropdown, true);
-      document.addEventListener('click', handleClickOutside, true);
-      return () => {
-          document.removeEventListener('keydown', handleHideDropdown, true);
-          document.removeEventListener('click', handleClickOutside, true);
-      };
-  }, []);
 
   return (
     <DropdownMenu positioningClass="headerDropdownMenu" buttonComponent={<img src="/static/icons/globe-wire.svg" alt={Sefaria._('Toggle Interface Language Menu')}/>}>
@@ -1222,10 +1192,10 @@ function InterfaceLanguageMenu({currentLang, translationLanguagePreference, setT
         </div>
         <DropdownMenuSeparator />
         <div className='languageFlex'>
-          <DropdownMenuItem  url={`/interface/hebrew?next=${getCurrentPage()}`} onClick={() => setCurLang("hebrew")} customCSS={`interfaceLinks-option int-bi ${(currentLang == 'hebrew') ? 'active':''}`}>
+          <DropdownMenuItem  url={`/interface/hebrew?next=${getCurrentPage()}`} onClick={() => setCurLang("hebrew")} customCSS={`interfaceLinks-option int-bi ${(curLang === 'hebrew') ? 'active':''}`}>
             עברית
           </DropdownMenuItem>
-          <DropdownMenuItem url={`/interface/english?next=${getCurrentPage()}`} onClick={() => setCurLang("english")} customCSS={`interfaceLinks-option int-bi ${(currentLang == 'english') ? 'active' : ''}`}>
+          <DropdownMenuItem url={`/interface/english?next=${getCurrentPage()}`} onClick={() => setCurLang("english")} customCSS={`interfaceLinks-option int-bi ${(curLang === 'english') ? 'active' : ''}`}>
             English
           </DropdownMenuItem>
         </div>

--- a/static/js/Misc.jsx
+++ b/static/js/Misc.jsx
@@ -1187,7 +1187,7 @@ function InterfaceLanguageMenu({currentLang, translationLanguagePreference, setT
   return (
     <DropdownMenu positioningClass="headerDropdownMenu" buttonComponent={<img src="/static/icons/globe-wire.svg" alt={Sefaria._('Toggle Interface Language Menu')}/>}>
       <div className="dropdownLinks-options">
-        <div className="interfaceLinks interfaceLinks-menu interfaceLinks-header">
+        <div className="interfaceLinks interfaceLinks-menu interfaceLinks-header languageHeader">
           <InterfaceText>Site Language</InterfaceText>
         </div>
         <DropdownMenuSeparator />

--- a/static/js/Misc.jsx
+++ b/static/js/Misc.jsx
@@ -23,7 +23,7 @@ import {SourceEditor} from "./SourceEditor";
 import {EditTextInfo} from "./BookPage";
 import ReactMarkdown from 'react-markdown';
 import TrackG4 from "./sefaria/trackG4";
-import {DropdownMenuItemWithIcon} from "./common/DropdownMenu";
+import {DropdownMenu, DropdownMenuItem, DropdownMenuItemWithCallback, DropdownMenuItemWithIcon, DropdownMenuSeparator} from "./common/DropdownMenu";
 
 /**
  * Component meant to simply denote a language specific string to go inside an InterfaceText element
@@ -1170,6 +1170,11 @@ DisplaySettingsButton.propTypes = {
 
 
 function InterfaceLanguageMenu({currentLang, translationLanguagePreference, setTranslationLanguagePreference}){
+  // TODO:
+  // Check if noah's code still relevant, how to integrate?
+  // Fix the CSS
+  // Need to re-integrate the checkmarks that appear when a language is selected
+  
   const [isOpen, setIsOpen] = useState(false);
   const wrapperRef = useRef(null);
 
@@ -1208,34 +1213,39 @@ function InterfaceLanguageMenu({currentLang, translationLanguagePreference, setT
   }, []);
 
   return (
-      <div className="interfaceLinks" ref={wrapperRef}>
-        <a className="interfaceLinks-button" onClick={handleClick}><img src="/static/icons/globe-wire.svg" alt={Sefaria._('Toggle Interface Language Menu')}/></a>
-        <div className={`interfaceLinks-menu ${ isOpen ? "open" : "closed"}`}>
-          <div className="interfaceLinks-header">
+    <DropdownMenu positioningClass="headerDropdownMenu" buttonComponent={<img src="/static/icons/globe-wire.svg" alt={Sefaria._('Toggle Interface Language Menu')}/>}>
+      <div className="dropdownLinks-options">
+        <DropdownMenuItem>
+          <div className="interfaceLinks interfaceLinks-menu interfaceLinks-header">
             <InterfaceText>Site Language</InterfaceText>
           </div>
-          <div className="interfaceLinks-options">
-            <a className={`interfaceLinks-option int-bi int-he ${(currentLang == 'hebrew') ? 'active':''}`} href={`/interface/hebrew?next=${getCurrentPage()}`}>עברית</a>
-            <a className={`interfaceLinks-option int-bi int-en ${(currentLang == 'english') ? 'active' : ''}`} href={`/interface/english?next=${getCurrentPage()}`}>English</a>
-          </div>
-          { !!translationLanguagePreference ? (
-            <>
-              <div className="interfaceLinks-header">
-                <InterfaceText>Preferred Translation</InterfaceText>
-              </div>
-              <div className="interfaceLinks-options trans-pref-header-container">
-                <InterfaceText>{Sefaria.translateISOLanguageCode(translationLanguagePreference, true)}</InterfaceText>
-                <a className="trans-pref-reset" onClick={handleTransPrefResetClick}>
-                  <img src="/static/img/circled-x.svg" className="reset-btn" />
-                  <span className="smallText">
-                    <InterfaceText>Reset</InterfaceText>
-                  </span>
-                </a>
-              </div>
-            </>
-          ) : null}
-        </div>
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem url={`/interface/hebrew?next=${getCurrentPage()}`}>
+          עברית
+        </DropdownMenuItem>
+        <DropdownMenuItem url={`/interface/english?next=${getCurrentPage()}`}>
+          English
+        </DropdownMenuItem>
       </div>
+    </DropdownMenu>
+
+          // { !!translationLanguagePreference ? (
+          //   <>
+          //     <div className="interfaceLinks-header">
+          //       <InterfaceText>Preferred Translation</InterfaceText>
+          //     </div>
+          //     <div className="interfaceLinks-options trans-pref-header-container">
+          //       <InterfaceText>{Sefaria.translateISOLanguageCode(translationLanguagePreference, true)}</InterfaceText>
+          //       <a className="trans-pref-reset" onClick={handleTransPrefResetClick}>
+          //         <img src="/static/img/circled-x.svg" className="reset-btn" />
+          //         <span className="smallText">
+          //           <InterfaceText>Reset</InterfaceText>
+          //         </span>
+          //       </a>
+          //     </div>
+          //   </>
+          // ) : null}
   );
 }
 InterfaceLanguageMenu.propTypes = {

--- a/static/js/Misc.jsx
+++ b/static/js/Misc.jsx
@@ -1171,11 +1171,10 @@ DisplaySettingsButton.propTypes = {
 
 function InterfaceLanguageMenu({currentLang, translationLanguagePreference, setTranslationLanguagePreference}){
   // TODO:
-  // Check if noah's code still relevant, how to integrate?
-  // Fix the CSS
-  // Need to re-integrate the checkmarks that appear when a language is selected
-  
+  // Fix the CSS (more spacing between elements, the spacing of the checkmark ::before class)
+
   const [isOpen, setIsOpen] = useState(false);
+  const [curLang, setCurLang] = useState(currentLang);
   const wrapperRef = useRef(null);
 
   const getCurrentPage = () => {
@@ -1184,6 +1183,9 @@ function InterfaceLanguageMenu({currentLang, translationLanguagePreference, setT
   const handleClick = (e) => {
     e.stopPropagation();
     setIsOpen(isOpen => !isOpen);
+  }
+  const saveLangPref = (lang) => {
+    setCurLang(lang);
   }
   const handleTransPrefResetClick = (e) => {
     e.stopPropagation();
@@ -1215,37 +1217,36 @@ function InterfaceLanguageMenu({currentLang, translationLanguagePreference, setT
   return (
     <DropdownMenu positioningClass="headerDropdownMenu" buttonComponent={<img src="/static/icons/globe-wire.svg" alt={Sefaria._('Toggle Interface Language Menu')}/>}>
       <div className="dropdownLinks-options">
-        <DropdownMenuItem>
-          <div className="interfaceLinks interfaceLinks-menu interfaceLinks-header">
-            <InterfaceText>Site Language</InterfaceText>
-          </div>
-        </DropdownMenuItem>
+        <div className="interfaceLinks interfaceLinks-menu interfaceLinks-header">
+          <InterfaceText>Site Language</InterfaceText>
+        </div>
         <DropdownMenuSeparator />
-        <DropdownMenuItem url={`/interface/hebrew?next=${getCurrentPage()}`}>
-          עברית
-        </DropdownMenuItem>
-        <DropdownMenuItem url={`/interface/english?next=${getCurrentPage()}`}>
-          English
-        </DropdownMenuItem>
+        <div className='languageFlex'>
+          <DropdownMenuItem  url={`/interface/hebrew?next=${getCurrentPage()}`} onClick={() => setCurLang("hebrew")} customCSS={`interfaceLinks-option int-bi ${(currentLang == 'hebrew') ? 'active':''}`}>
+            עברית
+          </DropdownMenuItem>
+          <DropdownMenuItem url={`/interface/english?next=${getCurrentPage()}`} onClick={() => setCurLang("english")} customCSS={`interfaceLinks-option int-bi ${(currentLang == 'english') ? 'active' : ''}`}>
+            English
+          </DropdownMenuItem>
+        </div>
       </div>
+      { !!translationLanguagePreference ? (
+            <>
+              <div className="interfaceLinks-header">
+                <InterfaceText>Preferred Translation</InterfaceText>
+              </div>
+              <div className="interfaceLinks-options trans-pref-header-container">
+                <InterfaceText>{Sefaria.translateISOLanguageCode(translationLanguagePreference, true)}</InterfaceText>
+                <a className="trans-pref-reset" onClick={handleTransPrefResetClick}>
+                  <img src="/static/img/circled-x.svg" className="reset-btn" />
+                  <span className="smallText">
+                    <InterfaceText>Reset</InterfaceText>
+                  </span>
+                </a>
+              </div>
+            </>
+          ) : null}
     </DropdownMenu>
-
-          // { !!translationLanguagePreference ? (
-          //   <>
-          //     <div className="interfaceLinks-header">
-          //       <InterfaceText>Preferred Translation</InterfaceText>
-          //     </div>
-          //     <div className="interfaceLinks-options trans-pref-header-container">
-          //       <InterfaceText>{Sefaria.translateISOLanguageCode(translationLanguagePreference, true)}</InterfaceText>
-          //       <a className="trans-pref-reset" onClick={handleTransPrefResetClick}>
-          //         <img src="/static/img/circled-x.svg" className="reset-btn" />
-          //         <span className="smallText">
-          //           <InterfaceText>Reset</InterfaceText>
-          //         </span>
-          //       </a>
-          //     </div>
-          //   </>
-          // ) : null}
   );
 }
 InterfaceLanguageMenu.propTypes = {

--- a/static/js/common/DropdownMenu.jsx
+++ b/static/js/common/DropdownMenu.jsx
@@ -11,51 +11,31 @@ const DropdownMenuSeparator = () => {
 
 }
 
-const DropdownMenuItem = ({url, children, newTab, onClick = null, customCSS = null, preventClose = false}) => {
-
-  const className = customCSS ? customCSS : 'interfaceLinks-option int-bi dropdownItem';
-  const commonProps = {
-    className,
-    'data-prevent-close': preventClose,
-    target: (newTab ? '_blank' : null),
-  };
+const DropdownMenuItem = ({url, children, newTab, customCSS = null, preventClose = false}) => {
 
   if (!newTab){
     newTab = false;
   }
 
-  if (onClick && url) {
-    return (
-      <a {...commonProps}
-         href={url}
-         onClick={onClick}>
+  const cssClasses = customCSS ? customCSS : 'interfaceLinks-option int-bi dropdownItem';
+
+  return (
+    <a className={cssClasses}
+       href={url}
+       target={newTab ? '_blank' : null}
+       data-prevent-close={preventClose}>
+      {children}
+    </a>
+
+  );
+}
+
+const DropdownMenuItemWithCallback = ({onClick, children, preventClose = false}) => {
+  return (
+    <div className={'interfaceLinks-option int-bi dropdownItem'} onClick={onClick} data-prevent-close={preventClose}>
         {children}
-      </a>
-  
-    );
-
-  }
-
-  else if (onClick){
-    return (
-      <div {...commonProps} onClick={onClick} >
-          {children}
-      </div>
-    );
-  }
-
-  else if (url){
-    return (
-      <a {...commonProps}
-         href={url}>
-        {children}
-      </a>
-    );
-  }
-
-  return null;
-
-
+    </div>
+  );
 }
 
 const DropdownMenuItemWithIcon = ({icon, textEn, textHe, descEn='', descHe=''}) => {
@@ -143,5 +123,6 @@ const DropdownMenu = ({children, buttonComponent, positioningClass}) => {
     DropdownMenu,
     DropdownMenuSeparator,
     DropdownMenuItemWithIcon,
-    DropdownMenuItem
+    DropdownMenuItem, 
+    DropdownMenuItemWithCallback
   };

--- a/static/js/common/DropdownMenu.jsx
+++ b/static/js/common/DropdownMenu.jsx
@@ -13,17 +13,22 @@ const DropdownMenuSeparator = () => {
 
 const DropdownMenuItem = ({url, children, newTab, onClick = null, customCSS = null, preventClose = false}) => {
 
+  const className = customCSS ? customCSS : 'interfaceLinks-option int-bi dropdownItem';
+  const commonProps = {
+    className,
+    'data-prevent-close': preventClose,
+    target: (newTab ? '_blank' : null),
+  };
+
   if (!newTab){
     newTab = false;
   }
 
-  if (onClick) {
+  if (onClick && url) {
     return (
-      <a className={ customCSS ? `${customCSS}` : `interfaceLinks-option int-bi dropdownItem`}
+      <a {...commonProps}
          href={url}
-         target={newTab ? '_blank' : null}
-         onClick={onClick}
-         data-prevent-close={preventClose}>
+         onClick={onClick}>
         {children}
       </a>
   
@@ -31,24 +36,26 @@ const DropdownMenuItem = ({url, children, newTab, onClick = null, customCSS = nu
 
   }
 
-  return (
-    <a className={ customCSS ? `${customCSS}` : `interfaceLinks-option int-bi dropdownItem`}
-       href={url}
-       target={newTab ? '_blank' : null}
-       data-prevent-close={preventClose}>
-      {children}
-    </a>
+  else if (onClick){
+    return (
+      <div {...commonProps} onClick={onClick} >
+          {children}
+      </div>
+    );
+  }
 
-  );
-}
-
-// Todo - remove?
-const DropdownMenuItemWithCallback = ({onClick, children, preventClose = false}) => {
-  return (
-    <div className={'interfaceLinks-option int-bi dropdownItem'} onClick={onClick} data-prevent-close={preventClose}>
+  else if (url){
+    return (
+      <a {...commonProps}
+         href={url}>
         {children}
-    </div>
-  );
+      </a>
+    );
+  }
+
+  return null;
+
+
 }
 
 const DropdownMenuItemWithIcon = ({icon, textEn, textHe, descEn='', descHe=''}) => {
@@ -136,6 +143,5 @@ const DropdownMenu = ({children, buttonComponent, positioningClass}) => {
     DropdownMenu,
     DropdownMenuSeparator,
     DropdownMenuItemWithIcon,
-    DropdownMenuItem,
-    DropdownMenuItemWithCallback
+    DropdownMenuItem
   };

--- a/static/js/common/DropdownMenu.jsx
+++ b/static/js/common/DropdownMenu.jsx
@@ -11,14 +11,28 @@ const DropdownMenuSeparator = () => {
 
 }
 
-const DropdownMenuItem = ({url, children, newTab, preventClose = false}) => {
+const DropdownMenuItem = ({url, children, newTab, onClick = null, customCSS = null, preventClose = false}) => {
 
   if (!newTab){
     newTab = false;
   }
 
+  if (onClick) {
+    return (
+      <a className={ customCSS ? `${customCSS}` : `interfaceLinks-option int-bi dropdownItem`}
+         href={url}
+         target={newTab ? '_blank' : null}
+         onClick={onClick}
+         data-prevent-close={preventClose}>
+        {children}
+      </a>
+  
+    );
+
+  }
+
   return (
-    <a className={`interfaceLinks-option int-bi dropdownItem`}
+    <a className={ customCSS ? `${customCSS}` : `interfaceLinks-option int-bi dropdownItem`}
        href={url}
        target={newTab ? '_blank' : null}
        data-prevent-close={preventClose}>
@@ -28,6 +42,7 @@ const DropdownMenuItem = ({url, children, newTab, preventClose = false}) => {
   );
 }
 
+// Todo - remove?
 const DropdownMenuItemWithCallback = ({onClick, children, preventClose = false}) => {
   return (
     <div className={'interfaceLinks-option int-bi dropdownItem'} onClick={onClick} data-prevent-close={preventClose}>

--- a/static/js/sheets/SheetOptions.jsx
+++ b/static/js/sheets/SheetOptions.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import {
   DropdownMenu,
-  DropdownMenuItem,
+  DropdownMenuItemWithCallback,
   DropdownMenuItemWithIcon
 } from "../common/DropdownMenu";
 import { SaveButtonWithText } from "../Misc";
@@ -73,21 +73,21 @@ const SheetOptions = ({historyObject, toggleSignUpModal, sheetID, editable}) => 
   }
   return (
         <DropdownMenu positioningClass="headerDropdownMenu" buttonComponent={<img src="/static/icons/ellipses.svg" alt="Options"/>}>
-          <DropdownMenuItem onClick={() => setSavingMode(true)}>
+          <DropdownMenuItemWithCallback onClick={() => setSavingMode(true)}>
             <SaveButtonWithText historyObject={historyObjectForSheet}/>
-          </DropdownMenuItem>
-          <DropdownMenuItem onClick={() => setCopyingMode(true)}>
+          </DropdownMenuItemWithCallback>
+          <DropdownMenuItemWithCallback onClick={() => setCopyingMode(true)}>
             <CopyButton/>
-          </DropdownMenuItem>
-          <DropdownMenuItem onClick={() => setCollectionsMode(true)}>
+          </DropdownMenuItemWithCallback>
+          <DropdownMenuItemWithCallback onClick={() => setCollectionsMode(true)}>
             <CollectionsButton editable={editable}/>
-          </DropdownMenuItem>
-          <DropdownMenuItem onClick={() => setExportingMode(true)}>
+          </DropdownMenuItemWithCallback>
+          <DropdownMenuItemWithCallback onClick={() => setExportingMode(true)}>
             <GoogleDocExportButton sheetID={sheetID}/>
-          </DropdownMenuItem>
-          <DropdownMenuItem onClick={() => setSharingMode(true)}>
+          </DropdownMenuItemWithCallback>
+          <DropdownMenuItemWithCallback onClick={() => setSharingMode(true)}>
             <ShareButton/>
-          </DropdownMenuItem>
+          </DropdownMenuItemWithCallback>
         </DropdownMenu>
     );
 }

--- a/static/js/sheets/SheetOptions.jsx
+++ b/static/js/sheets/SheetOptions.jsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from "react";
 import {
   DropdownMenu,
   DropdownMenuItem,
-  DropdownMenuItemWithCallback,
   DropdownMenuItemWithIcon
 } from "../common/DropdownMenu";
 import { SaveButtonWithText } from "../Misc";
@@ -74,21 +73,21 @@ const SheetOptions = ({historyObject, toggleSignUpModal, sheetID, editable}) => 
   }
   return (
         <DropdownMenu positioningClass="headerDropdownMenu" buttonComponent={<img src="/static/icons/ellipses.svg" alt="Options"/>}>
-          <DropdownMenuItemWithCallback onClick={() => setSavingMode(true)}>
+          <DropdownMenuItem onClick={() => setSavingMode(true)}>
             <SaveButtonWithText historyObject={historyObjectForSheet}/>
-          </DropdownMenuItemWithCallback>
-          <DropdownMenuItemWithCallback onClick={() => setCopyingMode(true)}>
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={() => setCopyingMode(true)}>
             <CopyButton/>
-          </DropdownMenuItemWithCallback>
-          <DropdownMenuItemWithCallback onClick={() => setCollectionsMode(true)}>
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={() => setCollectionsMode(true)}>
             <CollectionsButton editable={editable}/>
-          </DropdownMenuItemWithCallback>
-          <DropdownMenuItemWithCallback onClick={() => setExportingMode(true)}>
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={() => setExportingMode(true)}>
             <GoogleDocExportButton sheetID={sheetID}/>
-          </DropdownMenuItemWithCallback>
-          <DropdownMenuItemWithCallback onClick={() => setSharingMode(true)}>
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={() => setSharingMode(true)}>
             <ShareButton/>
-          </DropdownMenuItemWithCallback>
+          </DropdownMenuItem>
         </DropdownMenu>
     );
 }


### PR DESCRIPTION
## Description
- Refactoring the logged out language toggle to use our generic components
- In the process, consolidated `<DropdownMenuItem>` and `<DropdownMenuItemWithCallback>` into one component that can handle all possible configurations (@stevekaplan123 - would love your eyes on this in sheets to make sure I didn't break anything). 

## Code Changes
1. Subtle class name changes in `static/css/s2.css`, the additional of an extra flexbox div to enable the languages to shuffle (i.e. have the selected language rise to the top) without interfering with the title. 
2. `static/js/Misc.jsx` - Main body of work. 
3.  `static/js/common/DropdownMenu.jsx` - Refactoring and consolidation of `<DropdownMenuItem>`
4. `static/js/sheets/SheetOptions.jsx` - Implementing the consolidated `<DropdownMenuItem>` (@stevekaplan123 - this is the spot to check. 
