### PR TITLE
feat(passage): expand possible types for passage validation

### DIFF
--- a/sefaria/model/passage.py
+++ b/sefaria/model/passage.py
@@ -21,7 +21,7 @@ class Passage(abst.AbstractMongoRecord):
         "source"
     ]
 
-    possible_types = ["Mishnah", "Sugya", "passage", "biblical_story"]
+    possible_types = ["Mishnah", "Sugya", "passage", "biblical-story"]
 
     @classmethod
     def containing_segment(cls, ref):

--- a/sefaria/model/passage.py
+++ b/sefaria/model/passage.py
@@ -21,6 +21,8 @@ class Passage(abst.AbstractMongoRecord):
         "source"
     ]
 
+    possible_types = ["Mishnah", "Sugya", "passage", "biblical_story"]
+
     @classmethod
     def containing_segment(cls, ref):
         assert isinstance(ref, text.Ref)
@@ -36,7 +38,7 @@ class Passage(abst.AbstractMongoRecord):
 
     def _validate(self):
         super(Passage, self)._validate()
-        assert self.type == "Mishnah" or self.type == "Sugya" or self.type == "passage"
+        assert self.type in self.possible_types
 
     def ref(self):
         return text.Ref(self.full_ref)


### PR DESCRIPTION
This pull request includes updates to the `Passage` class in the `sefaria/model/passage.py` file to enhance type validation by introducing a list of possible types.

Enhancements to type validation:

* [`sefaria/model/passage.py`](diffhunk://#diff-6b400f0198af9f9e2d3d5c10f40475c38723e31c07d2387f5a07843e3483e1e0R24-R25): Added a new class attribute `possible_types` to store a list of valid types for the `Passage` class.
* [`sefaria/model/passage.py`](diffhunk://#diff-6b400f0198af9f9e2d3d5c10f40475c38723e31c07d2387f5a07843e3483e1e0L39-R41): Updated the `_validate` method to use the `possible_types` list for type validation, replacing the previous hardcoded checks.## Description
_A brief description of the PR_

## Code Changes
_The following changes were made to the files below_

## Notes
_Any additional notes go here_