### PR TITLE
[Sheets] Logged in user menu on desktop

### DIFF
--- a/static/js/Header.jsx
+++ b/static/js/Header.jsx
@@ -74,7 +74,7 @@ const LoggedOutDropdown = () => {
 }
 
 
-const LoggedInDropdown = () => {
+const LoggedInDropdown = ({module}) => {
 
   const getCurrentPage = () => {
     return encodeURIComponent(Sefaria.util.currentPath());
@@ -90,12 +90,34 @@ const LoggedInDropdown = () => {
                   <strong>{Sefaria.full_name}</strong>
               </DropdownMenuItem>
               <DropdownMenuSeparator/>
+
+              { module === 'library' && 
+              <>
               <DropdownMenuItem url={'/settings/account'}>
                   <InterfaceText>Account Settings</InterfaceText>
               </DropdownMenuItem>
               <DropdownMenuItem url={'/torahtracker'}>
                   <InterfaceText text={{'en': 'Torah Tracker', 'he': 'לימוד במספרים'}}/>
               </DropdownMenuItem>
+              </> }
+
+
+              { module === 'sheets' && 
+              <>
+              <DropdownMenuItem url={'/my/profile'}>
+                  <InterfaceText>Profile</InterfaceText>
+              </DropdownMenuItem>
+              <DropdownMenuItem url={'/sheets/saved'}>
+                <InterfaceText>Saved</InterfaceText>
+              </DropdownMenuItem>
+              <DropdownMenuItem url={'/sheets/history'}>
+                <InterfaceText>History</InterfaceText>
+              </DropdownMenuItem>
+              <DropdownMenuItem url={'/settings/account'}>
+                  <InterfaceText>Account Settings</InterfaceText>
+              </DropdownMenuItem>
+              </> }
+              
               <DropdownMenuSeparator/>
               <div className="languageHeader">
                   <InterfaceText>Site Language</InterfaceText>
@@ -110,9 +132,12 @@ const LoggedInDropdown = () => {
                   </DropdownMenuItem>
               </div>
               <DropdownMenuSeparator/>
+              
+              {module === 'library' && 
               <DropdownMenuItem url={'/updates'}>
                   <InterfaceText text={{'en': 'New Additions', 'he': 'חידושים בארון הספרים של ספריא'}}/>
-              </DropdownMenuItem>
+              </DropdownMenuItem>}
+              
               <DropdownMenuItem preventClose={true} url={'/help'}>
                   <InterfaceText text={{'en': 'Help', 'he': 'עזרה'}}/>
               </DropdownMenuItem>
@@ -208,7 +233,7 @@ class Header extends Component {
           <ModuleSwitcher />
 
           { Sefaria._uid ?
-            <LoggedInDropdown />
+            <LoggedInDropdown module={'sheets'}/>
             : <LoggedOutDropdown currentLang={Sefaria.interfaceLang}/>
           }
 

--- a/static/js/Header.jsx
+++ b/static/js/Header.jsx
@@ -137,7 +137,7 @@ const LoggedInDropdown = ({module}) => {
               <DropdownMenuItem url={'/updates'}>
                   <InterfaceText text={{'en': 'New Additions', 'he': 'חידושים בארון הספרים של ספריא'}}/>
               </DropdownMenuItem>}
-              
+
               <DropdownMenuItem preventClose={true} url={'/help'}>
                   <InterfaceText text={{'en': 'Help', 'he': 'עזרה'}}/>
               </DropdownMenuItem>
@@ -232,6 +232,7 @@ class Header extends Component {
 
           <ModuleSwitcher />
 
+          {/* TODO: Replace the hardcoded module passed in with the logic inherited from ReaderApp via the header */}
           { Sefaria._uid ?
             <LoggedInDropdown module={'sheets'}/>
             : <LoggedOutDropdown currentLang={Sefaria.interfaceLang}/>


### PR DESCRIPTION
## Description
Adding functionality based on a prop to account for logged in menu dropdown differences between sheets and library. 

## Code Changes
In `static/js/Header.jsx`, the `<LoggedInDropdown />` now accepts a prop for the module, and toggles what is displayed accordingly. 

## Notes
Note, for now (testing purposes) the value is hardcoded. This (as noted in the todo) will need to be refactored to inherit the Header's knowledge of which module it is in. 