### PR TITLE
Add from_tref class method to retrieve passages by tref

### DIFF
--- a/sefaria/model/passage.py
+++ b/sefaria/model/passage.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-from . import abstract as abst
+from . import abstract as abst, Ref
 from . import text
 import structlog
 logger = structlog.get_logger(__name__)
@@ -47,4 +47,10 @@ class Passage(abst.AbstractMongoRecord):
 class PassageSet(abst.AbstractMongoSet):
     recordClass = Passage
 
-
+    @classmethod
+    def from_tref(cls, tref):
+        ref = Ref(tref)
+        all_passages = cls().array()
+        containing_full_refs = [p.full_ref for p in all_passages if Ref(p.full_ref).contains(ref)]
+        query = {"full_ref": {"$in": containing_full_refs}}
+        return cls(query)


### PR DESCRIPTION
## Description:
This PR introduces a from_tref class method to the PassageSet class, allowing retrieval of passages by their tref. It accepts a tref, creates a Ref object, and queries the collection for passages whose references contain the given tref.

## Code Changes:

Added from_tref method to PassageSet in sefaria/model/passage.py.

## Notes
_Any additional notes go here_