### PR TITLE
[Mobile][Sheets] Logged In Secondary Nav

### DIFF
--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -15129,6 +15129,12 @@ span.ref-link-color-3 {color: blue}
   flex-direction: column;
 }
 
+.mobileProfileFlexContainer {
+  display: flex;
+  flex-direction: row;
+  align-items: end;
+}
+
 @-webkit-keyframes load5 {
 0%,100%{box-shadow:0 -2.6em 0 0 #ffffff,1.8em -1.8em 0 0 rgba(0,0,0,0.2),2.5em 0 0 0 rgba(0,0,0,0.2),1.75em 1.75em 0 0 rgba(0,0,0,0.2),0 2.5em 0 0 rgba(0,0,0,0.2),-1.8em 1.8em 0 0 rgba(0,0,0,0.2),-2.6em 0 0 0 rgba(0,0,0,0.5),-1.8em -1.8em 0 0 rgba(0,0,0,0.7)}
 12.5%{box-shadow:0 -2.6em 0 0 rgba(0,0,0,0.7),1.8em -1.8em 0 0 #ffffff,2.5em 0 0 0 rgba(0,0,0,0.2),1.75em 1.75em 0 0 rgba(0,0,0,0.2),0 2.5em 0 0 rgba(0,0,0,0.2),-1.8em 1.8em 0 0 rgba(0,0,0,0.2),-2.6em 0 0 0 rgba(0,0,0,0.2),-1.8em -1.8em 0 0 rgba(0,0,0,0.5)}

--- a/static/js/Header.jsx
+++ b/static/js/Header.jsx
@@ -397,7 +397,7 @@ const MobileNavMenu = ({onRefClick, showSearch, openTopic, openURL, close, visib
 
         {Sefaria._uid ?
         <>
-          <a href={module === "library" ? "/texts/saved" : "sheets/saved" } onClick={close}>
+          <a href={module === "library" ? "/texts/saved" : "/sheets/saved" } onClick={close}>
             <img src="/static/icons/bookmarks.svg" alt={Sefaria._('Bookmarks')} />
             {module === "library" && <InterfaceText text={{en: "Saved, History & Notes", he: "שמורים, היסטוריה והערות"}} />}
             {module === "sheets" && <InterfaceText text={{en: "Saved & History", he: "שמורים והיסטוריה"}} />}

--- a/static/js/Header.jsx
+++ b/static/js/Header.jsx
@@ -383,16 +383,18 @@ const MobileNavMenu = ({onRefClick, showSearch, openTopic, openURL, close, visib
         <InterfaceText>Donate</InterfaceText>
       </DonateLink>
 
-      {Sefaria._uid ?
+      <div className="mobileAccountLinks">
+
+      {Sefaria._uid && module === "sheets"?
         <>
           <a href="/my/profile" onClick={close}>
-          {/* TODO: Add profile image logic */}
-            <img src="/static/icons/bookmarks.svg" /> 
+          <div className="mobileProfileFlexContainer">
+            <ProfilePic url={Sefaria.profile_pic_url} name={Sefaria.full_name} len={25}/>
             <InterfaceText>Profile</InterfaceText>
+          </div>
           </a>
         </> : null }
 
-      <div className="mobileAccountLinks">
         {Sefaria._uid ?
         <>
           <a href={module === "library" ? "/texts/saved" : "sheets/saved" } onClick={close}>
@@ -444,7 +446,7 @@ const MobileNavMenu = ({onRefClick, showSearch, openTopic, openURL, close, visib
       { module === "sheets" &&
         <a href="/texts" target="_blank">
           <img src="/static/icons/book.svg" />
-          <InterfaceText>Sefaria Library</InterfaceText>
+          <InterfaceText text={{en: "Sefaria Library", he: "ספריית ספריא"}} />
         </a>
         } 
 

--- a/static/js/Header.jsx
+++ b/static/js/Header.jsx
@@ -256,7 +256,9 @@ class Header extends Component {
           showSearch={this.props.showSearch}
           openTopic={this.props.openTopic}
           openURL={this.props.openURL}
-          close={this.props.onMobileMenuButtonClick} />
+          close={this.props.onMobileMenuButtonClick}
+          // TODO - remove hardcoded value and integrate with header logic more generally
+          module={'sheets'} />
         }
         <GlobalWarningMessage />
       </div>
@@ -335,7 +337,7 @@ const LoggedInButtons = ({headerMode}) => {
   );
 }
 
-const MobileNavMenu = ({onRefClick, showSearch, openTopic, openURL, close, visible}) => {
+const MobileNavMenu = ({onRefClick, showSearch, openTopic, openURL, close, visible, module}) => {
   const classes = classNames({
     mobileNavMenu: 1,
     closed: !visible,
@@ -352,32 +354,60 @@ const MobileNavMenu = ({onRefClick, showSearch, openTopic, openURL, close, visib
             hideHebrewKeyboard={true}
         />
       </div>
+      {module === "library" && 
       <a href="/texts" onClick={close} className="textsPageLink">
         <img src="/static/icons/book.svg" />
         <InterfaceText context="Header">Texts</InterfaceText>
       </a>
-      <a href="/topics" onClick={close}>
+      }
+      <a href={module === "library" ? "/topics" : "/sheets/topics"} onClick={close}>
         <img src="/static/icons/topic.svg" />
         <InterfaceText>Topics</InterfaceText>
       </a>
+      {module === "sheets" && 
+      <a href="/sheets/collections" onClick={close} className="textsPageLink">
+        <img src="/static/icons/collection.svg" />
+        <InterfaceText context="Header">Collections</InterfaceText>
+      </a>
+      }
+
+     {module === "library" && 
       <a href="/calendars" onClick={close}>
         <img src="/static/icons/calendar.svg" />
         <InterfaceText>Learning Schedules</InterfaceText>
       </a>
+      }
 
       <DonateLink classes={"blue"} source="MobileNavMenu">
         <img src="/static/img/heart.png" alt="donation icon" />
         <InterfaceText>Donate</InterfaceText>
       </DonateLink>
 
+      {Sefaria._uid ?
+        <>
+          <a href="/my/profile" onClick={close}>
+          {/* TODO: Add profile image logic */}
+            <img src="/static/icons/bookmarks.svg" /> 
+            <InterfaceText>Profile</InterfaceText>
+          </a>
+        </> : null }
+
       <div className="mobileAccountLinks">
         {Sefaria._uid ?
         <>
-          <a href="/texts/saved" onClick={close}>
+          <a href={module === "library" ? "/texts/saved" : "sheets/saved" } onClick={close}>
             <img src="/static/icons/bookmarks.svg" alt={Sefaria._('Bookmarks')} />
-            <InterfaceText text={{en: "Saved, History & Notes", he: "שמורים, היסטוריה והערות"}} />
-
+            {module === "library" && <InterfaceText text={{en: "Saved, History & Notes", he: "שמורים, היסטוריה והערות"}} />}
+            {module === "sheets" && <InterfaceText text={{en: "Saved & History", he: "שמורים והיסטוריה"}} />}
           </a>
+        </> : null }
+
+        {Sefaria._uid && module === "sheets" ?
+        <>
+          <a href="/sheets/notifications">
+          <img src="/static/icons/notification.svg" />
+          <InterfaceText>Notifications</InterfaceText>
+        </a>
         </> : null }
 
         {Sefaria._uid ?
@@ -403,11 +433,20 @@ const MobileNavMenu = ({onRefClick, showSearch, openTopic, openURL, close, visib
         </a>
 
         <hr />
-
-        <a href="sheets.sefaria.org" target="_blank">
+        
+        { module === "library" &&
+        <a href="/sheets/" target="_blank">
           <img src="/static/icons/sheets-mobile-icon.svg" />
           <InterfaceText>Sheets</InterfaceText>
         </a>
+        } 
+
+      { module === "sheets" &&
+        <a href="/texts" target="_blank">
+          <img src="/static/icons/book.svg" />
+          <InterfaceText>Sefaria Library</InterfaceText>
+        </a>
+        } 
 
         <a href="developers.sefaria.org" target="_blank">
           <img src="/static/icons/dev-portal-mobile-icon.svg" />


### PR DESCRIPTION
## Description
Adjusting the mobile-web secondary nav menu in sheets to account for logged in states

## Code Changes
1. In `static/css/s2.css` a flex container for profile picture and text alignment (double check Hebrew on someone else's local)
2. In `static/js/Header.jsx` - a `module` prop, and conditional logic for what to display based on whether in sheets or library, and logged in or not. 

## Notes
1. The hardcoded value will need to be replaced as per the TODO comment. 
2. In https://github.com/Sefaria/Sefaria-Project/pull/2366 I forgot to account for conditionally rendering module switcher options (i.e. when someone is in `sheets` they should have the option to return to the library or to go to the dev portal. Alternatively, if someone is in `library` they should have the option to go to sheets or go to the dev portal). I intentionally made the change here and not in the other PR to avoid parallel code, since everything will be merged together in the end anyways. Please let me know if another approach would be better. 