### PR TITLE
Add "saved" icon to the Library header

### DIFF
--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -15129,6 +15129,18 @@ span.ref-link-color-3 {color: blue}
   flex-direction: column;
 }
 
+.librarySavedIcon{
+  width: 20px;
+  height: 20px;
+  margin-inline-start: 6px;
+  margin-top: 2px;
+}
+
+.librarySavedIcon img{
+  width: 100%;
+  height: 100%;
+}
+
 @-webkit-keyframes load5 {
 0%,100%{box-shadow:0 -2.6em 0 0 #ffffff,1.8em -1.8em 0 0 rgba(0,0,0,0.2),2.5em 0 0 0 rgba(0,0,0,0.2),1.75em 1.75em 0 0 rgba(0,0,0,0.2),0 2.5em 0 0 rgba(0,0,0,0.2),-1.8em 1.8em 0 0 rgba(0,0,0,0.2),-2.6em 0 0 0 rgba(0,0,0,0.5),-1.8em -1.8em 0 0 rgba(0,0,0,0.7)}
 12.5%{box-shadow:0 -2.6em 0 0 rgba(0,0,0,0.7),1.8em -1.8em 0 0 #ffffff,2.5em 0 0 0 rgba(0,0,0,0.2),1.75em 1.75em 0 0 rgba(0,0,0,0.2),0 2.5em 0 0 rgba(0,0,0,0.2),-1.8em 1.8em 0 0 rgba(0,0,0,0.2),-2.6em 0 0 0 rgba(0,0,0,0.2),-1.8em -1.8em 0 0 rgba(0,0,0,0.5)}

--- a/static/js/Header.jsx
+++ b/static/js/Header.jsx
@@ -205,6 +205,14 @@ class Header extends Component {
                 translationLanguagePreference={this.props.translationLanguagePreference}
                 setTranslationLanguagePreference={this.props.setTranslationLanguagePreference} /> : null}
 
+        { Sefaria._uid && this.props.module ==="library" ?
+        <div className='librarySavedIcon'>
+          <a href="/texts/saved" >
+            <img src='/static/icons/bookmarks.svg' />
+          </a>
+          </div>
+        : null }
+
           <ModuleSwitcher />
 
           { Sefaria._uid ?
@@ -271,6 +279,7 @@ Header.propTypes = {
   openTopic:    PropTypes.func.isRequired,
   openURL:      PropTypes.func.isRequired,
   hasBoxShadow: PropTypes.bool.isRequired,
+  module:       PropTypes.string.isRequired,
 };
 
 const LoggedOutButtons = ({mobile, loginOnly}) => {

--- a/static/js/Header.jsx
+++ b/static/js/Header.jsx
@@ -178,6 +178,12 @@ class Header extends Component {
       <img src="/static/img/logo-hebrew.png" alt="Sefaria Logo"/> :
       <img src="/static/img/logo.svg" alt="Sefaria Logo"/>;
 
+      const librarySavedIcon = <div className='librarySavedIcon'>
+                                  <a href="/texts/saved" >
+                                    <img src='/static/icons/bookmarks.svg' alt='Saved items' />
+                                  </a>
+                                </div>;
+
     const headerContent = (
       <>
 
@@ -205,13 +211,7 @@ class Header extends Component {
                 translationLanguagePreference={this.props.translationLanguagePreference}
                 setTranslationLanguagePreference={this.props.setTranslationLanguagePreference} /> : null}
 
-        { Sefaria._uid && this.props.module ==="library" ?
-        <div className='librarySavedIcon'>
-          <a href="/texts/saved" >
-            <img src='/static/icons/bookmarks.svg' alt='Saved items' />
-          </a>
-          </div>
-        : null }
+        { Sefaria._uid && this.props.module ==="library" ? librarySavedIcon : null }
 
           <ModuleSwitcher />
 

--- a/static/js/Header.jsx
+++ b/static/js/Header.jsx
@@ -208,7 +208,7 @@ class Header extends Component {
         { Sefaria._uid && this.props.module ==="library" ?
         <div className='librarySavedIcon'>
           <a href="/texts/saved" >
-            <img src='/static/icons/bookmarks.svg' />
+            <img src='/static/icons/bookmarks.svg' alt='Saved items' />
           </a>
           </div>
         : null }

--- a/static/js/ReaderApp.jsx
+++ b/static/js/ReaderApp.jsx
@@ -2116,7 +2116,8 @@ toggleSignUpModal(modalContentKind = SignUpModalKind.Default) {
         firstPanelLanguage={this.state.panels?.[0]?.settings?.language}
         hasBoxShadow={headerHasBoxShadow}
         translationLanguagePreference={this.state.translationLanguagePreference}
-        setTranslationLanguagePreference={this.setTranslationLanguagePreference} />
+        setTranslationLanguagePreference={this.setTranslationLanguagePreference} 
+        module={"library"}/>
     );
 
     var panels = [];

--- a/static/js/ReaderApp.jsx
+++ b/static/js/ReaderApp.jsx
@@ -2117,6 +2117,7 @@ toggleSignUpModal(modalContentKind = SignUpModalKind.Default) {
         hasBoxShadow={headerHasBoxShadow}
         translationLanguagePreference={this.state.translationLanguagePreference}
         setTranslationLanguagePreference={this.setTranslationLanguagePreference} 
+        // TODO: This hardcoded value needs to be replaced with the header logic for modules
         module={"library"}/>
     );
 


### PR DESCRIPTION
## Description
Adding the bookmarks icon to the header - conditionally if the user is both logged in and in sheets mode. 

## Code Changes
1. `static/css/s2.css` - Styling to align the icon with the others in the header
2. `static/js/Header.jsx` - Adding the icon with conditional logic, and the module prop to `<Header />`
3. `static/js/ReaderApp.jsx` - Passing the new module prop. Note, this is hardcoded. See `TODO` for the reminder to integrate once the entirety of the header comes together. 

## Notes
- A question about what to do with the module prop on `<Header />` renderings on static pages. @yitzhakc and @edamboritz curious to get your insight when you have a chance. 