### PR TITLE
[Sheets] Notifications Bell

### DIFF
--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -15129,17 +15129,19 @@ span.ref-link-color-3 {color: blue}
   flex-direction: column;
 }
 
-.librarySavedIcon{
+.sheetsNotificationsHeaderIcon {
   width: 20px;
-  height: 20px;
+  height: 18px;
   margin-inline-start: 6px;
   margin-top: 2px;
+  margin-bottom: 2px;
 }
 
-.librarySavedIcon img{
+.sheetsNotificationsHeaderIcon img{
   width: 100%;
   height: 100%;
 }
+
 
 @-webkit-keyframes load5 {
 0%,100%{box-shadow:0 -2.6em 0 0 #ffffff,1.8em -1.8em 0 0 rgba(0,0,0,0.2),2.5em 0 0 0 rgba(0,0,0,0.2),1.75em 1.75em 0 0 rgba(0,0,0,0.2),0 2.5em 0 0 rgba(0,0,0,0.2),-1.8em 1.8em 0 0 rgba(0,0,0,0.2),-2.6em 0 0 0 rgba(0,0,0,0.5),-1.8em -1.8em 0 0 rgba(0,0,0,0.7)}

--- a/static/js/Header.jsx
+++ b/static/js/Header.jsx
@@ -205,10 +205,10 @@ class Header extends Component {
                 translationLanguagePreference={this.props.translationLanguagePreference}
                 setTranslationLanguagePreference={this.props.setTranslationLanguagePreference} /> : null}
 
-        { Sefaria._uid && this.props.module ==="library" ?
-        <div className='librarySavedIcon'>
-          <a href="/texts/saved" >
-            <img src='/static/icons/bookmarks.svg' />
+        { Sefaria._uid && this.props.module ==="sheets" ?
+        <div className='sheetsNotificationsHeaderIcon'>
+          <a href="/sheets/notifications" >
+            <img src='/static/icons/notification.svg' />
           </a>
           </div>
         : null }

--- a/static/js/ReaderApp.jsx
+++ b/static/js/ReaderApp.jsx
@@ -2118,7 +2118,7 @@ toggleSignUpModal(modalContentKind = SignUpModalKind.Default) {
         translationLanguagePreference={this.state.translationLanguagePreference}
         setTranslationLanguagePreference={this.setTranslationLanguagePreference} 
         // TODO: This hardcoded value needs to be replaced with the header logic for modules
-        module={"library"}/>
+        module={"sheets"}/>
     );
 
     var panels = [];


### PR DESCRIPTION
## Description
Conditionally render the notifications bell in the header for logged-in sheets users only. 

## Code Changes
1. `static/css/s2.css` - Styling and alignment for the bell. 
2.  `static/js/Header.jsx` - Conditional render logic for the icon, adding module prop to Header. 
3. static/js/ReaderApp.jsx - Passing the new module prop. Note, this is hardcoded. See TODO for the reminder to integrate once the entirety of the header comes together.

## Notes
- Same question (as in https://github.com/Sefaria/Sefaria-Project/pull/2368) about what to do with the module prop on <Header /> renderings on static pages. @yitzhakc and @edamboritz curious to get your insight when you have a chance.