### PR TITLE
Adjust padding on secondary nav in Hebrew language site

### DIFF
--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -780,6 +780,7 @@ div:has(#bannerMessage) + .readerApp.singlePanel .mobileNavMenu {
   align-items: center;
   height: 100%;
   margin-top: 4px;
+  margin-inline-start: 4px;
 }
 .header .interfaceLinks {
   display: flex;


### PR DESCRIPTION
## Description
Fixing the padding on the help icon in the header. 

## Code Changes
In `static/css/s2.css` added a margin-inline-start to match the other icons. 

## Notes
Tested everything looks as expected in both Hebrew and English interfaces. 