### PR TITLE
implement shortest passage loader

### DIFF
--- a/sefaria/model/passage.py
+++ b/sefaria/model/passage.py
@@ -25,6 +25,7 @@ class Passage(abst.AbstractMongoRecord):
 
     @classmethod
     def containing_segment(cls, ref):
+        #get shortest passage containing this segment ref
         assert isinstance(ref, text.Ref)
         assert ref.is_segment_level()
         passages = PassageSet({"ref_list": ref.starting_ref().normal()})

--- a/sefaria/model/passage.py
+++ b/sefaria/model/passage.py
@@ -27,7 +27,8 @@ class Passage(abst.AbstractMongoRecord):
     def containing_segment(cls, ref):
         assert isinstance(ref, text.Ref)
         assert ref.is_segment_level()
-        return cls().load({"ref_list": ref.starting_ref().normal()})
+        passages = PassageSet({"ref_list": ref.starting_ref().normal()})
+        return min(passages, key=lambda passage: len(passage.ref_list)) if passages else None
 
     def _normalize(self):
         super(Passage, self)._normalize()


### PR DESCRIPTION
## Description
This PR introduces a feature to load the shortest passage from a set of passages. It updates the containing_segment method to return the shortest passage based on the number of references in its ref_list. If no passages are found, it returns None.
## Code Changes
Modified the containing_segment method in sefaria/model/passage.py to implement logic for finding the shortest passage.
## Notes
_Any additional notes go here_