### PR TITLE
Form start analytics event

### DIFF
--- a/static/js/TopicLandingPage/TopicLandingNewsletter.jsx
+++ b/static/js/TopicLandingPage/TopicLandingNewsletter.jsx
@@ -53,10 +53,7 @@ export const TopicLandingNewsletter = () => {
         });
     }
     return (
-        <div
-            className="topic-landing-newsletter-wrapper"
-            data-anl-batch={JSON.stringify(getNewsletterAnalyticsData())}
-        >
+        <div className="topic-landing-newsletter-wrapper" data-anl-batch={JSON.stringify(getNewsletterAnalyticsData())}>
             <div className="topic-landing-newsletter">
                 <h3 className="topic-landing-newsletter-text">
                     <InterfaceText>{NEWSLETTER_TEASER_TEXT}</InterfaceText>

--- a/static/js/TopicLandingPage/TopicLandingNewsletter.jsx
+++ b/static/js/TopicLandingPage/TopicLandingNewsletter.jsx
@@ -2,6 +2,20 @@ import React, { useRef, useState } from 'react';
 import Sefaria from '../sefaria/sefaria';
 import {InterfaceText} from "../Misc";
 
+const NEWSLETTER_TEASER_TEXT = "Stay curious. Get the Timeless Topics newsletter every Tuesday."
+
+const getNewsletterAnalyticsData = () => {
+    const lang = Sefaria.interfaceLang === 'hebrew' ? 'he' : 'en';
+    const newsletterName = Sefaria.getTopicLandingNewsletterMailingLists().join(", ");
+    return {
+        text: NEWSLETTER_TEASER_TEXT,
+        feature_name: "Newsletter Signup Form",
+        version: lang,
+        form_name: "newsletter_topics",
+        form_destination: newsletterName,
+    };
+};
+
 export const TopicLandingNewsletter = () => {
     const firstNameRef = useRef();
     const lastNameRef = useRef();
@@ -39,10 +53,13 @@ export const TopicLandingNewsletter = () => {
         });
     }
     return (
-        <div className="topic-landing-newsletter-wrapper" data-anl-feature_name="Newsletter Signup Form">
+        <div
+            className="topic-landing-newsletter-wrapper"
+            data-anl-batch={JSON.stringify(getNewsletterAnalyticsData())}
+        >
             <div className="topic-landing-newsletter">
                 <h3 className="topic-landing-newsletter-text">
-                    <InterfaceText>Stay curious. Get the Timeless Topics newsletter every Tuesday.</InterfaceText>
+                    <InterfaceText>{NEWSLETTER_TEASER_TEXT}</InterfaceText>
                 </h3>
                 <div className="topic-landing-newsletter-input-wrapper" data-anl-event="form_start:inputStart">
                     <div className="topic-landing-newsletter-input-row">
@@ -66,7 +83,14 @@ export const TopicLandingNewsletter = () => {
                             ref={emailRef}
                             onKeyUp={handleSubscribeKeyUp}
                         />
-                        <button type="submit" onKeyUp={handleSubscribeKeyUp} onClick={handleSubscribe}>{Sefaria._("Sign Up")}</button>
+                        <button
+                            type="submit"
+                            onKeyUp={handleSubscribeKeyUp}
+                            onClick={handleSubscribe}
+                            data-anl-event="form_submit:click"
+                        >
+                            {Sefaria._("Sign Up")}
+                        </button>
                     </div>
                     <div className="topic-landing-newsletter-input-row">
                         {subscribeMessage ?

--- a/static/js/TopicLandingPage/TopicLandingNewsletter.jsx
+++ b/static/js/TopicLandingPage/TopicLandingNewsletter.jsx
@@ -8,7 +8,7 @@ const getNewsletterAnalyticsData = () => {
     const lang = Sefaria.interfaceLang === 'hebrew' ? 'he' : 'en';
     const newsletterName = Sefaria.getTopicLandingNewsletterMailingLists().join(", ");
     return {
-        text: NEWSLETTER_TEASER_TEXT,
+        text: Sefaria._(NEWSLETTER_TEASER_TEXT),
         feature_name: "Newsletter Signup Form",
         version: lang,
         form_name: "newsletter_topics",

--- a/static/js/TopicLandingPage/TopicLandingNewsletter.jsx
+++ b/static/js/TopicLandingPage/TopicLandingNewsletter.jsx
@@ -44,7 +44,7 @@ export const TopicLandingNewsletter = () => {
                 <h3 className="topic-landing-newsletter-text">
                     <InterfaceText>Stay curious. Get the Timeless Topics newsletter every Tuesday.</InterfaceText>
                 </h3>
-                <div className="topic-landing-newsletter-input-wrapper">
+                <div className="topic-landing-newsletter-input-wrapper" data-anl-event="form_start:inputStart">
                     <div className="topic-landing-newsletter-input-row">
                         <input
                             type="text"

--- a/static/js/analyticsEventTracker.js
+++ b/static/js/analyticsEventTracker.js
@@ -4,6 +4,7 @@ const AnalyticsEventTracker = (function() {
         'content_id', 'content_type', 'panel_name', 'panel_category', 'position', 'ai',
         'text', 'experiment', 'feature_name', 'from', 'to', 'action', 'engagement_value',
         'engagement_type', 'logged_in', 'site_lang', 'traffic_type', 'promotion_name', 'link_type',
+        'form_name', 'form_destination',
     ]);
     const EVENT_ATTR = 'data-anl-event';
     const FIELD_ATTR_PREFIX = 'data-anl-';

--- a/templates/base.html
+++ b/templates/base.html
@@ -264,7 +264,7 @@
             });
 
             <!-- attach analyticsEventTracker -->
-            AnalyticsEventTracker.attach("#s2, #staticContentWrapper", ['click', 'scrollIntoView', 'toggle', 'mouseover', 'input']);
+            AnalyticsEventTracker.attach("#s2, #staticContentWrapper", ['click', 'scrollIntoView', 'toggle', 'mouseover', 'input', 'inputStart']);
           </script>
       <!-- End Google tag -->
     {% endif %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -260,7 +260,8 @@
             gtag('js', new Date());
             gtag('config', '{{ GOOGLE_GTAG }}', {
               'user_id': DJANGO_VARS.props ? DJANGO_VARS.props._uid : null,
-              'traffic_type': DJANGO_VARS.props && DJANGO_VARS.props._email.includes('sefaria.org') ? 'sefariaemail' : null
+              'traffic_type': DJANGO_VARS.props && DJANGO_VARS.props._email.includes('sefaria.org') ? 'sefariaemail' : null,
+              'site_lang': '{{ request.interfaceLang }}',
             });
 
             <!-- attach analyticsEventTracker -->


### PR DESCRIPTION
## Description
Adds 'form_name', 'form_destination' ga4 event types to analyticsEventTracker
Adds inputStart JS event to analyticsEventTracker so we can just track the first input to an element
Uses these features to implement analytics for topic landing newsletter