### PR TITLE
Bug/sc 32525/when opening all tanakh links in sidebar

### DIFF
--- a/static/js/LayoutButtons.jsx
+++ b/static/js/LayoutButtons.jsx
@@ -59,6 +59,7 @@ const LayoutButtons = () => {
             <InterfaceText>Layout</InterfaceText>
             <div className="layout-options">
                 {layoutOptions[layoutState].map(option => <LayoutButton
+                    key={option}
                     layoutOption={option}
                     layoutState={layoutState}
                 />)}

--- a/static/js/ReaderPanel.jsx
+++ b/static/js/ReaderPanel.jsx
@@ -698,6 +698,7 @@ class ReaderPanel extends Component {
       vowelsAndCantillationState: this.state.settings.vowels,
       punctuationState: this.state.settings.punctuationTalmud,
       width: this.state.width,
+      panelPosition: this.props.panelPosition,
     };
     const contextContentLang = {"language": this.getContentLanguageOverrideStateful()};
 

--- a/static/js/TextList.jsx
+++ b/static/js/TextList.jsx
@@ -177,7 +177,7 @@ class TextList extends Component {
       }
     }.bind(this);
 
-    let sectionLinks = Sefaria.getLinksFromCache(sectionRef);
+    let sectionLinks = Sefaria.getLinksFromCacheAndPreprocess(sectionRef);
     sectionLinks.map(link => {
       if (!("anchorRefExpanded" in link)) { link.anchorRefExpanded = Sefaria.splitRangingRef(link.anchorRef); }
     });

--- a/static/js/common/ToggleSwitch.jsx
+++ b/static/js/common/ToggleSwitch.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-function ToggleSwitch({name, disabled, onChange, isChecked, ariaLabelledBy}) {
+function ToggleSwitch({name, disabled, onChange, isChecked}) {
     return (
         <div className="toggle-switch-container">
           <div className="toggle-switch focus-visible">

--- a/static/js/common/ToggleSwitchLine.jsx
+++ b/static/js/common/ToggleSwitchLine.jsx
@@ -9,7 +9,6 @@ function ToggleSwitchLine({name, onChange, isChecked, text, disabled=false}) {
             <InterfaceText>{text}</InterfaceText>
             <ToggleSwitch
                 name={name}
-                id={name}
                 disabled={disabled}
                 onChange={onChange}
                 isChecked={isChecked}


### PR DESCRIPTION
## Description
Fix for not showing 'essay' links in their category filter (e.g. Steinslaz intro in Tanakh).

## Code Changes
In `TextList` use `Sefaria.getLinksFromCacheAndPreprocess` rather than `Sefaria.getLinksFromCache` for filtering the 'essay' links.

## Notes
The code here is very old. I'm not sure why we have different code for getting links in `TextList` and `ConnectionsSummary`. It seems duplicate but the old code is too complicated and hardly readable.