### PR TITLE
Render Profile Name in Library Dropdown as a non-link

### DIFF
--- a/static/js/Header.jsx
+++ b/static/js/Header.jsx
@@ -94,7 +94,7 @@ const LoggedInDropdown = ({module}) => {
                 </DropdownMenuItem>
               }
                { module === 'sheets' && 
-                <DropdownMenuItemLink preventClose={true}>
+                <DropdownMenuItemLink url={'/my/profile'} preventClose={true}>
                     <strong>{Sefaria.full_name}</strong>
                 </DropdownMenuItemLink>
               }

--- a/static/js/Header.jsx
+++ b/static/js/Header.jsx
@@ -15,7 +15,7 @@ import {
 } from './Misc';
 import {ProfilePic} from "./ProfilePic";
 import {HeaderAutocomplete} from './HeaderAutocomplete'
-import { DropdownMenu, DropdownMenuSeparator, DropdownMenuItem, DropdownMenuItemWithIcon } from './common/DropdownMenu';
+import { DropdownMenu, DropdownMenuSeparator, DropdownMenuItem, DropdownMenuItemLink, DropdownMenuItemWithIcon, DropdownMenuItemWithCallback } from './common/DropdownMenu';
 
 const LoggedOutDropdown = ({module}) => {
   const [isClient, setIsClient] = useState(false);
@@ -41,34 +41,35 @@ const LoggedOutDropdown = ({module}) => {
   return (
       <DropdownMenu positioningClass="headerDropdownMenu" buttonComponent={<img src='/static/icons/logged_out.svg'/>}>
           <div className='dropdownLinks-options'>
-              <DropdownMenuItem url={loginLink}>
+              <DropdownMenuItemLink url={loginLink}>
                   <InterfaceText text={{'en': 'Log in', 'he': 'התחברות'}}/>
-              </DropdownMenuItem>
-              <DropdownMenuItem url={registerLink}>
+              </DropdownMenuItemLink>
+              <DropdownMenuItemLink url={registerLink}>
                   <InterfaceText text={{'en': 'Sign up', 'he': 'להרשמה'}}/>
-              </DropdownMenuItem>
+              </DropdownMenuItemLink>
               <DropdownMenuSeparator/>
               <div className="languageHeader">
                   <InterfaceText>Site Language</InterfaceText>
               </div>
               <div className='languageToggleFlexContainer'>
                 <span className='englishLanguageButton'>
-                  <DropdownMenuItem url={`/interface/english?next=${getCurrentPage()}`}>
+                  <DropdownMenuItemLink url={`/interface/english?next=${getCurrentPage()}`}>
                     English
-                  </DropdownMenuItem>
+                  </DropdownMenuItemLink>
                 </span>
-                  <DropdownMenuItem url={`/interface/hebrew?next=${getCurrentPage()}`}>
+                  <DropdownMenuItemLink url={`/interface/hebrew?next=${getCurrentPage()}`}>
                       עברית
-                  </DropdownMenuItem>
+                  </DropdownMenuItemLink>
               </div>
               <DropdownMenuSeparator/>
-              {module === 'library' &&
-              <DropdownMenuItem url={'/updates'}>
-                  <InterfaceText text={{'en': 'New Additions', 'he': 'חידושים בארון הספרים של ספריא'}}/>
-              </DropdownMenuItem>}
-              <DropdownMenuItem url={'/help'}>
+              { module === 'library' &&
+                <DropdownMenuItemLink url={'/updates'}>
+                    <InterfaceText text={{'en': 'New Additions', 'he': 'חידושים בארון הספרים של ספריא'}}/>
+                </DropdownMenuItemLink>
+              }
+              <DropdownMenuItemLink url={'/help'}>
                   <InterfaceText text={{'en': 'Help', 'he': 'עזרה'}}/>
-              </DropdownMenuItem>
+              </DropdownMenuItemLink>
           </div>
       </DropdownMenu>
 );
@@ -87,37 +88,44 @@ const LoggedInDropdown = ({module}) => {
                                                  name={Sefaria.full_name}
                                                  len={25}/>}>
           <div className='dropdownLinks-options'>
-              <DropdownMenuItem preventClose={true}>
-                  <strong>{Sefaria.full_name}</strong>
-              </DropdownMenuItem>
+              { module === 'library' && 
+                <DropdownMenuItem preventClose={true}>
+                    <strong>{Sefaria.full_name}</strong>
+                </DropdownMenuItem>
+              }
+               { module === 'sheets' && 
+                <DropdownMenuItemLink preventClose={true}>
+                    <strong>{Sefaria.full_name}</strong>
+                </DropdownMenuItemLink>
+              }
               <DropdownMenuSeparator/>
 
               { module === 'library' && 
                 <>
-                <DropdownMenuItem url={'/settings/account'}>
+                <DropdownMenuItemLink url={'/settings/account'}>
                     <InterfaceText>Account Settings</InterfaceText>
-                </DropdownMenuItem>
-                <DropdownMenuItem url={'/torahtracker'}>
+                </DropdownMenuItemLink>
+                <DropdownMenuItemLink url={'/torahtracker'}>
                     <InterfaceText text={{'en': 'Torah Tracker', 'he': 'לימוד במספרים'}}/>
-                </DropdownMenuItem>
+                </DropdownMenuItemLink>
                 </> 
               }
 
 
               { module === 'sheets' && 
                 <>
-                <DropdownMenuItem url={'/my/profile'}>
+                <DropdownMenuItemLink url={'/my/profile'}>
                     <InterfaceText>Profile</InterfaceText>
-                </DropdownMenuItem>
-                <DropdownMenuItem url={'/sheets/saved'}>
+                </DropdownMenuItemLink>
+                <DropdownMenuItemLink url={'/sheets/saved'}>
                   <InterfaceText>Saved</InterfaceText>
-                </DropdownMenuItem>
-                <DropdownMenuItem url={'/sheets/history'}>
+                </DropdownMenuItemLink>
+                <DropdownMenuItemLink url={'/sheets/history'}>
                   <InterfaceText>History</InterfaceText>
-                </DropdownMenuItem>
-                <DropdownMenuItem url={'/settings/account'}>
+                </DropdownMenuItemLink>
+                <DropdownMenuItemLink url={'/settings/account'}>
                     <InterfaceText>Account Settings</InterfaceText>
-                </DropdownMenuItem>
+                </DropdownMenuItemLink>
                 </> 
               }
               
@@ -126,28 +134,29 @@ const LoggedInDropdown = ({module}) => {
                   <InterfaceText>Site Language</InterfaceText>
               </div>
               <div className='languageToggleFlexContainer'>
-                  <DropdownMenuItem url={`/interface/english?next=${getCurrentPage()}`}>
+                  <DropdownMenuItemLink url={`/interface/english?next=${getCurrentPage()}`}>
                       English
-                  </DropdownMenuItem>
+                  </DropdownMenuItemLink>
                   <span className="languageDot">&#183;</span>
-                  <DropdownMenuItem url={`/interface/hebrew?next=${getCurrentPage()}`}>
+                  <DropdownMenuItemLink url={`/interface/hebrew?next=${getCurrentPage()}`}>
                       עברית
-                  </DropdownMenuItem>
+                  </DropdownMenuItemLink>
               </div>
               <DropdownMenuSeparator/>
               
-              {module === 'library' && 
-              <DropdownMenuItem url={'/updates'}>
-                  <InterfaceText text={{'en': 'New Additions', 'he': 'חידושים בארון הספרים של ספריא'}}/>
-              </DropdownMenuItem>}
+              { module === 'library' && 
+                <DropdownMenuItemLink url={'/updates'}>
+                    <InterfaceText text={{'en': 'New Additions', 'he': 'חידושים בארון הספרים של ספריא'}}/>
+                </DropdownMenuItemLink>
+              }
 
-              <DropdownMenuItem preventClose={true} url={'/help'}>
+              <DropdownMenuItemLink preventClose={true} url={'/help'}>
                   <InterfaceText text={{'en': 'Help', 'he': 'עזרה'}}/>
-              </DropdownMenuItem>
+              </DropdownMenuItemLink>
               <DropdownMenuSeparator/>
-              <DropdownMenuItem url={'/logout'}>
+              <DropdownMenuItemLink url={'/logout'}>
                   <InterfaceText text={{'en': 'Log Out', 'he': 'ניתוק'}}/>
-              </DropdownMenuItem>
+              </DropdownMenuItemLink>
           </div>
       </DropdownMenu>
 );
@@ -158,23 +167,23 @@ const ModuleSwitcher = () => {
   return (
       <DropdownMenu positioningClass="headerDropdownMenu" buttonComponent={<img src='/static/icons/module_switcher_icon.svg'/>}>
           <div className='dropdownLinks-options'>
-              <DropdownMenuItem url={'/'} newTab={true}>
+              <DropdownMenuItemLink url={'/'} newTab={true}>
                   <DropdownMenuItemWithIcon icon={'/static/icons/library_icon.svg'} textEn={'Library'}
                                             textHe={'ספריה'}/>
-              </DropdownMenuItem>
+              </DropdownMenuItemLink>
               <DropdownMenuSeparator/>
-              <DropdownMenuItem url={'/sheets'} newTab={true}>
+              <DropdownMenuItemLink url={'/sheets'} newTab={true}>
                   <DropdownMenuItemWithIcon icon={'/static/icons/sheets_icon.svg'} textEn={'Sheets'} textHe={'דפים'}/>
-              </DropdownMenuItem>
+              </DropdownMenuItemLink>
               <DropdownMenuSeparator/>
-              <DropdownMenuItem url={'https://developers.sefaria.org'} newTab={true}>
+              <DropdownMenuItemLink url={'https://developers.sefaria.org'} newTab={true}>
                   <DropdownMenuItemWithIcon icon={'/static/icons/developers_icon.svg'} textEn={'Developers'}
                                             textHe={'מפתחים'}/>
-              </DropdownMenuItem>
+              </DropdownMenuItemLink>
               <DropdownMenuSeparator/>
-              <DropdownMenuItem url={'/products'} newTab={true}>
+              <DropdownMenuItemLink url={'/products'} newTab={true}>
                   <InterfaceText text={{'he': 'לכל המוצרים שלנו', 'en': 'See all products ›'}}/>
-              </DropdownMenuItem>
+              </DropdownMenuItemLink>
           </div>
       </DropdownMenu>
 );

--- a/static/js/common/DropdownMenu.jsx
+++ b/static/js/common/DropdownMenu.jsx
@@ -11,11 +11,7 @@ const DropdownMenuSeparator = () => {
 
 }
 
-const DropdownMenuItem = ({url, children, newTab, preventClose = false}) => {
-
-  if (!newTab){
-    newTab = false;
-  }
+const DropdownMenuItem = ({children, preventClose = false}) => {
 
   return (
     <div className={`interfaceLinks-option int-bi dropdownItem`}

--- a/static/js/common/DropdownMenu.jsx
+++ b/static/js/common/DropdownMenu.jsx
@@ -18,6 +18,21 @@ const DropdownMenuItem = ({url, children, newTab, preventClose = false}) => {
   }
 
   return (
+    <div className={`interfaceLinks-option int-bi dropdownItem`}
+       data-prevent-close={preventClose}>
+      {children}
+    </div>
+
+  );
+}
+
+const DropdownMenuItemLink = ({url, children, newTab, preventClose = false}) => {
+
+  if (!newTab){
+    newTab = false;
+  }
+
+  return (
     <a className={`interfaceLinks-option int-bi dropdownItem`}
        href={url}
        target={newTab ? '_blank' : null}
@@ -122,5 +137,6 @@ const DropdownMenu = ({children, buttonComponent, positioningClass}) => {
     DropdownMenuSeparator,
     DropdownMenuItemWithIcon,
     DropdownMenuItem,
+    DropdownMenuItemLink,
     DropdownMenuItemWithCallback
   };


### PR DESCRIPTION
## Description
In the logged-in library dropdown, a need arose for a `DropdownMenuItem` component which was not a link, and did not require a callback (to render the logged-in user's name without a link to their profile). 

This PR renames the existing `<DropdownMenuItem/>` component (which renders an `<a>` tag) to `<DropdownMenuItemLink/>`, and creates a new `<DropdownMenuItem/>` component which renders a simple `<div>`. 

## Code Changes
In `static/js/Header.jsx` - importing the new `<DropdownMenuItemLink/>` component, and replacing all instances of <DropdownMenuItem/>` to `<DropdownMenuItemLink/>`. 

In `static/js/common/DropdownMenu.jsx` - defining the new components. 

## Notes
I checked all of the other files for uses that need to be replaced, and did not find any. Worth someone else triple checking though :) 