### PR TITLE
[Sheets] Green "Create" Button in Header

### DIFF
--- a/static/js/Header.jsx
+++ b/static/js/Header.jsx
@@ -16,6 +16,7 @@ import {
 import {ProfilePic} from "./ProfilePic";
 import {HeaderAutocomplete} from './HeaderAutocomplete'
 import { DropdownMenu, DropdownMenuSeparator, DropdownMenuItem, DropdownMenuItemWithIcon } from './common/DropdownMenu';
+import Button from './common/Button';
 
 const LoggedOutDropdown = ({module}) => {
   const [isClient, setIsClient] = useState(false);
@@ -235,6 +236,8 @@ class Header extends Component {
             openTopic={this.props.openTopic}
             openURL={this.props.openURL}
         />
+
+        {this.props.module === "sheets" && <CreateButton />}
 
         { Sefaria._siteSettings.TORAH_SPECIFIC ? <HelpButton /> : null}
 
@@ -643,6 +646,15 @@ const HelpButton = () => {
         <img src="/static/img/help.svg" alt={Sefaria._("Help")}/>
       </a>
     </div>
+  );
+};
+
+const CreateButton = () => {
+  return (
+    <Button variant={"secondary"} onClick={() => window.location.href="/sheets/new"}>
+      {/* Hebrew is a placeholder */}
+      <InterfaceText text={{'en': 'Create', 'he': 'דף חדש'}} /> 
+    </Button>
   );
 };
 


### PR DESCRIPTION
## Description
Set the theme-able CSS button in the header to conditionally render for sheets only. 

## Code Changes
In `static/js/Header.jsx` creating the `Create` button component and conditionally rendering it. 

## Notes
The background color for the button does not seem to be automatically filling as expected given the behavior of the theme-able CSS. Same as in https://github.com/Sefaria/Sefaria-Project/pull/2383