### PR TITLE
fix(linker): exclude linker.v2 and v3 from languageSettingsMiddleware

### DIFF
--- a/sefaria/system/middleware.py
+++ b/sefaria/system/middleware.py
@@ -50,7 +50,7 @@ class LanguageSettingsMiddleware(MiddlewareMixin):
     Determines Interface and Content Language settings for each request.
     """
     def process_request(self, request):
-        excluded = ('/linker.js', "/api/", "/interface/", "/apple-app-site-association", STATIC_URL)
+        excluded = ('/linker.js', '/linker.v2.js', '/linker.v3.js', "/api/", "/interface/", "/apple-app-site-association", STATIC_URL)
         if any([request.path.startswith(start) for start in excluded]):
             request.interfaceLang = "english"
             request.contentLang = "bilingual"


### PR DESCRIPTION
## Description


## Code Changes
_The following changes were made to the files below_

## Notes
_Any additional notes go here_