### PR TITLE
Handle Nested Lists in New Editor

### DIFF
--- a/static/js/Editor.jsx
+++ b/static/js/Editor.jsx
@@ -519,10 +519,10 @@ function flattenLists(htmlString) {
   const doc = parser.parseFromString(htmlString, 'text/html');
 
   function flattenList(list) {
-    [...list.querySelectorAll('li')].forEach(item => {
+    list.querySelectorAll('li').forEach(item => {
       const nestedList = item.querySelector('ul, ol');
       if (nestedList) {
-        [...nestedList.querySelectorAll('li')].forEach(nestedItem => {
+        nestedList.querySelectorAll('li').forEach(nestedItem => {
           item.parentNode.insertBefore(nestedItem, item.nextSibling);
         });
         nestedList.remove();

--- a/static/js/Editor.jsx
+++ b/static/js/Editor.jsx
@@ -454,7 +454,7 @@ function renderSheetItem(source) {
                 {
                     type: sheet_item_els[sheetItemType],
                     options: source.options,
-                    children: parseSheetItemHTML(source.comment),
+                    children: parseSheetItemHTML(source.comment, true),
                     node: source.node,
                     lang: commentLang
                 }
@@ -462,13 +462,13 @@ function renderSheetItem(source) {
             return content
         }
         case 'outsideText': {
-            const lang = Sefaria.hebrew.isHebrew(source.outsideText, true) ? 'he' : 'en';
+            const lang = Sefaria.hebrew.isHebrew(source.outsideText) ? 'he' : 'en';
 
             const content = (
                 {
                     type: sheet_item_els[sheetItemType],
                     options: source.options,
-                    children: parseSheetItemHTML(source.outsideText, true),
+                    children: parseSheetItemHTML(source.outsideText),
                     node: source.node,
                     lang: lang
                 }
@@ -479,8 +479,8 @@ function renderSheetItem(source) {
             const content = (
                 {
                     type: sheet_item_els[sheetItemType],
-                    heText: parseSheetItemHTML(source.outsideBiText.he, true),
-                    enText: parseSheetItemHTML(source.outsideBiText.en, true),
+                    heText: parseSheetItemHTML(source.outsideBiText.he),
+                    enText: parseSheetItemHTML(source.outsideBiText.en),
                     options: source.options,
                     children: [
                         {text: ""},

--- a/static/js/Editor.jsx
+++ b/static/js/Editor.jsx
@@ -468,7 +468,7 @@ function renderSheetItem(source) {
                 {
                     type: sheet_item_els[sheetItemType],
                     options: source.options,
-                    children: parseSheetItemHTML(source.outsideText),
+                    children: parseSheetItemHTML(source.outsideText, true),
                     node: source.node,
                     lang: lang
                 }

--- a/static/js/Editor.jsx
+++ b/static/js/Editor.jsx
@@ -462,7 +462,7 @@ function renderSheetItem(source) {
             return content
         }
         case 'outsideText': {
-            const lang = Sefaria.hebrew.isHebrew(source.outsideText) ? 'he' : 'en';
+            const lang = Sefaria.hebrew.isHebrew(source.outsideText, true) ? 'he' : 'en';
 
             const content = (
                 {
@@ -479,8 +479,8 @@ function renderSheetItem(source) {
             const content = (
                 {
                     type: sheet_item_els[sheetItemType],
-                    heText: parseSheetItemHTML(source.outsideBiText.he),
-                    enText: parseSheetItemHTML(source.outsideBiText.en),
+                    heText: parseSheetItemHTML(source.outsideBiText.he, true),
+                    enText: parseSheetItemHTML(source.outsideBiText.en, true),
                     options: source.options,
                     children: [
                         {text: ""},
@@ -535,10 +535,10 @@ function flattenLists(htmlString) {
   return doc.body.innerHTML;
 }
 
-function parseSheetItemHTML(rawhtml) {
+function parseSheetItemHTML(rawhtml, DoFlattenLists=false) {
     let preparseHtml = rawhtml.replace(/\u00A0/g, ' ').replace(/(\r\n|\n|\r|\t)/gm, "");
     // Nested lists are not supported in new editor, so flatten nested lists created with old editor into one depth lists:
-    preparseHtml = flattenLists(preparseHtml);
+    DoFlattenLists && (preparseHtml = flattenLists(preparseHtml));
     const parsed = new DOMParser().parseFromString(preparseHtml, 'text/html');
     const fragment = deserialize(parsed.body);
     const slateJSON = fragment.length > 0 ? fragment : [{text: ''}];


### PR DESCRIPTION
This pull request introduces a new function to handle nested lists in the `static/js/Editor.jsx` file. The key change is the addition of a `flattenLists` function to ensure compatibility with the new editor that does not support nested lists.

Changes to handle nested lists:

* [`static/js/Editor.jsx`](diffhunk://#diff-0edb809ee68c59c1469d28011e2d3be7af1cc5f8ab4d6a994150091983abfa41R517-R541): Added the `flattenLists` function to flatten nested lists into one-depth lists and integrated it into the `parseSheetItemHTML` function to process HTML strings accordingly.## Description
_A brief description of the PR_
