### PR TITLE
Fix wring display date in US

### DIFF
--- a/django_topics/models/seasonal_topic.py
+++ b/django_topics/models/seasonal_topic.py
@@ -80,10 +80,12 @@ class SeasonalTopic(models.Model):
         return f"{self.topic.slug} ({self.start_date})"
 
     def get_display_start_date(self, diaspora=True):
-        return self.display_start_date_diaspora if diaspora else self.display_start_date_israel
+        date = self.display_start_date_diaspora if diaspora else self.display_start_date_israel
+        return date and date.date()  # Ensures a pure date, even if mistakenly set as datetime
 
     def get_display_end_date(self, diaspora=True):
-        return self.display_end_date_diaspora if diaspora else self.display_end_date_israel
+        date = self.display_end_date_diaspora if diaspora else self.display_end_date_israel
+        return date and date.date()  # Ensures a pure date
 
 
 class SeasonalTopicEnglish(SeasonalTopic):

--- a/django_topics/models/seasonal_topic.py
+++ b/django_topics/models/seasonal_topic.py
@@ -2,6 +2,7 @@ from django.db import models
 from django_topics.models import Topic
 from django.core.exceptions import ValidationError
 from django.utils.timezone import now
+from django.utils.timezone import localtime
 from datetime import datetime
 
 class SeasonalTopicManager(models.Manager):
@@ -12,7 +13,7 @@ class SeasonalTopicManager(models.Manager):
         @param date: datetime object
         @return:
         """
-        date = date or now().date()
+        date = date or localtime(now()).date()  # Ensure it's a date, not a datetime
         return (
             self.filter(start_date__lte=date, lang=lang)
             .order_by('-start_date')


### PR DESCRIPTION
This pull request includes changes to the `django_topics/models/seasonal_topic.py` file to ensure that the date used in the `get_seasonal_topic` method is properly localized.

Key changes:

* Added import for `localtime` from `django.utils.timezone` to the `django_topics/models/seasonal_topic.py` file.
* Modified the `get_seasonal_topic` method to use `localtime(now()).date()` instead of `now().date()` to ensure the date is localized.## Description
_A brief description of the PR_

## Code Changes
_The following changes were made to the files below_

## Notes
_Any additional notes go here_