### PR TITLE
Fix editing default ltr source and rtl translation

### DIFF
--- a/static/js/ConnectionsPanel.jsx
+++ b/static/js/ConnectionsPanel.jsx
@@ -1269,15 +1269,11 @@ WebPagesList.propTypes = {
 const AdvancedToolsList = ({srefs, canEditText, currVersions, setConnectionsMode, masterPanelLanguage, toggleSignUpModal}) => {
     const {textsData} = useContext(ReaderPanelContext);
     const editText = canEditText && textsData ? function () {
-      let refString = srefs[0];
-      const {primaryDirection, translationDirection} = textsData;
-      const currVersionsLangCode = masterPanelLanguage.slice(0,2);
-      const versionTitle = currVersions[currVersionsLangCode]?.versionTitle;
-      const direction = (masterPanelLanguage === 'english') ? translationDirection : primaryDirection;
-      const langCode = direction === 'rtl' ? 'he': 'en';
-      if (versionTitle) {
-        refString += "/" + encodeURIComponent(langCode) + "/" + encodeURIComponent(versionTitle);
-      }
+      const isTranslation = masterPanelLanguage === 'english';
+      const versionType = isTranslation ? 'translation' : 'primary';
+      const langCode = textsData[`${versionType}Direction`] === 'ltr' ? 'en': 'he';
+      const versionTitle = isTranslation ? textsData.versionTitle : textsData.heVersionTitle;
+      const refString = `${srefs[0]}/${encodeURIComponent(langCode)}/${encodeURIComponent(versionTitle)}`;
 
       let path = "/edit/" + refString;
       let currentPath = Sefaria.util.currentPath();

--- a/static/js/ConnectionsPanel.jsx
+++ b/static/js/ConnectionsPanel.jsx
@@ -1283,7 +1283,6 @@ const AdvancedToolsList = ({srefs, canEditText, currVersions, setConnectionsMode
       let currentPath = Sefaria.util.currentPath();
       let nextParam = "?next=" + encodeURIComponent(currentPath);
       path += nextParam;
-      //console.log(path);
       Sefaria.track.event("Tools", "Edit Text Click", refString,
         { hitCallback: () => window.location = path }
       );


### PR DESCRIPTION
## Description
In the RTL project we've change the way of categorizing texts - rather than ltr/rtl dichotomy, we have now (also) primary/translation dichotomy. The edit api still interprets he/en as ltr/rtl.
Therefore, when trying to edit ltr source or rtl translation, that are default (and therefore are missing in `currentVersions`), one got the wrong text to edit.
This PR changes the way we inquire the details of the version to edit - rather than taking it from `currVersions`, it's taken from the data itself, so we always have explicit version details. 