### PR TITLE
fix(topic): remove language from available languages list

### DIFF
--- a/sefaria/helper/topic.py
+++ b/sefaria/helper/topic.py
@@ -1338,6 +1338,8 @@ def delete_ref_topic_link(tref, to_topic, link_type, lang):
 
     if lang in link.order.get('curatedPrimacy', []):
         link.order['curatedPrimacy'].pop(lang)
+    if lang in link.order.get('availableLangs', []):
+        link.order['availableLangs'].remove(lang)
     if lang in getattr(link, 'descriptions', {}):
         link.descriptions.pop(lang)
 


### PR DESCRIPTION
This pull request includes a small change to the `sefaria/helper/topic.py` file. The change ensures that the specified language is also removed from the `availableLangs` list when deleting a reference topic link.

* [`sefaria/helper/topic.py`](diffhunk://#diff-19364da9061bcb429f3f3c5f63aeab5541e461154bd59e61719b2cd68f631356R1341-R1342): Added a check and removal of the specified language from the `availableLangs` list in the `delete_ref_topic_link` function.## Description
_A brief description of the PR_

## Code Changes
_The following changes were made to the files below_

## Notes
_Any additional notes go here_