### PR TITLE
Remove topics launch banner

### DIFF
--- a/static/js/ReaderApp.jsx
+++ b/static/js/ReaderApp.jsx
@@ -34,7 +34,6 @@ import {
   CookiesNotification,
   CommunityPagePreviewControls
 } from './Misc';
-import { TopicsLaunchBanner } from './TopicsLaunchBanner';
 import { Promotions } from './Promotions';
 import Component from 'react-class';
 import  { io }  from 'socket.io-client';
@@ -2258,8 +2257,7 @@ toggleSignUpModal(modalContentKind = SignUpModalKind.Default) {
         <AdContext.Provider value={this.getUserContext()}>
           <div id="readerAppWrap">
             <InterruptingMessage />
-            <TopicsLaunchBanner onClose={this.setContainerMode} />
-            {/*<Banner onClose={this.setContainerMode} />*/}
+            <Banner onClose={this.setContainerMode} />
             <div className={classes} onClick={this.handleInAppLinkClick}>
               {header}
               {panels}

--- a/templates/base.html
+++ b/templates/base.html
@@ -99,8 +99,6 @@
     <link rel="stylesheet" href="{%  static 'css/s2-print.css' %}" media="print" />
     <!-- Specific styling to correct behavior of Unbounce banners -->
     <link rel="stylesheet" href="{%  static 'css/unbounce-banner.css' %}">
-    <!-- Styling for temporary Topics Launch banner -->
-    <link rel="stylesheet" href="{% static 'css/topics-launch-banner.css' %}" />
 
     {% block static_css %}
     {% if not html %}


### PR DESCRIPTION
## Description
Removes the code related to the custom topics launch banner, so that it isn't imported and doesn't show.

## Notes
Most of the code related to the banner was left in case MarCom decides they want to show the banner again.