### PR TITLE
chore: exclude essay links from linksummary count but not from textlist

### DIFF
--- a/static/js/TextList.jsx
+++ b/static/js/TextList.jsx
@@ -177,20 +177,14 @@ class TextList extends Component {
       }
     }.bind(this);
 
-    let sectionLinks = Sefaria.getLinksFromCacheAndPreprocess(sectionRef);
+    let sectionLinks = Sefaria.getLinksFromCacheAndPreprocess(sectionRef, excludedSheet, false);
     sectionLinks.map(link => {
       if (!("anchorRefExpanded" in link)) { link.anchorRefExpanded = Sefaria.splitRangingRef(link.anchorRef); }
     });
     let overlaps = link => (!(link.anchorRefExpanded.every(aref => Sefaria.util.inArray(aref, refs) === -1)));
-    let links = Sefaria._filterLinks(sectionLinks, filter)
+    return Sefaria._filterLinks(sectionLinks, filter)
       .filter(overlaps)
       .sort(sortConnections);
-
-    if (excludedSheet) {
-      links = Sefaria._filterSheetFromLinks(links, excludedSheet);
-    }
-
-    return links;
   }
 
   render() {

--- a/static/js/TextList.jsx
+++ b/static/js/TextList.jsx
@@ -177,14 +177,21 @@ class TextList extends Component {
       }
     }.bind(this);
 
-    let sectionLinks = Sefaria.getLinksFromCacheAndPreprocess(sectionRef, excludedSheet, false);
+    let sectionLinks = Sefaria.getLinksFromCacheAndDedupe(sectionRef);
+
     sectionLinks.map(link => {
       if (!("anchorRefExpanded" in link)) { link.anchorRefExpanded = Sefaria.splitRangingRef(link.anchorRef); }
     });
     let overlaps = link => (!(link.anchorRefExpanded.every(aref => Sefaria.util.inArray(aref, refs) === -1)));
-    return Sefaria._filterLinks(sectionLinks, filter)
+    let links = Sefaria._filterLinks(sectionLinks, filter)
       .filter(overlaps)
       .sort(sortConnections);
+
+    if (excludedSheet) {
+      links = Sefaria._filterSheetFromLinks(links, excludedSheet);
+    }
+
+    return links;
   }
 
   render() {

--- a/static/js/sefaria/sefaria.js
+++ b/static/js/sefaria/sefaria.js
@@ -1553,7 +1553,7 @@ Sefaria = extend(Sefaria, {
       return true;
     }
   },
-  getLinksFromCacheAndPreprocess: function(ref, excludedSheet) {
+  getLinksFromCacheAndPreprocess: function(ref, excludedSheet = null, excludeEssays = false) {
     let links = [];
     if (typeof ref == "string") {
       links = this.getLinksFromCache(ref);
@@ -1566,7 +1566,7 @@ Sefaria = extend(Sefaria, {
       links = this._dedupeLinks(links); // by aggregating links to each ref above, we can get duplicates of links to spanning refs
     }
     links = excludedSheet ? this._filterSheetFromLinks(links, excludedSheet) : links;
-    return links.filter(link => link.type !== "essay");
+    return excludeEssays ? links.filter(link => link.type !== "essay") : links;
   },
   linkSummary: function(ref, excludedSheet) {
     // Returns an ordered array summarizing the link counts by category and text
@@ -1641,7 +1641,7 @@ Sefaria = extend(Sefaria, {
         ],
     };
     if (!this.linksLoaded(ref)) { return []; }
-    const links = this.getLinksFromCacheAndPreprocess(ref, excludedSheet);
+    const links = this.getLinksFromCacheAndPreprocess(ref, excludedSheet, true);
     const normRef = Sefaria.humanRef(ref);
     const cacheKey = normRef + "/" + excludedSheet;
     if (!this.shouldBuildLinkSummaries(cacheKey, links)) {  // don't need to build _linkSummaries for this ref

--- a/static/js/sefaria/sefaria.js
+++ b/static/js/sefaria/sefaria.js
@@ -1553,7 +1553,7 @@ Sefaria = extend(Sefaria, {
       return true;
     }
   },
-  getLinksFromCacheAndPreprocess: function(ref, excludedSheet = null, excludeEssays = false) {
+  getLinksFromCacheAndDedupe: function(ref) {
     let links = [];
     if (typeof ref == "string") {
       links = this.getLinksFromCache(ref);
@@ -1565,8 +1565,7 @@ Sefaria = extend(Sefaria, {
       });
       links = this._dedupeLinks(links); // by aggregating links to each ref above, we can get duplicates of links to spanning refs
     }
-    links = excludedSheet ? this._filterSheetFromLinks(links, excludedSheet) : links;
-    return excludeEssays ? links.filter(link => link.type !== "essay") : links;
+    return links;
   },
   linkSummary: function(ref, excludedSheet) {
     // Returns an ordered array summarizing the link counts by category and text
@@ -1641,7 +1640,9 @@ Sefaria = extend(Sefaria, {
         ],
     };
     if (!this.linksLoaded(ref)) { return []; }
-    const links = this.getLinksFromCacheAndPreprocess(ref, excludedSheet, true);
+    let links = this.getLinksFromCacheAndDedupe(ref);
+    links = excludedSheet ? this._filterSheetFromLinks(links, excludedSheet) : links;
+    links = links.filter(link => link.type !== "essay");
     const normRef = Sefaria.humanRef(ref);
     const cacheKey = normRef + "/" + excludedSheet;
     if (!this.shouldBuildLinkSummaries(cacheKey, links)) {  // don't need to build _linkSummaries for this ref


### PR DESCRIPTION
## Description
Essay links don't show up in the Connections Panel.

## Code Changes
This bug is due to a recent change to sefaria.js in getLinksFromCacheAndPreprocess.
This function filters out essay links because it is called by linkSummary() from the ConnectionsPanel.  This filtering should happen because linkSummary is only for "normal"/non-essay links that are in "Commentary", "Talmud", and other categories.  However, when TextList renders and retrieves links from cache using getLinksFromCacheAndPreprocess we should _not_ filter out essay links because TextList is how essay links get displayed.  I simply added a parameter to getLinksFromCacheAndPreprocess to handle this possibility.