### PR TITLE
Fix Curated Primacy Initial Computation and Propely Handle Duplicate Refs in Text Fetching

### DIFF
--- a/static/js/TopicPage.jsx
+++ b/static/js/TopicPage.jsx
@@ -52,9 +52,7 @@ const fetchBulkText = (translationLanguagePreference, inRefs) =>
         Object.assign(tempRef, outRef);
       }
     }
-    const result = inRefs.map(ref => [ref.ref, ref]);
-
-    return result; // Return the list of tuples [key, value]
+    return inRefs.map(ref => [ref.ref, ref]);
   });
 
 

--- a/static/js/TopicPage.jsx
+++ b/static/js/TopicPage.jsx
@@ -38,26 +38,29 @@ import {ContentText} from "./ContentText";
 
 const norm_hebrew_ref = tref => tref.replace(/[׳״]/g, '');
 
-
 const fetchBulkText = (translationLanguagePreference, inRefs) =>
   Sefaria.getBulkText(
     inRefs.map(x => x.ref),
     true, 500, 600,
     translationLanguagePreference
   ).then(outRefs => {
+    // Hydrate inRefs with text from outRefs
     for (let tempRef of inRefs) {
-      // annotate outRefs with `order` and `dataSources` from `topicRefs`
-      if (outRefs[tempRef.ref]) {
-        outRefs[tempRef.ref].order = tempRef.order;
-        outRefs[tempRef.ref].dataSources = tempRef.dataSources;
-        if(tempRef.descriptions) {
-            outRefs[tempRef.ref].descriptions = tempRef.descriptions;
-        }
+      const outRef = outRefs[tempRef.ref];
+
+      if (outRef) {
+        // Add text from outRefs to inRefs
+        tempRef.he = outRef.he;
+        tempRef.en = outRef.en;
+        tempRef.lang = outRef.lang;
       }
     }
-    return Object.entries(outRefs);
-  }
-);
+
+    // Convert inRefs to a list of tuples in the form [key, value]
+    const result = inRefs.map(ref => [ref.ref, ref]);
+
+    return result; // Return the list of tuples [key, value]
+  });
 
 
 const fetchBulkSheet = inSheets =>

--- a/static/js/TopicPage.jsx
+++ b/static/js/TopicPage.jsx
@@ -49,14 +49,9 @@ const fetchBulkText = (translationLanguagePreference, inRefs) =>
       const outRef = outRefs[tempRef.ref];
 
       if (outRef) {
-        // Add text from outRefs to inRefs
-        tempRef.he = outRef.he;
-        tempRef.en = outRef.en;
-        tempRef.lang = outRef.lang;
+        Object.assign(tempRef, outRef);
       }
     }
-
-    // Convert inRefs to a list of tuples in the form [key, value]
     const result = inRefs.map(ref => [ref.ref, ref]);
 
     return result; // Return the list of tuples [key, value]


### PR DESCRIPTION
## Description
This PR fixes 2 issues:

1. The curated primacy was initially generated incorrectly, based on counting ref-links with availLang filed. Now it's computed curectly based on the max existing curatedPrimacy.
2. The client didn't handle properly the case of 2 duplicate sources for one topic page (one learning-team and one by ctonjob). this pr fixes that by a more correct processing of the server-returned data.

## Code Changes
_The following changes were made to the files below_

## Notes
_Any additional notes go here_