### PR TITLE
fix: essay links should have their own category

### DIFF
--- a/sefaria/client/wrapper.py
+++ b/sefaria/client/wrapper.py
@@ -69,7 +69,7 @@ def format_link_object_for_client(link, with_text, ref, pos=None):
         com["text"]      = text.text if isinstance(text.text, str) else JaggedTextArray(text.text).flatten_to_array()
         com["he"]        = text.he if isinstance(text.he, str) else JaggedTextArray(text.he).flatten_to_array()
 
-    # if the the link is commentary, strip redundant info (e.g. "Rashi on Genesis 4:2" -> "Rashi")
+    # if the link is commentary, strip redundant info (e.g. "Rashi on Genesis 4:2" -> "Rashi")
     # this is now simpler, and there is explicit data on the index record for it.
     if com["type"] == "commentary":
         com["collectiveTitle"] = {
@@ -79,11 +79,10 @@ def format_link_object_for_client(link, with_text, ref, pos=None):
     else:
         com["collectiveTitle"] = {'en': linkRef.index.title, 'he': linkRef.index.get_title("he")}
 
-    if com["type"] != "commentary" and com["category"] == "Commentary":
-        com["category"] = "Quoting Commentary"
-
     if com["type"] == "essay":
-        com["category"] = "essay"
+        com["category"] = "Essay"
+    elif com["type"] != "commentary" and com["category"] == "Commentary":
+        com["category"] = "Quoting Commentary"
 
     if linkRef.index_node.primary_title("he"):
         com["heTitle"] = linkRef.index_node.primary_title("he")

--- a/sefaria/client/wrapper.py
+++ b/sefaria/client/wrapper.py
@@ -80,7 +80,10 @@ def format_link_object_for_client(link, with_text, ref, pos=None):
         com["collectiveTitle"] = {'en': linkRef.index.title, 'he': linkRef.index.get_title("he")}
 
     if com["type"] != "commentary" and com["category"] == "Commentary":
-            com["category"] = "Quoting Commentary"
+        com["category"] = "Quoting Commentary"
+
+    if com["type"] == "essay":
+        com["category"] = "essay"
 
     if linkRef.index_node.primary_title("he"):
         com["heTitle"] = linkRef.index_node.primary_title("he")

--- a/static/js/ConnectionFilters.jsx
+++ b/static/js/ConnectionFilters.jsx
@@ -147,7 +147,7 @@ TextFilter.propTypes = {
   updateRecent:    PropTypes.bool,
   inRecentFilters: PropTypes.bool,
   filterSuffix:    PropTypes.string,  // Optionally add a string to the filter parameter set (but not displayed)
-  enDisplayedText: PropTypes.string,  // displayedText fields used when link is 'essay' and we don't want to show the book title
+  enDisplayedText: PropTypes.string,  // displayedText fields used when link category is 'Essay' and we don't want to show the book title
   heDisplayedText: PropTypes.string,
 };
 

--- a/static/js/ConnectionsPanel.jsx
+++ b/static/js/ConnectionsPanel.jsx
@@ -1075,7 +1075,7 @@ class ConnectionsSummary extends Component {
 
     return (
       <div>
-        {isTopLevel ? essaySummary : null}
+        {isTopLevel && essaySummary}
         {connectionsSummary}
         {summaryToggle}
       </div>

--- a/static/js/TextList.jsx
+++ b/static/js/TextList.jsx
@@ -177,7 +177,7 @@ class TextList extends Component {
       }
     }.bind(this);
 
-    let sectionLinks = Sefaria.getLinksFromCacheAndPreprocess(sectionRef);
+    let sectionLinks = Sefaria.getLinksFromCache(sectionRef);
     sectionLinks.map(link => {
       if (!("anchorRefExpanded" in link)) { link.anchorRefExpanded = Sefaria.splitRangingRef(link.anchorRef); }
     });

--- a/static/js/sefaria/sefaria.js
+++ b/static/js/sefaria/sefaria.js
@@ -1511,7 +1511,7 @@ Sefaria = extend(Sefaria, {
           const newlinks = Sefaria.getLinksFromCache(r);
           links = links.concat(newlinks);
       });
-      links = links.filter(l => l["type"] === "essay");
+      links = links.filter(l => l["category"] === "Essay");
       return links.length > 0;
   },
   essayLinks: function(ref, versions) {
@@ -1523,7 +1523,7 @@ Sefaria = extend(Sefaria, {
     links = this._dedupeLinks(links); // by aggregating links to each ref above, we can get duplicates of links to spanning refs
     let essayLinks = [];
     for (let i=0; i<links.length; i++) {
-      if (links[i]["type"] === "essay" && "displayedText" in links[i]) {
+      if (links[i]["category"] === "Essay" && "displayedText" in links[i]) {
         const linkLang = links[i]["anchorVersion"]["language"];
         const currVersionTitle = versions[linkLang] ? versions[linkLang]["versionTitle"] : "NONE";
         const linkVersionTitle = links[i]["anchorVersion"]["title"];

--- a/static/js/sefaria/sefaria.js
+++ b/static/js/sefaria/sefaria.js
@@ -1476,15 +1476,15 @@ Sefaria = extend(Sefaria, {
     // Filters array `links` for only those that match array `filter`.
     // If `filter` ends with "|Quoting" return Quoting Commentary only,
     // otherwise commentary `filters` will return only links with type `commentary`
-    if (filter.length == 0) { return links; }
+    if (filter.length === 0) { return links; }
 
-    var filterAndSuffix = filter[0].split("|");
+    const filterAndSuffix = filter[0].split("|");
     filter              = [filterAndSuffix[0]];
-    var isQuoting       = filterAndSuffix.length == 2 && filterAndSuffix[1] == "Quoting";
-    var isEssay         = filterAndSuffix.length == 2 && filterAndSuffix[1] == "Essay";
-    var index           = Sefaria.index(filter);
-    var isCommentary    = index && !isQuoting &&
-                            (index.categories[0] == "Commentary" || index.primary_category == "Commentary");
+    const isQuoting       = filterAndSuffix.length === 2 && filterAndSuffix[1] === "Quoting";
+    const isEssay         = filterAndSuffix.length === 2 && filterAndSuffix[1] === "Essay";
+    const index           = Sefaria.index(filter);
+    const isCommentary    = index && !isQuoting &&
+                            (index.categories[0] === "Commentary" || index.primary_category === "Commentary");
 
     return links.filter(function(link){
       if (isCommentary && link.category !== "Commentary") { return false; }


### PR DESCRIPTION
## Description
Essay links do not show text in the Connections Panel.

## Code Changes
1. To get essay links to show up: TextList calls getLinksFromCache instead of getLinksFromCacheAndPreprocess because the preprocess function removes essay links thus preventing essay links from ever being shown in the TextList.
2. To make sure essay links don't show up when they shouldn't show up (they recently were showing up in "All Tanakh" links in a recent bug): Links API now makes the category of essay links "essay" instead of "commentary" or "tanakh".  This way essay links will never show up when the user views commentary or tanakh.
