### PR TITLE
Hebrew newsletter form sign up producing wrong data in Salesforce

### DIFF
--- a/sefaria/helper/crm/crm_connection_manager.py
+++ b/sefaria/helper/crm/crm_connection_manager.py
@@ -38,7 +38,7 @@ class CrmConnectionManager(object):
         """
         pass
 
-    def subscribe_to_lists(self, email, first_name=None, last_name=None, lang="en", educator=False):
+    def subscribe_to_lists(self, email, first_name=None, last_name=None, educator=False, lang="en"):
         CrmConnectionManager.validate_email(email)
         CrmConnectionManager.validate_name(first_name)
         CrmConnectionManager.validate_name(last_name)

--- a/sefaria/helper/crm/dummy_crm.py
+++ b/sefaria/helper/crm/dummy_crm.py
@@ -21,8 +21,8 @@ class DummyConnectionManager(CrmConnectionManager):
     def change_user_email(self, uid, new_email):
         return True
 
-    def subscribe_to_lists(self, email, first_name=None, last_name=None, lang="en", educator=False):
-        CrmConnectionManager.subscribe_to_lists(self, email, first_name, last_name, lang, educator)
+    def subscribe_to_lists(self, email, first_name=None, last_name=None, educator=False, lang="en"):
+        CrmConnectionManager.subscribe_to_lists(self, email, first_name, last_name, educator, lang)
         return True
 
     def find_crm_id(self, email=None):

--- a/sefaria/helper/crm/salesforce.py
+++ b/sefaria/helper/crm/salesforce.py
@@ -130,13 +130,13 @@ class SalesforceConnectionManager(CrmConnectionManager):
         email: str, 
         first_name: Optional[str] = None, 
         last_name: Optional[str] = None, 
-        lang: str = "en", 
         educator: bool = False,
+        lang: str = "en",
         mailing_lists: Optional[list[str]] = None) -> Any:
 
         mailing_lists = mailing_lists or []
 
-        CrmConnectionManager.subscribe_to_lists(self, email, first_name, last_name, lang, educator)
+        CrmConnectionManager.subscribe_to_lists(self, email, first_name, last_name, educator, lang)
         if lang == "he":
             language = "Hebrew"
         else:


### PR DESCRIPTION
## Description
This fixes the order and type of parameters sent to Salesforce. The interface language and educator fields were in the wrong order and causing Hebrew users to be signed up for the wrong version of the newsletter mailing lists.

## Notes
* The existing data on Salesforce from previous submissions also needs to be fixed using a one-time script or flow to correct the order of the fields.
* The user's desired newsletters may need to be resent from ActiveCampaign in their preferred language