### PR TITLE
fix(editor): fix for when editor incorrectly deletes text when first …

### DIFF
--- a/static/js/Editor.jsx
+++ b/static/js/Editor.jsx
@@ -249,8 +249,10 @@ export const deserialize = el => {
 
     if (ELEMENT_TAGS[nodeName]) {
         let new_children = children
-        if(!children[0]) {
-            new_children = [{'text':''}]
+        // for some reason, if there's only one child, and it's null, the editor crashes
+        // but null children are fine if there are multiple children
+        if(!children[0] && children.length === 1) {
+            new_children = [{'text':''}];
         }
         const attrs = {
             ...ELEMENT_TAGS[nodeName](el),

--- a/static/js/Editor.jsx
+++ b/static/js/Editor.jsx
@@ -251,7 +251,7 @@ export const deserialize = el => {
         let new_children = children
         // for some reason, if there's only one child, and it's null, the editor crashes
         // but null children are fine if there are multiple children
-        if(!children[0] && children.length === 1) {
+        if(!children[0] && children.length <= 1) {
             new_children = [{'text':''}];
         }
         const attrs = {


### PR DESCRIPTION
…child is null but there is other actual content.

## Description
When deserializing HTML nodes, if the first child is null the current editor will delete all children. This is due to a bug if there is only one child and it is null.

## Code Changes
The fix checks that the first child is NULL and there is only one child.