### PR TITLE
Logout from sheets module will redirect to sheets homepage

### DIFF
--- a/sefaria/views.py
+++ b/sefaria/views.py
@@ -13,7 +13,7 @@ from random import choice
 from django.utils.translation import ugettext as _
 from django.conf import settings
 from django.http import HttpResponse, HttpResponseRedirect, Http404, HttpResponseBadRequest
-from django.shortcuts import render, redirect
+from django.shortcuts import render, redirect, resolve_url
 from django.template.loader import render_to_string
 from django.template.response import TemplateResponse
 from django.utils.http import is_safe_url
@@ -83,7 +83,13 @@ class CustomLoginView(StaticViewMixin, LoginView):
     authentication_form = SefariaLoginForm
 
 class CustomLogoutView(StaticViewMixin, LogoutView):
-    pass
+
+    def get_next_page(self):
+        next_page = self.request.GET.get('next')
+        if next_page:
+            return resolve_url(next_page)
+        return super().get_next_page()
+
 
 class CustomPasswordResetDoneView(StaticViewMixin, PasswordResetDoneView):
     pass

--- a/static/js/Header.jsx
+++ b/static/js/Header.jsx
@@ -156,7 +156,7 @@ const LoggedInDropdown = ({module}) => {
                   <InterfaceText text={{'en': 'Help', 'he': 'עזרה'}}/>
               </DropdownMenuItemLink>
               <DropdownMenuSeparator/>
-              <DropdownMenuItemLink url={'/logout'}>
+              <DropdownMenuItemLink url={Sefaria.getLogoutUrl()}>
                   <InterfaceText text={{'en': 'Log Out', 'he': 'ניתוק'}}/>
               </DropdownMenuItemLink>
           </div>
@@ -534,7 +534,7 @@ const MobileNavMenu = ({onRefClick, showSearch, openTopic, openURL, close, visib
         <hr />
 
         {Sefaria._uid ?
-        <a href="/logout" className="logout">
+        <a href={Sefaria.getLogoutUrl()} className="logout">
           <img src="/static/icons/logout.svg" />
           <InterfaceText>Logout</InterfaceText>
         </a>
@@ -621,7 +621,7 @@ const ProfilePicMenu = ({len, url, name}) => {
               </a></div>
             </div>
             <hr className="interfaceLinks-hr"/>
-            <div><a className="interfaceLinks-row logout" id="logout-link" href="/logout">
+            <div><a className="interfaceLinks-row logout" id="logout-link" href={Sefaria.getLogoutUrl()}>
               <InterfaceText>Logout</InterfaceText>
             </a></div>
           </div> : null}

--- a/static/js/sefaria/sefaria.js
+++ b/static/js/sefaria/sefaria.js
@@ -3499,7 +3499,11 @@ _media: {},
       setResponse(prevResponses => !prevResponses ? tempResponses : prevResponses.concat(tempResponses));
       lastEndIndex += increment;
     }
-  }
+  },
+  getLogoutUrl: () => {
+    const next = Sefaria.activeModule === 'sheets' ? 'sheets' : 'texts';
+    return `/logout?next=/${next}`;
+  },
 });
 
 Sefaria.unpackDataFromProps = function(props) {


### PR DESCRIPTION
## Description
Previuously we've used the Django CustomLogoutView and defined  `LOGOUT_REDIRECT_URL`.
Now we'll override Django's `get_next_page`, and get the next page from the next param of the request.

## Code Changes
sefaria.js -  add function `getLogoutUrl` that defines once the logout url with the next param according to the module.
Header.jsx - use `getLogoutUrl` anywhere rather than a magic string.
sefaria/views.py - override `CustomLogoutView.get_next_page` for getting next from the url params if exists, rather fall to Django's `get_next_page`.