### PR TITLE
encodeURIComponent in history

### DIFF
--- a/static/js/ReaderApp.jsx
+++ b/static/js/ReaderApp.jsx
@@ -771,8 +771,12 @@ class ReaderApp extends Component {
         }
       }
     }
-    // Replace the first only & with a ?
-    hist.url = hist.url.replace(/&/, "?");
+    // Encode the path and replace the first only & with a ?
+    const ampersandIndex = hist.url.indexOf('&');
+    let path = ampersandIndex !== -1 ? hist.url.slice(0, ampersandIndex) : hist.url;
+    path =  path.split('/').map(p => encodeURIComponent(p)).join('/');
+    const params = ampersandIndex !== -1 ? '?' + hist.url.slice(ampersandIndex+1) : '';
+    hist.url = `${path}${params}`;
 
     return hist;
   }

--- a/static/js/ReaderApp.jsx
+++ b/static/js/ReaderApp.jsx
@@ -771,7 +771,11 @@ class ReaderApp extends Component {
         }
       }
     }
-    // Encode the path and replace the first only & with a ?
+    // The URL currently has two problems:
+    // 1. The path is not encoded. For example, a book title might contain characters like '?' that should be encoded,
+    //    while '/' should be preserved as a separator.
+    // 2. The query parameters are all concatenated using an '&', but the first one should start with a '?'.
+    // This bloc fixes both issues.
     const ampersandIndex = hist.url.indexOf('&');
     let path = ampersandIndex !== -1 ? hist.url.slice(0, ampersandIndex) : hist.url;
     path =  path.split('/').map(p => encodeURIComponent(p)).join('/');


### PR DESCRIPTION
## Description
Unfortunately we're using our ouw router for saving history.
In this router we're using the index title which can contain a wuestion mark, and break the url when refreshing.
The best would be encoding components when neccesary, but the url making has a toocomplicated code with many options.
This fix takes the final stage of the url making, when we replace the first `&` to `?`, and encode the path only, with escaping from encoding slashed.
