### PR TITLE
fix(editor): replace line breaks with spaces in parseSheetItemHTML

### DIFF
--- a/static/js/Editor.jsx
+++ b/static/js/Editor.jsx
@@ -538,7 +538,10 @@ function flattenLists(htmlString) {
 }
 
 function parseSheetItemHTML(rawhtml) {
-    let preparseHtml = rawhtml.replace(/\u00A0/g, ' ').replace(/(\r\n|\n|\r|\t)/gm, "");
+    // replace non-breaking spaces with regular spaces and replace line breaks with spaces
+    let preparseHtml = rawhtml
+      .replace(/\u00A0/g, ' ')
+      .replace(/(\r\n|\n|\r|\t)/gm, " ");
     // Nested lists are not supported in new editor, so flatten nested lists created with old editor into one depth lists:
     preparseHtml = flattenLists(preparseHtml);
     const parsed = new DOMParser().parseFromString(preparseHtml, 'text/html');


### PR DESCRIPTION
This pull request makes a minor improvement to the `parseSheetItemHTML` function in `static/js/Editor.jsx` by adding a clarifying comment to explain the purpose of replacing non-breaking spaces and line breaks in the `preparseHtml` variable.

* [`static/js/Editor.jsx`](diffhunk://#diff-0edb809ee68c59c1469d28011e2d3be7af1cc5f8ab4d6a994150091983abfa41L541-R544): Added a comment to describe the replacement of non-breaking spaces with regular spaces and line breaks with spaces in the `parseSheetItemHTML` function.## Description
_A brief description of the PR_

## Code Changes
_The following changes were made to the files below_

## Notes
_Any additional notes go here_