### PR TITLE
chore: replace initialSearchType with activeModule

### DIFF
--- a/reader/views.py
+++ b/reader/views.py
@@ -820,7 +820,6 @@ def search(request):
     props={
         "initialMenu": "search",
         "initialQuery": search_params["query"],
-        "initialSearchType": search_params["tab"],
         "initialSearchFilters": search_params["filters"],
         "initialSearchFilterAggTypes": search_params["filterAggTypes"],
         "initialSearchField": search_params["field"],

--- a/sourcesheets/views.py
+++ b/sourcesheets/views.py
@@ -1043,7 +1043,6 @@ def sheets_with_ref(request, tref):
     search_params = get_search_params(request.GET)
 
     props={
-        "initialSearchType": "sheet",
         "initialSearchField": search_params["field"],
         "initialSearchFilters": search_params["filters"],
         "initialSearchFilterAggTypes": search_params["filterAggTypes"],

--- a/static/js/ReaderApp.jsx
+++ b/static/js/ReaderApp.jsx
@@ -45,7 +45,7 @@ class ReaderApp extends Component {
     // Currently these get generated in reader/views.py then regenerated again in ReaderApp.
     this.MIN_PANEL_WIDTH       = 360.0;
     let panels                 = [];
-    const searchType = props.initialSearchType || 'text';  // should really be set by URL such as sheets.sefaria.org or www.sefaria.org
+    const searchType = SearchState.moduleToSearchType(Sefaria.activeModule);
     if (props.initialMenu) {
       // If a menu is specified in `initialMenu`, make a panel for it
       panels[0] = {
@@ -148,7 +148,7 @@ class ReaderApp extends Component {
       translationsSlug:        state.translationsSlug        || null,
       searchQuery:             state.searchQuery             || null,
       showHighlight:           state.showHighlight           || null,
-      searchState:             state.searchState             || new SearchState({ type: this.props.initialSearchType || 'text' }),
+      searchState:             state.searchState             || new SearchState({ type: SearchState.moduleToSearchType(Sefaria.activeModule)}),
       compare:                 state.compare                 || false,
       openSidebarAsConnect:    state.openSidebarAsConnect    || false,
       bookRef:                 state.bookRef                 || null,
@@ -1204,7 +1204,7 @@ toggleSignUpModal(modalContentKind = SignUpModalKind.Default) {
           filtersValid: true,
           aggregationsToUpdate,
         }) : new SearchState({
-        type: this.props.initialSearchType || 'text',
+        type: SearchState.moduleToSearchType(Sefaria.activeModule),
         availableFilters,
         filterRegistry,
         orphanFilters,
@@ -1716,7 +1716,7 @@ toggleSignUpModal(modalContentKind = SignUpModalKind.Default) {
   showSearch(searchQuery) {
     const hasSearchState = !!this.state.panels && this.state.panels.length && !!this.state.panels[0].searchState;
     const searchState =  hasSearchState  ? this.state.panels[0].searchState.update({ filtersValid: false })
-        : new SearchState({ type: this.props.initialSearchType || 'text'});
+        : new SearchState({ type: SearchState.moduleToSearchType(Sefaria.activeModule)});
     this.setSinglePanelState({mode: "Menu", menuOpen: "search", searchQuery, searchState });
   }
   searchInCollection(searchQuery, collection) {
@@ -2285,7 +2285,6 @@ ReaderApp.propTypes = {
   initialMenu:                 PropTypes.string,
   initialCollection:           PropTypes.string,
   initialQuery:                PropTypes.string,
-  initialSearchType:           PropTypes.string,
   initialSearchFilters:        PropTypes.array,
   initialSearchField:          PropTypes.string,
   initialSearchSortType:       PropTypes.string,

--- a/static/js/sefaria/searchState.js
+++ b/static/js/sefaria/searchState.js
@@ -1,5 +1,6 @@
 import Util from './util';
 import FilterNode from './FilterNode';
+import Sefaria from "./sefaria";
 
 class SearchState {
   constructor({
@@ -118,6 +119,10 @@ class SearchState {
       }
     }
     return true;
+  }
+
+  static moduleToSearchType(active_module) {
+    return active_module === 'library' ? 'text' : 'sheet';
   }
 
   makeURL({ prefix, isStart }) {

--- a/static/js/sefaria/searchState.js
+++ b/static/js/sefaria/searchState.js
@@ -1,6 +1,5 @@
 import Util from './util';
 import FilterNode from './FilterNode';
-import Sefaria from "./sefaria";
 
 class SearchState {
   constructor({


### PR DESCRIPTION
## Description
Search modularization was done this previous summer, but there is one last step that we had to put off, which is that search pages need to display differently based on active module.  This implements that change.

## Code Changes
initialSearchType was a placeholder for activeModule.  It's now replaced.  One decision that may be questionable is to use a conversion function moduleToSearchType and place it into searchstate.js.