### PR TITLE
fix: sheets banner spacing

### DIFF
--- a/static/js/Misc.jsx
+++ b/static/js/Misc.jsx
@@ -2074,10 +2074,15 @@ const GenericBanner = ({message, children}) => {
 
 const LearnAboutNewEditorBanner = () => {
   const cookieName = "learned_about_new_editor";
-  const shouldShowNotification = Sefaria._inBrowser && !document.cookie.includes(cookieName);
-  const [showNotification, toggleShowNotification] = useState(shouldShowNotification);
+  const initialShouldShowNotification = !$.cookie(cookieName);
+  const [showNotification, setShowNotification] = useState(false);
   const [enURL, heURL] = ["/sheets/393695", "/sheets/399333"];
   const linkURL = Sefaria._v({en: enURL, he: heURL});
+
+  useEffect(() => {
+    // Force rerendering of the component when initially rendered by ssr
+    setShowNotification(initialShouldShowNotification);
+  }, [initialShouldShowNotification]);
 
   const handleLearnMoreClick = () => {
     window.open(linkURL, '_blank');
@@ -2085,7 +2090,7 @@ const LearnAboutNewEditorBanner = () => {
 
   const setCookie = () => {
     $.cookie(cookieName, 1, {path: "/", expires: 20*365});
-    toggleShowNotification(false);
+    setShowNotification(false);
   }
 
   if (!showNotification) {


### PR DESCRIPTION
This pull request refactors the `LearnAboutNewEditorBanner` component in `static/js/Misc.jsx` to improve state handling and ensure proper behavior when rendered on the server side. The key changes involve replacing the state initialization logic and introducing a `useEffect` hook to manage state updates.
