### PR TITLE
fix: Prevent mangling of , (and other chars?) on URL

### DIFF
--- a/static/js/ReaderApp.jsx
+++ b/static/js/ReaderApp.jsx
@@ -771,16 +771,8 @@ class ReaderApp extends Component {
         }
       }
     }
-    // The URL currently has two problems:
-    // 1. The path is not encoded. For example, a book title might contain characters like '?' that should be encoded,
-    //    while '/' should be preserved as a separator.
-    // 2. The query parameters are all concatenated using an '&', but the first one should start with a '?'.
-    // This bloc fixes both issues.
-    const ampersandIndex = hist.url.indexOf('&');
-    let path = ampersandIndex !== -1 ? hist.url.slice(0, ampersandIndex) : hist.url;
-    path =  path.split('/').map(p => encodeURIComponent(p)).join('/');
-    const params = ampersandIndex !== -1 ? '?' + hist.url.slice(ampersandIndex+1) : '';
-    hist.url = `${path}${params}`;
+    // Replace the first only & with a ?
+    hist.url = hist.url.replace(/&/, "?");
 
     return hist;
   }


### PR DESCRIPTION
Revert "fix(makeHistory): use encodeURIComponent on title for encoding question marks in history."

This reverts commit ea2ddb306980a14732bbb152ae67dfdd3a1ce30e.

## Description
_A brief description of the PR_

## Code Changes
_The following changes were made to the files below_

## Notes
_Any additional notes go here_