### PR TITLE
Encode manually question mark in titles in makeHistoryState.

### DIFF
--- a/static/js/ReaderApp.jsx
+++ b/static/js/ReaderApp.jsx
@@ -773,7 +773,7 @@ class ReaderApp extends Component {
     }
     // Replace question marks that can be included in titles
     // (not using encodeURIComponent for this can run twice and encode the % of the first running)
-    hist.url = hist.url.replace('?', '%3F')
+    hist.url = hist.url.replace(/\?/g, '%3F')
     // Replace the first only & with a ?
     hist.url = hist.url.replace(/&/, "?");
 

--- a/static/js/ReaderApp.jsx
+++ b/static/js/ReaderApp.jsx
@@ -771,16 +771,11 @@ class ReaderApp extends Component {
         }
       }
     }
-    // The URL currently has two problems:
-    // 1. The path is not encoded. For example, a book title might contain characters like '?' that should be encoded,
-    //    while '/' should be preserved as a separator.
-    // 2. The query parameters are all concatenated using an '&', but the first one should start with a '?'.
-    // This bloc fixes both issues.
-    const ampersandIndex = hist.url.indexOf('&');
-    let path = ampersandIndex !== -1 ? hist.url.slice(0, ampersandIndex) : hist.url;
-    path =  path.split('/').map(p => encodeURIComponent(p)).join('/');
-    const params = ampersandIndex !== -1 ? '?' + hist.url.slice(ampersandIndex+1) : '';
-    hist.url = `${path}${params}`;
+    // Replace question marks that can be included in titles
+    // (not using encodeURIComponent for this can run twice and encode the % of the first running)
+    hist.url = hist.url.replace('?', '%3F')
+    // Replace the first only & with a ?
+    hist.url = hist.url.replace(/&/, "?");
 
     return hist;
   }


### PR DESCRIPTION
## Description
We want to support question marks in titles. `makeHistoryState` creates the url in a very complicated way, so it's hard to say where exactly the ref can be inserted and handle it. Here we are changing the ? to %3F after making the whole url, and before inserting the question marks that signs the params part.

## Notes
using encodeURIComponent cause problems for it can run twice so in the first time it will change ? to %3F and in the second it will encode the %. Also, it seems we support commas in the url and are changing space to underscores, so encodeURIComponent do more than we want.