### PR TITLE
fix(editor): remove extra spaces between HTML tags in preparseHtml

### DIFF
--- a/static/js/Editor.jsx
+++ b/static/js/Editor.jsx
@@ -544,6 +544,8 @@ function parseSheetItemHTML(rawhtml) {
       .replace(/(\r\n|\n|\r|\t)/gm, " ");
     // Nested lists are not supported in new editor, so flatten nested lists created with old editor into one depth lists:
     preparseHtml = flattenLists(preparseHtml);
+    // remove extra spaces between html tags - new editor table deserialization doesn't like them
+    preparseHtml = preparseHtml.replace(/>\s+</g, '><');
     const parsed = new DOMParser().parseFromString(preparseHtml, 'text/html');
     const fragment = deserialize(parsed.body);
     const slateJSON = fragment.length > 0 ? fragment : [{text: ''}];


### PR DESCRIPTION
## Description
_A brief description of the PR_

## Code Changes
_The following changes were made to the files below_

## Notes
_Any additional notes go here_