### PR TITLE
Encode question marks in titles from autocpmleter

### DIFF
--- a/static/js/HeaderAutocomplete.jsx
+++ b/static/js/HeaderAutocomplete.jsx
@@ -147,6 +147,7 @@ const SearchSuggestionInner = ({ value, type, displayedLabel, label, url, pic,
                                 wrapperClasses,
                               universalIndex, highlightedIndex, getItemProps, onClick}) => {
   const isHebrew = Sefaria.hebrew.isHebrew(label);
+  url = url?.replace(/\?/g, '%3F');
   return (
       <a href={url} onClick={onClick} className={`search-suggestion-link-wrapper ${wrapperClasses}`}>
           <div
@@ -442,7 +443,7 @@ export const HeaderAutocomplete = ({onRefClick, showSearch, openTopic, openURL, 
     const redirectToObject = (onChange, item) => {
         Sefaria.track.event("Search", `Search Box Navigation - ${item.type}`, item.key);
         clearSearchBox(onChange);
-        const url = item.url
+        const url = item.url.replace(/\?/g, '%3F');
         const handled = openURL(url);
         if (!handled) {
           window.location = url;

--- a/static/js/ReaderApp.jsx
+++ b/static/js/ReaderApp.jsx
@@ -1166,13 +1166,14 @@ toggleSignUpModal(modalContentKind = SignUpModalKind.Default) {
     } else if (path.match(/^\/translations\/.+/)) {
       let slug = path.slice(14);
       this.openTranslationsPage(slug);
-    } else if (Sefaria.isRef(path.slice(1))) {
+    } else if (Sefaria.isRef(path.slice(1).replace(/%3F/g, '?'))) {
+      const ref = path.slice(1).replace(/%3F/g, '?');
       const currVersions = {
         en: Sefaria.util.getObjectFromUrlParam(params.get("ven")),
         he: Sefaria.util.getObjectFromUrlParam(params.get("vhe"))
       };
-      const options = {showHighlight: path.slice(1).indexOf("-") !== -1};   // showHighlight when ref is ranged
-      openPanel(Sefaria.humanRef(path.slice(1)), currVersions, options);
+      const options = {showHighlight: ref.indexOf("-") !== -1};   // showHighlight when ref is ranged
+      openPanel(Sefaria.humanRef(ref), currVersions, options);
     } else {
       return false
     }

--- a/static/js/sefaria/sefaria.js
+++ b/static/js/sefaria/sefaria.js
@@ -19,7 +19,7 @@ let Sefaria = Sefaria || {
   books: [],
   booksDict: {},
   last_place: [],
-  apiHost: "" // Defaults to localhost, override to talk another server
+  apiHost: "https://www.sefaria.org" // Defaults to localhost, override to talk another server
 };
 
 if (typeof window !== 'undefined') {

--- a/static/js/sefaria/sefaria.js
+++ b/static/js/sefaria/sefaria.js
@@ -19,7 +19,7 @@ let Sefaria = Sefaria || {
   books: [],
   booksDict: {},
   last_place: [],
-  apiHost: "https://www.sefaria.org" // Defaults to localhost, override to talk another server
+  apiHost: "" // Defaults to localhost, override to talk another server
 };
 
 if (typeof window !== 'undefined') {


### PR DESCRIPTION
## Code Changes
HeaderAutocomplete.jsx - Encode the question marks for using the url in openURL and href
ReaderApp.jsx - Return them to be question marks where we're treating them as refs.