### PR TITLE
chore(question mark): control for question mark in templating url and…

### DIFF
--- a/sefaria/model/text.py
+++ b/sefaria/model/text.py
@@ -4721,7 +4721,7 @@ class Ref(object, metaclass=RefCacheType):
         :return string: normal url form
         """
         if not self._url:
-            self._url = self.normal().replace(" ", "_").replace(":", ".")
+            self._url = self.normal().replace(" ", "_").replace(":", ".").replace("?", "%3F")
 
             # Change "Mishna_Brachot_2:3" to "Mishna_Brachot.2.3", but don't run on "Mishna_Brachot"
             if len(self.sections) > 0:

--- a/sefaria/model/topic.py
+++ b/sefaria/model/topic.py
@@ -64,7 +64,7 @@ class AuthorIndexAggregation(AuthorWorksAggregation):
         return self._index.get_title(lang)
 
     def get_url(self):
-        return f'/{self._index.title.replace(" ", "_")}'
+        return f'/{self._index.title.replace(" ", "_").replace("?", "%3F")}'
 
 
 class AuthorCategoryAggregation(AuthorWorksAggregation):

--- a/static/js/VersionBlock/VersionBlock.jsx
+++ b/static/js/VersionBlock/VersionBlock.jsx
@@ -127,8 +127,9 @@ class VersionBlock extends Component {
       payloadVersion.newVersionTitle = this.state.versionTitle;
     }
     this.setState({"error": "Saving.  Page will reload on success."});
+    const title = v.title.replace(/\?/g, "%3F");
     $.ajax({
-      url: `/api/version/flags/${v.title}/${v.language}/${v.versionTitle}`,
+      url: `/api/version/flags/${title}/${v.language}/${v.versionTitle}`,
       dataType: 'json',
       type: 'POST',
       data: {json: JSON.stringify(payloadVersion)},


### PR DESCRIPTION
This pull request addresses URL encoding issues by ensuring that question marks (`?`) are properly encoded as `%3F` in generated URLs. The changes are implemented in both the backend and frontend to maintain consistency.

### Backend Changes:
* In `sefaria/model/text.py`, the `url` method now replaces `?` with `%3F` when generating URLs to ensure proper encoding.

### Frontend Changes:
* In `static/js/VersionBlock/VersionBlock.jsx`, the `title` variable is updated to replace `?` with `%3F` before being used in the URL for an API request, ensuring consistency with the backend encoding.