### PR TITLE
fix: Add indexes for calendar collections

### DIFF
--- a/sefaria/system/database.py
+++ b/sefaria/system/database.py
@@ -177,6 +177,17 @@ def ensure_indices(active_db=None):
         ('messages', [[("room_id", pymongo.ASCENDING), ("timestamp", pymongo.DESCENDING)]], {}),
         ('vstate', ["title"], {}),
         ('vstate', ["flags.enComplete"], {}),
+        ('daily_mishnayot',["date"], {}),
+        ('dafyomi', ["date"], {}),
+        ('daily_rambam', ["date"], {}),
+        ('arukh_hashulchan', ["date"], {}),
+        ('daily_rambam_three', ["date"], {}),
+        ('tanakh_yomi', ["date"], {}),
+        ('daily_tikkunei_zohar', ["date"], {}),
+        ('daf_weekly', ["date"], {}),
+        ('halakhah_yomit', ["date"], {}),
+        ('parshiot', ["date"], {}), # Also parsha name?
+        ('tanya_yomi', ["date"],  {}),
     ]
 
     for col, args, kwargs in indices:


### PR DESCRIPTION
## Description
These calendar requests are stable across a day.  They're putting repetitive unnecessary pressure on mongo. They could be cached at a higher level.   But at least, this speeds them up by putting indexes on the collections.

