### PR TITLE
Fix question mark in index title break navigation

### DIFF
--- a/reader/views.py
+++ b/reader/views.py
@@ -291,7 +291,7 @@ def catchall(request, tref, sheet=None):
         except InputError:
             raise Http404
 
-        uref = oref.url()
+        uref = oref.url(False)
         if uref and tref != uref:
             return reader_redirect(uref)
 

--- a/sefaria/model/text.py
+++ b/sefaria/model/text.py
@@ -4716,21 +4716,29 @@ class Ref(object, metaclass=RefCacheType):
         """
         return TextChunk(self, lang, vtitle, exclude_copyrighted=exclude_copyrighted)
 
-    def url(self):
+    def url(self, encode_html=True):
         """
         :return string: normal url form
         """
-        if not self._url:
-            self._url = self.normal().replace(" ", "_").replace(":", ".").replace("?", "%3F")
+        if not self._url or not encode_html:
+            url = self.normal()
+
+            html_encoding_map = {'?': '%3F'}
+            pretty_url_map = {' ': '_', ':': '.'}
+            replace_map = pretty_url_map if not encode_html else pretty_url_map | html_encoding_map
+            for key, value in replace_map.items():
+                url = url.replace(key, value)
 
             # Change "Mishna_Brachot_2:3" to "Mishna_Brachot.2.3", but don't run on "Mishna_Brachot"
             if len(self.sections) > 0:
-                last = self._url.rfind("_")
-                if last == -1:
-                    return self._url
-                lref = list(self._url)
-                lref[last] = "."
-                self._url = "".join(lref)
+                last = url.rfind("_")
+                if last != -1:
+                    lref = list(url)
+                    lref[last] = "."
+                    url = "".join(lref)
+            if not encode_html:
+                return url
+            self._url = url
         return self._url
 
     def noteset(self, public=True, uid=None):

--- a/sefaria/model/text.py
+++ b/sefaria/model/text.py
@@ -4731,11 +4731,8 @@ class Ref(object, metaclass=RefCacheType):
 
             # Change "Mishna_Brachot_2:3" to "Mishna_Brachot.2.3", but don't run on "Mishna_Brachot"
             if len(self.sections) > 0:
-                last = url.rfind("_")
-                if last != -1:
-                    lref = list(url)
-                    lref[last] = "."
-                    url = "".join(lref)
+                url = '.'.join(url.rsplit('_', 1))
+
             if not encode_html:
                 return url
             self._url = url

--- a/sefaria/model/text.py
+++ b/sefaria/model/text.py
@@ -4718,6 +4718,7 @@ class Ref(object, metaclass=RefCacheType):
 
     def url(self, encode_html=True):
         """
+        :param encode_html: boolean - True for encoding also HTML chars, or only our own things (like space to underscore)
         :return string: normal url form
         """
         if not self._url or not encode_html:


### PR DESCRIPTION
## Description
In previous fix we've changed also the `Ref.url` in the server side to encode question mark with `%3f`. This cause to a situation where the client side requests some ref with `%3F` and get 301 to the same url, because Django returns the question mark, and the server side thinks it's different from the normal url ref.

## Code Changes
The `url` method now have a new default arg for getting the url without HTML encoding (i.e. with a question mark rather than `%3F`).
Noth that this method also sets the value of `._url`, and this attribute will remain encoded.
Also I've refactored the way we're replacing the last occurrence of underscore.