### PR TITLE
Fix sheets tags test case

### DIFF
--- a/reader/tests.py
+++ b/reader/tests.py
@@ -118,7 +118,7 @@ class PagesTest(SefariaTestCase):
         response = c.get('/sheets/new?editor=1')
         self.assertEqual(200, response.status_code)
 
-    def test_new_sheet(self):
+    def test_sheets_tags(self):
         response = c.get('/sheets/tags')
         self.assertEqual(200, response.status_code)
 
@@ -722,11 +722,11 @@ class PostTextNameChange(SefariaTestCase):
         self.assertEqual(0, IndexSet({"title": "Ploni"}).count())
         self.assertEqual(1, IndexSet({"title": "Shmoni"}).count())
 
-        # Check change propogated to Links
+        # Check change propagated to Links
         self.assertEqual(0, VersionSet({"title": "Ploni on Job"}).count())
         self.assertEqual(1, VersionSet({"title": "Shmoni on Job"}).count())
 
-        # Check change propogated to Links
+        # Check change propagated to Links
         self.assertEqual(0, LinkSet({"refs": {"$regex": "^Ploni on Job"}}).count())
         self.assertEqual(3, LinkSet({"refs": {"$regex": "^Shmoni on Job"}}).count())
 


### PR DESCRIPTION
## Description
This small PR fixes the `test_new_sheet` test case which is silently ignored due to duplication. 

## Code Changes
The PR renames one of the `test_new_sheet` tests. It also fixes a small typo along the way.

## Notes