### PR TITLE
chore: preview popup does not close

### DIFF
--- a/static/js/Misc.jsx
+++ b/static/js/Misc.jsx
@@ -3077,7 +3077,7 @@ const Autocompleter = ({getSuggestions, showSuggestionsOnSelect, inputPlaceholde
       }
 
       {previewText ?
-          <div className="textPreviewContainer">
+          <div className="textPreviewContainer" onMouseDown={(e) => e.preventDefault()}>
             <div className="textPreview">
               <div className="inner">{previewText}</div>
             </div>


### PR DESCRIPTION
## Description
Don't close autocomplete popup unless user clicks outside of the popup.