### PR TITLE
Make Editor Elemets Covered by Icon Flexbox Clickable

### DIFF
--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -9341,6 +9341,10 @@ body.interface-english .publishBox .react-tags__suggestions ul {
   justify-content: space-between;
   top: 80px;
   z-index: 1;
+  pointer-events: none; /* make editor elements covered by the icons horizontal box clickable and interactable  */
+}
+.floatingEditorIcons > * {
+  pointer-events: auto; /* Children (icons) can still be clicked */
 }
 .interface-hebrew .floatingEditorIcons{
     flex-direction: row-reverse;


### PR DESCRIPTION
…ing icons

## Description
This pull request introduces changes to the `static/css/s2.css` file to improve the user interaction with floating editor icons. Specifically, it ensures that elements covered by the icons remain clickable while maintaining the interactivity of the icons themselves.

### Enhancements to user interaction:

* [`static/css/s2.css`](diffhunk://#diff-955c39f598ccfd3089cc912d24ee511b4b30f3c61ee73569fc4bce4d390c3877R9344-R9347): Added `pointer-events: none` to the `.publishBox .react-tags__suggestions ul` selector to ensure editor elements beneath the floating icons are clickable and interactable. Additionally, added `pointer-events: auto` to `.floatingEditorIcons > *` to preserve the clickability of the icons themselves.
## Code Changes
_The following changes were made to the files below_

## Notes
_Any additional notes go here_