### PR TITLE
Fix admin/reset/index

### DIFF
--- a/sefaria/views.py
+++ b/sefaria/views.py
@@ -725,9 +725,10 @@ def reset_ref(request, tref):
     if oref.is_book_level():
         model.library.refresh_index_record_in_cache(oref.index)
         model.library.reset_text_titles_cache()
-        vs = model.VersionState(index=oref.index)
+        index = model.library.get_index(tref)  # Get a fresh instance of the index
+        vs = model.VersionState(index=index)
         vs.refresh()
-        model.library.update_index_in_toc(oref.index)
+        model.library.update_index_in_toc(index)
 
         if MULTISERVER_ENABLED:
             server_coordinator.publish_event("library", "refresh_index_record_in_cache", [oref.index.title])


### PR DESCRIPTION
## Description
Fixes a bug with admin/reset/index after changing an index structure.

## Code Changes
In views.py, get a fresh instance of the index after refreshing cache, rather than get it from Ref that was loaded before. That fixes the bug with admin/reset/index.
