### PR TITLE
Exclude <a> tags from being wrapped again.

### DIFF
--- a/sefaria/model/tests/library_test.py
+++ b/sefaria/model/tests/library_test.py
@@ -310,6 +310,11 @@ class Test_he_get_refs_in_text(object):
         wrapped = library.get_wrapped_refs_string(st, lang="he", citing_only=True)
         assert wrapped != res and wrapped == st
 
+    def test_already_wrapped_refs(self):
+        st = 'wick (<a class="refLink" data-ref="Jerusalem Talmud Shabbat 2:3:2" href="/Jerusalem_Talmud_Shabbat.2.3.2">Note 16</a>) and'
+        wrapped = library.get_wrapped_refs_string(st, lang="en")
+        assert wrapped == st
+
 
 class Test_get_titles_in_text(object):
 

--- a/sefaria/model/text.py
+++ b/sefaria/model/text.py
@@ -6024,9 +6024,9 @@ class Library(object):
             substrings = re.split(html_a_tag_reg, st)
         new_string = ''
         for i, substring in enumerate(substrings):
-            if i // 2 != i / 2:  # An <a> tag
+            if i % 2 == 1:  # An <a> tag
                 new_string += substring
-            elif i // 2 == i / 2 and substring:
+            elif i % 2 == 0 and substring:
                 new_string += self.apply_action_for_all_refs_in_string(substring, self._wrap_ref_match, lang,
                                                                        citing_only, reg, title_nodes)
         return new_string

--- a/sefaria/model/text.py
+++ b/sefaria/model/text.py
@@ -6017,8 +6017,11 @@ class Library(object):
         :param citing_only: boolean whether to use only records explicitly marked as being referenced in text
         :return: string:
         """
-        html_a_tag_reg = '(<a [^<>]*>.*?</a>)'  # Assuming no nested <a> within <a>
-        substrings = re.split(html_a_tag_reg, st)
+        if '<a' not in st:  # This is 30 times faster than re.split, and applies for most cases
+            substrings = [st]
+        else:
+            html_a_tag_reg = '(<a [^<>]*>.*?</a>)'  # Assuming no nested <a> within <a>
+            substrings = re.split(html_a_tag_reg, st)
         new_string = ''
         for i, substring in enumerate(substrings):
             if i // 2 != i / 2:  # An <a> tag

--- a/sefaria/model/text.py
+++ b/sefaria/model/text.py
@@ -6017,7 +6017,7 @@ class Library(object):
         :param citing_only: boolean whether to use only records explicitly marked as being referenced in text
         :return: string:
         """
-        if '<a' not in st:  # This is 30 times faster than re.split, and applies for most cases
+        if '<a ' not in st:  # This is 30 times faster than re.split, and applies for most cases
             substrings = [st]
         else:
             html_a_tag_reg = '(<a [^<>]*>.*?</a>)'  # Assuming no nested <a> within <a>

--- a/sefaria/model/text.py
+++ b/sefaria/model/text.py
@@ -6009,14 +6009,24 @@ class Library(object):
 
     def get_wrapped_refs_string(self, st, lang=None, citing_only=False, reg=None, title_nodes=None):
         """
-        Returns a string with the list of Ref objects derived from string wrapped in <a> tags
+        Returns a string with the list of Ref objects derived from string wrapped in <a> tags,
+        excluding refs that are already wrapped in the data
 
         :param string st: the input string
         :param lang: "he" or "en"
         :param citing_only: boolean whether to use only records explicitly marked as being referenced in text
         :return: string:
         """
-        return self.apply_action_for_all_refs_in_string(st, self._wrap_ref_match, lang, citing_only, reg, title_nodes)
+        html_a_tag_reg = '(<a [^<>]*>.*?</a>)'  # Assuming no nested <a> within <a>
+        substrings = re.split(html_a_tag_reg, st)
+        new_string = ''
+        for i, substring in enumerate(substrings):
+            if i // 2 != i / 2:  # An <a> tag
+                new_string += substring
+            elif i // 2 == i / 2 and substring:
+                new_string += self.apply_action_for_all_refs_in_string(substring, self._wrap_ref_match, lang,
+                                                                       citing_only, reg, title_nodes)
+        return new_string
 
     def apply_action_for_all_refs_in_string(self, st, action, lang=None, citing_only=None, reg=None, title_nodes=None):
         """


### PR DESCRIPTION
## Description
In our data we have `<a>` tags. When requestong for it our links wrapper doesn't consider that, so they can be re-wrapped, or worse, their ref attributes cab be wrapped, ruining the html structure.
This PR excludes the a tags from being wrapped.

## Code Changes
In `get_wrapped_refs_string` the a tags are splitted out by regex, and the wrapping applied only on the other substrings.
The regex assume we have no `<a>` tags nested within `<a>` tags (which we shouldn't have).

## Performance
We have 2 cases:
1. segment without <a> tags - `re.split` takes time (~3ms for 'normal' segment), and for that reason I've added an if statement that takes ~0.1ms for a 'normal' segment, so a section request will take few ms more than previously.
2. segment with <a> tags - here we apply `re.split`, and have more calls to `apply_action_for_all_refs_in_string`, but on the other hand, any call takes much shorter string, which has a big influence for the regex parsing which this function does. In a check on Jerusalem Talmud Shabbat 2:5:1, we have *gained* more than 10ms for the section request (and it has also Hebrew that has no tags).