### PR TITLE
Create new `change_lexicon_headword` func

### DIFF
--- a/sefaria/helper/schema.py
+++ b/sefaria/helper/schema.py
@@ -1070,7 +1070,7 @@ def change_lexicon_headword(parent_lexicon, old_headword, new_headword):
         needs_rewrite = lambda x, *args: bool(re.search(old_ref_reg, x))
         cascade(index.title, rewriter, needs_rewrite, True)
 
-    #word forms
+    # word forms
     print('Updating word forms')
     db.word_form.update_many(
         {


### PR DESCRIPTION
## Description
Create new `change_lexicon_headword` functuin for safely changing headwords. It will:

- change the entry itself
- change prev and next entries' `next` and `prev` attributes.
- change index `firstWord`, `lastWord` and `headwordsMap` if needed.
- change links' refs
- change word forms