### PR TITLE
Fix Annual Report Dispaly on iOS

### DIFF
--- a/templates/static/annualreport.html
+++ b/templates/static/annualreport.html
@@ -14,8 +14,34 @@
             position:absolute; left: 0; right: 0; bottom: 0; top: 0px;
         }
     </style>
+    <script>
+      const isIOS = () => /iPad|iPhone|iPod/.test(navigator.userAgent);
+
+      document.addEventListener('DOMContentLoaded', () => {
+        const frame = document.getElementById('pdfFrame');
+        if (!frame) return;
+
+        // Create a button to open the annual report PDF in a separate tab/window
+        // PDFs don't work in iFrames on iOS
+        // Remove the broken inline frame
+        if (isIOS()) {
+          const link = document.createElement('a');
+          link.href = frame.src;
+          link.target = '_blank';
+          link.rel = 'noopener';
+          link.textContent = 'Tap here to open the annual report (PDF)';
+          link.style.display = 'block';
+          link.style.padding = '3rem';
+          link.style.fontSize = '4rem';
+          link.style.textAlign = 'center';
+          frame.replaceWith(link);
+        }
+      });
+    </script>
 </head>
 <body>
-    <iframe style="border: 1px solid #777;" src="{{ pdfURL }}" width="100%" height="100%" frameborder="0" allowfullscreen=""></iframe>
+  <div id="content">
+    <iframe id="pdfFrame" style="border: 1px solid #777;" src="{{ pdfURL }}" width="100%" height="100%" frameborder="0" allowfullscreen=""></iframe>
+  </div>
 </body>
 </html>


### PR DESCRIPTION
## Description
* **Problem:** Mobile Safari intentionally downgrades a PDF that sits inside an `<iframe>` to a single static image for performance and security reasons.
* **Solution:** Replace iframe with a link on iOS to open the referenced PDF in a new tab

## Code Changes
* A function has been added to check whether the browser is an iOS based one and to dynamically add a link to open the PDF
* An `id` has been added to the `iframe` so that it can be properly referenced