### PR TITLE
chore: TopicSideColumn uses shouldDisplayTopic

### DIFF
--- a/reader/views.py
+++ b/reader/views.py
@@ -3109,7 +3109,7 @@ def topic_page(request, slug, test_version=None):
     """
     slug = SluggedAbstractMongoRecord.normalize_slug(slug)
     topic_obj = Topic.init(slug)
-    if topic_obj is None or request.active_module not in DjangoTopic.objects.get_pools_by_topic_slug(slug):
+    if topic_obj is None or request.active_module not in topic_obj.get_pools():
         raise Http404
 
     short_lang = get_short_lang(request.interfaceLang)

--- a/sefaria/helper/topic.py
+++ b/sefaria/helper/topic.py
@@ -227,8 +227,7 @@ def annotate_topic_link(link: dict, link_topic_dict: dict) -> Union[dict, None]:
         link['description'] = getattr(topic, 'description', {})
     else:
         link['description'] = {}
-    if not topic.should_display():
-        link['shouldDisplay'] = False
+    link['shouldDisplay'] = topic.should_display()
     link['pools'] = topic.get_pools()
     link['order'] = link.get('order', None) or {}
     link['order']['numSources'] = getattr(topic, 'numSources', 0)

--- a/sefaria/helper/topic.py
+++ b/sefaria/helper/topic.py
@@ -229,6 +229,7 @@ def annotate_topic_link(link: dict, link_topic_dict: dict) -> Union[dict, None]:
         link['description'] = {}
     if not topic.should_display():
         link['shouldDisplay'] = False
+    link['pools'] = topic.get_pools()
     link['order'] = link.get('order', None) or {}
     link['order']['numSources'] = getattr(topic, 'numSources', 0)
     return link
@@ -238,7 +239,7 @@ def annotate_topic_link(link: dict, link_topic_dict: dict) -> Union[dict, None]:
 def get_all_topics(limit=1000, displayableOnly=True, activeModule='library'):
     query = {"shouldDisplay": {"$ne": False}, "numSources": {"$gt": 0}} if displayableOnly else {}
     topic_list = TopicSet(query, limit=limit, sort=[('numSources', -1)])
-    return [t for t in topic_list if activeModule in DjangoTopic.objects.get_pools_by_topic_slug(t.slug)]
+    return [t for t in topic_list if activeModule in t.get_pools()]
 
 @django_cache(timeout=24 * 60 * 60)
 def get_num_library_topics():

--- a/sefaria/model/topic.py
+++ b/sefaria/model/topic.py
@@ -514,7 +514,7 @@ class Topic(abst.SluggedAbstractMongoRecord, AbstractTitledObject):
                 'slug': self.slug,
                 "shouldDisplay": True if len(children) > 0 else self.should_display(),
                 "displayOrder": getattr(self, "displayOrder", 10000),
-                "pools": DjangoTopic.objects.get_pools_by_topic_slug(self.slug)})
+                "pools": self.get_pools()})
             if getattr(self, "categoryDescription", False):
                 d['categoryDescription'] = self.categoryDescription
             description = getattr(self, "description", None)

--- a/static/js/TopicPage.jsx
+++ b/static/js/TopicPage.jsx
@@ -880,7 +880,7 @@ TopicLink.propTypes = {
 
 const TopicSideColumn = ({ slug, links, clearAndSetTopic, parashaData, tref, setNavTopic, timePeriod, properties, topicTitle, multiPanel, topicImage }) => {
   const category = Sefaria.displayTopicTocCategory(slug);
-  const linkTypeArray = links ? Object.values(links).filter(linkType => !!linkType && linkType.shouldDisplay && linkType.links.filter(l => l.shouldDisplay !== false).length > 0) : [];
+  const linkTypeArray = links ? Object.values(links).filter(linkType => !!linkType && linkType.shouldDisplay && linkType.links.filter(l => Sefaria.shouldDisplayTopic(l)).length > 0) : [];
   if (linkTypeArray.length === 0) {
     linkTypeArray.push({
       title: {
@@ -911,7 +911,7 @@ const TopicSideColumn = ({ slug, links, clearAndSetTopic, parashaData, tref, set
         return a.title.en.localeCompare(b.title.en);
       })
       .map(({ title, pluralTitle, links }) => {
-        const linksToDisplay = links.filter(l => l.shouldDisplay !== false);
+        const linksToDisplay = links.filter(l => Sefaria.shouldDisplayTopic(l));
         const hasPlural = linksToDisplay.length > 1 && pluralTitle;
         const pluralizedTitle = {
           en: hasPlural ? pluralTitle.en : title.en,

--- a/static/js/TopicPage.jsx
+++ b/static/js/TopicPage.jsx
@@ -235,7 +235,7 @@ const TopicCategory = ({topic, topicTitle, setTopic, setNavTopic}) => {
     }, [topic]);
 
     let topicBlocks = subtopics
-      .filter(Sefaria.shouldDisplayTopic)
+      .filter(Sefaria.shouldDisplayInActiveModule)
       .sort(Sefaria.sortTopicsCompareFn)
       .map((topic, i) => <TopicTOCCard topic={topic} setTopic={setTopic} setNavTopic={setNavTopic} key={i}/>);
 
@@ -880,7 +880,7 @@ TopicLink.propTypes = {
 
 const TopicSideColumn = ({ slug, links, clearAndSetTopic, parashaData, tref, setNavTopic, timePeriod, properties, topicTitle, multiPanel, topicImage }) => {
   const category = Sefaria.displayTopicTocCategory(slug);
-  const linkTypeArray = links ? Object.values(links).filter(linkType => !!linkType && linkType.shouldDisplay && linkType.links.filter(l => Sefaria.shouldDisplayTopic(l)).length > 0) : [];
+  const linkTypeArray = links ? Object.values(links).filter(linkType => !!linkType?.shouldDisplay && linkType.links.filter(l => Sefaria.shouldDisplayInActiveModule(l)).length > 0) : [];
   if (linkTypeArray.length === 0) {
     linkTypeArray.push({
       title: {
@@ -911,7 +911,7 @@ const TopicSideColumn = ({ slug, links, clearAndSetTopic, parashaData, tref, set
         return a.title.en.localeCompare(b.title.en);
       })
       .map(({ title, pluralTitle, links }) => {
-        const linksToDisplay = links.filter(l => Sefaria.shouldDisplayTopic(l));
+        const linksToDisplay = links.filter(l => Sefaria.shouldDisplayInActiveModule(l));
         const hasPlural = linksToDisplay.length > 1 && pluralTitle;
         const pluralizedTitle = {
           en: hasPlural ? pluralTitle.en : title.en,

--- a/static/js/TopicPageAll.jsx
+++ b/static/js/TopicPageAll.jsx
@@ -48,7 +48,7 @@ class TopicPageAll extends Component {
     const isHeInt = Sefaria.interfaceLang == "hebrew";
 
     const topicBlocks = this.state.topicList && this.state.topicList.filter(item => {
-      if (!Sefaria.shouldDisplayTopic(item)) {
+      if (!Sefaria.shouldDisplayInActiveModule(item)) {
         return false; // Exclude topics that are not valid for the current module
       }
       if (!hasFilter) {

--- a/static/js/sefaria/sefaria.js
+++ b/static/js/sefaria/sefaria.js
@@ -2746,11 +2746,10 @@ _media: {},
   },
   shouldDisplayTopic: function(topic) {
     /*
-    Returns true if topic should be displayed in the topic list or TOC.
-    'topic' is a topic object in this.topicList or this.topic_toc
+    Returns true if topic should be displayed in the topic list, topic TOC, or topic page side column.
      */
     const inActiveModule = topic?.pools?.includes(Sefaria.activeModule);
-    return !!topic.shouldDisplay && inActiveModule;
+    return topic.shouldDisplay !== false && inActiveModule;
   },
   sortTopicsCompareFn: function(a, b) {
     // a compare function that is useful for sorting topics

--- a/static/js/sefaria/sefaria.js
+++ b/static/js/sefaria/sefaria.js
@@ -2744,12 +2744,12 @@ _media: {},
           return d;
         });
   },
-  shouldDisplayTopic: function(topic) {
+  shouldDisplayInActiveModule: function(topic) {
     /*
     Returns true if topic should be displayed in the topic list, topic TOC, or topic page side column.
      */
     const inActiveModule = topic?.pools?.includes(Sefaria.activeModule);
-    return topic.shouldDisplay !== false && inActiveModule;
+    return !!topic?.shouldDisplay && inActiveModule;
   },
   sortTopicsCompareFn: function(a, b) {
     // a compare function that is useful for sorting topics


### PR DESCRIPTION
## Description
Related topics display in the sidebar on topic pages.  If we are in a topic page in the sheets module, related topics should only display if they themselves have sheets.  Likewise, in a topic page in the library module, related topics should only display if they themselves have library sources.

## Code Changes
1.  Minor syntax change on the back-end: I'm calling topic.get_pools() instead of calling the pools object itself.  This is easier to read and I didn't know we had this function before.
2. The main change is that in the back-end,  sefaria/helper/topic.py, topic links are populated with get_pools() so taht in the front end, in TopicSideColumn, we can check if we should display the topic link given the current active module.