### PR TITLE
Some additions to change_lexicon_headword

### DIFF
--- a/sefaria/helper/schema.py
+++ b/sefaria/helper/schema.py
@@ -1038,6 +1038,9 @@ def change_lexicon_headword(parent_lexicon, old_headword, new_headword):
             dictionary_node.headwordMap = hw_map
         return dictionary_node
 
+    assert LexiconEntry().load({'parent_lexicon': parent_lexicon, 'headword': new_headword}) is None, \
+        f'Entry of {parent_lexicon} with headword {new_headword} already exists'
+
     # change entry itself
     print('Updating entry')
     entry = LexiconEntry().load({'parent_lexicon': parent_lexicon, 'headword': old_headword})

--- a/sefaria/helper/schema.py
+++ b/sefaria/helper/schema.py
@@ -1096,3 +1096,16 @@ def change_lexicon_headword(parent_lexicon, old_headword, new_headword):
     )
 
     library.rebuild()
+
+    # other entries in the same dictionary that includes wrapped ref for the old headword
+    # changing another entry is too complicated, for any lexicon has different entries structure, so it will be only printed
+    if index:
+        quoted = []
+        for entry in LexiconEntrySet({'parent_lexicon': parent_lexicon}):
+            oref = Ref(f'{index.title}, {entry.headword}')
+            entry_text = ' '.join(oref.index_node.get_text())
+            if ref in entry_text:
+                quoted.append(f'"{entry.headword}"')
+        if quoted:
+            print(f'Other entries in this lexicon with this old headword as ref: {", ".join(quoted)}')
+        print('Warning: old ref can appear as wrapped ref in other places in the library.')


### PR DESCRIPTION
## Description
Add assertion that new headword does not exist.
Add message about other entries in the same lexicon with wrapped ref to the old headword, and general warnging about the option that a wrapped ref appears somewhere in our library.