### PR TITLE
fix(Editor): fix divine name replacement logic

### DIFF
--- a/static/js/Editor.jsx
+++ b/static/js/Editor.jsx
@@ -701,7 +701,6 @@ const BoxedSheetElement = ({ attributes, children, element, divineName }) => {
     useEffect(() => {
       const replacement = divineName || "noSub";
       const editors = [sheetSourceHeEditor, sheetSourceEnEditor];
-      console.log("Replacing divine names with:", replacement);
 
       for (const editor of editors) {
         Editor.withoutNormalizing(editor, () => {


### PR DESCRIPTION
## Description
Replaces divine names correctly in both Hebrew / English Slate editors. The old solution tried Transforms.setNodes, which can’t mutate a leaf’s text. We now walk all text nodes bottom-up, remove each matching leaf, and re-insert a new leaf with the updated string while preserving existing marks fixing the override.