### PR TITLE
fix: add space between verse number and verse text in segment display new editor

### DIFF
--- a/static/js/sefaria/sheetsUtils.js
+++ b/static/js/sefaria/sheetsUtils.js
@@ -32,7 +32,7 @@ function placedSegmentMapper(lang, segmented, includeNumbers, s) {
         const num = (lang=="he") ? Sefaria.hebrew.encodeHebrewNumeral(s.number) : s.number;
         numStr = "<small>(" + num + ")</small> ";
     }
-    let str = "<span class='segment'>" + numStr + s[lang] + "</span> ";
+    let str = "<span class='segment'>" + numStr + s[lang] + " </span> ";
     if (segmented) {
         str = "<p>" + str + "</p>";
     }


### PR DESCRIPTION
adding a white space between verse numbers and the actaul verse string. images attaced before and after fix
![image](https://github.com/user-attachments/assets/8214c277-91cd-40a6-8a0f-02e5feadf407)
![image](https://github.com/user-attachments/assets/63d56eb1-a44b-48e3-90d6-338051625949)
