### PR TITLE
In the sheet editor, open suggestion and preview above when there is no room below.

### DIFF
--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -11069,10 +11069,22 @@ background-color: white;
   position: relative;
 }
 
+.connectionsPanel .autocompleterPopups {
+  position: absolute;
+  height: 100%;
+  width: 100%;
+}
+
 .addInterfaceInput .suggestionBoxContainer,
 .addInterfaceInput .textPreviewContainer {
   position: absolute;
   z-index: 1;
+}
+
+.editorContent .show-above .suggestionBoxContainer,
+.editorContent .show-above .autocompleterPopups {
+  top: auto;
+  bottom: 100%;
 }
 
 .addInterfaceInput .suggestionBox,

--- a/static/js/Misc.jsx
+++ b/static/js/Misc.jsx
@@ -2903,7 +2903,6 @@ const Autocompleter = ({getSuggestions, showSuggestionsOnSelect, inputPlaceholde
 
 
   const checkSpaceBelow = useCallback(() => {
-    console.log(0, popsEl)
     const input = inputEl.current;
     const pops = popsEl.current;
     if (!input || !pops) return;
@@ -2913,8 +2912,6 @@ const Autocompleter = ({getSuggestions, showSuggestionsOnSelect, inputPlaceholde
     const popsTop = Math.min(...Array.from(pops.children).map(c => c.getBoundingClientRect().top))
     const popsBottom = Math.max(...Array.from(pops.children).map(c => c.getBoundingClientRect().bottom))
     const popsHeight = popsBottom - popsTop;
-    console.log(10, popsTop, popsBottom)
-    console.log(11, spaceBelow , popsHeight , spaceAbove )
     setShouldShowAbove(spaceBelow < popsHeight && spaceAbove >= popsHeight);
   }, []);
   useEffect(() => {

--- a/static/js/Misc.jsx
+++ b/static/js/Misc.jsx
@@ -1,5 +1,5 @@
 //const React      = require('react');
-import React, {useContext, useEffect, useRef, useState} from 'react';
+import React, {useContext, useEffect, useRef, useState, useCallback} from 'react';
 import ReactDOM from 'react-dom';
 import $ from './sefaria/sefariaJquery';
 import {CollectionsModal} from "./CollectionsWidget";
@@ -2888,9 +2888,46 @@ const Autocompleter = ({getSuggestions, showSuggestionsOnSelect, inputPlaceholde
   const [showAddButton, setShowAddButton] = useState(false);
   const [showCurrentSuggestions, setShowCurrentSuggestions] = useState(true);
   const [inputClassNames, setInputClassNames] = useState(classNames({selected: 0}));
+  const [shouldShowAbove, setShouldShowAbove] = useState(false);
   const suggestionEl = useRef(null);
   const inputEl = useRef(null);
+  const popsEl = useRef(null);
   const buttonClassNames = classNames({button: 1, small: 1});
+
+  useEffect(
+    () => {
+         const element = document.querySelector('.textPreviewSegment.highlight');
+         if (element) {element.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'start' })}
+    }, [previewText]
+  )
+
+
+  const checkSpaceBelow = useCallback(() => {
+    console.log(0, popsEl)
+    const input = inputEl.current;
+    const pops = popsEl.current;
+    if (!input || !pops) return;
+    const inputRect = input.getBoundingClientRect();
+    const spaceBelow = window.innerHeight - inputRect.bottom
+    const spaceAbove = inputRect.top;
+    const popsTop = Math.min(...Array.from(pops.children).map(c => c.getBoundingClientRect().top))
+    const popsBottom = Math.max(...Array.from(pops.children).map(c => c.getBoundingClientRect().bottom))
+    const popsHeight = popsBottom - popsTop;
+    console.log(10, popsTop, popsBottom)
+    console.log(11, spaceBelow , popsHeight , spaceAbove )
+    setShouldShowAbove(spaceBelow < popsHeight && spaceAbove >= popsHeight);
+  }, []);
+  useEffect(() => {
+    window.addEventListener('resize', checkSpaceBelow);
+    window.addEventListener('scroll', checkSpaceBelow, true);
+    return () => {
+      window.removeEventListener('resize', checkSpaceBelow);
+      window.removeEventListener('scroll', checkSpaceBelow, true);
+    };
+  }, []);
+  useEffect(() => {
+    checkSpaceBelow()
+  }, [currentSuggestions, showCurrentSuggestions, previewText]);
 
   const getWidthOfInput = () => {
     //Create a temporary div w/ all of the same styles as the input since we can't measure the input
@@ -2918,13 +2955,6 @@ const Autocompleter = ({getSuggestions, showSuggestionsOnSelect, inputPlaceholde
     document.body.removeChild(tmp);
     return theWidth;
   }
-
-  useEffect(
-    () => {
-         const element = document.querySelector('.textPreviewSegment.highlight');
-         if (element) {element.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'start' })}
-    }, [previewText]
-  )
 
   const resizeInputIfNeeded = () => {
     const currentWidth = getWidthOfInput();
@@ -3010,7 +3040,6 @@ const Autocompleter = ({getSuggestions, showSuggestionsOnSelect, inputPlaceholde
     }
   }
 
-
   const generatePreviewText = (ref) => {
         Sefaria.getText(ref, {context:1, stripItags: 1}).then(text => {
            let segments = Sefaria.makeSegments(text, true);
@@ -3061,7 +3090,8 @@ const Autocompleter = ({getSuggestions, showSuggestionsOnSelect, inputPlaceholde
                     handleSelection(inputValue, currentSuggestions)
                 }}>{buttonTitle}</button> : null}
 
-      {showCurrentSuggestions && currentSuggestions && currentSuggestions.length > 0 ?
+      <div className={`autocompleterPopups ${shouldShowAbove ? 'show-above' : ''}`} ref={popsEl}>
+        {showCurrentSuggestions && currentSuggestions && currentSuggestions.length > 0 ?
           <div className="suggestionBoxContainer">
           <select
               ref={suggestionEl}
@@ -3084,8 +3114,8 @@ const Autocompleter = ({getSuggestions, showSuggestionsOnSelect, inputPlaceholde
           </div>
 
           : null
-
       }
+      </div>
 
     </div>
     )


### PR DESCRIPTION
## Description
In the sheet edtior, when adding source by ref there is a popup for suggestion, and another one for preview. These popups are open below also when there is no room for them. Now, they will open above where there is no room below (and there is room above).

## Code Changes
In `Autocompleter` component: 

- The suggestion element and preview element wrapped by a `div` with `ref`. This div can get classname `show-above`.
- New function `checkSpaceBelow` added. It checks if there is no space below and there is space above and set `shouldShowAbove`. This function measures the height of the popup by its children, for the children has `position: absolute`. It's wrapped by `useCallback`, because it's not changing in the lifecycle of the component (it's depends on react's refs), and is used in listeners, so for cleaning the listener we must have the function that the listener was created with).
- This function is used by `useEffect` when suggestions or preview are changed, and also by listeners to resize and toggle (that added by another `useEffect`).

In `s2.css`: rules for `show-above`.

## Notes
This component is also used in other places for admins (adding topics in side bar and editting topics). Since it's only for admnis, and it seems that the setting there is different, this PR don't change these places. Some css was added so that these places won't break.