### PR TITLE
Support spotify in sheets.

### DIFF
--- a/static/js/Sheet.jsx
+++ b/static/js/Sheet.jsx
@@ -607,6 +607,10 @@ class SheetMedia extends Component {
     var mediaClass = "media fullWidth";
     var mediaURL = this.props.source.media;
     var caption  = this.props.source.caption;
+    let parsedUrl
+    if (mediaURL) {
+      parsedUrl = new URL(mediaURL);
+    }
 
     if (this.isImage()) {
       mediaLink = '<img class="addedMedia" src="' + mediaURL + '" />';
@@ -621,6 +625,19 @@ class SheetMedia extends Component {
 
     else if (mediaURL.match(/https?:\/\/w\.soundcloud\.com\/player\/\?url=.*/i) != null) {
       mediaLink = '<iframe width="100%" height="166" scrolling="no" frameborder="no" src="' + mediaURL + '"></iframe>';
+    }
+
+    else if (parsedUrl.hostname.includes("spotify.com")) {
+      const [,, type] = parsedUrl.pathname.split("/");
+      const height = type === "episode" ? 152 : 80;
+      return `<iframe 
+        src=${mediaURL}
+        width="100%"
+        height="${height}"
+        frameborder="0"
+        allow="autoplay; encrypted-media" 
+        loading="lazy">
+      </iframe>`;
     }
 
     else if (mediaURL.match(/\.(mp3)$/i) != null) {

--- a/static/js/Sheet.jsx
+++ b/static/js/Sheet.jsx
@@ -629,7 +629,12 @@ class SheetMedia extends Component {
 
     else if (parsedUrl.hostname.includes("spotify.com")) {
       const [,, type] = parsedUrl.pathname.split("/");
-      const height = type === "episode" ? 152 : 80;
+
+      // Spotify embed heights are fixed by Spotify's player design.
+      // DO NOT change these values — reducing them will cut off content.
+      const SPOTIFY_IFRAME_HEIGHT_WITH_METADATA = 152; // episode
+      const SPOTIFY_IFRAME_HEIGHT_COMPACT = 80; // music tracks
+      const height = type === "episode" ? SPOTIFY_IFRAME_HEIGHT_WITH_METADATA : SPOTIFY_IFRAME_HEIGHT_COMPACT;
       return `<iframe 
         src=${mediaURL}
         width="100%"


### PR DESCRIPTION
## Description
We're supporting spotify in the editor but not in the viewer. This PR fixes this issue.

## Code Changes
- Add spotify option to `Sheet.jsx`.
- Use parsed url rather than raw url in the if statement. This is much clean than the regex match we're using for other options.