### PR TITLE
Bug/sc 34949/when i try to delete a note in the hebrew

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,10 @@ node_modules
 /.vscode
 *.code-workspace
 
+# Cursor #
+##########
+.cursor/
+
 # pystest cache #
 #####################
 /.pytest_cache
@@ -141,7 +145,3 @@ dump/*
 /playwright/.cache/
 /playwright-profile/
 .env
-
-# Cursor #
-##########
-.cursor/

--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,9 @@ dump/*
 /test-results/
 /playwright-report/
 /playwright/.cache/
+/playwright-profile/
+.env
+
+# Cursor #
+##########
+.cursor/

--- a/static/js/ConnectionsPanel.jsx
+++ b/static/js/ConnectionsPanel.jsx
@@ -1518,7 +1518,6 @@ class AddNoteBox extends Component {
     this.setState({ isPrivate: false });
   }
   deleteNote() {
-    alert(Sefaria._("Something went wrong (that's all I know)."));
     if (!confirm(Sefaria._("Are you sure you want to delete this note?"))) { return; }
     Sefaria.deleteNote(this.props.noteId).then(this.props.onDelete);
   }


### PR DESCRIPTION

There was an erroneous alert after trying to delete a note in addition and before the alert we want.
I simply removed it.  
Also added to gitignore some local development files (Used for cursor + palywright MCP + .env)

Testing:
I checked the error didn't pop up anymore but that the note was deleted