### PR TITLE
Prevent scrolling when closing side bar after SSR

### DIFF
--- a/reader/views.py
+++ b/reader/views.py
@@ -350,10 +350,13 @@ def make_panel_dict(oref, primaryVersion, translationVersion, filter, versionFil
     else:
         section_ref = oref.first_available_section_ref()
         oref = section_ref if section_ref else oref
+        refs = oref.split_spanning_ref()  # Split the ref if spanning across sections, if not inserts it to a list
+        if mode == 'Text':  # In text mode refs should be section refs
+            refs = [r.section_ref() for r in refs]
         panel = {
             "mode": mode,
             "ref": oref.normal(),
-            "refs": [oref.normal()] if not oref.is_spanning() else [r.normal() for r in oref.split_spanning_ref()],
+            "refs": [r.normal() for r in refs],
             "currVersions": {"en": translationVersion, "he": primaryVersion},
             "filter": filter,
             "versionFilter": versionFilter,


### PR DESCRIPTION
## Description
This bug was introduced by the 'rtl' project.
When arriving at a page via ssr in segment level, in the first time of closing sidebar it scrolls to the beginning of the section.
While I don't what was the change (in rtl) that caused this (and definitely my fix is different), I think this PR is right per se, so fixing bug with it should be right.

## Code Changes
The change is in `make_panel_dict` on `reader.views`:
- The main change is making the `refs` being section, although the ref is segment. When sidebar is open, not after ssr, refs are section refs, so there is no reason that it won't be the case when getting segment with ssr.
- That's true only when the ReaderPAnel mode is `Text`. When it's `Connections`, we want only the segmet to show. When it's `TextAndConnections`, i.e. mobile, there is no bug (I'm not sure how it should behave theorteically but it works).
- For that I've took the `refs` creation out of the dict creation. I also applied `split_spanning_ref` in any case, rather than `is_spanning` case only - this should have no effect, for in cases where ref is not spanning, `split_spanning_ref` only put it into a list.