### PR TITLE
Chore/sc 31762/api auth

### DIFF
--- a/reader/views.py
+++ b/reader/views.py
@@ -2124,7 +2124,7 @@ def all_notes_api(request):
         else:
             res = [note.contents(with_string_id=True) for note in NoteSet({"owner": request.user.id}, sort=[("_id", -1)]) ]
     else:
-        resr = {"error": "Not implemented."}
+        res = {"error": "Not implemented."}
     return jsonResponse(res, callback=request.GET.get("callback", None))
 
 

--- a/reader/views.py
+++ b/reader/views.py
@@ -1525,14 +1525,10 @@ def complete_version_api(request):
     except BookNameError:
         return jsonResponse({"error": f"No index named: {title}"})
 
-    if not request.user.is_authenticated:
-        key = body_data.get('apikey')[0]
-        if not key:
-            return jsonResponse({"error": "You must be logged in or use an API key to save texts."})
-        apikey = db.apikeys.find_one({"key": key})
+    if not request.user.is_staff:
+        return notStaffOrApiResponse()
+    if request.is_api_authenticated:
         method = 'API'
-        if not apikey:
-            return jsonResponse({"error": "Unrecognized API key."})
     else:
         method = None
         internal_do_post = csrf_protect(internal_do_post())

--- a/reader/views.py
+++ b/reader/views.py
@@ -1525,8 +1525,8 @@ def complete_version_api(request):
     except BookNameError:
         return jsonResponse({"error": f"No index named: {title}"})
 
-    if not request.user.is_staff:
-        return notStaffOrApiResponse()
+    if not request.user.is_authenticated:
+        return authenticationRequiredResponse()
     if request.is_api_authenticated:
         method = 'API'
     else:

--- a/reader/views.py
+++ b/reader/views.py
@@ -2753,7 +2753,7 @@ def updates_api(request, gid=None):
                             })
 
     elif request.method == "POST":
-        if not not request.user.is_staff:
+        if not request.user.is_staff:
             return notStaffOrApiResponse()
         elif request.is_api_authenticated:
             payload = json.loads(request.POST.get("json"))

--- a/reader/views.py
+++ b/reader/views.py
@@ -2390,7 +2390,7 @@ def category_api(request, path=None):
             return notStaffOrApiResponse()
         if request.is_api_authenticated:
             kwargs = {"method": "API"}
-        else:
+        else:  # a logged-in staff member
             kwargs = {}
             _internal_do_post = csrf_protect(_internal_do_post)
         uid = request.user.id
@@ -2546,7 +2546,7 @@ def terms_api(request, name):
             return notStaffOrApiResponse()
         if request.is_api_authenticated:
             kwargs = {"method": "API"}
-        else:
+        else:  # a logged-in staff member
             kwargs = {}
             _internal_do_post = csrf_protect(_internal_do_post)
         uid = request.user.id
@@ -2773,7 +2773,7 @@ def updates_api(request, gid=None):
             except AssertionError as e:
                 return jsonResponse({"error": str(e)})
 
-        else:
+        else:  # a logged-in staff member
             @csrf_protect
             def protected_post(request):
                 payload = json.loads(request.POST.get("json"))

--- a/reader/views.py
+++ b/reader/views.py
@@ -1692,6 +1692,8 @@ def index_api(request, title, raw=False):
         if request.user.is_staff:
             admin_post = csrf_protect(index_post)
             return admin_post(request, request.user.id, j, None, raw)
+        if not request.user.is_authenticated:
+            return authenticationRequiredResponse()
         return notStaffOrApiResponse()
 
     def index_post(request, uid, j, method, raw):
@@ -2308,6 +2310,8 @@ def flag_text_api(request, title, lang, version):
 
     _attributes_to_save = Version.optional_attrs + ["versionSource", "direction", "isSource", "isPrimary"]
 
+    if not request.user.is_authenticated:
+        return authenticationRequiredResponse()
     if not request.user.is_staff:
         return notStaffOrApiResponse()
     if request.is_api_authenticated:
@@ -2380,6 +2384,8 @@ def category_api(request, path=None):
             func = tracker.update if update else tracker.add
             return func(uid, Category, cat, **kwargs).contents()
 
+        if not request.user.is_authenticated:
+            return authenticationRequiredResponse()
         if not request.user.is_staff:
             return notStaffOrApiResponse()
         if request.is_api_authenticated:
@@ -2534,6 +2540,8 @@ def terms_api(request, name):
                     return {"error": 'Term "%s" does not exist.' % name}
                 return tracker.delete(uid, Term, t._id)
 
+        if not request.user.is_authenticated:
+            return authenticationRequiredResponse()
         if not request.user.is_staff:
             return notStaffOrApiResponse()
         if request.is_api_authenticated:
@@ -2753,6 +2761,8 @@ def updates_api(request, gid=None):
                             })
 
     elif request.method == "POST":
+        if not request.user.is_authenticated:
+            return authenticationRequiredResponse()
         if not request.user.is_staff:
             return notStaffOrApiResponse()
         elif request.is_api_authenticated:
@@ -3123,6 +3133,8 @@ def topics_api(request, topic, v2=False):
         response = get_topic(v2, topic, request.interfaceLang, with_html=with_html, with_links=with_links, annotate_links=annotate_links, with_refs=with_refs, group_related=group_related, annotate_time_period=annotate_time_period, ref_link_type_filters=ref_link_type_filters, with_indexes=with_indexes)
         return jsonResponse(response, callback=request.GET.get("callback", None))
     elif request.method == "POST":
+        if not request.user.is_authenticated:
+            return authenticationRequiredResponse()
         if not request.user.is_staff:
             return notStaffOrApiResponse()
         topic_data = json.loads(request.POST["json"])

--- a/reader/views.py
+++ b/reader/views.py
@@ -2070,7 +2070,7 @@ def notes_api(request, note_id_or_ref):
             note["_id"] = ObjectId(note["_id"])
         if not request.user.is_authenticated:
             return authenticationRequiredResponse()
-        uid = note["owner"]=  request.user.id
+        uid = note["owner"] = request.user.id
         if request.is_api_authenticated:
             response = format_object_for_client(
                 func(uid, Note, note, method="API")

--- a/scripts/move_draft_text.py
+++ b/scripts/move_draft_text.py
@@ -182,12 +182,3 @@ if __name__ == '__main__':
             args.versionlist = version_arr
     copier = ServerTextCopier(args.destination_server, args.apikey, args.title, args.noindex, args.versionlist, args.links, args.step)
     copier.do_copy()
-
-    try:
-        url = os.environ["SLACK_URL"]
-        message = json.dumps({'text': 'Upload Complete'})
-        request = urllib.request.Request(url, message.encode('utf-8'))
-        urllib.request.urlopen(request)
-
-    except KeyError:
-        pass

--- a/scripts/move_draft_text.py
+++ b/scripts/move_draft_text.py
@@ -144,7 +144,7 @@ class ServerTextCopier(object):
         jpayload = json.dumps(payload)
         data = urllib.parse.urlencode({'json': jpayload}).encode('utf-8')
         req = urllib.request.Request(full_url, data)
-        req.add_header("X-APIKEY", self._apikey)
+        req.add_header("AUTHORIZATION", self._apikey)
         req.add_header("Content-Type", "application/x-www-form-urlencoded")
         try:
             response = urllib.request.urlopen(req)

--- a/scripts/move_draft_text.py
+++ b/scripts/move_draft_text.py
@@ -142,9 +142,10 @@ class ServerTextCopier(object):
         params = params or {}
         full_url = f"{self._dest_server}/{url}?{urllib.parse.urlencode(params)}"
         jpayload = json.dumps(payload)
-        values = {'json': jpayload, 'apikey': self._apikey}
-        data = urllib.parse.urlencode(values).encode('utf-8')
+        data = urllib.parse.urlencode({'json': jpayload}).encode('utf-8')
         req = urllib.request.Request(full_url, data)
+        req.add_header("X-APIKEY", self._apikey)
+        req.add_header("Content-Type", "application/x-www-form-urlencoded")
         try:
             response = urllib.request.urlopen(req)
             if 'prof' in full_url:

--- a/scripts/post_sheet.py
+++ b/scripts/post_sheet.py
@@ -32,7 +32,7 @@ else:
   post = urllib.parse.urlencode({'json': post_json})
 
   req = urllib.request.Request(host + "/api/sheets", post)
-  req.add_header("X-APIKEY", SEFARIA_API_KEY)
+  req.add_header("AUTHORIZATION", SEFARIA_API_KEY)
   req.add_header("Content-Type", "application/x-www-form-urlencoded")
 
   try:

--- a/scripts/post_sheet.py
+++ b/scripts/post_sheet.py
@@ -29,10 +29,11 @@ else:
   del sheet["_id"]
 
   post_json = json.dumps(sheet)
-  values = {'json': post_json, 'apikey': SEFARIA_API_KEY}
-  post = urllib.parse.urlencode(values)  
+  post = urllib.parse.urlencode({'json': post_json})
 
-  req = urllib.request.Request(host + "/api/sheets", post)  
+  req = urllib.request.Request(host + "/api/sheets", post)
+  req.add_header("X-APIKEY", SEFARIA_API_KEY)
+  req.add_header("Content-Type", "application/x-www-form-urlencoded")
 
   try:
     response = urllib.request.urlopen(req)

--- a/scripts/scheduled/reindex_elasticsearch_cronjob.py
+++ b/scripts/scheduled/reindex_elasticsearch_cronjob.py
@@ -20,7 +20,7 @@ up-to-date mongo dump).
 last_sheet_timestamp = datetime.now().isoformat()
 update_pagesheetrank()
 index_all()
-r = requests.post("https://www.sefaria.org/admin/index-sheets-by-timestamp", data={"timestamp": last_sheet_timestamp}, headers={"X-APIKEY": SEFARIA_BOT_API_KEY})
+r = requests.post("https://www.sefaria.org/admin/index-sheets-by-timestamp", data={"timestamp": last_sheet_timestamp}, headers={"AUTHORIZATION": SEFARIA_BOT_API_KEY})
 if "error" in r.text:
     raise Exception("Error when calling admin/index-sheets-by-timestamp API: " + r.text)
 else:

--- a/scripts/scheduled/reindex_elasticsearch_cronjob.py
+++ b/scripts/scheduled/reindex_elasticsearch_cronjob.py
@@ -20,7 +20,7 @@ up-to-date mongo dump).
 last_sheet_timestamp = datetime.now().isoformat()
 update_pagesheetrank()
 index_all()
-r = requests.post("https://www.sefaria.org/admin/index-sheets-by-timestamp", data={"timestamp": last_sheet_timestamp, "apikey": SEFARIA_BOT_API_KEY})
+r = requests.post("https://www.sefaria.org/admin/index-sheets-by-timestamp", data={"timestamp": last_sheet_timestamp}, headers={"X-APIKEY": SEFARIA_BOT_API_KEY})
 if "error" in r.text:
     raise Exception("Error when calling admin/index-sheets-by-timestamp API: " + r.text)
 else:

--- a/sefaria/client/util.py
+++ b/sefaria/client/util.py
@@ -2,7 +2,7 @@
 import json
 from datetime import datetime
 
-from django.http import HttpResponse
+from django.http import HttpResponse, HttpResponseForbidden, JsonResponse
 from django.core.mail import EmailMultiAlternatives
 from webpack_loader import utils as webpack_utils
 
@@ -44,6 +44,17 @@ def celeryResponse(task_id: str, sub_task_ids: list[str] = None):
     if sub_task_ids:
         data['sub_task_ids'] = sub_task_ids
     return jsonResponse(data, status=202)
+
+
+def authenticationRequiredResponse(data=None):
+    if data is None:
+        data = {}
+    return JsonResponse({"error": "Authentication required", **data}, status=401)
+
+
+def notStaffOrApiResponse():
+    return HttpResponseForbidden("Authentication failed. Must be staff or provide a valid API key.")
+
 
 def send_email(subject, message_html, from_email, to_email):
     msg = EmailMultiAlternatives(subject, message_html, "Sefaria <hello@sefaria.org>", [to_email], reply_to=[from_email])

--- a/sefaria/client/util.py
+++ b/sefaria/client/util.py
@@ -8,6 +8,7 @@ from webpack_loader import utils as webpack_utils
 
 from sefaria import settings as sls
 # from sefaria.model.user_profile import UserProfile
+from typing import Optional
 
 
 def jsonResponse(data, callback=None, status=200):
@@ -46,7 +47,7 @@ def celeryResponse(task_id: str, sub_task_ids: list[str] = None):
     return jsonResponse(data, status=202)
 
 
-def authenticationRequiredResponse(data=None):
+def authenticationRequiredResponse(data: Optional[dict] = None) -> JsonResponse:
     if data is None:
         data = {}
     return JsonResponse({"error": "Authentication required", **data}, status=401)

--- a/sefaria/settings.py
+++ b/sefaria/settings.py
@@ -120,6 +120,7 @@ MIDDLEWARE = [
     'sefaria.system.middleware.CORSDebugMiddleware',
     'sefaria.system.middleware.SharedCacheMiddleware',
     'sefaria.system.multiserver.coordinator.MultiServerEventListenerMiddleware',
+    'sefaria.system.middleware.ApiKeyAuthenticationMiddleware',
     'django_structlog.middlewares.RequestMiddleware',
     #'easy_timezones.middleware.EasyTimezoneMiddleware',
     #'django.middleware.cache.UpdateCacheMiddleware',

--- a/sefaria/system/middleware.py
+++ b/sefaria/system/middleware.py
@@ -231,7 +231,7 @@ class ApiKeyAuthenticationMiddleware:
     def __call__(self, request):
         request.is_api_authenticated = False
         if not request.user.is_authenticated:
-            apikey = request.META.get("HTTP_X_APIKEY") or request.POST.get("apikey")
+            apikey = request.META.get("HTTP_X_APIKEY") or request.POST.get("apikey") or request.GET.get("apikey")
             if apikey:
                 try:
                     apikey = db.apikeys.find_one({"key": apikey})

--- a/sefaria/system/middleware.py
+++ b/sefaria/system/middleware.py
@@ -228,6 +228,7 @@ class ApiKeyAuthenticationMiddleware:
         self.get_response = get_response
 
     def __call__(self, request):
+        request.is_api_authenticated = False
         if not request.user.is_authenticated:
             apikey = request.META.get("HTTP_X_APIKEY") or request.POST.get("apikey")
             if apikey:

--- a/sefaria/system/middleware.py
+++ b/sefaria/system/middleware.py
@@ -225,6 +225,16 @@ class ProfileMiddleware(MiddlewareMixin):
 
 
 class ApiKeyAuthenticationMiddleware:
+    """
+    Middleware that authenticates API requests using an API key.
+
+    If the request is not made by an already authenticated user,
+    this middleware checks for an API key in the `HTTP_X_APIKEY` header,
+    `POST` data, or `GET` parameters. If a valid API key is found and
+    associated with a user, the middleware sets `request.user` to that user
+    and adds an `is_api_authenticated` attribute to the request.
+    """
+
     def __init__(self, get_response):
         self.get_response = get_response
 

--- a/sefaria/system/middleware.py
+++ b/sefaria/system/middleware.py
@@ -229,7 +229,7 @@ class ApiKeyAuthenticationMiddleware:
     Middleware that authenticates API requests using an API key.
 
     If the request is not made by an already authenticated user,
-    this middleware checks for an API key in the `HTTP_X_APIKEY` header,
+    this middleware checks for an API key in the `HTTP_AUTHORIZATION` and (old) `HTTP_X_APIKEY` header,
     `POST` data, or `GET` parameters. If a valid API key is found and
     associated with a user, the middleware sets `request.user` to that user
     and adds an `is_api_authenticated` attribute to the request.
@@ -241,7 +241,10 @@ class ApiKeyAuthenticationMiddleware:
     def __call__(self, request):
         request.is_api_authenticated = False
         if not request.user.is_authenticated:
-            apikey = request.META.get("HTTP_X_APIKEY") or request.POST.get("apikey") or request.GET.get("apikey")
+            apikey = (request.META.get("HTTP_AUTHORIZATION") or
+                      request.META.get("HTTP_X_APIKEY") or
+                      request.GET.get("apikey") or
+                      request.POST.get("apikey"))
             if apikey:
                 try:
                     apikey = db.apikeys.find_one({"key": apikey})

--- a/sefaria/system/middleware.py
+++ b/sefaria/system/middleware.py
@@ -234,6 +234,7 @@ class ApiKeyAuthenticationMiddleware:
                 try:
                     user = User.objects.get(api_key=apikey)  # Adjust to your logic
                     request.user = user
+                    request.is_api_authenticated = True
                 except User.DoesNotExist:
                     pass
         response = self.get_response(request)

--- a/sefaria/system/middleware.py
+++ b/sefaria/system/middleware.py
@@ -239,6 +239,6 @@ class ApiKeyAuthenticationMiddleware:
                     request.user = user
                     request.is_api_authenticated = True
                 except (User.DoesNotExist, KeyError):
-                    pass
+                    pass  # Invalid API key: no matching user or missing uid — treat as unauthenticated
         response = self.get_response(request)
         return response

--- a/sefaria/system/tests/middleware.py
+++ b/sefaria/system/tests/middleware.py
@@ -29,7 +29,7 @@ class ApiKeyMiddlewareTestBase(TestCase):
 class ApiKeyMiddlewareTests(ApiKeyMiddlewareTestBase):
     def test_middleware_authenticated_with_valid_apikey(self):
         request = self.anonymous_request
-        request.META["HTTP_X_APIKEY"] = "valid-key"
+        request.META["HTTP_AUTHORIZATION"] = "valid-key"
 
         mw = middleware_module.ApiKeyAuthenticationMiddleware(self.get_response)
         response = mw(request)
@@ -44,7 +44,7 @@ class ApiKeyMiddlewareTests(ApiKeyMiddlewareTestBase):
 
     def test_middleware_invalid_apikey_does_not_authenticate(self):
         request = self.anonymous_request
-        request.META["HTTP_X_APIKEY"] = "invalid-key"
+        request.META["HTTP_AUTHORIZATION"] = "invalid-key"
         self.mock_get_user.side_effect = User.DoesNotExist
 
         mw = middleware_module.ApiKeyAuthenticationMiddleware(self.get_response)

--- a/sefaria/system/tests/middleware.py
+++ b/sefaria/system/tests/middleware.py
@@ -1,0 +1,80 @@
+from unittest.mock import patch, Mock
+from django.test import TestCase, RequestFactory
+from django.contrib.auth.models import AnonymousUser
+from django.http import HttpResponse
+import sefaria.system.middleware as middleware_module
+from django.contrib.auth import get_user_model
+
+User = get_user_model()
+
+
+class ApiKeyMiddlewareTestBase(TestCase):
+    def setUp(self):
+        self.user = User.objects.create(username="mockuser")
+
+        self.anonymous_request = RequestFactory().get("/")
+        self.anonymous_request.user = AnonymousUser()
+        self.logged_in_request = RequestFactory().get("/")
+        self.logged_in_request.user = self.user
+        self.get_response = lambda r: HttpResponse("ok")
+
+        self.mock_apikeys = Mock()
+        self.mock_apikeys.find_one.return_value = {"uid": self.user.id}
+        self.mock_get_user = patch.object(middleware_module.User.objects, "get", return_value=self.user).start()
+        self.patch_db = patch.object(middleware_module.db, "apikeys", self.mock_apikeys).start()
+
+        self.addCleanup(patch.stopall)
+
+
+class ApiKeyMiddlewareTests(ApiKeyMiddlewareTestBase):
+    def test_middleware_authenticated_with_valid_apikey(self):
+        request = self.anonymous_request
+        request.META["HTTP_X_APIKEY"] = "valid-key"
+
+        mw = middleware_module.ApiKeyAuthenticationMiddleware(self.get_response)
+        response = mw(request)
+
+        self.mock_apikeys.find_one.assert_called_once_with({"key": "valid-key"})
+        self.mock_get_user.assert_called_once_with(id=self.user.id)
+
+        self.assertTrue(request.is_api_authenticated)
+        self.assertEqual(request.user.username, "mockuser")
+        self.assertTrue(request.user.is_authenticated)
+        self.assertEqual(response.status_code, 200)
+
+    def test_middleware_invalid_apikey_does_not_authenticate(self):
+        request = self.anonymous_request
+        request.META["HTTP_X_APIKEY"] = "invalid-key"
+        self.mock_get_user.side_effect = User.DoesNotExist
+
+        mw = middleware_module.ApiKeyAuthenticationMiddleware(self.get_response)
+        response = mw(request)
+
+        self.mock_apikeys.find_one.assert_called_once_with({"key": "invalid-key"})
+        self.mock_get_user.assert_called_once_with(id=self.user.id)
+
+        self.assertFalse(request.is_api_authenticated)
+        self.assertTrue(isinstance(self.anonymous_request.user, AnonymousUser))
+        self.assertFalse(request.user.is_authenticated)
+        self.assertEqual(response.status_code, 200)
+
+    def test_middleware_logged_out_user_without_apikey_provided(self):
+        request = self.anonymous_request
+
+        mw = middleware_module.ApiKeyAuthenticationMiddleware(self.get_response)
+        response = mw(request)
+
+        self.assertFalse(request.is_api_authenticated)
+        self.assertFalse(request.user.is_authenticated)
+        self.assertEqual(response.status_code, 200)
+
+    def test_middleware_logged_in_user_without_apikey_provided(self):
+        request = self.logged_in_request
+
+        mw = middleware_module.ApiKeyAuthenticationMiddleware(self.get_response)
+        response = mw(request)
+
+        self.assertFalse(request.is_api_authenticated)
+        self.assertEqual(request.user, self.user)
+        self.assertTrue(request.user.is_authenticated)
+        self.assertEqual(response.status_code, 200)

--- a/sefaria/views.py
+++ b/sefaria/views.py
@@ -39,7 +39,8 @@ import sefaria.system.cache as scache
 from sefaria.helper.crm.crm_mediator import CrmMediator
 from sefaria.helper.crm.salesforce import SalesforceNewsletterListRetrievalError
 from sefaria.system.cache import get_shared_cache_elem, in_memory_cache, set_shared_cache_elem
-from sefaria.client.util import jsonResponse, send_email, read_webpack_bundle, notStaffOrApiResponse
+from sefaria.client.util import jsonResponse, send_email, read_webpack_bundle, notStaffOrApiResponse, \
+    authenticationRequiredResponse
 from sefaria.forms import SefariaNewUserForm, SefariaNewUserFormAPI, SefariaDeleteUserForm, SefariaDeleteSheet
 from sefaria.settings import MAINTENANCE_MESSAGE, USE_VARNISH, MULTISERVER_ENABLED
 from sefaria.model.user_profile import UserProfile, user_link
@@ -1178,6 +1179,8 @@ def index_sheets_by_timestamp(request):
     import dateutil.parser
 
     user = request.user
+    if not user.is_authenticated:
+        return authenticationRequiredResponse()
     if not user.is_staff:
         return notStaffOrApiResponse()
 

--- a/sefaria/views.py
+++ b/sefaria/views.py
@@ -39,7 +39,7 @@ import sefaria.system.cache as scache
 from sefaria.helper.crm.crm_mediator import CrmMediator
 from sefaria.helper.crm.salesforce import SalesforceNewsletterListRetrievalError
 from sefaria.system.cache import get_shared_cache_elem, in_memory_cache, set_shared_cache_elem
-from sefaria.client.util import jsonResponse, send_email, read_webpack_bundle
+from sefaria.client.util import jsonResponse, send_email, read_webpack_bundle, authenticationRequiredResponse
 from sefaria.forms import SefariaNewUserForm, SefariaNewUserFormAPI, SefariaDeleteUserForm, SefariaDeleteSheet
 from sefaria.settings import MAINTENANCE_MESSAGE, USE_VARNISH, MULTISERVER_ENABLED
 from sefaria.model.user_profile import UserProfile, user_link
@@ -1176,17 +1176,10 @@ def versions_csv(request):
 @csrf_exempt
 def index_sheets_by_timestamp(request):
     import dateutil.parser
-    from django.contrib.auth.models import User
 
-    key = request.POST.get("apikey")
-    if not key:
-        return jsonResponse({"error": "You must be logged in or use an API key to index sheets by timestamp."})
-    apikey = db.apikeys.find_one({"key": key})
-    if not apikey:
-        return jsonResponse({"error": "Unrecognized API key."})
-    user = User.objects.get(id=apikey["uid"])
+    user = request.user
     if not user.is_staff:
-        return jsonResponse({"error": "Only Sefaria Moderators can add or edit terms."})
+        return authenticationRequiredResponse()
 
     timestamp = request.POST.get('timestamp')
     try:

--- a/sefaria/views.py
+++ b/sefaria/views.py
@@ -39,7 +39,7 @@ import sefaria.system.cache as scache
 from sefaria.helper.crm.crm_mediator import CrmMediator
 from sefaria.helper.crm.salesforce import SalesforceNewsletterListRetrievalError
 from sefaria.system.cache import get_shared_cache_elem, in_memory_cache, set_shared_cache_elem
-from sefaria.client.util import jsonResponse, send_email, read_webpack_bundle, authenticationRequiredResponse
+from sefaria.client.util import jsonResponse, send_email, read_webpack_bundle, notStaffOrApiResponse
 from sefaria.forms import SefariaNewUserForm, SefariaNewUserFormAPI, SefariaDeleteUserForm, SefariaDeleteSheet
 from sefaria.settings import MAINTENANCE_MESSAGE, USE_VARNISH, MULTISERVER_ENABLED
 from sefaria.model.user_profile import UserProfile, user_link
@@ -1179,7 +1179,7 @@ def index_sheets_by_timestamp(request):
 
     user = request.user
     if not user.is_staff:
-        return authenticationRequiredResponse()
+        return notStaffOrApiResponse()
 
     timestamp = request.POST.get('timestamp')
     try:


### PR DESCRIPTION
## Description
We are using in many of our views for both site's users and API. Threefore in many views we have logic for checking if an api request is authenticated. This PR moves this logic to a middleware and refactor all the views accordingly.

## Code Changes
- `system.middleware.py` - if user is not authenticated but have apikey, it add its user to the `request.user`. Also it add the attribute `is_api_authenticated` to all requests.
- `settings` - adds the middlware to `MIDDLEWARE`
- `system.tests.middleware.py`
- `sefaria.client.util.py` - new `authenticationRequiredResponse` and `notStaffOrApiResponse` for use in views, rather than variety of different respnses.
- `reader.views.py` `sefaria.views.py` `sourcesheets.views.py` - refactor of authentication handling when now everything is done by `request.user` and `request.is_api_authenticated` and using the new response objects. This is a hard to read diff, I've checked it twice, but i think it's important that someone else will check it.
- `scripts/move_draft_text.py` `scripts/post_sheet.py` `scripts/scheduled/reindex_elasticsearch_cronjob.py` - scripts sending api request with apikey - refactored to send it in the headers.

## Notes
Since I've touched  `move_draft_text`, I've also removed the slack message at its end - it osn't working, throws error and unnecessary because the real job is done on celery.
