### PR TITLE
Bug/sc 903/mishnah berakhot chapter jumps

### DIFF
--- a/static/js/TextColumn.jsx
+++ b/static/js/TextColumn.jsx
@@ -38,7 +38,6 @@ class TextColumn extends Component {
          content_type: Sefaria.index(this.props.bookTitle).primary_category,
          item_id: this.props.bookTitle
        }
-      console.log(params)
       gtag("event", "select_content", params)
 
     this.node.addEventListener("scroll", this.handleScroll);
@@ -54,13 +53,11 @@ class TextColumn extends Component {
 
     if (prevProps.mode === "Text" && this.props.mode === "TextAndConnections") {
       // When opening mobile connections panel, scroll to highlighted
-      // console.log("scroll to highlight for mobile connections open")
       this.scrollToHighlighted();
 
     } else if (this.state.showScrollPlaceholders && !prevState.showScrollPlaceholders && !this.initialScrollTopSet) {
       // After scroll placeholders are first rendered, scroll down so top placeholder
       // is out of view and scrolling up is possible.
-      // console.log("scrolling for ScrollPlaceholders first render")
       this.setInitialScrollPosition();
 
     } else if (this.props.srefs.length === 1 &&
@@ -68,7 +65,6 @@ class TextColumn extends Component {
         !prevProps.srefs.some(r => Sefaria.refContains(this.props.srefs[0], r))) {
       // If we are switching to a single ref not in the current TextColumn,
       // treat it as a fresh open.
-      // console.log("setting initialScroll for brand new ref")
       this.setInitialScrollPosition();
 
     } else if (prevProps.srefs.length === this.props.srefs.length &&
@@ -80,11 +76,9 @@ class TextColumn extends Component {
     } else if ((this.props.settings.language !== prevProps.settings.language) ||
         !Sefaria.areBothVersionsEqual(prevProps.currVersions, this.props.currVersions)) {
       // When the content the changes but we are anchored on a line, scroll to it
-      // console.log("scroll to highlighted on text content change")
       this.scrollToHighlighted();
     } else if (layoutWidthChanged) {
       // When the width of the text column changes, keep highlighted text in place
-      // console.log("restore scroll by percentage for layout Width Change")
       this.restoreScrollPositionByPercentage();
     }
     
@@ -158,7 +152,6 @@ class TextColumn extends Component {
 
     // TextRanges in the column may be initial rendered in "loading" state without data.
     // When the data loads we may need to change scroll position or render addition ranges.
-    // console.log("handle text load: ", ref);
     if (this.$container.find(".basetext.loading").length) {
       // Don't mess with scroll positions until all sections of text have loaded,
       // prevent race conditions when mutliple section may load out of order.
@@ -173,7 +166,6 @@ class TextColumn extends Component {
     // When content loads check if we already need to load another section below, which
     // occurs when the loaded section is very short and whitespace is already visible below it.
     // Only check down, a text load should never trigger an infinite scroll up
-    // console.log("Checking infinite scroll down");
     this.adjustInfiniteScroll(true);
 
     if (this.loadingContentAtTop) {
@@ -228,7 +220,6 @@ class TextColumn extends Component {
   restoreScrollPositionAfterTopLoad() {
     // After one or more new TextRanges have just loaded in the first position, scroll
     // down to the TextRange that was visible before, so the TextColumn doesn't jump.
-    // console.log("checking restore scroll after up");
     const $texts  = this.$container.find(".basetext");
     if ($texts.length < 2 || $texts.eq(0).hasClass("loading") ) { return; }
 
@@ -237,7 +228,6 @@ class TextColumn extends Component {
     const adjust = this.scrollPlaceholderHeight + this.scrollPlaceholderMargin;
     const top = targetTop + (2*this.node.scrollTop) - adjust;
     this.setScrollTop(top);
-    // console.log("scroll to restore after infinite up: " + top)
   }
   restoreScrollPositionByPercentage() {
     // After the layout width of the column changes, restore the scroll to the same percentage

--- a/static/js/TextColumn.jsx
+++ b/static/js/TextColumn.jsx
@@ -252,7 +252,7 @@ class TextColumn extends Component {
 
     let refs         = this.props.srefs.slice();
     const $lastText    = $node.find(".textRange.basetext").last();
-    if (!$lastText.length) { console.log("no last basetext"); return; }
+    if (!$lastText.length) { return; }
     const lastTop      = $lastText.position().top;
     const lastBottom   = lastTop + $lastText.outerHeight();
     const windowHeight = $node.outerHeight();


### PR DESCRIPTION
## Description
The fix solves a bug where navigating a text with the TOC would then cause the page to jump.

## Code Changes
Fixing code changes
1. Changed the calculation of restoreScrollPositionAfterTopLoad - removing a `2*` that was causing trouble
2. Fixed the infinite scroll state persisting after chapter navigation

Other code changes
1. Refactoring code into functions and adding comments for readability
2. Changed the clearing of loadingContentAtTop - bring it forward to when we know the loading finished

## Notes
I cleaned out a bunch of old console logs (mostly commented out)