### PR TITLE
Add SA to cross-check GA

### DIFF
--- a/static/js/Header.jsx
+++ b/static/js/Header.jsx
@@ -16,71 +16,68 @@ import {
 import {ProfilePic} from "./ProfilePic";
 import {HeaderAutocomplete} from './HeaderAutocomplete'
 
-class Header extends Component {
-  constructor(props) {
-    super(props)
-    this.state = {
-      mobileNavMenuOpen: false,
-    };
-  }
-  componentDidMount() {
-    window.addEventListener('keydown', this.handleFirstTab);
-  }
-  handleFirstTab(e) {
-    if (e.keyCode === 9) { // tab (i.e. I'm using a keyboard)
-      document.body.classList.add('user-is-tabbing');
-      window.removeEventListener('keydown', this.handleFirstTab);
+const Header = (props) => {
+
+  useEffect(() => {
+    const handleFirstTab = (e) => {
+      if (e.keyCode === 9) { // tab (i.e. I'm using a keyboard)
+        document.body.classList.add('user-is-tabbing');
+        window.removeEventListener('keydown', handleFirstTab);
+      }
     }
-  }
-  toggleMobileNavMenu() {
-    this.setState({mobileNavMenuOpen: !this.state.mobileNavMenuOpen});
-  }
-  render() {
-    if (this.props.hidden && !this.props.mobileNavMenuOpen) {
-      return null;
+
+    window.addEventListener('keydown', handleFirstTab);
+
+    return () => {
+      window.removeEventListener('keydown', handleFirstTab);
     }
-    const logo = Sefaria.interfaceLang == "hebrew" ?
-      <img src="/static/img/logo-hebrew.png" alt="Sefaria Logo"/> :
-      <img src="/static/img/logo.svg" alt="Sefaria Logo"/>;
+  }, []);
 
-    const headerContent = (
-      <>
+  if (props.hidden && !props.mobileNavMenuOpen) {
+    return null;
+  }
 
-        <div className="headerNavSection">
-          { Sefaria._siteSettings.TORAH_SPECIFIC ?
-          <a className="home" href="/" >{logo}</a> : null }
-          <a href="/texts" className="textLink"><InterfaceText context="Header">Texts</InterfaceText></a>
-            <a href="/topics" className="textLink"><InterfaceText context="Header">Explore</InterfaceText></a>
-          <a href="/community" className="textLink"><InterfaceText>Community</InterfaceText></a>
-          <DonateLink classes={"textLink donate"} source={"Header"}><InterfaceText>Donate</InterfaceText></DonateLink>
-        </div>
+  const logo = Sefaria.interfaceLang == "hebrew" ?
+    <img src="/static/img/logo-hebrew.png" alt="Sefaria Logo"/> :
+    <img src="/static/img/logo.svg" alt="Sefaria Logo"/>;
 
-        <div className="headerLinksSection">
-        <HeaderAutocomplete
-            onRefClick={this.props.onRefClick}
-            showSearch={this.props.showSearch}
-            openTopic={this.props.openTopic}
-            openURL={this.props.openURL}
-        />
+  const headerContent = (
+    <>
+      <div className="headerNavSection">
+        { Sefaria._siteSettings.TORAH_SPECIFIC ?
+        <a className="home" href="/" >{logo}</a> : null }
+        <a href="/texts" className="textLink"><InterfaceText context="Header">Texts</InterfaceText></a>
+          <a href="/topics" className="textLink"><InterfaceText context="Header">Explore</InterfaceText></a>
+        <a href="/community" className="textLink"><InterfaceText>Community</InterfaceText></a>
+        <DonateLink classes={"textLink donate"} source={"Header"}><InterfaceText>Donate</InterfaceText></DonateLink>
+      </div>
+
+      <div className="headerLinksSection">
+      <HeaderAutocomplete
+          onRefClick={props.onRefClick}
+          showSearch={props.showSearch}
+          openTopic={props.openTopic}
+          openURL={props.openURL}
+      />
 
 
-          { Sefaria._uid ?
-            <LoggedInButtons headerMode={this.props.headerMode}/>
-            : <LoggedOutButtons headerMode={this.props.headerMode}/>
-          }
-          { !Sefaria._uid && Sefaria._siteSettings.TORAH_SPECIFIC ?
-              <InterfaceLanguageMenu
-                currentLang={Sefaria.interfaceLang}
-                translationLanguagePreference={this.props.translationLanguagePreference}
-                setTranslationLanguagePreference={this.props.setTranslationLanguagePreference} /> : null}
-        </div>
-      </>
+        { Sefaria._uid ?
+          <LoggedInButtons headerMode={props.headerMode}/>
+          : <LoggedOutButtons headerMode={props.headerMode}/>
+        }
+        { !Sefaria._uid && Sefaria._siteSettings.TORAH_SPECIFIC ?
+            <InterfaceLanguageMenu
+              currentLang={Sefaria.interfaceLang}
+              translationLanguagePreference={props.translationLanguagePreference}
+              setTranslationLanguagePreference={props.setTranslationLanguagePreference} /> : null}
+      </div>
+    </>
     );
 
     const mobileHeaderContent = (
       <>
         <div>
-          <button onClick={this.props.onMobileMenuButtonClick} aria-label={Sefaria._("Menu")} className="menuButton">
+          <button onClick={props.onMobileMenuButtonClick} aria-label={Sefaria._("Menu")} className="menuButton">
             <i className="fa fa-bars"></i>
           </button>
         </div>
@@ -90,40 +87,40 @@ class Header extends Component {
           <a className="home" href="/texts" >{logo}</a> : null }
         </div>
 
-        {this.props.hasLanguageToggle ?
-        <div className={this.props.firstPanelLanguage + " mobileHeaderLanguageToggle"}>
-          <LanguageToggleButton toggleLanguage={this.props.toggleLanguage} />
+        {props.hasLanguageToggle ?
+        <div className={props.firstPanelLanguage + " mobileHeaderLanguageToggle"}>
+          <LanguageToggleButton toggleLanguage={props.toggleLanguage} />
         </div> :
         <div></div>}
       </>
     );
 
-    const headerClasses = classNames({header: 1, mobile: !this.props.multiPanel});
+    const headerClasses = classNames({header: 1, mobile: !props.multiPanel});
     const headerInnerClasses = classNames({
       headerInner: 1,
-      boxShadow: this.props.hasBoxShadow,
-      mobile: !this.props.multiPanel
+      boxShadow: props.hasBoxShadow,
+      mobile: !props.multiPanel
     });
     return (
       <div className={headerClasses} role="banner">
         <div className={headerInnerClasses}>
-          {this.props.multiPanel ? headerContent : mobileHeaderContent}
+          {props.multiPanel ? headerContent : mobileHeaderContent}
         </div>
 
-        {this.props.multiPanel ? null :
+        {props.multiPanel ? null :
         <MobileNavMenu
-          visible={this.props.mobileNavMenuOpen}
-          onRefClick={this.props.onRefClick}
-          showSearch={this.props.showSearch}
-          openTopic={this.props.openTopic}
-          openURL={this.props.openURL}
-          close={this.props.onMobileMenuButtonClick} />
+          visible={props.mobileNavMenuOpen}
+          onRefClick={props.onRefClick}
+          showSearch={props.showSearch}
+          openTopic={props.openTopic}
+          openURL={props.openURL}
+          close={props.onMobileMenuButtonClick} />
         }
         <GlobalWarningMessage />
       </div>
     );
-  }
 }
+
 Header.propTypes = {
   multiPanel:   PropTypes.bool.isRequired,
   headerMode:   PropTypes.bool.isRequired,
@@ -410,4 +407,4 @@ const HelpButton = () => {
 };
 
 
-export default Header;
+export { Header } ;

--- a/static/js/Header.jsx
+++ b/static/js/Header.jsx
@@ -11,36 +11,12 @@ import {
   InterfaceLanguageMenu,
   InterfaceText,
   LanguageToggleButton,
-  DonateLink
+  DonateLink,
+  useOnceFullyVisible
 } from './Misc';
 import {ProfilePic} from "./ProfilePic";
 import {HeaderAutocomplete} from './HeaderAutocomplete'
 
-function useOnceFullyVisible(onVisible, key) {
-  const targetRef = useRef(null);
-
-  useEffect(() => {
-    if (sessionStorage.getItem(key)) return;
-    const node = targetRef.current;
-    if (!node) return;
-
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry.isIntersecting && entry.intersectionRatio === 1) {
-          onVisible();
-          sessionStorage.setItem(key, "true");
-          observer.disconnect();
-        }
-      },
-      { threshold: 1 }
-    );
-
-    observer.observe(node);
-    return () => observer.disconnect();
-  }, [onVisible, key]);
-
-  return targetRef;
-}
 
 const Header = (props) => {
 
@@ -438,4 +414,4 @@ const HelpButton = () => {
 };
 
 
-export {Header, useOnceFullyVisible};
+export {Header};

--- a/static/js/Misc.jsx
+++ b/static/js/Misc.jsx
@@ -24,6 +24,7 @@ import {EditTextInfo} from "./BookPage";
 import ReactMarkdown from 'react-markdown';
 import TrackG4 from "./sefaria/trackG4";
 import { ReaderApp } from './ReaderApp';
+import { useOnceFullyVisible } from './Header';
 
 
 /**
@@ -1443,8 +1444,19 @@ const SmallBlueButton = ({onClick, tabIndex, text}) => {
 };
 
 
-const CategoryColorLine = ({category}) =>
-  <div className="categoryColorLine" style={{background: Sefaria.palette.categoryColor(category)}}/>;
+const CategoryColorLine = ({ category }) => {
+  const headerRef = useOnceFullyVisible(() => {
+    sa_event("header_viewed", { impression_type: "category_color_line" });
+    if (Sefaria._debug) console.log("sa: we got a view event (category color line)!");
+  }, "sa.header_viewed");
+  return (
+    <div
+      className="categoryColorLine"
+      style={{ background: Sefaria.palette.categoryColor(category) }}
+      ref={headerRef}
+    />
+  );
+};
 
 
 class ProfileListing extends Component {

--- a/static/js/Misc.jsx
+++ b/static/js/Misc.jsx
@@ -24,8 +24,32 @@ import {EditTextInfo} from "./BookPage";
 import ReactMarkdown from 'react-markdown';
 import TrackG4 from "./sefaria/trackG4";
 import { ReaderApp } from './ReaderApp';
-import { useOnceFullyVisible } from './Header';
 
+function useOnceFullyVisible(onVisible, key) {
+  const targetRef = useRef(null);
+
+  useEffect(() => {
+    if (sessionStorage.getItem(key)) return;
+    const node = targetRef.current;
+    if (!node) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting && entry.intersectionRatio === 1) {
+          onVisible();
+          sessionStorage.setItem(key, "true");
+          observer.disconnect();
+        }
+      },
+      { threshold: 1 }
+    );
+
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [onVisible, key]);
+
+  return targetRef;
+}
 
 /**
  * Component meant to simply denote a language specific string to go inside an InterfaceText element
@@ -3317,5 +3341,6 @@ export {
   LangSelectInterface,
   PencilSourceEditor,
   SmallBlueButton,
-  LearnAboutNewEditorBanner
+  LearnAboutNewEditorBanner,
+  useOnceFullyVisible
 };

--- a/static/js/Misc.jsx
+++ b/static/js/Misc.jsx
@@ -1469,7 +1469,7 @@ const SmallBlueButton = ({onClick, tabIndex, text}) => {
 
 
 const CategoryColorLine = ({ category }) => {
-  const headerRef = useOnceFullyVisible(() => {
+  const categoryColorLineRef = useOnceFullyVisible(() => {
     sa_event("header_viewed", { impression_type: "category_color_line" });
     if (Sefaria._debug) console.log("sa: we got a view event (category color line)!");
   }, "sa.header_viewed");
@@ -1477,7 +1477,7 @@ const CategoryColorLine = ({ category }) => {
     <div
       className="categoryColorLine"
       style={{ background: Sefaria.palette.categoryColor(category) }}
-      ref={headerRef}
+      ref={categoryColorLineRef}
     />
   );
 };

--- a/static/js/ReaderApp.jsx
+++ b/static/js/ReaderApp.jsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 import extend from 'extend';
 import PropTypes from 'prop-types';
 import Sefaria from './sefaria/sefaria';
-import Header from './Header';
+import { Header } from './Header';
 import ReaderPanel from './ReaderPanel';
 import $ from './sefaria/sefariaJquery';
 import EditCollectionPage from './EditCollectionPage';
@@ -218,6 +218,18 @@ class ReaderApp extends Component {
     } else if (Sefaria.isNewVisitor()) {
       // Initialize entries for first-time visitors to determine if they are new or returning presently or in the future
       Sefaria.markUserAsNewVisitor();
+    }
+
+    if (sessionStorage.getItem("sa.reader_app_mounted") == null) {
+      sessionStorage.setItem("sa.reader_app_mounted", "true");
+      sa_event("reader_app_mounted");
+      if (Sefaria._debug) console.log("sa: reader app has loaded!");
+    }
+    if (localStorage.getItem("sa.intersection_observer_api_checked") == null) {
+      if (!(IntersectionObserver in window)) {
+        sa_event("intersection_observer_not_supported");
+      }
+      localStorage.setItem("sa.intersection_observer_api_checked", "true");
     }
   }
   componentWillUnmount() {

--- a/static/js/ReaderApp.jsx
+++ b/static/js/ReaderApp.jsx
@@ -220,12 +220,12 @@ class ReaderApp extends Component {
       Sefaria.markUserAsNewVisitor();
     }
 
-    if (sessionStorage.getItem("sa.reader_app_mounted") == null) {
+    if (sessionStorage.getItem("sa.reader_app_mounted") === null) {
       sessionStorage.setItem("sa.reader_app_mounted", "true");
       sa_event("reader_app_mounted");
       if (Sefaria._debug) console.log("sa: reader app has loaded!");
     }
-    if (localStorage.getItem("sa.intersection_observer_api_checked") == null) {
+    if (localStorage.getItem("sa.intersection_observer_api_checked") === null) {
       if (!('IntersectionObserver' in window)) {
         sa_event("intersection_observer_not_supported");
       }

--- a/static/js/ReaderApp.jsx
+++ b/static/js/ReaderApp.jsx
@@ -226,7 +226,7 @@ class ReaderApp extends Component {
       if (Sefaria._debug) console.log("sa: reader app has loaded!");
     }
     if (localStorage.getItem("sa.intersection_observer_api_checked") == null) {
-      if (!(IntersectionObserver in window)) {
+      if (!('IntersectionObserver' in window)) {
         sa_event("intersection_observer_not_supported");
       }
       localStorage.setItem("sa.intersection_observer_api_checked", "true");

--- a/templates/base.html
+++ b/templates/base.html
@@ -153,6 +153,32 @@
         })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
     </script>
     {% endif %}
+    
+    <!-- Simple Analytics -->
+    {# Allow queuing of events in case embed script hasn't loaded yet when calling sa_event #}
+    <script>
+      window.sa_event = window.sa_event || function () {
+        const a = [].slice.call(arguments);
+        window.sa_event.q ? window.sa_event.q.push(a) : window.sa_event.q = [a];
+      };
+    </script>
+    {% if DEBUG %}
+    <script 
+      data-hostname="sa-dev.sefaria.org" 
+      data-collect-dnt="true" 
+      data-allow-params="with,p1,p2,p3,p4,p5,w1,w2,w3,w4,w5" 
+      async 
+      src="https://scripts.simpleanalyticscdn.com/latest.dev.js">
+    </script>
+    {% else %}
+    <script 
+      data-hostname="sefaria.org" 
+      data-collect-dnt="true" 
+      data-allow-params="with,p1,p2,p3,p4,p5,w1,w2,w3,w4,w5" 
+      async 
+      src="https://scripts.simpleanalyticscdn.com/latest.js">
+    </script>
+    {% endif %}
 
     <!-- Unbounce Embed Code -->
     <script src="https://fd810a0513c94a16a52ef4d0d9b9c6c8.js.ubembed.com" async></script> 
@@ -275,5 +301,21 @@
     {% render_bundle 'main' %}
 
     {% block js %}{% endblock %}
+    
+    <!-- Default metadata for Simple Analytics -->
+    <script>
+      const SESSION_KEY = 'sa_custom_session_id';
+      if (sessionStorage.getItem(SESSION_KEY) == null) {
+        sessionStorage.setItem(SESSION_KEY, crypto.randomUUID());
+      }
+      sa_metadata = {
+        logged_in: DJANGO_VARS?.props._uid != null,
+        interface_lang: DJANGO_VARS?.props.interfaceLang === 'hebrew' ? 'he' : 'en',
+        device_type: DJANGO_VARS?.props.multiPanel ? 'desktop' : 'mobile',
+        user_type: Sefaria.isReturningVisitor() ? 'old' : 'new',
+        custom_session_id: sessionStorage.getItem(SESSION_KEY),
+        ...(DJANGO_VARS?.props._email.includes('sefaria.org') && { traffic_type: 'sefaria_email' })
+      };
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Description

**Simple Analytics (SA)** has been added alongside GA to verify event counts and isolate any `IntersectionObserver` problems. SA’s raw, unsampled logs and its stricter bot filtering will help us determine if real humans are seeing fewer impressions or if GA is inflating page views.

A couple fixed elements were wired up to validate the observer itself. The fixed elements must become fully visible at least once per session. When that happens, each of their hooks fires exactly one impression event and tags the session with a key so that it can later be confirmed through analysis.

## Code Changes

- **Embed Simple Analytics** in base.html.
  - Production script plus a dev script that points at a separate hostname, so test traffic doesn’t taint production numbers
  - SA automatically strips bots it recognizes
- **Include consistent app‑level metadata** in every SA event, the same fields already being sent to GA, plus some additional ones.
  - Generate and send an explicit `session_uuid` so the ID is visible in SA dashboards and easy to join on later.
- **Convert Header component to a functional component** so that hooks can be used cleanly
- **Add useOnceFullyVisible hook** (inside the Header file). It attaches an IntersectionObserver and fires a callback only after the element has been 100% in view
- **Emit a `header_viewed` event** the first time the header or the category color line is fully visible. One of those two elements appears in every session.
- **On ReaderApp mount**
  - Fire `reader_app_mounted` to mark a standard app startup.
  - Fire `intersection_observer_not_supported` if the browser lacks `IntersectionObserver`. These two events will help explain any missing impression data.