### PR TITLE
Closing ConnectionsPanel won't affect main panel's `refs` and `currentlyVisibleRef`

### DIFF
--- a/static/js/ReaderApp.jsx
+++ b/static/js/ReaderApp.jsx
@@ -1713,8 +1713,6 @@ toggleSignUpModal(modalContentKind = SignUpModalKind.Default) {
         const parent = this.state.panels[n-1];
         parent.filter = [];
         parent.highlightedRefs = [];
-        parent.refs = parent.refs.map(ref => Sefaria.ref(ref).sectionRef);
-        parent.currentlyVisibleRef = parent.currentlyVisibleRef ? Sefaria.ref(parent.currentlyVisibleRef).sectionRef : null;
       }
       this.state.panels.splice(n, 1);
       if (this.state.panels[n] && (this.state.panels[n].mode === "Connections" || this.state.panels[n].compare)) {


### PR DESCRIPTION
## Description
When starting from a segment ref (e.g. from url or search bar) the `TextRange` is created with the segment ref as key. Opening and closing the sidebar causes the key to change to the section ref, so the `TextRange` is remounted and jumps to its beginning.
On its face, there is no reason to change the `refs` and `currentlyVisibleRef` in this situation - the `TextRange` can continue to havethe segment ref as it was before.

## Notes
Turns out that when the segment ref remains, it will be highlighted with blue even after closing the sidebar.