### PR TITLE
fix(topics): Return null on link to sheet search if no title exists

### DIFF
--- a/static/js/TopicPage.jsx
+++ b/static/js/TopicPage.jsx
@@ -932,7 +932,9 @@ const TopicSideColumn = ({ slug, links, clearAndSetTopic, parashaData, tref, set
 
 
   const LinkToSheetsSearchComponent = () => {
-
+    if (!topicTitle) {
+      return null;
+    }
     let searchUrlEn = `/search?q=${topicTitle.en}&tab=sheet&tvar=1&tsort=relevance&stopics_enFilters=${topicTitle.en}&svar=1&ssort=relevance`;
     let searchUrlHe = `/search?q=${topicTitle.he}&tab=sheet&tvar=1&tsort=relevance&stopics_heFilters=${topicTitle.he}&svar=1&ssort=relevance`;
       return (


### PR DESCRIPTION
## Description
Bugfix to prevent error on rendering the link to sheet search from a topic page where there is no topic title

## Code Changes
Added a validation conditional to `LinkToSheetsSearchComponent` in `TopicPage.jsx`

## Notes
