### PR TITLE
Fix Simple Analytics metadata collection

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -162,23 +162,6 @@
         window.sa_event.q ? window.sa_event.q.push(a) : window.sa_event.q = [a];
       };
     </script>
-    {% if DEBUG %}
-    <script 
-      data-hostname="sa-dev.sefaria.org" 
-      data-collect-dnt="true" 
-      data-allow-params="with,p1,p2,p3,p4,p5,w1,w2,w3,w4,w5" 
-      async 
-      src="https://scripts.simpleanalyticscdn.com/latest.dev.js">
-    </script>
-    {% else %}
-    <script 
-      data-hostname="sefaria.org" 
-      data-collect-dnt="true" 
-      data-allow-params="with,p1,p2,p3,p4,p5,w1,w2,w3,w4,w5" 
-      async 
-      src="https://scripts.simpleanalyticscdn.com/latest.js">
-    </script>
-    {% endif %}
 
     <!-- Unbounce Embed Code -->
     <script src="https://fd810a0513c94a16a52ef4d0d9b9c6c8.js.ubembed.com" async></script> 
@@ -305,17 +288,38 @@
     <!-- Default metadata for Simple Analytics -->
     <script>
       const SESSION_KEY = 'sa_custom_session_id';
-      if (sessionStorage.getItem(SESSION_KEY) == null) {
+      if (sessionStorage.getItem(SESSION_KEY) === null) {
         sessionStorage.setItem(SESSION_KEY, crypto.randomUUID());
       }
+      const SA_KEY = 'sa_id';
+      if (localStorage.getItem(SA_KEY) === null) {
+        localStorage.setItem(SA_KEY, crypto.randomUUID());
+      }
       sa_metadata = {
-        logged_in: DJANGO_VARS?.props._uid != null,
-        interface_lang: DJANGO_VARS?.props.interfaceLang === 'hebrew' ? 'he' : 'en',
-        device_type: DJANGO_VARS?.props.multiPanel ? 'desktop' : 'mobile',
+        logged_in: Boolean(DJANGO_VARS.props._uid),
+        interface_lang: DJANGO_VARS.props.interfaceLang === 'hebrew' ? 'he' : 'en',
+        device_type: DJANGO_VARS.props.multiPanel ? 'desktop' : 'mobile',
         user_type: Sefaria.isReturningVisitor() ? 'old' : 'new',
         custom_session_id: sessionStorage.getItem(SESSION_KEY),
-        ...(DJANGO_VARS?.props._email.includes('sefaria.org') && { traffic_type: 'sefaria_email' })
+        sefaria_id: localStorage.getItem(SA_KEY),
+        ...(DJANGO_VARS.props._email.includes('sefaria.org') && { traffic_type: 'sefaria_email' })
       };
     </script>
+
+    {% if DEBUG %}
+    <script 
+      defer 
+      data-hostname="sa-dev.sefaria.org" 
+      data-collect-dnt="true" 
+      src="https://scripts.simpleanalyticscdn.com/latest.dev.js">
+    </script>
+    {% else %}
+    <script 
+      defer 
+      data-hostname="sefaria.org" 
+      data-collect-dnt="true" 
+      src="https://scripts.simpleanalyticscdn.com/latest.js">
+    </script>
+    {% endif %}
 </body>
 </html>


### PR DESCRIPTION
## Description
After looking at the data being collected by Simple Analytics, it was found that the intended metadata is missing for many users. There is a possible race where the metadata would be undefined before the embed script is included and the event queue is flushed.

## Code Changes
* Move loading of embed script to after definition of metadata
* Make embed script `defer` to ensure it's executed after metadata definition code at its place in the HTML document
* Fix various equality errors that could cause potential issues