### PR TITLE
Clean Divs from sheet texts to prevent white screens

### DIFF
--- a/static/js/Editor.jsx
+++ b/static/js/Editor.jsx
@@ -541,6 +541,11 @@ function flattenLists(htmlString) {
 
   return doc.body.innerHTML;
 }
+function replaceDivWithBr(html){
+     return html
+    .replace(/<div[^>]*>/g, '')     // remove opening <div> tags (with or without attributes)
+    .replace(/<\/div>/g, '<br>');   // replace closing </div> tags with <br>
+}
 function replaceBrWithNewLine(html) {
   return html.replace(/<br\s*\/?>\s*/gi, '\n');
   }
@@ -548,7 +553,9 @@ function replaceBrWithNewLine(html) {
 function parseSheetItemHTML(rawhtml) {
     console.log(rawhtml);
     // replace non-breaking spaces with regular spaces and replace line breaks with spaces
-    let preparseHtml = rawhtml.replace(/\u00A0/g, ' ')
+    let preparseHtml = rawhtml.replace(/\u00A0/g, ' ');
+
+    preparseHtml = replaceDivWithBr(preparseHtml);
     preparseHtml = replaceBrWithNewLine(preparseHtml);
     // Nested lists are not supported in new editor, so flatten nested lists created with old editor into one depth lists:
     preparseHtml = flattenLists(preparseHtml);


### PR DESCRIPTION
This pull request introduces a new helper function to improve HTML preprocessing in the `Editor.jsx` file. The most notable change is the addition of `replaceDivWithBr`, which ensures that `<div>` tags are replaced with `<br>` tags during HTML parsing.

### HTML preprocessing improvements:

* [`static/js/Editor.jsx`](diffhunk://#diff-0edb809ee68c59c1469d28011e2d3be7af1cc5f8ab4d6a994150091983abfa41R544-R558): Added the `replaceDivWithBr` function to remove opening `<div>` tags and replace closing `<div>` tags with `<br>`. Integrated this function into the `parseSheetItemHTML` workflow to enhance the handling of HTML content.## Description
_A brief description of the PR_

## Code Changes
_The following changes were made to the files below_

## Notes
_Any additional notes go here_