### PR TITLE
Modify Text API to Wrap Citations using Marked Up Text Chunk

### DIFF
--- a/sefaria/model/text_request_adapter.py
+++ b/sefaria/model/text_request_adapter.py
@@ -249,7 +249,6 @@ class TextRequestAdapter:
                     sections_to_chunk[i] = marked_up_chunk
 
 
-            print(marked_up_chunks)
             def wrapper(string, sections):
                 print(sections)
                 chunk : MarkedUpTextChunk = sections_to_chunk.get(sections[0], None)

--- a/sefaria/model/text_request_adapter.py
+++ b/sefaria/model/text_request_adapter.py
@@ -178,62 +178,6 @@ class TextRequestAdapter:
                 shared_data[cache_key] = ne_by_secs
             return shared_data[cache_key]
 
-        def _ref_to_href(ref: str) -> str:
-            """
-            Turn 'Numbers 14' or 'Genesis 22:1' into '/Numbers.14' or '/Genesis.22.1'.
-            Feel free to swap this out if your routing is different.
-            """
-            return "/" + re.sub(r"[:\s]+", ".", ref.strip())
-
-        def wrap_citations_with_links(s: str, spans: List[Dict], end_inclusive: bool = False) -> str:
-            """
-            Wrap each citation span with <a class="refLink" ...>…</a>.
-
-            Args:
-                s: the original string.
-                spans: list of dicts with at least:
-                       - 'charRange': [start, end] (end is exclusive by default)
-                       - 'ref': e.g. 'Numbers 14'
-                       - 'text' (optional): visible text for the link (defaults to substring)
-                end_inclusive: set True if your charRange end is inclusive.
-
-            Returns:
-                Modified string with anchor tags inserted.
-            """
-            if not spans:
-                return s
-
-            # Insert from the right so earlier insertions don't shift later indices.
-            spans_sorted = sorted(spans, key=lambda sp: sp["charRange"][0], reverse=True)
-
-            out = s
-            for sp in spans_sorted:
-                start, end = sp["charRange"]
-                if end_inclusive:
-                    end += 1
-
-                # Clamp & sanity check
-                start = max(0, start)
-                end = min(len(out), end)
-                if start >= end:
-                    continue
-
-                # Use provided visible text if present, else slice from the string
-                visible = sp.get("text")
-                if not visible:
-                    visible = out[start:end]
-
-                ref = sp.get("ref", "").strip()
-                href = _ref_to_href(ref)
-                anchor = (
-                    f'<a class="refLink" href="{href}" data-ref="{escape(ref)}">'
-                    f'{escape(visible)}</a>'
-                )
-
-                out = out[:start] + anchor + out[end:]
-
-            return out
-
         # helper to build a segment-level link-wrapper once per version
         def build_link_wrapper(lang, version_text):
             marked_up_chunks = []


### PR DESCRIPTION
This pull request introduces enhanced handling of marked-up text segments by integrating the new `MarkedUpTextChunk.apply_spans_to_text` method into the text processing pipeline. The main improvement is that segment-level references within texts are now wrapped with HTML anchor tags using pre-defined spans, allowing for more precise and customizable markup compared to the previous regex-based approach.

**Marked-up text integration:**

* Added the `apply_spans_to_text` method to the `MarkedUpTextChunk` class, which applies span-based HTML anchor tags to a given text segment, ensuring that references are accurately marked up and validated against the text.
* Updated the segment-level link-wrapping logic in `make_named_entities_dict` (within `text_request_adapter.py`) to use `MarkedUpTextChunk` instances and their `apply_spans_to_text` method, replacing the previous regex-based reference wrapping approach.

**Dependency and import updates:**

* Added necessary imports for `MarkedUpTextChunk`, `re`, and other typing modules in both `marked_up_text_chunk.py` and `text_request_adapter.py` to support the new functionality. [[1]](diffhunk://#diff-96d144581c2e5728bf7afa66c26bac8fb8132de10105df70ee32e0a198d0f089R4-R7) [[2]](diffhunk://#diff-d42ecaa55ca81f346b614f436c44fb69821f09763886a9187797c8b199e83f40R6-R8)## Description
_A brief description of the PR_

## Code Changes
_The following changes were made to the files below_

## Notes
_Any additional notes go here_