### PR TITLE
Remove Topic Title Disambiguation from Search Query

### DIFF
--- a/static/js/TopicPage.jsx
+++ b/static/js/TopicPage.jsx
@@ -930,6 +930,9 @@ const TopicSideColumn = ({ slug, links, clearAndSetTopic, parashaData, tref, set
     : null
   );
 
+  const removeBrackettedDisambiguation = (str) => {
+    return str.replace(/\(.*?\)/g, '').trim();
+  }
 
   const LinkToSheetsSearchComponent = () => {
     if (!topicTitle?.en || !topicTitle?.he) {
@@ -937,8 +940,10 @@ const TopicSideColumn = ({ slug, links, clearAndSetTopic, parashaData, tref, set
       console.warn("Topic title is not set, cannot generate search URLs for sheets.");
       return null;
     }
-    let searchUrlEn = `/search?q=${topicTitle.en}&tab=sheet&tvar=1&tsort=relevance&stopics_enFilters=${topicTitle.en}&svar=1&ssort=relevance`;
-    let searchUrlHe = `/search?q=${topicTitle.he}&tab=sheet&tvar=1&tsort=relevance&stopics_heFilters=${topicTitle.he}&svar=1&ssort=relevance`;
+    const cleanHeTitle = removeBrackettedDisambiguation(topicTitle.he);
+    const cleanEnTitle = removeBrackettedDisambiguation(topicTitle.en);
+    let searchUrlEn = `/search?q=${cleanEnTitle}&tab=sheet&tvar=1&tsort=relevance&stopics_enFilters=${cleanEnTitle}&svar=1&ssort=relevance`;
+    let searchUrlHe = `/search?q=${cleanHeTitle}&tab=sheet&tvar=1&tsort=relevance&stopics_heFilters=${cleanHeTitle}&svar=1&ssort=relevance`;
       return (
         <TopicSideSection title={{ en: "Sheets", he: "דפי מקורות" }}>
           <InterfaceText>


### PR DESCRIPTION
This pull request improves the user experience when generating sheet search URLs for topics by ensuring that any bracketed disambiguation (e.g., "(Torah portion)") is removed from topic titles before constructing the URLs. This helps produce cleaner and more relevant search queries.

Enhancement to search URL generation:

* Added a new helper function `removeBrackettedDisambiguation` in `TopicPage.jsx` to strip bracketed phrases from topic titles before using them in sheet search URLs.
* Updated the `LinkToSheetsSearchComponent` to use the cleaned topic titles for both English and Hebrew search URLs, resulting in more accurate and user-friendly search queries.…from topic titles

## Description
_A brief description of the PR_

## Code Changes
_The following changes were made to the files below_

## Notes
_Any additional notes go here_