### PR TITLE
Zendesk link fixes - tests and some final touches

### DIFF
--- a/e2e-tests/tests/banner.spec.ts
+++ b/e2e-tests/tests/banner.spec.ts
@@ -40,8 +40,9 @@ test('Banner links exist - English', async ({ context }) => {
     await page2.close();
     
     // Testing Help link
-    await page.getByRole('banner').getByRole('link', { name: 'Help' }).click();
-    expect(getPathAndParams(page.url())).toContain("/hc/en-us")
+    const helpLink = page.getByRole('banner').getByRole('link', { name: 'Help' });
+    const helpHref = await helpLink.getAttribute('href');
+    expect(helpHref).toContain("/hc/en-us");
 
     const page1Promise = page.waitForEvent('popup');
     await page.getByRole('banner').getByRole('link', { name: 'Donate' }).click();
@@ -97,8 +98,9 @@ test('Banner links exist - Hebrew', async ({ context }) => {
     expect(getPathAndParams(page.url())).toBe("/register?next=%2Fsearch%3Fq%3Dlove%26tab%3Dtext%26tvar%3D1%26tsort%3Drelevance%26svar%3D1%26ssort%3Drelevance");
     
     // Testing Help link
-    await page.getByRole('banner').getByRole('link', { name: 'עזרה' }).click();
-    expect(getPathAndParams(page.url())).toContain("/hc/he");
+    const heHelpLink = page.getByRole('banner').getByRole('link', { name: 'עזרה' });
+    const heHelpHref = await heHelpLink.getAttribute('href');
+    expect(heHelpHref).toContain("/hc/he");
 
 });
 

--- a/static/js/Header.jsx
+++ b/static/js/Header.jsx
@@ -276,7 +276,7 @@ const MobileNavMenu = ({onRefClick, showSearch, openTopic, openURL, close, visib
         </a>
 
 
-        <a href="/help">
+        <a href={Sefaria._v({he: Sefaria._siteSettings.HELP_CENTER_URLS.HE, en: Sefaria._siteSettings.HELP_CENTER_URLS.EN_US})} target="_blank">
           <img src="/static/icons/help.svg" />
           <InterfaceText>Get Help</InterfaceText>
         </a>
@@ -363,7 +363,7 @@ const ProfilePicMenu = ({len, url, name}) => {
                 <a className={`${(Sefaria.interfaceLang == 'hebrew') ? 'active':''}`} href={`/interface/hebrew?next=${getCurrentPage()}`} id="select-hebrew-interface-link">עברית</a>
                 <a className={`${(Sefaria.interfaceLang == 'english') ? 'active':''}`} href={`/interface/english?next=${getCurrentPage()}`} id="select-english-interface-link">English</a>
               </div>
-              <div><a className="interfaceLinks-row bottom" id="help-link" href="/help">
+              <div><a className="interfaceLinks-row bottom" id="help-link" href={Sefaria._v({he: Sefaria._siteSettings.HELP_CENTER_URLS.HE, en: Sefaria._siteSettings.HELP_CENTER_URLS.EN_US})} target="_blank">
                 <InterfaceText>Help</InterfaceText>
               </a></div>
             </div>
@@ -407,7 +407,7 @@ const HelpButton = () => {
   const url = Sefaria._v({he: Sefaria._siteSettings.HELP_CENTER_URLS.HE, en: Sefaria._siteSettings.HELP_CENTER_URLS.EN_US});
   return (
     <div className="help">
-      <a href={url}>
+      <a href={url} target="_blank">
         <img src="/static/img/help.svg" alt={Sefaria._("Help")}/>
       </a>
     </div>

--- a/static/js/Header.jsx
+++ b/static/js/Header.jsx
@@ -276,7 +276,10 @@ const MobileNavMenu = ({onRefClick, showSearch, openTopic, openURL, close, visib
         </a>
 
 
-        <a href={Sefaria._v({he: Sefaria._siteSettings.HELP_CENTER_URLS.HE, en: Sefaria._siteSettings.HELP_CENTER_URLS.EN_US})} target="_blank">
+        <a href={Sefaria._v({
+          he: Sefaria._siteSettings.HELP_CENTER_URLS.HE, 
+          en: Sefaria._siteSettings.HELP_CENTER_URLS.EN_US
+        })} target="_blank">
           <img src="/static/icons/help.svg" />
           <InterfaceText>Get Help</InterfaceText>
         </a>
@@ -363,7 +366,10 @@ const ProfilePicMenu = ({len, url, name}) => {
                 <a className={`${(Sefaria.interfaceLang == 'hebrew') ? 'active':''}`} href={`/interface/hebrew?next=${getCurrentPage()}`} id="select-hebrew-interface-link">עברית</a>
                 <a className={`${(Sefaria.interfaceLang == 'english') ? 'active':''}`} href={`/interface/english?next=${getCurrentPage()}`} id="select-english-interface-link">English</a>
               </div>
-              <div><a className="interfaceLinks-row bottom" id="help-link" href={Sefaria._v({he: Sefaria._siteSettings.HELP_CENTER_URLS.HE, en: Sefaria._siteSettings.HELP_CENTER_URLS.EN_US})} target="_blank">
+              <div><a className="interfaceLinks-row bottom" id="help-link" href={Sefaria._v({
+                he: Sefaria._siteSettings.HELP_CENTER_URLS.HE, 
+                en: Sefaria._siteSettings.HELP_CENTER_URLS.EN_US
+              })} target="_blank">
                 <InterfaceText>Help</InterfaceText>
               </a></div>
             </div>
@@ -404,7 +410,10 @@ const MobileInterfaceLanguageToggle = () => {
 
 
 const HelpButton = () => {
-  const url = Sefaria._v({he: Sefaria._siteSettings.HELP_CENTER_URLS.HE, en: Sefaria._siteSettings.HELP_CENTER_URLS.EN_US});
+  const url = Sefaria._v({
+    he: Sefaria._siteSettings.HELP_CENTER_URLS.HE, 
+    en: Sefaria._siteSettings.HELP_CENTER_URLS.EN_US
+  });
   return (
     <div className="help">
       <a href={url} target="_blank">


### PR DESCRIPTION
Fixed the tests that were failing.
They now just check the href is correct and don't click on the links.

I also changed a few more links from `/help` to use direct links.
I also made sure they open in a new tab