### PR TITLE
Add Google Analytics events in same locations as Simple Analytics events

### DIFF
--- a/static/js/BannerImpressionProbe.jsx
+++ b/static/js/BannerImpressionProbe.jsx
@@ -22,7 +22,7 @@ const BannerImpressionProbe = () => {
           console.log(`BannerImpressionProbe: Simulated Strapi data loaded after ${apiDelay.toFixed(0)}ms`);
         }
       }, apiDelay);
-    }, 2000); // Simulate rendering delay that real banners have
+    }, 2000);
 
     return () => {
       clearTimeout(renderTimer);
@@ -50,40 +50,20 @@ const BannerImpressionProbe = () => {
       style={{
         // Prevent from showing up in document flow
         position: "fixed",
-        top: "50vh", // Use viewport units for better cross-browser consistency
-        left: "50vw",
+        top: "50%",
+        left: "50%",
         width: "1px",
         height: "1px",
         opacity: 0.001, // Minimum opacity for IntersectionObserver to detect
         pointerEvents: "none", // Prevent all mouse/touch interactions
-        zIndex: -2147483648, // Minimum possible z-index (32-bit signed integer min)
-        overflow: "hidden",
-        // Ensure no visual artifacts
-        background: "transparent",
-        border: "none",
-        outline: "none",
-        boxShadow: "none",
-        transform: "translateZ(-1px)", // Push behind everything in 3D space
-        willChange: "auto", // Prevent browser optimization issues
-        contain: "layout style paint", // CSS containment - isolates rendering
         userSelect: "none", // Prevent text selection
+        zIndex: -1,
+        overflow: "hidden",
+        border: "none",
+        contain: "layout style paint", // CSS containment - prevent layout and style outside of it from being affected
       }}
       aria-hidden="true" // Hide from screen readers
-      role="presentation" // Additional accessibility hiding
-      tabIndex={-1} // Prevent keyboard focus
     >
-      {/* Minimal content for IntersectionObserver detection */}
-      <span
-        style={{
-          position: "absolute",
-          width: "1px",
-          height: "1px",
-          overflow: "hidden",
-          whiteSpace: "nowrap",
-        }}
-      >
-        .
-      </span>
     </div>
   );
 };

--- a/static/js/BannerImpressionProbe.jsx
+++ b/static/js/BannerImpressionProbe.jsx
@@ -1,0 +1,91 @@
+
+import Sefaria from "./sefaria/sefaria";
+import { useEffect, useState } from "react";
+import { useOnceFullyVisible } from "./Misc";
+
+const BannerImpressionProbe = () => {
+  const [shouldRender, setShouldRender] = useState(false);
+  const [dataLoaded, setDataLoaded] = useState(false);
+
+  // Simulate the delayed rendering that real banners have
+  useEffect(() => {
+    let renderTimer, apiCallTimer;
+
+    renderTimer = setTimeout(() => {
+      setShouldRender(true);
+      // Simulate the API call to Strapi that real banners make
+      // Mock API delay (300-800ms)
+      const apiDelay = Math.random() * 500 + 300;
+      apiCallTimer = setTimeout(() => {
+        setDataLoaded(true);
+        if (Sefaria._debug) {
+          console.log(`BannerImpressionProbe: Simulated Strapi data loaded after ${apiDelay.toFixed(0)}ms`);
+        }
+      }, apiDelay);
+    }, 2000); // Simulate rendering delay that real banners have
+
+    return () => {
+      clearTimeout(renderTimer);
+      clearTimeout(apiCallTimer);
+    };
+  }, []);
+
+  const probeRef = useOnceFullyVisible(() => {
+    sa_event("banner_probe_viewed");
+    gtag("event", "banner_probe_viewed");
+
+    if (Sefaria._debug) {
+      console.log("BannerImpressionProbe: Analytics events fired");
+    }
+  }, `sa.banner_probe`);
+
+  // Don't render anything until delays have passed
+  if (!shouldRender || !dataLoaded) {
+    return null;
+  }
+
+  return (
+    <div
+      ref={probeRef}
+      style={{
+        // Prevent from showing up in document flow
+        position: "fixed",
+        top: "50vh", // Use viewport units for better cross-browser consistency
+        left: "50vw",
+        width: "1px",
+        height: "1px",
+        opacity: 0.001, // Minimum opacity for IntersectionObserver to detect
+        pointerEvents: "none", // Prevent all mouse/touch interactions
+        zIndex: -2147483648, // Minimum possible z-index (32-bit signed integer min)
+        overflow: "hidden",
+        // Ensure no visual artifacts
+        background: "transparent",
+        border: "none",
+        outline: "none",
+        boxShadow: "none",
+        transform: "translateZ(-1px)", // Push behind everything in 3D space
+        willChange: "auto", // Prevent browser optimization issues
+        contain: "layout style paint", // CSS containment - isolates rendering
+        userSelect: "none", // Prevent text selection
+      }}
+      aria-hidden="true" // Hide from screen readers
+      role="presentation" // Additional accessibility hiding
+      tabIndex={-1} // Prevent keyboard focus
+    >
+      {/* Minimal content for IntersectionObserver detection */}
+      <span
+        style={{
+          position: "absolute",
+          width: "1px",
+          height: "1px",
+          overflow: "hidden",
+          whiteSpace: "nowrap",
+        }}
+      >
+        .
+      </span>
+    </div>
+  );
+};
+
+export { BannerImpressionProbe };

--- a/static/js/Header.jsx
+++ b/static/js/Header.jsx
@@ -37,6 +37,7 @@ const Header = (props) => {
 
   const headerRef = useOnceFullyVisible(() => {
     sa_event("header_viewed", { impression_type: "regular_header" });
+    gtag("event", "header_viewed", { impression_type: "regular_header" });
     if (Sefaria._debug) console.log("sa: we got a view event! (regular header)");
   }, "sa.header_viewed");
 

--- a/static/js/Misc.jsx
+++ b/static/js/Misc.jsx
@@ -1547,6 +1547,7 @@ const SmallBlueButton = ({onClick, tabIndex, text}) => {
 const CategoryColorLine = ({ category }) => {
   const categoryColorLineRef = useOnceFullyVisible(() => {
     sa_event("header_viewed", { impression_type: "category_color_line" });
+    gtag("event", "header_viewed", { impression_type: "category_color_line" });
     if (Sefaria._debug) console.log("sa: we got a view event (category color line)!");
   }, "sa.header_viewed");
   return (

--- a/static/js/Misc.jsx
+++ b/static/js/Misc.jsx
@@ -2016,6 +2016,7 @@ const InterruptingMessage = ({
       campaignID: modalName,
       adType: "modal",
     });
+    sa_event("modal_interacted_with_" + eventDescription, { campaignID: modalName });
   };
 
   const trackModalImpression = () => {
@@ -2024,6 +2025,7 @@ const InterruptingMessage = ({
       campaignID: strapi.modal.internalModalName,
       adType: "modal",
     });
+    sa_event("modal_viewed", { campaignID: strapi.modal.internalModalName });
   };
 
   const shouldShow = () => {
@@ -2191,6 +2193,7 @@ const Banner = ({ onClose }) => {
       campaignID: bannerName,
       adType: "banner",
     });
+    sa_event("banner_interacted_with_" + eventDescription, { campaignID: bannerName });
   };
 
   const trackBannerImpression = () => {
@@ -2198,6 +2201,7 @@ const Banner = ({ onClose }) => {
       campaignID: strapi.banner.internalBannerName,
       adType: "banner",
     });
+    sa_event("banner_viewed", { campaign_id: strapi.banner.internalBannerName });
   };
 
   const shouldShow = () => {

--- a/static/js/ReaderApp.jsx
+++ b/static/js/ReaderApp.jsx
@@ -39,6 +39,7 @@ import Component from 'react-class';
 import  { io }  from 'socket.io-client';
 import { SignUpModalKind } from './sefaria/signupModalContent';
 import {shouldUseEditor} from './sefaria/sheetsUtils';
+import { BannerImpressionProbe } from './BannerImpressionProbe';
 
 class ReaderApp extends Component {
   constructor(props) {
@@ -2322,6 +2323,7 @@ toggleSignUpModal(modalContentKind = SignUpModalKind.Default) {
               {communityPagePreviewControls}
               <CookiesNotification />
             </div>
+            <BannerImpressionProbe />
           </div>
         </AdContext.Provider>
       </StrapiDataProvider>

--- a/static/js/ReaderApp.jsx
+++ b/static/js/ReaderApp.jsx
@@ -223,11 +223,13 @@ class ReaderApp extends Component {
     if (sessionStorage.getItem("sa.reader_app_mounted") === null) {
       sessionStorage.setItem("sa.reader_app_mounted", "true");
       sa_event("reader_app_mounted");
+      gtag("event", "reader_app_mounted");
       if (Sefaria._debug) console.log("sa: reader app has loaded!");
     }
     if (localStorage.getItem("sa.intersection_observer_api_checked") === null) {
       if (!('IntersectionObserver' in window)) {
         sa_event("intersection_observer_not_supported");
+        gtag("event", "intersection_observer_not_supported");
       }
       localStorage.setItem("sa.intersection_observer_api_checked", "true");
     }


### PR DESCRIPTION
## Description

To help determine the discrepancy issues with Google Analytics, **GA4** events have been added to the same DOM events as Simple Analytics (SA) events. Once data is collected from both firing at the same points, the platforms can be directly compared. **GA version:** GA4 via gtag('event', ...). **Parity:** SA and GA use identical event names/params where supported.

## Code Changes

- Adds Simple Analytics events to fire during impressions and interactions for banners/modals.
- Adds **GA4** events to the same DOM events as the previous areas where Simple Analytics events were added.
- Adds a new `BannerImpressionProbe` component that simulates the behavior of a Strapi-driven `Banner` at the same DOM level, emitting both GA4 and SA events when an impression occurs.

## Notes

- The `BannerImpressionProbe` component is **invisible** and should not influence the application's interactions, layout, or styling or any other components. The code was tested in multiple browsers to confirm this. The component was constructed and styled to be as minimally invasive as possible.
- Having events fire from the **non-visible probe component** for both platforms should help verify any remaining issues when using the `IntersectionObserver` API.
- An impression is recorded the first time the element meets the `IntersectionObserver` visibility threshold.
