### PR TITLE
Remove Divs from Editor's Serialization

### DIFF
--- a/static/js/Editor.jsx
+++ b/static/js/Editor.jsx
@@ -311,7 +311,6 @@ export const serialize = (content) => {
         }, {preTags: "", postTags: ""});
 
         const withBreaks = content.text.replace(/(?:\r\n|\r|\n)/g, '<br>'); // preserve br tags, as part of white-screen fix, they are now our serialized representation of new lines. The Sheet Reader relies on them as well.
-
         return (`${tagStringObj.preTags}${withBreaks}${tagStringObj.postTags}`)
 
     }
@@ -336,7 +335,7 @@ export const serialize = (content) => {
                 if (content["text-align"] == "center") {
                     return `<div style='text-align: center'>${paragraphHTML}</div>`
                 }
-                return `<div>${paragraphHTML}</div>`
+                return `${paragraphHTML}`
             }
 
             case 'list-item': {
@@ -551,7 +550,6 @@ function replaceBrWithNewLine(html) {
   }
 
 function parseSheetItemHTML(rawhtml) {
-    console.log(rawhtml);
     // replace non-breaking spaces with regular spaces and replace line breaks with spaces
     let preparseHtml = rawhtml.replace(/\u00A0/g, ' ');
 


### PR DESCRIPTION
This pull request makes minor adjustments to the `static/js/Editor.jsx` file, mainly focused on HTML serialization and parsing. The changes streamline the output of serialized content and remove unnecessary code.

Formatting and serialization improvements:

* Serialization now omits wrapping paragraphs in `<div>` tags when not center-aligned, outputting only the paragraph HTML instead.
* The `serialize` function's output remains unchanged except for minor formatting, ensuring `<br>` tags are preserved for line breaks as before.

Code cleanup:

* Removed a console log statement from `parseSheetItemHTML` to clean up debugging output.…ucture in HTML rendering

## Description
_A brief description of the PR_

## Code Changes
_The following changes were made to the files below_

## Notes
_Any additional notes go here_