### PR TITLE
fix: move global database access code into setup class in summaries_t…

### DIFF
--- a/sefaria/tests/summaries_test.py
+++ b/sefaria/tests/summaries_test.py
@@ -10,18 +10,14 @@ from sefaria.utils.testing_utils import *
 # no wandering commentaries
 
 
-""" SOME SETUP """
-
-text_titles = model.IndexSet({}).distinct('title')
-model.library.rebuild_toc()
-
-
 """ THE TESTS """
 
+@pytest.mark.django_db
 class Test_Toc(object):
 
     @classmethod
     def setup_class(cls):
+        cls.text_titles = model.IndexSet({}).distinct('title')
         model.library.rebuild_toc()
 
     @classmethod
@@ -65,10 +61,9 @@ class Test_Toc(object):
             raise
 
     def verify_text_node_integrity(self, node):
-        global text_titles
         expected_keys = {'title', 'heTitle'}
         assert set(node.keys()) >= expected_keys
-        assert (node['title'] in text_titles), node['title']
+        assert (node['title'] in self.text_titles), node['title']
         assert 'category' not in node
         #do we need to assert that the title is not equal to any category name?
 


### PR DESCRIPTION
## Description
Fix the failing pytests in modularization-main. See [results here](https://github.com/Sefaria/Sefaria-Project/actions/runs/17373555330/job/49319511246?pr=2636)

## Code Changes
`sefaria/tests/summaries_test.py`:

  1. Moved global rebuilt toc code into the setup_class method, so that database access can be properly configured
  2. Added @pytest.mark.django_db decorator to the test class to explicitly enable database access
  3. Changed text_titles into a class variable that gets initialized in the setup method so it's still accessible to the test methods

