### PR TITLE
chore: refactor sheet.jsx and dont pass editorSaveState and editable …

### DIFF
--- a/static/js/UserProfile.jsx
+++ b/static/js/UserProfile.jsx
@@ -520,7 +520,7 @@ const EditorToggleHeader = ({usesneweditor}) => {
 
 
 const UserBackground = ({profile: p, showBio, multiPanel}) => {
-    // used in ProfileSummary and in SheetContentSidebar, renders user education, organization, and location info
+    // used in ProfileSummary and in SheetSidebar, renders user education, organization, and location info
     // if 'showBio', render p.bio; this property corresponds to "About me" in the profile edit view
     const social = ['facebook', 'twitter', 'youtube', 'linkedin'];
     let infoList = [];

--- a/static/js/sheets/Sheet.jsx
+++ b/static/js/sheets/Sheet.jsx
@@ -133,8 +133,6 @@ class Sheet extends Component {
       const usingEditor = shouldUseEditor(sheet?.id);
       content = usingEditor ? this.getEditor(sheet) : this.getReader(sheet);
     }
-    return <div className={classes}>{content}</div>
-
   }
 }
 

--- a/static/js/sheets/Sheet.jsx
+++ b/static/js/sheets/Sheet.jsx
@@ -63,27 +63,8 @@ class Sheet extends Component {
      Sefaria.sheets._loadSheetByID[this.props.id].collections = Sefaria.getUserCollectionsForSheetFromCache(this.props.id);
      this.forceUpdate();
   }
-
-  render() {
-    const classes = classNames({sheetsInPanel: 1});
-    const sheet = this.getSheetFromCache();
-    const editable = Sefaria._uid === sheet?.owner;
-    let content, editor;
-    if (!sheet) {
-      content = (<LoadingMessage />);
-      editor = (<LoadingMessage />);
-    }
-    else {
-      const sidebar = <SheetContentSidebar
-                                  authorStatement={sheet.ownerName}
-                                  authorUrl={sheet.ownerProfileUrl}
-                                  authorImage={sheet.ownerImageUrl}
-                                  collections={sheet.collections}
-                                  toggleSignUpModal={this.props.toggleSignUpModal}
-                                  topics={sheet.topics}
-                                  editorSaveState={this.props.editorSaveState}
-                              />;
-        editor = <div className="sidebarLayout">
+  getEditor = (sheet) => (
+              <div className="sidebarLayout">
                   <div className="sheetContent">
                     <SefariaEditor
                         data={sheet}
@@ -103,41 +84,62 @@ class Sheet extends Component {
                         setEditorSaveState={this.props.setEditorSaveState}
                     />
                   </div>
-                  {sidebar}
-                </div>;
-      content = (
-          <div className="sidebarLayout">
-            <SheetContent
-                style={this.props.style}
-                sources={sheet.sources}
-                title={sheet.title}
-                handleClick={this.handleClick}
-                sheetSourceClick={this.props.onSegmentClick}
-                highlightedNode={this.props.highlightedNode} // for example, "3" -- the third node in the sheet
-                highlightedRefs={this.props.highlightedRefs} // for example, ["Genesis 1:1"] or ["Sheet 4:3"] -- the actual source
-                highlightedRefsInSheet={this.props.highlightedRefsInSheet}
-                scrollToHighlighted={this.props.scrollToHighlighted}
-                editable={editable}
-                setSelectedWords={this.props.setSelectedWords}
-                sheetID={sheet.id}
-                authorStatement={sheet.ownerName}
-                authorID={sheet.owner}
-                authorUrl={sheet.ownerProfileUrl}
-                authorImage={sheet.ownerImageUrl}
-                summary={sheet.summary}
-                toggleSignUpModal={this.props.toggleSignUpModal}
-                historyObject={this.props.historyObject}
-            />
-            {sidebar}
-          </div>
+                  <SheetContentSidebar
+                        authorStatement={sheet.ownerName}
+                        authorUrl={sheet.ownerProfileUrl}
+                        authorImage={sheet.ownerImageUrl}
+                        collections={sheet.collections}
+                        toggleSignUpModal={this.props.toggleSignUpModal}
+                        topics={sheet.topics}
+                        editorSaveState={this.props.editorSaveState}
+                  />;
+            </div>);
+  getContent = (sheet) => (
+    <div className="sidebarLayout">
+      <SheetContent
+          style={this.props.style}
+          sources={sheet.sources}
+          title={sheet.title}
+          handleClick={this.handleClick}
+          sheetSourceClick={this.props.onSegmentClick}
+          highlightedNode={this.props.highlightedNode} // for example, "3" -- the third node in the sheet
+          highlightedRefs={this.props.highlightedRefs} // for example, ["Genesis 1:1"] or ["Sheet 4:3"] -- the actual source
+          highlightedRefsInSheet={this.props.highlightedRefsInSheet}
+          scrollToHighlighted={this.props.scrollToHighlighted}
+          setSelectedWords={this.props.setSelectedWords}
+          sheetID={sheet.id}
+          authorStatement={sheet.ownerName}
+          authorID={sheet.owner}
+          authorUrl={sheet.ownerProfileUrl}
+          authorImage={sheet.ownerImageUrl}
+          summary={sheet.summary}
+          toggleSignUpModal={this.props.toggleSignUpModal}
+          historyObject={this.props.historyObject}
+      />
+      <SheetContentSidebar
+            authorStatement={sheet.ownerName}
+            authorUrl={sheet.ownerProfileUrl}
+            authorImage={sheet.ownerImageUrl}
+            collections={sheet.collections}
+            toggleSignUpModal={this.props.toggleSignUpModal}
+            topics={sheet.topics}
+      />;
+    </div>
+  );
+  render() {
+    const classes = classNames({sheetsInPanel: 1});
+    const sheet = this.getSheetFromCache();
+    if (!sheet) {
+      return <div className={classes}><LoadingMessage /></div>
+    }
+    else {
+      const usingEditor = shouldUseEditor(sheet?.id);
+      return (
+        <div className={classes}>
+          { usingEditor ? this.getEditor(sheet) : this.getContent(sheet) }
+        </div>
       );
     }
-    const usingEditor = shouldUseEditor(sheet?.id);
-    return (
-      <div className={classes}>
-         { usingEditor ? editor : content }
-      </div>
-    );
   }
 }
 

--- a/static/js/sheets/Sheet.jsx
+++ b/static/js/sheets/Sheet.jsx
@@ -5,7 +5,7 @@ import Component from 'react-class'
 import $  from '../sefaria/sefariaJquery';
 import Sefaria  from '../sefaria/sefaria';
 import { SefariaEditor } from '../Editor';
-import SheetContentSidebar from "./SheetContentSidebar";
+import SheetSidebar from "./SheetSidebar";
 import {
   LoadingMessage,
 } from '../Misc'; 
@@ -84,17 +84,9 @@ class Sheet extends Component {
                         setEditorSaveState={this.props.setEditorSaveState}
                     />
                   </div>
-                  <SheetContentSidebar
-                        authorStatement={sheet.ownerName}
-                        authorUrl={sheet.ownerProfileUrl}
-                        authorImage={sheet.ownerImageUrl}
-                        collections={sheet.collections}
-                        toggleSignUpModal={this.props.toggleSignUpModal}
-                        topics={sheet.topics}
-                        editorSaveState={this.props.editorSaveState}
-                  />;
+                  {this.getSidebar(sheet, true)}
             </div>);
-  getContent = (sheet) => (
+  getReader = (sheet) => (
     <div className="sidebarLayout">
       <SheetContent
           style={this.props.style}
@@ -116,30 +108,33 @@ class Sheet extends Component {
           toggleSignUpModal={this.props.toggleSignUpModal}
           historyObject={this.props.historyObject}
       />
-      <SheetContentSidebar
-            authorStatement={sheet.ownerName}
-            authorUrl={sheet.ownerProfileUrl}
-            authorImage={sheet.ownerImageUrl}
-            collections={sheet.collections}
-            toggleSignUpModal={this.props.toggleSignUpModal}
-            topics={sheet.topics}
-      />;
+      {this.getSidebar(sheet, false)}
     </div>
+  );
+  getSidebar = (sheet, editor) => (
+    <SheetSidebar
+          authorStatement={sheet.ownerName}
+          authorUrl={sheet.ownerProfileUrl}
+          authorImage={sheet.ownerImageUrl}
+          collections={sheet.collections}
+          toggleSignUpModal={this.props.toggleSignUpModal}
+          topics={sheet.topics}
+          editorSaveState={editor &&this.props.editorSaveState}
+    />
   );
   render() {
     const classes = classNames({sheetsInPanel: 1});
     const sheet = this.getSheetFromCache();
+    let content;
     if (!sheet) {
-      return <div className={classes}><LoadingMessage /></div>
+      content = <LoadingMessage />;
     }
     else {
       const usingEditor = shouldUseEditor(sheet?.id);
-      return (
-        <div className={classes}>
-          { usingEditor ? this.getEditor(sheet) : this.getContent(sheet) }
-        </div>
-      );
+      content = usingEditor ? this.getEditor(sheet) : this.getReader(sheet);
     }
+    return <div className={classes}>{content}</div>
+
   }
 }
 

--- a/static/js/sheets/Sheet.jsx
+++ b/static/js/sheets/Sheet.jsx
@@ -119,7 +119,7 @@ class Sheet extends Component {
           collections={sheet.collections}
           toggleSignUpModal={this.props.toggleSignUpModal}
           topics={sheet.topics}
-          editorSaveState={editor &&this.props.editorSaveState}
+          editorSaveState={editor && this.props.editorSaveState}
     />
   );
   render() {

--- a/static/js/sheets/SheetContentSidebar.jsx
+++ b/static/js/sheets/SheetContentSidebar.jsx
@@ -18,7 +18,7 @@ const SheetContentSidebar = ({authorImage, authorStatement, authorUrl, toggleSig
                                     {Sefaria._(authorStatement)}
                                 </a>;
     return <div className="sheetContentSidebar">
-            {Sefaria.multiPanel && <EditorSaveStateIndicator state={editorSaveState}/>}
+            {Sefaria.multiPanel && !!editorSaveState && <EditorSaveStateIndicator state={editorSaveState}/>}
             <ProfilePic
                 url={authorImage}
                 len={100}

--- a/static/js/sheets/SheetSidebar.jsx
+++ b/static/js/sheets/SheetSidebar.jsx
@@ -5,7 +5,7 @@ import React, { useEffect, useState } from "react";
 import { UserBackground } from "../UserProfile";
 import { EditorSaveStateIndicator } from "../Editor";
 
-const SheetContentSidebar = ({authorImage, authorStatement, authorUrl, toggleSignUpModal, collections, topics, editorSaveState}) => {
+const SheetSidebar = ({authorImage, authorStatement, authorUrl, toggleSignUpModal, collections, topics, editorSaveState}) => {
     const [loading, setLoading] = useState(true);
     const [profile, setProfile] = useState(null);
     useEffect(() => {
@@ -74,4 +74,4 @@ const SheetSidebarList = ({items, type}) => {
               </div>
           </div>;
 }
-export default SheetContentSidebar;
+export default SheetSidebar;


### PR DESCRIPTION
## Description
"Saved" indicator in sheets should not show up if I'm not editing a sheet and looking at someone else's sheet!

## Code Changes
1. Don't render EditorSaveStateIndicator if we're not editing right now!
2. Re-organize code in Sheet.jsx so that memory is used efficiently -- previously we were loading up SheetContent and Editor even though we are only using one of them at a time.  I also think the way I organized it makes it easier to read.