### PR TITLE
preserve wrapping div of lists in serialization

### DIFF
--- a/static/js/Editor.jsx
+++ b/static/js/Editor.jsx
@@ -332,7 +332,13 @@ export const serialize = (content) => {
                 const paragraphHTML = content.children.reduce((acc, text) => {
                     return (acc + serialize(text))
                 }, "");
-                return paragraphHTML
+                if (!/<\/?(ul|ol|li)[^>]*>/i.test(preparseHtml)) {
+                    return `<div>${paragraphHTML}</div>`  // use wrapping divs to enable deserializer to parse lists properly
+                }
+                else
+                {
+                    return paragraphHTML
+                }
             }
 
             case 'list-item': {


### PR DESCRIPTION
This pull request introduces a small but important change to the `serialize` function in `Editor.jsx` to improve how lists are handled during HTML serialization. The change ensures that when a paragraph does not contain list-related HTML tags, it is wrapped in a `<div>`, which helps the deserializer correctly parse lists.

Improvements to HTML serialization for lists:

* Updated the `serialize` function to wrap paragraph content in a `<div>` unless it already contains list-related tags (`<ul>`, `<ol>`, `<li>`), improving list parsing during deserialization.…ap in divs based on list presence

## Description
_A brief description of the PR_

## Code Changes
_The following changes were made to the files below_

## Notes
_Any additional notes go here_