### PR TITLE
chore: re-factor SheetsHomePage

### DIFF
--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -1597,6 +1597,9 @@ a.interfaceLinks-option.active, a.interfaceLinks-option.inactive {
 .bookPage.compare .content {
   padding: 30px 10px;
 }
+.singlePanel .readerNavMenu .content .contentInner {
+  min-height: revert;
+}
 .readerNavMenu .content .contentInner {
   width: 725px;
   margin: 0 auto;

--- a/static/js/NavSidebar.jsx
+++ b/static/js/NavSidebar.jsx
@@ -8,7 +8,7 @@ import { Promotions } from './Promotions'
 import {SignUpModalKind} from "./sefaria/signupModalContent";
 import Button from "./common/Button";
 
-const NavSidebar = ({sidebarModules}) => {
+const NavSidebar = ({sidebarModules, includeFooter = true}) => {
   return <div className="navSidebar sans-serif">
     {sidebarModules.map((m, i) =>
       <SidebarModules
@@ -16,7 +16,7 @@ const NavSidebar = ({sidebarModules}) => {
         props={m.props || {}}
         key={i} />
     )}
-    <SidebarFooter />
+    {!!includeFooter && <SidebarFooter />} 
   </div>
 };
 

--- a/static/js/sheets/SheetsHomePage.jsx
+++ b/static/js/sheets/SheetsHomePage.jsx
@@ -1,5 +1,5 @@
 import React  from 'react';
-import {NavSidebar} from "../NavSidebar";
+import {NavSidebar, SidebarFooter} from "../NavSidebar";
 import {SheetsTopicsCalendar, SheetsTopicsTOC} from "./SheetsHomePageTopicsTOC";
 const SheetsHeroBanner = ({title, message, videoOptions, posterImg}) => {
     /*
@@ -19,36 +19,68 @@ const SheetsHeroBanner = ({title, message, videoOptions, posterImg}) => {
         </div>;
 }
 
-const SheetsSidebar = () => {
+const SheetsHomePageSidebar = ({includeFooter = false}) => {
     const sidebarModules = [
     {type: "CreateASheet"},
     {type: "WhatIsASourceSheet"},
   ];
-    return <NavSidebar sidebarModules={sidebarModules} />
+    return <NavSidebar sidebarModules={sidebarModules} includeFooter={includeFooter} />
 }
 
 
 
 const SheetsHomePage = ({setNavTopic, setTopic, multiPanel}) => {
-  const sheetsTopicsTOC = <SheetsTopicsTOC handleClick={setNavTopic}/>;
-  return <div className="readerNavMenu sheetsHomepage" key="0">
-            <div className="content">
-                <SheetsHeroBanner title="Join the Torah Conversation"
+  const sheetsHeroBanner = <SheetsHeroBanner title="Join the Torah Conversation"
                                   message="Create, share, and discover source sheets."
                                   videoOptions={["/static/img/home-video.webm", "/static/img/home-video.mp4"]}
-                                  posterImg="/static/img/home-video.jpg"
-                />
+                                  posterImg="/static/img/home-video.jpg"/>;
+  const sheetsTopicsCalendar = <SheetsTopicsCalendar handleClick={setTopic}/>;
+  const sheetsTopicsTOC = <SheetsTopicsTOC handleClick={setNavTopic}/>;
+
+  if (multiPanel) {
+    return <SheetsHomePageDesktop sheetsHeroBanner={sheetsHeroBanner} 
+                                  sheetsTopicsCalendar={sheetsTopicsCalendar} 
+                                  sheetsTopicsTOC={sheetsTopicsTOC} />;
+  }
+  else {
+    return <SheetsHomePageMobile sheetsHeroBanner={sheetsHeroBanner} 
+                                 sheetsTopicsCalendar={sheetsTopicsCalendar} 
+                                 sheetsTopicsTOC={sheetsTopicsTOC} />;
+  }     
+}
+ 
+const SheetsHomePageMobile = ({sheetsHeroBanner, sheetsTopicsCalendar, sheetsTopicsTOC}) => {
+  return <div className="readerNavMenu sheetsHomepage" key="0">
+            <div className="content">
+                {sheetsHeroBanner}
                 <div className="sidebarLayout">
                     <div className="contentInner">
                         <div className="sheetsTopics">
-                            <SheetsTopicsCalendar handleClick={setTopic}/>
-                            {multiPanel && sheetsTopicsTOC}
+                            {sheetsTopicsCalendar}
                         </div>
                     </div>
-                    <SheetsSidebar/>
-                    {!multiPanel && sheetsTopicsTOC}
+                    <SheetsHomePageSidebar includeFooter={false} />
+                    {sheetsTopicsTOC}
+                    <div className="sans-serif"><SidebarFooter /></div>
                 </div>
             </div>
         </div>
 }
+
+const SheetsHomePageDesktop = ({sheetsHeroBanner, sheetsTopicsCalendar, sheetsTopicsTOC}) => {
+    return <div className="readerNavMenu sheetsHomepage" key="0">
+              <div className="content">
+                  {sheetsHeroBanner}
+                  <div className="sidebarLayout">
+                      <div className="contentInner">
+                          <div className="sheetsTopics">
+                              {sheetsTopicsTOC}
+                              {sheetsTopicsCalendar}
+                          </div>
+                      </div>
+                      <SheetsHomePageSidebar includeFooter={true} />
+                  </div>
+              </div>
+          </div>
+  }
 export { SheetsHomePage };


### PR DESCRIPTION
## Description
CSS and ordering of sheets home page on mobile were buggy.

## Code Changes
Two issues:  
1. NavSidebar includes SidebarFooter by default.  However, in this case, we actually want NavSidebar to display in the middle of the page, so I added a parameter 'includeFooter' to NavSidebar. 
2. The sheets home page is meant to look very differently in desktop vs mobile, but we only have one component, SheetsHomepage, which gets passed a parameter 'multiPanel' to determine how to display.  This was already awkward before, but with the change in (1) above (i.e. passing 'includeFooter' to NavSidebar), SheetsHomepage would become very hard to read, so I decided to break it into two components, one for desktop and one for mobile.  'multiPanel' now simply determines which component gets displayed.