### PR TITLE
Removed the scaling of the sheet page - fixing font size issue

### DIFF
--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -9192,6 +9192,7 @@ a.sheetAuthorName:hover {
 .sheetMetaDataBox .sidebarLayout .items {
   display: flex;
   justify-content: space-between;
+  align-items: center;
 }
 .marginInlineIndent {
   margin-inline-start: 15px;

--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -10889,7 +10889,6 @@ span.purim-emoji img{
 /* Sheets */
 
 .sheetsInPanel {
-  font-size: 62.5%;
   overflow-y: scroll;
   overflow-x: hidden;
   height: 100%;


### PR DESCRIPTION
The font size was too small.
This was because a patch that reduced the font size to `font-size: 62.5%`
It seems like the core issue was solved so removing the scaling should be OK.

The commit that introduced the [font-size problem](https://github.com/Sefaria/Sefaria-Project/commit/dab6fa7520d1fd3fd9a4a136beddb78f3d04e188)

Fix language-toggle alignment (broke after the initial change) by vertically centering sheet header items.