### PR TITLE
fix(Editor): update condition to wrap paragraph HTML in <p> tags

### DIFF
--- a/static/js/Editor.jsx
+++ b/static/js/Editor.jsx
@@ -332,9 +332,12 @@ export const serialize = (content) => {
                 const paragraphHTML = content.children.reduce((acc, text) => {
                     return (acc + serialize(text))
                 }, "");
-                return `<div>${paragraphHTML}</div>`  // use wrapping "divs" to enable deserializer to parse lists properly
+                if (/<\/?(ul|ol|li)[^>]*>/i.test(paragraphHTML)) {
+                    return `<div>${paragraphHTML}</div>`  // use wrapping "divs" to enable deserializer to parse lists properly
+                } else {
+                    return `<p>${paragraphHTML}</p>` // use wrapping "p"s to enable deserializer to parse nodes properly, otherwise lists get lost. The reason p's are used instead of divs is to prevent extra spacing.
+                }
             }
-
             case 'list-item': {
                 const liHtml = content.children.reduce((acc, text) => {
                     return (acc + serialize(text))


### PR DESCRIPTION
This pull request updates the serialization logic in the `serialize` function in `Editor.jsx` to ensure that list elements are correctly wrapped for proper deserialization. The main change is an adjustment to how the function determines whether to wrap content in a `<div>` or `<p>` tag, which helps preserve list structure during serialization and deserialization.

**Serialization logic improvements:**

* Changed the condition to wrap content containing list elements (`ul`, `ol`, `li`) in a `<div>`, and all other content in a `<p>`, ensuring that lists are correctly parsed and not lost during deserialization.…list presence

## Description
_A brief description of the PR_

## Code Changes
_The following changes were made to the files below_

## Notes
_Any additional notes go here_