### PR TITLE
Fix globe switching language

### DIFF
--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -714,6 +714,10 @@ div:has(#bannerMessage) + .readerApp.singlePanel .mobileNavMenu {
   padding-block-start: 5px;
   padding-block-end: 2px;
 }
+.globeLanguageToggle .languageHeader {
+  padding: 12px;
+  border-bottom: 1px solid #CCCCCC;
+}
 
 .header .interfaceLinks {
   display: flex;
@@ -805,7 +809,9 @@ div:has(#bannerMessage) + .readerApp.singlePanel .mobileNavMenu {
   padding: 4px;
   max-width: 220px;
 }
-.header .interfaceLinks .interfaceLinks-option {
+.header .interfaceLinks .interfaceLinks-option,
+.globeLanguageToggle .englishLanguageLink,
+.globeLanguageToggle .hebrewLanguageLink {
   display: flex;
   text-decoration: none;
   font-style: normal;
@@ -819,14 +825,12 @@ div:has(#bannerMessage) + .readerApp.singlePanel .mobileNavMenu {
 .header .interfaceLinks .interfaceLinks-option:hover {
   background-color: var(--lighter-grey);
 }
-.header .languageFlex .interfaceLinks-option:hover {
-  background-color: var(--lighter-grey);
-  text-decoration: none;
-}
 .header .interfaceLinks .interfaceLinks-menu.open {
   display: block;
 }
-.interface-hebrew .header .interfaceLinks .interfaceLinks-option.int-bi {
+.interface-hebrew .header .interfaceLinks .interfaceLinks-option.int-bi,
+.interface-hebrew .globeLanguageToggle .englishLanguageLink,
+.interface-hebrew .globeLanguageToggle .hebrewLanguageLink {
   direction: rtl;
 }
 .interface-english .header .interfaceLinks .interfaceLinks-option.int-bi {
@@ -888,7 +892,9 @@ div.interfaceLinks-row a {
 .header .profile-menu-he {
   color: #666666;
 }
-.header .interfaceLinks-option::before {
+.header .interfaceLinks-option::before,
+.globeLanguageToggle .hebrewLanguageLink::before,
+.globeLanguageToggle .englishLanguageLink::before {
   content: "";
   font-family: FontAwesome;
   color: #999;
@@ -905,11 +911,15 @@ a.interfaceLinks-option.int-bi.inactive {
 a.interfaceLinks-option.active, a.interfaceLinks-option.inactive {
   padding: 7px;
 }
-.header .interfaceLinks-option.active::before {
+.header .interfaceLinks-option.active::before,
+.globeLanguageToggle .hebrewLanguageLink.active::before,
+.globeLanguageToggle .englishLanguageLink.active::before {
   content: "\f00c";
   padding: 0 8px;
 }
-.header .interfaceLinks-option.inactive::before {
+.header .interfaceLinks-option.inactive::before,
+.globeLanguageToggle .hebrewLanguageLink::before,
+.globeLanguageToggle .englishLanguageLink::before {
   content: "";
   padding: 0 15px;
 }
@@ -15057,6 +15067,9 @@ span.ref-link-color-3 {color: blue}
 .header .headerDropdownMenu .dropdownLinks-menu a {
   color: #000000;
 }
+.header .headerDropdownMenu .dropdownLinks-menu .globeLanguageToggle a {
+  color: #666666;
+}
 .sheetsInPanel .headerDropdownMenu a.headerDropdownMenu::after {
   display: inline-block;
   height: 10px;
@@ -15428,6 +15441,19 @@ span.ref-link-color-3 {color: blue}
   height: 23px;
   padding-inline: 15px;
 }
+.globeLanguageToggle .dropdownLanguageToggle {
+  flex-direction: column;
+  align-items: unset;
+  height: unset;
+  padding: 4px 0;
+}
+.interface-hebrew .globeLanguageToggle .dropdownLanguageToggle {
+  flex-direction: column-reverse;
+}
+.globeLanguageToggle .englishLanguageLink:hover,
+.globeLanguageToggle .hebrewLanguageLink:hover {
+  background-color: var(--lighter-grey);
+}
 .interface-english .dropdownLanguageToggle a.hebrewLanguageLink,
 .interface-hebrew .dropdownLanguageToggle a.englishLanguageLink {
   color: #666666;
@@ -15438,11 +15464,14 @@ span.ref-link-color-3 {color: blue}
   padding: 10px 2px;
 }
 
-
-
 .englishLanguageButton::after {
   content: "•";
   padding: 6px;
+}
+
+.globeLanguageToggle .englishLanguageButton::after {
+  content: none;
+  padding: unset;
 }
 
 .profilePicAndButtonContainer {
@@ -15549,11 +15578,6 @@ span.ref-link-color-3 {color: blue}
 .librarySavedIcon img{
   width: 100%;
   height: 100%;
-}
-.languageFlex {
-  display: flex;
-  flex-direction: column;
-  direction:ltr;
 }
 
 @-webkit-keyframes load5 {

--- a/static/js/Header.jsx
+++ b/static/js/Header.jsx
@@ -10,7 +10,6 @@ import {
   GlobalWarningMessage,
   InterfaceLanguageMenu,
   InterfaceText,
-  getCurrentPage,
   LanguageToggleButton,
   DonateLink,
   useOnceFullyVisible
@@ -19,25 +18,18 @@ import {ProfilePic} from "./ProfilePic";
 import {HeaderAutocomplete} from './HeaderAutocomplete'
 import { DropdownMenu, DropdownMenuSeparator, DropdownMenuItem, DropdownMenuItemWithIcon, DropdownLanguageToggle } from './common/DropdownMenu';
 import Button from './common/Button';
+import {useNextParam} from './Hooks'
   
 const LoggedOutDropdown = ({module}) => {
   const [isClient, setIsClient] = useState(false);
-  const [next, setNext] = useState("/");
-  const [loginLink, setLoginLink] = useState("/login?next=/");
-  const [registerLink, setRegisterLink] = useState("/register?next=/");
+  const next = useNextParam();
+  const loginLink = `/login?next=${next}`;
+  const registerLink = `/register?next=${next}`;
 
   useEffect(()=>{
     setIsClient(true);
   }, []);
 
-  useEffect(()=> {
-    if(isClient){
-      setNext(encodeURIComponent(Sefaria.util.currentPath()));
-      setLoginLink("/login?next="+next);
-      setRegisterLink("/register?next="+next);
-    }
-  })
-  
   return (
       <DropdownMenu positioningClass="headerDropdownMenu" buttonComponent={<img src='/static/icons/logged_out.svg'/>}>
           <div className='dropdownLinks-options'>
@@ -328,19 +320,12 @@ Header.propTypes = {
 
 const LoggedOutButtons = ({mobile, loginOnly}) => {
   const [isClient, setIsClient] = useState(false);
-  const [next, setNext] = useState("/");
-  const [loginLink, setLoginLink] = useState("/login?next=/");
-  const [registerLink, setRegisterLink] = useState("/register?next=/");
+  const next = useNextParam();
+  const loginLink = `/login?next=${next}`;
+  const registerLink = `/register?next=${next}`;
   useEffect(()=>{
     setIsClient(true);
   }, []);
-  useEffect(()=> {
-    if(isClient){
-      setNext(encodeURIComponent(Sefaria.util.currentPath()));
-      setLoginLink("/login?next="+next);
-      setRegisterLink("/register?next="+next);
-    }
-  })
   const classes = classNames({accountLinks: !mobile, anon: !mobile});
   return (
     <div className={classes}>
@@ -542,6 +527,7 @@ const MobileNavMenu = ({onRefClick, showSearch, openTopic, openURL, close, visib
 const ProfilePicMenu = ({len, url, name}) => {
   const [isOpen, setIsOpen] = useState(false);
   const wrapperRef = useRef(null);
+  const currentUrl = useNextParam();
 
   const menuClick = (e) => {
     var el = e.target;
@@ -601,8 +587,8 @@ const ProfilePicMenu = ({len, url, name}) => {
                 <InterfaceText>Account Settings</InterfaceText>
               </a></div>
               <div className="interfaceLinks-row languages">
-                <a className={`${(Sefaria.interfaceLang == 'hebrew') ? 'active':''}`} href={`/interface/hebrew?next=${getCurrentPage()}`} id="select-hebrew-interface-link">עברית</a>
-                <a className={`${(Sefaria.interfaceLang == 'english') ? 'active':''}`} href={`/interface/english?next=${getCurrentPage()}`} id="select-english-interface-link">English</a>
+                <a className={`${(Sefaria.interfaceLang == 'hebrew') ? 'active':''}`} href={`/interface/hebrew?next=${currentUrl}`} id="select-hebrew-interface-link">עברית</a>
+                <a className={`${(Sefaria.interfaceLang == 'english') ? 'active':''}`} href={`/interface/english?next=${currentUrl}`} id="select-english-interface-link">English</a>
               </div>
               <div><a className="interfaceLinks-row bottom" id="help-link" href={Sefaria._v({
                 he: Sefaria._siteSettings.HELP_CENTER_URLS.HE, 
@@ -623,7 +609,7 @@ const ProfilePicMenu = ({len, url, name}) => {
 
 
 const MobileInterfaceLanguageToggle = () => {
-  const currentURL = getCurrentPage();
+  const currentURL = useNextParam();
 
   const links = Sefaria.interfaceLang == "hebrew" ?
     <>

--- a/static/js/Hooks.jsx
+++ b/static/js/Hooks.jsx
@@ -273,6 +273,13 @@ function usePaginatedLoad(fetchDataByPage, setter, identityElement, numPages, re
   }, [fetchPage]);
 }
 
+function useNextParam() {
+  const [next, setNext] = useState(null);
+  useEffect(() => {
+    setNext(encodeURIComponent(Sefaria.util.currentPath()));
+  });
+  return next;
+}
 
 export {
   useScrollToLoad,
@@ -281,4 +288,5 @@ export {
   useDebounce,
   useContentLang,
   useIncrementalLoad,
+  useNextParam,
 };

--- a/static/js/Misc.jsx
+++ b/static/js/Misc.jsx
@@ -23,9 +23,12 @@ import {SourceEditor} from "./SourceEditor";
 import {EditTextInfo} from "./BookPage";
 import ReactMarkdown from 'react-markdown';
 import TrackG4 from "./sefaria/trackG4";
-import { ReaderApp } from './ReaderApp';
 import ReaderDisplayOptionsMenu from "./ReaderDisplayOptionsMenu";
-import {DropdownMenu, DropdownMenuItem, DropdownMenuItemWithIcon, DropdownMenuSeparator} from "./common/DropdownMenu";
+import {
+  DropdownLanguageToggle,
+  DropdownMenu,
+  DropdownMenuItemWithIcon,
+} from "./common/DropdownMenu";
 import Button from "./common/Button";
 
 function useOnceFullyVisible(onVisible, key) {
@@ -1243,12 +1246,6 @@ DisplaySettingsButton.propTypes = {
 
 function InterfaceLanguageMenu({currentLang, translationLanguagePreference, setTranslationLanguagePreference}){
 
-  const [isOpen, setIsOpen] = useState(false);
-
-  const getCurrentPage = () => {
-    return isOpen ? (encodeURIComponent(Sefaria.util.currentPath())) : "/";
-  }
-
   const handleTransPrefResetClick = (e) => {
     e.stopPropagation();
     setTranslationLanguagePreference(null);
@@ -1256,19 +1253,8 @@ function InterfaceLanguageMenu({currentLang, translationLanguagePreference, setT
 
   return (
     <DropdownMenu positioningClass="headerDropdownMenu" buttonComponent={<img src="/static/icons/globe-wire.svg" alt={Sefaria._('Toggle Interface Language Menu')}/>}>
-      <div className="dropdownLinks-options">
-        <div className="interfaceLinks interfaceLinks-menu interfaceLinks-header languageHeader">
-          <InterfaceText>Site Language</InterfaceText>
-        </div>
-        <DropdownMenuSeparator />
-        <div className='languageFlex'>
-          <DropdownMenuItem url={`/interface/hebrew?next=${getCurrentPage()}`} customCSS={`interfaceLinks-option int-bi ${(currentLang === 'hebrew') ? 'active':'inactive'}`}>
-            עברית
-          </DropdownMenuItem>
-          <DropdownMenuItem url={`/interface/english?next=${getCurrentPage()}`} customCSS={`interfaceLinks-option int-bi ${(currentLang === 'english') ? 'active' : 'inactive'}`}>
-            English
-          </DropdownMenuItem>
-        </div>
+      <div className="dropdownLinks-options globeLanguageToggle">
+        <DropdownLanguageToggle currentLang={currentLang}/>
       </div>
       { !!translationLanguagePreference ? (
             <>

--- a/static/js/Misc.jsx
+++ b/static/js/Misc.jsx
@@ -687,10 +687,6 @@ TextBlockLink.defaultProps = {
 };
 
 
-const getCurrentPage = () => {
-  return encodeURIComponent(Sefaria.util.currentPath());
-}
-
 class LanguageToggleButton extends Component {
   toggle(e) {
     e.preventDefault();
@@ -3516,7 +3512,6 @@ export {
   LangSelectInterface,
   PencilSourceEditor,
   SmallBlueButton,
-  getCurrentPage,
   GuideButton,
   ArrowButton as Arrow,
   transformValues,

--- a/static/js/common/DropdownMenu.jsx
+++ b/static/js/common/DropdownMenu.jsx
@@ -140,7 +140,7 @@ const DropdownMenu = ({children, buttonComponent, positioningClass}) => {
 
 
 
-const DropdownLanguageToggle = () => {
+const DropdownLanguageToggle = ({currentLang}) => {
   const englishLink = Sefaria.util.fullURL(`/interface/english?next=${getCurrentPage()}`);
   const hebrewLink = Sefaria.util.fullURL(`/interface/hebrew?next=${getCurrentPage()}`);
   return (
@@ -150,16 +150,19 @@ const DropdownLanguageToggle = () => {
       </div>
       <div className='dropdownLanguageToggle'>
       <span className='englishLanguageButton'>
-        <a className="englishLanguageLink" href={englishLink}>
+        <a className={`englishLanguageLink ${(currentLang === 'english') ? 'active': ''}`} href={englishLink}>
           English
         </a>
       </span>
-      <a className="hebrewLanguageLink" href={hebrewLink}>
+      <a className={`hebrewLanguageLink ${(currentLang === 'hebrew') ? 'active': ''}`} href={hebrewLink}>
         עברית
       </a>
       </div>
     </>
   )
+}
+DropdownLanguageToggle.propTypes = {
+    currentLang: PropTypes.string,
 }
 
   export {

--- a/static/js/common/DropdownMenu.jsx
+++ b/static/js/common/DropdownMenu.jsx
@@ -1,7 +1,8 @@
 import React, {useEffect, useRef, useState} from 'react';
 import PropTypes from "prop-types";
-import { InterfaceText, getCurrentPage } from '../Misc';
+import { InterfaceText } from '../Misc';
 import Sefaria from '../sefaria/sefaria';
+import {useNextParam} from "../Hooks";
 
 const DropdownMenuSeparator = () => {
 
@@ -139,10 +140,10 @@ const DropdownMenu = ({children, buttonComponent, positioningClass}) => {
   };
 
 
-
 const DropdownLanguageToggle = ({currentLang}) => {
-  const englishLink = Sefaria.util.fullURL(`/interface/english?next=${getCurrentPage()}`);
-  const hebrewLink = Sefaria.util.fullURL(`/interface/hebrew?next=${getCurrentPage()}`);
+  const next = useNextParam();
+  const englishLink = Sefaria.util.fullURL(`/interface/english?next=${next}`);
+  const hebrewLink = Sefaria.util.fullURL(`/interface/hebrew?next=${next}`);
   return (
     <>
       <div className="languageHeader">


### PR DESCRIPTION
## The problem
The switching of language from the globe popover goes to the homepage (while it isn't happening in the profile menu language toggle).

## Description
1. First step was to refactor both toggles to the same component (both has the same title, and same 2 buttons, but with different styles).
2. Turns out that the probelm was that the `next` param in the toggle got the current path from a static function, so it isn't changing after it's mounted (it didn't happen in the other toggle, because its parent has a hook that triggers re-render). For solving it I made a new custom hook `useNextParam`, and refactor the code to use it in any place we need to use next param.

## Code Changes
For #1 I've changed `InterfaceLanguageMenu` (in Misc.jsx) to use `DropdownLanguageToggle`, and added the prop `currentLang` to it. This prop adds `active` classname to the active language (which needed in the InterfaceLanguageMenu). Now I had to move logic in the css, for getting two different styles menus from the same component.
For #2 I added   `useNextParam` hook and removed `getCurrentPage` static function (Misc.jsx). I refactored the code to use it in 2 cases:
1. Where it has used `getCurrentPage` (some places in Header.jsx and `DropdownLanguageToggle` in Dropdown.jsx).
2. Where we had duplicate logic for getting the `next` param other places in Header.jsx).

## Notes
Unfortunately, we have our own router. That means we hardly can track it, so the new hook has no dependencies and it triggers too many re-renders (this was also the situation in some places of Header.jsx).
We can (a) work on the new hook to find a way to reduce it, (b) return to our logic in master branch where menus are re-rendered when they are open and closed, or (c) live with it, it seems not to be so bad.