### PR TITLE
Fixing Filtering Condition of Inline Images

### DIFF
--- a/static/js/ContentText.jsx
+++ b/static/js/ContentText.jsx
@@ -28,13 +28,6 @@ const VersionContent = ({primary, translation, imageLoadCallback}) => {
     return Object.keys(versions).map((key) => {
         const version = versions[key];
         const lang = (version.direction === 'rtl') ? 'he' : 'en';
-        // const toFilter = key === 'primary' && !!primary && !!translation;
-        // const toFilter = (
-        //   key === 'primary' &&
-        //   !!primary?.text &&
-        //   !!translation?.text
-        // );
-        // inside the reader render logic where you compute toFilter
         const primaryText = primary?.text;
         const translationText = translation?.text;
 

--- a/static/js/ContentText.jsx
+++ b/static/js/ContentText.jsx
@@ -28,7 +28,12 @@ const VersionContent = ({primary, translation, imageLoadCallback}) => {
     return Object.keys(versions).map((key) => {
         const version = versions[key];
         const lang = (version.direction === 'rtl') ? 'he' : 'en';
-        const toFilter = key === 'primary' && !!primary && !!translation;
+        // const toFilter = key === 'primary' && !!primary && !!translation;
+        const toFilter = (
+          key === 'primary' &&
+          !!primary?.text &&
+          !!translation?.text
+        );
         return (Sefaria.isFullSegmentImage(version.text)) ?
             (<VersionImageSpan lang={lang} content={version.text || ''} toFilter={toFilter} imageLoadCallback={imageLoadCallback}/>) :
                 (<ContentSpan lang={lang} content={version.text || ''} isHTML={true} primaryOrTranslation={key}/>);

--- a/static/js/ContentText.jsx
+++ b/static/js/ContentText.jsx
@@ -29,11 +29,24 @@ const VersionContent = ({primary, translation, imageLoadCallback}) => {
         const version = versions[key];
         const lang = (version.direction === 'rtl') ? 'he' : 'en';
         // const toFilter = key === 'primary' && !!primary && !!translation;
-        const toFilter = (
-          key === 'primary' &&
-          !!primary?.text &&
-          !!translation?.text
-        );
+        // const toFilter = (
+        //   key === 'primary' &&
+        //   !!primary?.text &&
+        //   !!translation?.text
+        // );
+        // inside the reader render logic where you compute toFilter
+        const primaryText = primary?.text;
+        const translationText = translation?.text;
+
+        const bothHaveImages =
+          Sefaria.isFullSegmentImage(primaryText) &&
+          Sefaria.isFullSegmentImage(translationText);
+
+        // Show only one image in bilingual mode, prefer the translated side.
+        // We suppress the PRIMARY side when both sides have an image.
+        const toFilter =
+          key === 'primary' && bothHaveImages;
+
         return (Sefaria.isFullSegmentImage(version.text)) ?
             (<VersionImageSpan lang={lang} content={version.text || ''} toFilter={toFilter} imageLoadCallback={imageLoadCallback}/>) :
                 (<ContentSpan lang={lang} content={version.text || ''} isHTML={true} primaryOrTranslation={key}/>);

--- a/static/js/ContentText.jsx
+++ b/static/js/ContentText.jsx
@@ -28,12 +28,10 @@ const VersionContent = ({primary, translation, imageLoadCallback}) => {
     return Object.keys(versions).map((key) => {
         const version = versions[key];
         const lang = (version.direction === 'rtl') ? 'he' : 'en';
-        const primaryText = primary?.text;
-        const translationText = translation?.text;
 
         const bothHaveImages =
-          Sefaria.isFullSegmentImage(primaryText) &&
-          Sefaria.isFullSegmentImage(translationText);
+          Sefaria.isFullSegmentImage(primary?.text) &&
+          Sefaria.isFullSegmentImage(translation?.text);
 
         // Show only one image in bilingual mode, prefer the translated side.
         // We suppress the PRIMARY side when both sides have an image.


### PR DESCRIPTION
This pull request makes a small update to the logic for filtering content in the `VersionContent` component. The change ensures that the filter condition checks for the existence of the `text` property within both `primary` and `translation` objects, rather than just their truthiness.

* Updated the `toFilter` condition in `static/js/ContentText.jsx` to check for `primary?.text` and `translation?.text` instead of just `primary` and `translation`.…ion text

## Description
_A brief description of the PR_

## Code Changes
_The following changes were made to the files below_

## Notes
_Any additional notes go here_