### PR TITLE
Changed guide cookie to set on load

### DIFF
--- a/static/js/GuideOverlay.jsx
+++ b/static/js/GuideOverlay.jsx
@@ -204,8 +204,8 @@ const GuideOverlay = ({
       // Auto view fires when guide shows without being forced (no cookie exists)
       trackGuideEvent("guide_view_auto", guideType);
       setIsVisible(true);
-      setCookie(); // Guide should only show once, so we set the cookie when it shows
       loadGuideData();
+      setCookie(); // Guide should only show once, so we set the cookie when it shows
     }
   }, []);
 


### PR DESCRIPTION
Updated the guide to set the cookie on load instead of on close.
This was people with small screens or people who just get confused won't see the guide every time.

* I moved the call to `setCookie` to be in the effect that manages loading
* I removed the call from `handleClose`
* I removed the `shouldSetCookie` param form `handleClose` because it's no longer needed - we never set cookie

Tested this locally by removing the cookie -> seeing a load -> refreshing => no guide loads (as expected)