### PR TITLE
Library polish headers and navigation - CSS changes

### DIFF
--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -15427,6 +15427,7 @@ span.ref-link-color-3 {color: blue}
   line-height: 18px;
   height: 23px;
   padding-inline: 15px;
+  margin-top: 7px;
 }
 .interface-english .dropdownLanguageToggle a.hebrewLanguageLink,
 .interface-hebrew .dropdownLanguageToggle a.englishLanguageLink {

--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -1748,6 +1748,7 @@ a.interfaceLinks-option.active, a.interfaceLinks-option.inactive {
   padding-inline: 10px 10px;
   margin-inline: -15px -15px;
   margin-block: -5px -5px;
+  padding-bottom: 10px;
 }
 .singlePanel .recentlyViewed ul {
   display: revert;

--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -14987,7 +14987,7 @@ span.ref-link-color-3 {color: blue}
 }
 
 .dropdownSeparator {
-  border: 1px solid var(--light-grey);
+  border-top: 1px solid var(--light-grey);
   margin-block: 5px;
 }
 .sheetMetaDataBox .dropdownLinks-button {

--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -823,6 +823,9 @@ div:has(#bannerMessage) + .readerApp.singlePanel .mobileNavMenu {
   background-color: var(--lighter-grey);
   text-decoration: none;
 }
+.dropdownItem[data-prevent-close="true"]:hover {
+  text-decoration: none;
+}
 .header .interfaceLinks .interfaceLinks-menu.open {
   display: block;
 }

--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -449,6 +449,17 @@ input.noselect {
 .headerInner .headerLinksSection > * {
   margin-inline-start: 3%;
 }
+.headerLinksSection .sefaria-common-button {
+  width: 67px;
+  height: 30px;
+  padding: 0;
+  line-height: 18px;
+  font-size: 14px;
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
 .header .header-nav {
   margin-top: 1px;
 }

--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -1947,6 +1947,7 @@ a.interfaceLinks-option.active, a.interfaceLinks-option.inactive {
   justify-content: center;
   margin-left: 0;
   margin-right: 0;
+  margin-top: 22px;
 }
 .navSidebar .button .get-start {
   white-space: nowrap;

--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -1898,7 +1898,7 @@ a.interfaceLinks-option.active, a.interfaceLinks-option.inactive {
 
 .navSidebarLink.language {
   font-size: 18px;
-  margin-top: 16px;
+  margin-top: 6px;
   display: flex;
   flex-wrap:wrap;
 }
@@ -15400,7 +15400,7 @@ span.ref-link-color-3 {color: blue}
 
 .footerContainer a {
   padding-top: 10px;
-  padding-inline-end: 6px;
+  padding-inline-end: 16px;
 }
 
 .stickySidebarFooter {

--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -15555,6 +15555,7 @@ span.ref-link-color-3 {color: blue}
   display: flex;
   flex-direction: column;
   direction:ltr;
+  margin-bottom: 10px;
 }
 
 @-webkit-keyframes load5 {

--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -971,6 +971,9 @@ a.interfaceLinks-option.active, a.interfaceLinks-option.inactive {
 .mobileHeaderCenter {
   text-align: center;
 }
+.mobileHeaderCenter img.home {
+  margin-inline-end: 0;
+}
 .header .headerInner.mobile .mobileHeaderLanguageToggle {
   text-align: end;
 }


### PR DESCRIPTION
## Description
This PR includes several CSS changes, all were requested in [this one ticket](https://app.shortcut.com/sefaria/story/37204/library-polish-headers-and-navigation)

## Code Changes
These were all the requested changes as summarised by CC (Claude Code):

Cross Platform:
  - Translations Module spacing (16px → 6px margin-top)
  - Sidebar footer spacing (6px → 16px padding-inline-end)

Desktop Only:
  - Site Header dropdown dividers (removed double styling for top and bottom)
  - User Menu spacing (added 10px margin-top)
  - Language Switcher spacing (added 10px margin-bottom)
  - Sign Up Button (added component specific styling)
  - Living Library spacing (added 22px margin-top)
  - User Menu hover (removed text-decoration)

Mobile Web:
  - Recently Viewed module (added 10px padding-bottom)
  - Safari logo centering (removed inherited margin)

## Notes
I tested all changes locally