### PR TITLE
fix(search): update sheet count method to use count_documents since count() is deprecated

### DIFF
--- a/sefaria/pagesheetrank.py
+++ b/sefaria/pagesheetrank.py
@@ -393,7 +393,7 @@ def calculate_sheetrank():
         return temp_sources_count
 
     sheetrank_dict = defaultdict(int)
-    len_sheets = db.sheets.find().count()
+    len_sheets = db.sheets.count_documents({})
     sheets = get_all_sheets()
     sources_count = 0
     for i, sheet in enumerate(sheets):


### PR DESCRIPTION
## Description
The reindex elasticsearch cronjob has been failing since it uses a deprecated pymongo function Cursor.count(). Instead, it's recommended to use Collection.count_documents().