### PR TITLE
Replace paragraph tags with line breaks for outside text rendering

### DIFF
--- a/static/js/Sheet.jsx
+++ b/static/js/Sheet.jsx
@@ -533,12 +533,22 @@ class SheetOutsideText extends Component {
         this.props.source.options ? this.props.source.options.indented : null
     );
 
+   const paragraphsToBreaks = (html)=> {
+    return html
+      .replace(/<\/p>\s*<p>/gi, '<br/>')
+      .replace(/<p[^>]*>/gi, '')
+      .replace(/<\/p>/gi, '<br/>');
+    }
+
+    const outsideHTML = paragraphsToBreaks(
+      Sefaria.util.cleanHTML(this.props.source.outsideText)
+    );
     return (
       <section className="SheetOutsideText">
         <div className={containerClasses} data-node={this.props.source.node} onClick={(e) => this.shouldPassClick(e)} aria-label={"Click to see " + this.props.linkCount +  " connections to this source"} tabIndex="0" onKeyPress={function(e) {e.charCode == 13 ? this.props.sheetSourceClick(e):null}.bind(this)} >
 
           <div className={lang}>{this.props.source.options && this.props.source.options.sourcePrefix && this.props.source.options.sourcePrefix != "" ? <sup className="sourcePrefix">{this.props.source.options.sourcePrefix}</sup> : null }
-              <div className="sourceContentText" dangerouslySetInnerHTML={ {__html: Sefaria.util.cleanHTML(this.props.source.outsideText)} }></div>
+            <div className="sourceContentText" dangerouslySetInnerHTML={{ __html: outsideHTML }} />
           </div>
 
           <div className="clearFix"></div>


### PR DESCRIPTION
This pull request refactors how outside text is rendered in the `SheetOutsideText` component to improve HTML formatting and display. The main change is the introduction of a utility function to convert paragraph tags into line breaks, ensuring more consistent and readable output.

**Rendering improvements:**

* Added the `paragraphsToBreaks` function to replace paragraph tags with line breaks, which standardizes the formatting of `outsideText` HTML content before rendering.
* Updated the `dangerouslySetInnerHTML` usage to use the cleaned and reformatted `outsideHTML`, improving the display of outside text in the sheet.…rendering

## Description
_A brief description of the PR_

## Code Changes
_The following changes were made to the files below_

## Notes
_Any additional notes go here_