### PR TITLE
Fix auto completions

### DIFF
--- a/reader/views.py
+++ b/reader/views.py
@@ -2663,13 +2663,13 @@ def terms_api(request, name):
     return jsonResponse({"error": "Unsupported HTTP method."})
 
 
-def get_name_completions(name, limit, topic_override=False, type=None, topic_pool=None, exact_continuations=False, order_by_matched_length=False):
+def get_name_completions(name, limit, topic_override=False, types=None, topic_pool=None, exact_continuations=False, order_by_matched_length=False):
     """
     Function to get completions (objects and titles) for a given name.
     :param name: string to get completions for
     :param limit: int number of items to return
     :param topic_override: bool
-    :param type: string - get only completions of objects of this specific type
+    :param types: list of strings - get only completions of objects of those specific types
     :param topic_pool: string - get completions of topic-objects of this specific topic pool
     :param exact_continuations: bool - if true get only completions of objects whose title contains an exact match to 'name'
     :param order_by_matched_length: bool - if true return completion objects by ascending order of length - such that shorter titles whose greater part is a match to 'name' will appear first.
@@ -2699,7 +2699,7 @@ def get_name_completions(name, limit, topic_override=False, type=None, topic_poo
             completion_objects = [o for n in completions for o in lexicon_ac.get_data(n)]
 
         else:
-            completions, completion_objects = completer.complete(name, limit, type=type, topic_pool=topic_pool, exact_continuations=exact_continuations, order_by_matched_length=order_by_matched_length)
+            completions, completion_objects = completer.complete(name, limit, types=types, topic_pool=topic_pool, exact_continuations=exact_continuations, order_by_matched_length=order_by_matched_length)
             object_data = completer.get_object(name)
 
     except DictionaryEntryNotFoundError as e:
@@ -2709,7 +2709,7 @@ def get_name_completions(name, limit, topic_override=False, type=None, topic_poo
         completions = list(OrderedDict.fromkeys(t))  # filter out dupes
         completion_objects = [o for n in completions for o in lexicon_ac.get_data(n)]
     except InputError:  # Not a Ref
-        completions, completion_objects = completer.complete(name, limit, type=type, topic_pool=topic_pool, exact_continuations=exact_continuations, order_by_matched_length=order_by_matched_length)
+        completions, completion_objects = completer.complete(name, limit, types=types, topic_pool=topic_pool, exact_continuations=exact_continuations, order_by_matched_length=order_by_matched_length)
         object_data = completer.get_object(name)
 
     return {
@@ -2730,11 +2730,11 @@ def name_api(request, name):
     name = name[1:] if topic_override else name
     # Number of results to return.  0 indicates no limit
     LIMIT = int(request.GET.get("limit", 10))
-    type = request.GET.get("type", None)
+    types = request.GET.getlist("type", None)
     topic_pool = request.GET.get("topic_pool", None)
     exact_continuations = bool(int(request.GET.get("exact_continuations", False)))
     order_by_matched_length = bool(int(request.GET.get("order_by_matched_length", False)))
-    completions_dict = get_name_completions(name, LIMIT, topic_override, type=type, topic_pool=topic_pool, exact_continuations=exact_continuations, order_by_matched_length=order_by_matched_length)
+    completions_dict = get_name_completions(name, LIMIT, topic_override, types=types, topic_pool=topic_pool, exact_continuations=exact_continuations, order_by_matched_length=order_by_matched_length)
     ref = completions_dict["ref"]
     topic = completions_dict["topic"]
     d = {

--- a/reader/views.py
+++ b/reader/views.py
@@ -2663,14 +2663,14 @@ def terms_api(request, name):
     return jsonResponse({"error": "Unsupported HTTP method."})
 
 
-def get_name_completions(name, limit, topic_override=False, type=None, active_module=None, exact_continuations=False, order_by_matched_length=False):
+def get_name_completions(name, limit, topic_override=False, type=None, topic_pool=None, exact_continuations=False, order_by_matched_length=False):
     """
     Function to get completions (objects and titles) for a given name.
     :param name: string to get completions for
     :param limit: int number of items to return
     :param topic_override: bool
     :param type: string - get only completions of objects of this specific type
-    :param active_module: string - filter out objects irrelevant for this module ('library' vs 'sheets').  If active_module is None, results for both modules are returned.
+    :param topic_pool: string - get completions of topic-objects of this specific topic pool
     :param exact_continuations: bool - if true get only completions of objects whose title contains an exact match to 'name'
     :param order_by_matched_length: bool - if true return completion objects by ascending order of length - such that shorter titles whose greater part is a match to 'name' will appear first.
     """
@@ -2699,7 +2699,7 @@ def get_name_completions(name, limit, topic_override=False, type=None, active_mo
             completion_objects = [o for n in completions for o in lexicon_ac.get_data(n)]
 
         else:
-            completions, completion_objects = completer.complete(name, limit, type=type, active_module=active_module, exact_continuations=exact_continuations, order_by_matched_length=order_by_matched_length)
+            completions, completion_objects = completer.complete(name, limit, type=type, topic_pool=topic_pool, exact_continuations=exact_continuations, order_by_matched_length=order_by_matched_length)
             object_data = completer.get_object(name)
 
     except DictionaryEntryNotFoundError as e:
@@ -2709,7 +2709,7 @@ def get_name_completions(name, limit, topic_override=False, type=None, active_mo
         completions = list(OrderedDict.fromkeys(t))  # filter out dupes
         completion_objects = [o for n in completions for o in lexicon_ac.get_data(n)]
     except InputError:  # Not a Ref
-        completions, completion_objects = completer.complete(name, limit, type=type, active_module=active_module, exact_continuations=exact_continuations, order_by_matched_length=order_by_matched_length)
+        completions, completion_objects = completer.complete(name, limit, type=type, topic_pool=topic_pool, exact_continuations=exact_continuations, order_by_matched_length=order_by_matched_length)
         object_data = completer.get_object(name)
 
     return {
@@ -2731,10 +2731,10 @@ def name_api(request, name):
     # Number of results to return.  0 indicates no limit
     LIMIT = int(request.GET.get("limit", 10))
     type = request.GET.get("type", None)
-    active_module = request.GET.get('active_module', None)
+    topic_pool = request.GET.get("topic_pool", None)
     exact_continuations = bool(int(request.GET.get("exact_continuations", False)))
     order_by_matched_length = bool(int(request.GET.get("order_by_matched_length", False)))
-    completions_dict = get_name_completions(name, LIMIT, topic_override, type=type, active_module=active_module, exact_continuations=exact_continuations, order_by_matched_length=order_by_matched_length)
+    completions_dict = get_name_completions(name, LIMIT, topic_override, type=type, topic_pool=topic_pool, exact_continuations=exact_continuations, order_by_matched_length=order_by_matched_length)
     ref = completions_dict["ref"]
     topic = completions_dict["topic"]
     d = {

--- a/sefaria/model/autospell.py
+++ b/sefaria/model/autospell.py
@@ -201,7 +201,7 @@ class AutoCompleter(object):
         except KeyError:
             return None
 
-    def complete(self, instring, limit=0, redirected=False, type=None, topic_pool=None, exact_continuations=False, order_by_matched_length=False):
+    def complete(self, instring, limit=0, redirected=False, types=None, topic_pool=None, exact_continuations=False, order_by_matched_length=False):
         """
         Wrapper for Completions object - prioritizes and aggregates completion results.
         In the case where there are no results, tries to swap keyboards and get completion results from the other language.
@@ -215,7 +215,7 @@ class AutoCompleter(object):
         if len(instring) >= self.max_completion_length:
             return [], []
         cm = Completions(self, self.lang, instring, limit,
-                         do_autocorrect=len(instring) < self.max_autocorrect_length, type=type, topic_pool=topic_pool, exact_continuations=exact_continuations, order_by_matched_length=order_by_matched_length)
+                         do_autocorrect=len(instring) < self.max_autocorrect_length, types=types, topic_pool=topic_pool, exact_continuations=exact_continuations, order_by_matched_length=order_by_matched_length)
         cm.process()
         if cm.has_results():
             return cm.get_completion_strings(), cm.get_completion_objects()
@@ -258,7 +258,7 @@ class Completions(object):
         "Term": "Term",
         "User": "User"}
 
-    def __init__(self, auto_completer, lang, instring, limit=0, do_autocorrect = True, type=None, topic_pool=None, exact_continuations=False, order_by_matched_length=False):
+    def __init__(self, auto_completer, lang, instring, limit=0, do_autocorrect=True, types=None, topic_pool=None, exact_continuations=False, order_by_matched_length=False):
         """
         An object that contains a single search, delegates to different methods of completions, and aggregates results.
         :param auto_completer:
@@ -283,7 +283,7 @@ class Completions(object):
         self._completion_objects = []
         self._candidate_type_counters = defaultdict(int)
         self._type_limit = 3
-        self.type = type
+        self.types = types
         self.topic_pool = topic_pool
         self.exact_continuations = exact_continuations
         self.order_by_matched_length = order_by_matched_length
@@ -344,13 +344,13 @@ class Completions(object):
         return list(list1), list(list2)
 
     def _has_required_type(self, completion_object):
-        if not self.type:
+        if not self.types:
             return True
 
         co_type = completion_object["type"]
         normalized_type = self._type_norm_map[co_type]
 
-        if normalized_type != self.type:
+        if normalized_type not in self.types:
             return False
 
         if normalized_type == 'Topic' and self.topic_pool:

--- a/static/js/Editor.jsx
+++ b/static/js/Editor.jsx
@@ -1016,7 +1016,7 @@ const AddInterfaceInput = ({ inputType, resetInterface }) => {
         if (input === "") {
             return results;
         }
-        const d = await Sefaria.getName(input, 5, 'ref');
+        const d = await Sefaria.getName(input, 5, ['ref']);
         if (d.is_section || d.is_segment) {
             results.helperPromptText = null;
             results.currentSuggestions = null;

--- a/static/js/HeaderAutocomplete.jsx
+++ b/static/js/HeaderAutocomplete.jsx
@@ -363,7 +363,6 @@ export const HeaderAutocomplete = ({onRefClick, showSearch, openTopic, openURL, 
         }
         try {
         let types = Sefaria.activeModule === Sefaria.SHEETS_MODULE ? ['Topic', 'User', 'Collection'] : undefined;
-        console.log(types);
         const d = await Sefaria.getName(inputValue, undefined, types, Sefaria.activeModule);
 
         let comps = d["completion_objects"].map(o => {

--- a/static/js/HeaderAutocomplete.jsx
+++ b/static/js/HeaderAutocomplete.jsx
@@ -362,7 +362,9 @@ export const HeaderAutocomplete = ({onRefClick, showSearch, openTopic, openURL, 
           return[];
         }
         try {
-        const d = await Sefaria.getName(inputValue);
+        let types = Sefaria.activeModule === Sefaria.SHEETS_MODULE ? ['Topic', 'User', 'Collection'] : undefined;
+        console.log(types);
+        const d = await Sefaria.getName(inputValue, undefined, types, Sefaria.activeModule);
 
         let comps = d["completion_objects"].map(o => {
           const c = {...o};

--- a/static/js/SourceEditor.jsx
+++ b/static/js/SourceEditor.jsx
@@ -73,7 +73,7 @@ const SourceEditor = ({topic, close, origData={}}) => {
         if (input === "") {  // this occurs when there was text in the inputbox and user just erased it
             return results;
         }
-        const d = await Sefaria.getName(input, 0, 'ref');
+        const d = await Sefaria.getName(input, 0, ['ref']);
         if (d.is_section || d.is_segment) {
             results.helperPromptText = null;
             results.currentSuggestions = null;

--- a/static/js/TopicLandingPage/TopicLandingSearch.jsx
+++ b/static/js/TopicLandingPage/TopicLandingSearch.jsx
@@ -51,7 +51,7 @@ const getSuggestions = async (input) => {
     const isInputHebrew = Sefaria.hebrew.isHebrew(word);
     const lang = isInputHebrew? 'he' : 'en';
 
-    const rawCompletions = await Sefaria.getName(word,20, ["Topic"], true, true);
+    const rawCompletions = await Sefaria.getName(word,20, ["Topic"], "library",true, true);
     const completionObjects = _parseSuggestions(rawCompletions["completion_objects"], lang);
     return completionObjects.map((suggestion) => ({
       text: suggestion.title,

--- a/static/js/TopicLandingPage/TopicLandingSearch.jsx
+++ b/static/js/TopicLandingPage/TopicLandingSearch.jsx
@@ -51,7 +51,7 @@ const getSuggestions = async (input) => {
     const isInputHebrew = Sefaria.hebrew.isHebrew(word);
     const lang = isInputHebrew? 'he' : 'en';
 
-    const rawCompletions = await Sefaria.getName(word,20, "Topic", true, true);
+    const rawCompletions = await Sefaria.getName(word,20, ["Topic"], true, true);
     const completionObjects = _parseSuggestions(rawCompletions["completion_objects"], lang);
     return completionObjects.map((suggestion) => ({
       text: suggestion.title,

--- a/static/js/TopicSearch.jsx
+++ b/static/js/TopicSearch.jsx
@@ -36,7 +36,7 @@ class TopicSearch extends Component {
         topics.push({title: this.props.createNewTopicStr+word, key: ""})
         return topics;
      };
-    const rawCompletions = await Sefaria.getName(word, undefined, 'Topic');
+    const rawCompletions = await Sefaria.getName(word, undefined, ['Topic']);
     const completion_objects = parseCompletions(rawCompletions['completion_objects'])
     results.currentSuggestions = completion_objects
         .map(suggestion => ({

--- a/static/js/s1/editor.js
+++ b/static/js/s1/editor.js
@@ -635,7 +635,7 @@ $(function() {
 
 	$("#newTextOK").click(function(){
         var ref = $("#newTextName").val();
-		Sefaria.getName(ref, undefined, 'ref')
+		Sefaria.getName(ref, undefined, ['ref'])
 			   .then(function(q) {
 					if(!q.is_ref) {
 						// This is an unknown text

--- a/static/js/sefaria/sefaria.js
+++ b/static/js/sefaria/sefaria.js
@@ -1351,15 +1351,20 @@ Sefaria = extend(Sefaria, {
   _lookups: {},
 
   // getName w/ refOnly true should work as a replacement for parseRef - it uses a callback rather than return value.  Besides that - same data.
-  getName: function(name, limit = undefined, type=undefined, exactContinuations=undefined, orderByMatchedLength=undefined) {
+  getName: function(name, limit = undefined, types=undefined, exactContinuations=undefined, orderByMatchedLength=undefined) {
     const trimmed_name = name.trim();
-    let params = {active_module: this.activeModule};
+    let params = {};
     // if (refOnly) { params["ref_only"] = 1; }
-    if (limit != undefined) { params["limit"] = limit; }
-    if (type != undefined) { params["type"] = type; }
+    if (types != undefined) { params["type"] = types; }
     if (exactContinuations) { params["exact_continuations"] = 1; }
     if (orderByMatchedLength) { params["order_by_matched_length"] = 1; }
-    let queryString = Object.keys(params).map(key => key + '=' + params[key]).join('&');
+    let queryString = Object.keys(params).map(key => {
+        const value = params[key];
+        if (Array.isArray(value)) {
+            return value.map(v => `${encodeURIComponent(key)}=${encodeURIComponent(v)}`).join('&');
+        }
+        return `${encodeURIComponent(key)}=${encodeURIComponent(value)}`;
+    }).join('&');
     queryString = (queryString ? "?" + queryString : "");
     return this._cachedApiPromise({
         url:   this.apiHost + "/api/name/" + encodeURIComponent(trimmed_name) + queryString,

--- a/static/js/sefaria/sefaria.js
+++ b/static/js/sefaria/sefaria.js
@@ -1351,11 +1351,13 @@ Sefaria = extend(Sefaria, {
   _lookups: {},
 
   // getName w/ refOnly true should work as a replacement for parseRef - it uses a callback rather than return value.  Besides that - same data.
-  getName: function(name, limit = undefined, types=undefined, exactContinuations=undefined, orderByMatchedLength=undefined) {
+  getName: function(name, limit = undefined, types=undefined, topicPool=undefined, exactContinuations=undefined, orderByMatchedLength=undefined) {
     const trimmed_name = name.trim();
     let params = {};
     // if (refOnly) { params["ref_only"] = 1; }
+    if (limit != undefined) { params["limit"] = limit; }
     if (types != undefined) { params["type"] = types; }
+    if (topicPool !== undefined) { params["topic_pool"] = topicPool; }
     if (exactContinuations) { params["exact_continuations"] = 1; }
     if (orderByMatchedLength) { params["order_by_matched_length"] = 1; }
     let queryString = Object.keys(params).map(key => {

--- a/static/js/sefaria/util.js
+++ b/static/js/sefaria/util.js
@@ -963,7 +963,7 @@ class Util {
                 }.bind(this))
             .autocomplete({
                 source: function(request, response) {
-                  Sefaria.getName(request.term, undefined, 'ref')
+                  Sefaria.getName(request.term, undefined, ['ref'])
                          .then(d => d.completions)
                          .then(response);
                 },
@@ -1059,7 +1059,7 @@ Util.RefValidator.prototype = {
   },
   _lookupAndRoute: function(inString) {
       if (this.current_lookup_ajax) {this.current_lookup_ajax.cancel();}
-      this.current_lookup_ajax = Sefaria.makeCancelable(Sefaria.getName(inString, undefined, 'ref'));
+      this.current_lookup_ajax = Sefaria.makeCancelable(Sefaria.getName(inString, undefined, ['ref']));
       this.current_lookup_ajax.promise.then(data => {
               // If this query has been outpaced by typing, just return.
               if (this.$input.val() != inString) { this.current_lookup_ajax = null; return; }

--- a/static/js/sheets.js
+++ b/static/js/sheets.js
@@ -160,7 +160,7 @@ $(function() {
 	$(document).on("click", "#inlineAddSourceOK", function() {
 		var $target = $("#addInterface").prev(".sheetItem");
         var ref = $("#inlineAdd").val();
-		Sefaria.getName(ref, undefined, 'ref').then(function(q) {
+		Sefaria.getName(ref, undefined, ['ref']).then(function(q) {
             addSource(q, undefined, "insert", $target);
             $('#inlineAdd').val('');
             $("#inlineTextPreview").html("");

--- a/static/js/sheets/PublishMenu.jsx
+++ b/static/js/sheets/PublishMenu.jsx
@@ -109,7 +109,7 @@ const PublishMenu = ({sheet, publishCallback}) => {
     }
     const updateSuggestedTags = (input) => {
     if (input === "") return
-    Sefaria.getName(input, 5, "Topic").then(d => {
+    Sefaria.getName(input, 5, ["Topic"]).then(d => {
         const topics = d.completion_objects
             .map((filteredObj, index) => ({
                 id: index,


### PR DESCRIPTION
## Background
The problem this PR addresses is the autocompletion suggestion in adding a source to a sheet (from the sheet).
For understanding the issue, one should know the history:
1. Auto completions are genereated by names api. They are used in some places in the site.
2. In master we have 2 relevent params - `type` for getting only one type of auto completions, and `topic_pool` for getting the topic for only one pool (library or sheets).
3. In MDL we change the auto completins of the main search, so any module will get only results that are related to the module. For that purpose, the `get_name_completions` uses the `active_module` (shich is added by middleware to requests).
The problem is that in when one wants to add a source to sheet, he's in the sheets module but needs the results from the library.
 
## API considareations
I think the adding of `active_module` param was wrong. Here are my considerations:
1. It has the above problem.
2. API public endpoint should not vary based on our subdomains. The API is an external-facing contract and should be independent of our internal routing.
3. The results are filtered base on types and topic pool, so we should use/refactor existing params to get the desired result. 

## Solution
I first reverted the api and its uses to what it is in master (not git revert for some weird git issue).
Then I refactored the `type` param to support multiple values per request.

## Code changes
1. Reverting of the code in both server and client sides.
2. Refactoring code to support multiple `type` values (and renaming the `type` to `types`) - also in both sides.
3. Add the desired types to the HeaderAutocomplete when being on sheets module.

## Note for reviewers
Most of the diff here is taken from master. Maybe it would be easier to read it against master rather than modularization-main (but I'm not sure how it can be done).