### PR TITLE
Revert back to previous method for newlines in Strapi

### DIFF
--- a/static/js/Misc.jsx
+++ b/static/js/Misc.jsx
@@ -1989,12 +1989,18 @@ const transformValues = (obj, callback) => {
   return newObj;
 };
 
-export const replaceNewLinesWithLinebreaks = (content) => {
-  return transformValues(
-    content,
-    (s) => s.replace(/\n(?!\n)/g, "  \n")
-  );
-}
+// Use optional parameter with destructuring
+export const replaceNewLinesWithLinebreaks = (content, options = {}) => {
+  const { mode = "standard" } = options ?? {};
+
+  if (mode === "strapi") {
+    // Strapi needs to have all the newslines in markdown replaced with &nbsp; entities, extra space at the end for good measure
+    return transformValues(content, (s) => s.replace(/\n/gi, "&nbsp; \n") + "&nbsp; \n&nbsp; \n");
+  }
+
+  // Replace single newlines only, preserving double newlines (paragraph breaks)
+  return transformValues(content, (s) => s.replace(/\n(?!\n)/g, " \n"));
+};
 
 const InterruptingMessage = ({
                                onClose,
@@ -2130,7 +2136,8 @@ const InterruptingMessage = ({
                   <div id="defaultModalBody" className="line-break">
                     <InterfaceText
                       markdown={replaceNewLinesWithLinebreaks(
-                        strapi.modal.modalText
+                        strapi.modal.modalText,
+                        { mode: "strapi" }
                       )}
                     />
                   </div>
@@ -2294,7 +2301,8 @@ const Banner = ({ onClose }) => {
             <div id="bannerTextBox">
               <InterfaceText
                 markdown={replaceNewLinesWithLinebreaks(
-                  strapi.banner.bannerText
+                  strapi.banner.bannerText,
+                  { mode: 'strapi' }
                 )}
               />
             </div>


### PR DESCRIPTION
## Description
The `replaceNewLinesWithLinebreaks` previously used a different method for replacing newlines specifically for Strapi. See here: https://github.com/Sefaria/Sefaria-Project/blame/0759899f44c4184e00d4eeea69bd2f7688a7200e/static/js/Misc.jsx#L1992. It was changed recently to work with other uses of markdown throughout the codebase, but that introduced a bug for Strapi end users.  The data received from Strapi needs to have all the newlines in markdown replaced with &nbsp; entities in order to work properly. I have been compensating by editing modals/banners in Strapi to do what I previously had the code do.

## Code Changes
The `replaceNewLinesWithLinebreaks` was changed to handle both scenarios in the codebase with an options object to represent the mode. The default will be the one now where a mode isn't passed and what the code was recently changed to.