### PR TITLE
chore: put inside script tags

### DIFF
--- a/templates/edit_profile.html
+++ b/templates/edit_profile.html
@@ -149,7 +149,7 @@
 {% block js %}
 	<script src="{% static 'ckeditor/ckeditor.js' %}"></script>
 	<script src="{% static 'ckeditor/adapters/jquery.js' %}"></script>
-	<script>{% include "js/django-csrf.js" %}</script>
+	<script src="{% static 'js/django-csrf.js' %}"></script>
     <script>
 
 		CKEDITOR.config.font_names =


### PR DESCRIPTION
## Description
Django-csrf.js needs to be inside script tags to actually run and not show as text!