### PR TITLE
Refactor language switching to use onClick handlers instead of useEff…

### DIFF
--- a/static/js/Footer.jsx
+++ b/static/js/Footer.jsx
@@ -1,0 +1,130 @@
+import React  from 'react';
+import Sefaria  from './sefaria/sefaria';
+import PropTypes from'prop-types';
+import $  from './sefaria/sefariaJquery';
+import { InterfaceText, DonateLink } from './Misc';
+import {NewsletterSignUpForm} from "./NewsletterSignUpForm";
+
+import Component from 'react-class';
+
+const Section = ({en, he, children}) => (
+    <div className="section">
+      <div className="header">
+         <InterfaceText text={{en:en, he:he}}/>
+      </div>
+      {children}
+    </div>
+);
+
+const Link = ({href, en, he, blank, targetModule}) => (
+    <a href={href} target={blank ? "_blank" : "_self"} data-target-module={targetModule}>
+      <InterfaceText text={{en:en, he:he}}/>
+    </a>
+);
+
+class Footer extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {};
+  }
+  componentDidMount() {
+    this.setState({isClient: true});
+  }
+  trackLanguageClick(language){
+    Sefaria.track.setInterfaceLanguage('interface language footer', language);
+  }
+  handleLanguageChange(e, language, langCode) {
+    e.preventDefault();
+    this.trackLanguageClick(language);
+    const currentPath = encodeURIComponent(Sefaria.util.currentPath());
+    window.location.href = `/interface/${langCode}?next=${currentPath}`;
+  }
+  render() {
+    if (!Sefaria._siteSettings.TORAH_SPECIFIC) { return null; }
+
+    const fbURL = Sefaria.interfaceLang == "hebrew" ? "https://www.facebook.com/sefaria.org.il" : "https://www.facebook.com/sefaria.org";
+    const blgURL = Sefaria.interfaceLang == "hebrew" ? "https://blog.sefaria.org.il/" : "https://blog.sefaria.org/";
+    const helpURL = Sefaria.interfaceLang == "hebrew" ? Sefaria._siteSettings.HELP_CENTER_URLS.HE : Sefaria._siteSettings.HELP_CENTER_URLS.EN_US;
+    return (
+      <footer id="footer" className="static sans-serif">
+        <div id="footerInner">
+            <Section en="About" he="אודות">
+                <Link href="/about" en="What is Sefaria?" he="מהי ספריא" />
+                <Link href={helpURL} en="Help" he="עזרה" />
+                <Link href="/team" en="Team" he="צוות" />
+                <Link href="/products" en="Products" he="מוצרים" />
+                <Link href="/ai" en="AI on Sefaria" he="השימוש ב-AI בספריא" />
+                <Link href="/testimonials" en="Testimonials" he="חוות דעת" />
+                <Link href="/metrics" en="Metrics" he="מדדים" />
+                <Link href="/annualreport" en="Annual Report" he='דו"ח שנתי' />
+                <Link href="/terms" en="Terms of Use" he="תנאי שימוש" />
+                <Link href="/privacy-policy" en="Privacy Policy" he="מדיניות פרטיות" />
+            </Section>
+
+            <Section en="Tools" he="כלים">
+                <Link href="/educators" en="Teach with Sefaria" he="מלמדים עם ספריא" />
+                <Link href="/calendars" en="Learning Schedules" he="לוח לימוד יומי" />
+                <Link href="/visualizations" en="Visualizations" he="תרשימים גרפיים" />
+                <Link href="/mobile" en="Mobile Apps" he="ספריא בנייד" />
+                <Link href="/daf-yomi" en="Daf Yomi" he="דף יומי" />
+                <Link href="/torah-tab" en="Torah Tab" he="תורה טאב" />
+                <Link href="/people" en="Authors" he="מחברים" />
+                <Link href="/sheets/collections" en="Collections" he="אסופות" targetModule={Sefaria.SHEETS_MODULE} />
+                <Link href="/updates" en="New Additions" he="עדכונים" />
+            </Section>
+
+            <Section en="Developers" he="מפתחים">
+                <Link href="https://developers.sefaria.org" en="Get Involved" he="הצטרפו אלינו" blank={true} />
+                <Link href="https://developers.sefaria.org/reference" en="API Docs" he="מסמכי API" blank={true} />
+                <Link href="https://github.com/Sefaria/Sefaria-Project" en="Fork us on GitHub" he="Github" blank={true} />
+                <Link href="https://github.com/Sefaria/Sefaria-Export" en="Download our Data" he="בסיס נתונים" blank={true} />
+            </Section>
+
+            <Section en="Join Us" he="הצטרפו אלינו">
+                <DonateLink source={"Footer"}><InterfaceText text={{en:"Donate", he:"תרומות"}}/></DonateLink>
+                <Link href="/ways-to-give" en="Ways to Give" he="אפשרויות תרומה" />
+                <Link href="/supporters" en="Supporters" he="תומכים" />
+                <Link href="/jobs" en="Jobs" he="דרושים" />
+                <Link href="https://store.sefaria.org" en="Shop" he="חנות" />
+            </Section>
+
+          <div className="section last connect">
+              <div className="header connect">
+                  <InterfaceText>Connect</InterfaceText>
+              </div>
+              <NewsletterSignUpForm contextName="Footer" />
+              <div className="socialLinks">
+                  <Link href="https://www.instagram.com/sefariaproject/" en="Instagram" he="אינסטגרם" blank={true} />
+                  &bull;
+                  <Link href={fbURL} en="Facebook" he="פייסבוק" blank={true} />
+                  <br />
+
+                  <Link href="https://www.youtube.com/user/SefariaProject" en="YouTube" he="יוטיוב" blank={true} />
+                  &bull;
+                  <Link href={blgURL} en="Blog" he="בלוג" blank={true}/>
+                  <br />
+
+                  <Link href="https://www.linkedin.com/company/sefaria/" en="LinkedIn" he="לינקדאין" blank={true} />
+                  &bull;
+                  <Link href="mailto:hello@sefaria.org" en="Email" he="דוא&quot;ל" />
+              </div>
+              <div id="siteLanguageToggle">
+                  <div id="siteLanguageToggleLabel">
+                      <InterfaceText>Site Language</InterfaceText>
+                  </div>
+                  <a href="/interface/english" id="siteLanguageEnglish"
+                     onClick={(e) => this.handleLanguageChange(e, "English", "english")}>English
+                  </a>
+                  |
+                  <a href="/interface/hebrew" id="siteLanguageHebrew"
+                      onClick={(e) => this.handleLanguageChange(e, "Hebrew", "hebrew")}>עברית
+                  </a>
+              </div>
+          </div>
+        </div>
+      </footer>
+    );
+  }
+}
+
+export default Footer;

--- a/static/js/Header.jsx
+++ b/static/js/Header.jsx
@@ -1,183 +1,154 @@
-import React, { useState, useEffect, useRef } from 'react';
-import PropTypes from 'prop-types';
-import ReactDOM from 'react-dom';
+import React, { useState, useEffect, useRef} from 'react';
+import PropTypes  from 'prop-types';
+import ReactDOM  from 'react-dom';
 import Component from 'react-class';
-import classNames from 'classnames';
-import $ from './sefaria/sefariaJquery';
-import Sefaria from './sefaria/sefaria';
+import classNames  from 'classnames';
+import $  from './sefaria/sefariaJquery';
+import Sefaria  from './sefaria/sefaria';
 import {
   SearchButton,
   GlobalWarningMessage,
   InterfaceLanguageMenu,
   InterfaceText,
-  getCurrentPage,
   LanguageToggleButton,
   DonateLink,
   useOnceFullyVisible
 } from './Misc';
-import { ProfilePic } from "./ProfilePic";
-import { HeaderAutocomplete } from './HeaderAutocomplete'
-import { DropdownMenu, DropdownMenuSeparator, DropdownMenuItem, DropdownModuleItem, DropdownLanguageToggle } from './common/DropdownMenu';
-import Util from './sefaria/util';
+import {ProfilePic} from "./ProfilePic";
+import {HeaderAutocomplete} from './HeaderAutocomplete'
+import { DropdownMenu, DropdownMenuSeparator, DropdownMenuItem, DropdownMenuItemWithIcon, DropdownLanguageToggle } from './common/DropdownMenu';
 import Button from './common/Button';
-
-const LoggedOutDropdown = ({ module }) => {
-  const [isClient, setIsClient] = useState(false);
-  const [next, setNext] = useState("/");
-  const [loginLink, setLoginLink] = useState("/login?next=/");
-  const [registerLink, setRegisterLink] = useState("/register?next=/");
-
-  useEffect(() => {
-    setIsClient(true);
-  }, []);
-
-  useEffect(() => {
-    if (isClient) {
-      setNext(encodeURIComponent(Sefaria.util.currentPath()));
-      setLoginLink("/login?next=" + next);
-      setRegisterLink("/register?next=" + next);
-    }
-  })
+  
+const LoggedOutDropdown = ({module}) => {
+  const handleAuthClick = (e, path) => {
+    e.preventDefault();
+    const currentPath = encodeURIComponent(Sefaria.util.currentPath());
+    window.location.href = `${path}?next=${currentPath}`;
+  };
 
   return (
-    <DropdownMenu positioningClass="headerDropdownMenu" buttonComponent={
-      <button className="header-dropdown-button" aria-label={Sefaria._("Account menu")}>
-        <img src='/static/icons/logged_out.svg' alt={Sefaria._("Login")} />
-      </button>
-    }>
-      <div className='dropdownLinks-options'>
-        <DropdownMenuItem url={loginLink}>
-          <InterfaceText text={{ 'en': 'Log in', 'he': 'התחברות' }} />
-        </DropdownMenuItem>
-        <DropdownMenuItem url={registerLink}>
-          <InterfaceText text={{ 'en': 'Sign up', 'he': 'להרשמה' }} />
-        </DropdownMenuItem>
-        <DropdownMenuSeparator />
-        <DropdownLanguageToggle />
-        <DropdownMenuSeparator />
-        {module === Sefaria.LIBRARY_MODULE &&
-          <DropdownMenuItem url={'/updates'}>
-            <InterfaceText text={{ 'en': 'New Additions', 'he': 'חידושים בארון הספרים של ספריא' }} />
-          </DropdownMenuItem>
-        }
-        <DropdownMenuItem url={'/help'}>
-          <InterfaceText text={{ 'en': 'Help', 'he': 'עזרה' }} />
-        </DropdownMenuItem>
-      </div>
-    </DropdownMenu>
-  );
+      <DropdownMenu positioningClass="headerDropdownMenu" buttonComponent={<img src='/static/icons/logged_out.svg'/>}>
+          <div className='dropdownLinks-options'>
+              <DropdownMenuItem url="/login">
+                  <a href="/login" onClick={(e) => handleAuthClick(e, '/login')}>
+                      <InterfaceText text={{'en': 'Log in', 'he': 'התחברות'}}/>
+                  </a>
+              </DropdownMenuItem>
+              <DropdownMenuItem url="/register">
+                  <a href="/register" onClick={(e) => handleAuthClick(e, '/register')}>
+                      <InterfaceText text={{'en': 'Sign up', 'he': 'להרשמה'}}/>
+                  </a>
+              </DropdownMenuItem>
+              <DropdownMenuSeparator/>
+              <DropdownLanguageToggle/>
+              <DropdownMenuSeparator/>
+              { module === Sefaria.LIBRARY_MODULE &&
+                <DropdownMenuItem url={'/updates'}>
+                    <InterfaceText text={{'en': 'New Additions', 'he': 'חידושים בארון הספרים של ספריא'}}/>
+                </DropdownMenuItem>
+              }
+              <DropdownMenuItem url={'/help'}>
+                  <InterfaceText text={{'en': 'Help', 'he': 'עזרה'}}/>
+              </DropdownMenuItem>
+          </div>
+      </DropdownMenu>
+);
 }
 
-const LoggedInDropdown = ({ module }) => {
+const LoggedInDropdown = ({module}) => {
   return (
-    <DropdownMenu positioningClass="headerDropdownMenu"
-      buttonComponent={<ProfilePic url={Sefaria.profile_pic_url}
-        name={Sefaria.full_name}
-        len={25} />}>
-      <div className='dropdownLinks-options'>
-        {module === Sefaria.LIBRARY_MODULE &&
-          <DropdownMenuItem preventClose={true}>
-            <strong>{Sefaria.full_name}</strong>
-          </DropdownMenuItem>
-        }
-        {module === Sefaria.VOICES_MODULE &&
-          <DropdownMenuItem url={`/profile/${Sefaria.slug}`} preventClose={true} targetModule={Sefaria.VOICES_MODULE}>
-            <strong>{Sefaria.full_name}</strong>
-          </DropdownMenuItem>
-        }
-        <DropdownMenuSeparator />
+      <DropdownMenu positioningClass="headerDropdownMenu" 
+                    buttonComponent={<ProfilePic url={Sefaria.profile_pic_url}
+                                                 name={Sefaria.full_name}
+                                                 len={25}/>}>
+          <div className='dropdownLinks-options'>
+              { module === Sefaria.LIBRARY_MODULE && 
+                <DropdownMenuItem preventClose={true}>
+                    <strong>{Sefaria.full_name}</strong>
+                </DropdownMenuItem>
+              }
+               { module === Sefaria.SHEETS_MODULE && 
+                <DropdownMenuItem url={`/sheets/profile/${Sefaria.slug}`} preventClose={true} targetModule={Sefaria.SHEETS_MODULE}>
+                    <strong>{Sefaria.full_name}</strong>
+                </DropdownMenuItem>
+              }
+              <DropdownMenuSeparator/>
 
-        {module === Sefaria.LIBRARY_MODULE &&
-          <>
-            <DropdownMenuItem url={'/settings/account'} targetModule={Sefaria.LIBRARY_MODULE}>
-              <InterfaceText>Account Settings</InterfaceText>
-            </DropdownMenuItem>
-            <DropdownMenuItem url={'/torahtracker'}>
-              <InterfaceText text={{ 'en': 'Torah Tracker', 'he': 'לימוד במספרים' }} />
-            </DropdownMenuItem>
-          </>
-        }
+              { module === Sefaria.LIBRARY_MODULE && 
+                <>
+                <DropdownMenuItem url={'/settings/account'} targetModule={Sefaria.LIBRARY_MODULE}>
+                    <InterfaceText>Account Settings</InterfaceText>
+                </DropdownMenuItem>
+                <DropdownMenuItem url={'/torahtracker'}>
+                    <InterfaceText text={{'en': 'Torah Tracker', 'he': 'לימוד במספרים'}}/>
+                </DropdownMenuItem>
+                </> 
+              }
 
 
-        {module === Sefaria.VOICES_MODULE &&
-          <>
-            <DropdownMenuItem url={`/profile/${Sefaria.slug}`} targetModule={Sefaria.VOICES_MODULE}>
-              <InterfaceText>Profile</InterfaceText>
-            </DropdownMenuItem>
-            <DropdownMenuItem url={'/saved'} targetModule={Sefaria.VOICES_MODULE}>
-              <InterfaceText>Saved</InterfaceText>
-            </DropdownMenuItem>
-            <DropdownMenuItem url={'/history'} targetModule={Sefaria.VOICES_MODULE}>
-              <InterfaceText>History</InterfaceText>
-            </DropdownMenuItem>
-            <DropdownMenuItem url={'/settings/account'} targetModule={Sefaria.LIBRARY_MODULE}>
-              <InterfaceText>Account Settings</InterfaceText>
-            </DropdownMenuItem>
-          </>
-        }
+              { module === Sefaria.SHEETS_MODULE && 
+                <>
+                <DropdownMenuItem url={`/sheets/profile/${Sefaria.slug}`} targetModule={Sefaria.SHEETS_MODULE}>
+                    <InterfaceText>Profile</InterfaceText>
+                </DropdownMenuItem>
+                <DropdownMenuItem url={'/sheets/saved'} targetModule={Sefaria.SHEETS_MODULE}>
+                  <InterfaceText>Saved</InterfaceText>
+                </DropdownMenuItem>
+                <DropdownMenuItem url={'/sheets/history'} targetModule={Sefaria.SHEETS_MODULE}>
+                  <InterfaceText>History</InterfaceText>
+                </DropdownMenuItem>
+                <DropdownMenuItem url={'/settings/account'} targetModule={Sefaria.LIBRARY_MODULE}>
+                    <InterfaceText>Account Settings</InterfaceText>
+                </DropdownMenuItem>
+                </> 
+              }
+              
+              <DropdownMenuSeparator/>
+              <DropdownLanguageToggle/>
+              <DropdownMenuSeparator/>
+              
+              { module === Sefaria.LIBRARY_MODULE && 
+                <DropdownMenuItem url={'/updates'}>
+                    <InterfaceText text={{'en': 'New Additions', 'he': 'חידושים בארון הספרים של ספריא'}}/>
+                </DropdownMenuItem>
+              }
 
-        <DropdownMenuSeparator />
-        <DropdownLanguageToggle />
-        <DropdownMenuSeparator />
-
-        {module === Sefaria.LIBRARY_MODULE &&
-          <DropdownMenuItem url={'/updates'}>
-            <InterfaceText text={{ 'en': 'New Additions', 'he': 'חידושים בארון הספרים של ספריא' }} />
-          </DropdownMenuItem>
-        }
-
-        <DropdownMenuItem preventClose={true} url={'/help'}>
-          <InterfaceText text={{ 'en': 'Help', 'he': 'עזרה' }} />
-        </DropdownMenuItem>
-        <DropdownMenuSeparator />
-        <DropdownMenuItem url={Sefaria.getLogoutUrl()}>
-          <InterfaceText text={{ 'en': 'Log Out', 'he': 'ניתוק' }} />
-        </DropdownMenuItem>
-      </div>
-    </DropdownMenu>
-  );
+              <DropdownMenuItem preventClose={true} url={'/help'}>
+                  <InterfaceText text={{'en': 'Help', 'he': 'עזרה'}}/>
+              </DropdownMenuItem>
+              <DropdownMenuSeparator/>
+              <DropdownMenuItem url={Sefaria.getLogoutUrl()}>
+                  <InterfaceText text={{'en': 'Log Out', 'he': 'ניתוק'}}/>
+              </DropdownMenuItem>
+          </div>
+      </DropdownMenu>
+);
 }
 
 const ModuleSwitcher = () => {
-  const logoPath = Sefaria.interfaceLang === "hebrew" ? "/static/img/logo-hebrew.png" : "/static/img/logo.svg";
+  const libraryURL = Sefaria.moduleRoutes[Sefaria.LIBRARY_MODULE];
+  const sheetsURL = Sefaria.moduleRoutes[Sefaria.SHEETS_MODULE];
   return (
-    <DropdownMenu positioningClass="headerDropdownMenu" buttonComponent={
-      <button className="header-dropdown-button" aria-label={Sefaria._("Library")}>
-        <img src='/static/icons/module_switcher_icon.svg' alt={Sefaria._("Library")} />
-      </button>
-    }>
-      <div className='dropdownLinks-options moduleDropdown'>
-        <DropdownMenuItem url={"/about"} newTab={false} customCSS="dropdownItem dropdownLogoItem">
-          <img src={logoPath} alt={Sefaria._('Sefaria')} className='dropdownLogo' />
-
-        </DropdownMenuItem>
-        <DropdownMenuSeparator />
-        <DropdownModuleItem
-          url={"/"}
-          newTab={Sefaria.activeModule !== Sefaria.LIBRARY_MODULE}
-          targetModule={Sefaria.LIBRARY_MODULE}
-          dotColor={'--sefaria-blue'}
-          text={{ en: "Library", he: Sefaria._("Library") }} />
-        <DropdownMenuSeparator />
-        <DropdownModuleItem
-          url={"/"}
-          newTab={Sefaria.activeModule !== Sefaria.VOICES_MODULE}
-          targetModule={Sefaria.VOICES_MODULE}
-          dotColor={'--sheets-green'}
-          text={{ en: "Voices", he: Sefaria._("Voices") }} />
-        <DropdownMenuSeparator />
-        <DropdownModuleItem
-          url={'https://developers.sefaria.org'}
-          newTab={true}
-          dotColor={'--devportal-purple'}
-          text={{ en: "Developers", he: Sefaria._("Developers") }} />
-        <DropdownMenuSeparator />
-        <DropdownMenuItem url={'/products'} newTab={true} customCSS="dropdownItem dropdownMoreItem">
-          <InterfaceText text={{ en: 'More from Sefaria' + ' ›', he: Sefaria._('More from Sefaria') + ' ›' }} />
-        </DropdownMenuItem>
-      </div>
-    </DropdownMenu>
-  );
+      <DropdownMenu positioningClass="headerDropdownMenu" buttonComponent={<img src='/static/icons/module_switcher_icon.svg'/>}>
+          <div className='dropdownLinks-options'>
+              <DropdownMenuItem url={libraryURL} newTab={Sefaria.activeModule !== Sefaria.LIBRARY_MODULE} targetModule={Sefaria.LIBRARY_MODULE}>
+                  <DropdownMenuItemWithIcon icon={'/static/icons/library_icon.svg'} textEn={"Library"}/>
+              </DropdownMenuItem>
+              <DropdownMenuSeparator/>
+              <DropdownMenuItem url={sheetsURL} newTab={Sefaria.activeModule !== Sefaria.SHEETS_MODULE} targetModule={Sefaria.SHEETS_MODULE}>  
+                  <DropdownMenuItemWithIcon icon={'/static/icons/sheets_icon.svg'} textEn={'Sheets'}/>
+              </DropdownMenuItem>
+              <DropdownMenuSeparator/>
+              <DropdownMenuItem url={'https://developers.sefaria.org'} newTab={true}>
+                  <DropdownMenuItemWithIcon icon={'/static/icons/developers_icon.svg'} textEn={'Developers'}/>
+              </DropdownMenuItem>
+              <DropdownMenuSeparator/>
+              <DropdownMenuItem url={'/products'} newTab={true}>
+                <InterfaceText text={{'he': 'לכל המוצרים שלנו', 'en': 'See all products ›'}}/>
+              </DropdownMenuItem>
+          </div>
+      </DropdownMenu>
+);
 }
 
 const Header = (props) => {
@@ -196,31 +167,30 @@ const Header = (props) => {
       window.removeEventListener('keydown', handleFirstTab);
     }
   }, []);
+  const short_lang = Sefaria._getShortInterfaceLang();
 
-  const path = `/static/img/${Sefaria.activeModule}-logo-${Sefaria.interfaceLang}.svg`;
-  const logo = (
-    <img src={path} className="home" alt={Sefaria._(`Sefaria ${Sefaria.activeModule} logo`)}/>
+  const libraryLogoPath = Sefaria.interfaceLang === "hebrew"  ? "logo-hebrew.png" : "logo.svg";
+  const libraryLogo = (
+    <img src={`/static/img/${libraryLogoPath}`} className="home" alt="Sefaria Logo"/>
   );
 
-  const librarySavedIcon = <div className='librarySavedIcon'>
-                                <a
-                                  href="/texts/saved"
-                                  data-target-module={Sefaria.LIBRARY_MODULE}
-                                  onKeyDown={(e) => Util.handleKeyboardClick(e)}
-                                >
-                                  <img src='/static/icons/bookmarks.svg' alt={Sefaria._('Saved items')} />
-                                </a>
-                              </div>;
+  const sheetsLogoPath = `/static/img/${short_lang}_sheets_logo.svg`;
+  const sheetsLogo = (
+    <img src={sheetsLogoPath} alt="Sefaria Sheets Logo" className="home"/>
+  );
 
+  const logo = props.module === Sefaria.LIBRARY_MODULE ? libraryLogo : sheetsLogo;
+
+      const librarySavedIcon = <div className='librarySavedIcon'>
+                                  <a href="/texts/saved" data-target-module={Sefaria.LIBRARY_MODULE}>
+                                    <img src='/static/icons/bookmarks.svg' alt='Saved items' />
+                                  </a>
+                                </div>;
   const sheetsNotificationsIcon = <div className='sheetsNotificationsHeaderIcon'>
-    <a
-      href="/notifications"
-      data-target-module={Sefaria.VOICES_MODULE}
-      onKeyDown={(e) => Util.handleKeyboardClick(e)}
-    >
-      <img src='/static/icons/notification.svg' alt={Sefaria._("Notifications")} />
-    </a>
-  </div>;
+                                        <a href="/sheets/notifications" data-target-module={Sefaria.SHEETS_MODULE}>
+                                          <img src='/static/icons/notification.svg' />
+                                        </a>
+                                      </div>;
 
   const headerRef = useOnceFullyVisible(() => {
     sa_event("header_viewed", { impression_type: "regular_header" });
@@ -231,116 +201,98 @@ const Header = (props) => {
   if (props.hidden && !props.mobileNavMenuOpen) {
     return null;
   }
-
+  
   const headerContent = (
     <>
-      <nav className="headerNavSection" aria-label="Primary navigation">
-        {Sefaria._siteSettings.TORAH_SPECIFIC && logo}
-        {props.module === Sefaria.LIBRARY_MODULE &&
+        <div className="headerNavSection">
+          { Sefaria._siteSettings.TORAH_SPECIFIC && logo }
+          {props.module === Sefaria.LIBRARY_MODULE && 
           <>
-            <a
-              href="/texts"
-              className="textLink"
-              onKeyDown={(e) => Util.handleKeyboardClick(e)}
-            >
+            <a href="/texts" className="textLink">
               <InterfaceText context="Header">Texts</InterfaceText>
             </a>
-            <a
-              href="/topics"
-              className="textLink"
-              onKeyDown={(e) => Util.handleKeyboardClick(e)}
-            >
+            <a href="/topics" className="textLink">
               <InterfaceText context="Header">Topics</InterfaceText>
             </a>
           </>
-        }
-        {props.module === Sefaria.VOICES_MODULE &&
+          }
+          {props.module === Sefaria.SHEETS_MODULE && 
           <>
-            <a
-              href="/topics"
-              data-target-module={Sefaria.VOICES_MODULE}
-              className="textLink"
-              onKeyDown={(e) => Util.handleKeyboardClick(e)}
-            >
+            <a href="/sheets/topics" data-target-module={Sefaria.SHEETS_MODULE} className="textLink">
               <InterfaceText context="Header">Topics</InterfaceText>
             </a>
-            <a
-              href="/collections"
-              data-target-module={Sefaria.VOICES_MODULE}
-              className="textLink"
-              onKeyDown={(e) => Util.handleKeyboardClick(e)}
-            >
+            <a href="/sheets/collections" data-target-module={Sefaria.SHEETS_MODULE} className="textLink">
               <InterfaceText context="Header">Collections</InterfaceText>
             </a>
           </>
-        }
-        <DonateLink classes={"textLink donate"} source={"Header"}><InterfaceText>Donate</InterfaceText></DonateLink>
-      </nav>
+          }
+          <DonateLink classes={"textLink donate"} source={"Header"}><InterfaceText>Donate</InterfaceText></DonateLink>
+        </div>
 
       <div className="headerLinksSection">
-        <HeaderAutocomplete
+      <HeaderAutocomplete
           onRefClick={props.onRefClick}
           showSearch={props.showSearch}
           openTopic={props.openTopic}
           openURL={props.openURL}
-        />
+      />
 
-        {!Sefaria._uid && props.module === Sefaria.LIBRARY_MODULE && <SignUpButton />}
-        {props.module === Sefaria.VOICES_MODULE && <CreateButton />}
-        {Sefaria._siteSettings.TORAH_SPECIFIC && <HelpButton />}
+        {!Sefaria._uid && props.module === Sefaria.LIBRARY_MODULE && <SignUpButton/>}
+        {props.module === Sefaria.SHEETS_MODULE && <CreateButton />}
+        { Sefaria._siteSettings.TORAH_SPECIFIC && <HelpButton />}
 
-        {!Sefaria._uid && Sefaria._siteSettings.TORAH_SPECIFIC ?
-          <InterfaceLanguageMenu
-            currentLang={Sefaria.interfaceLang}
-            translationLanguagePreference={props.translationLanguagePreference}
-            setTranslationLanguagePreference={props.setTranslationLanguagePreference} /> : null}
+        { !Sefaria._uid && Sefaria._siteSettings.TORAH_SPECIFIC ?
+              <InterfaceLanguageMenu
+                currentLang={Sefaria.interfaceLang}
+                translationLanguagePreference={props.translationLanguagePreference}
+                setTranslationLanguagePreference={props.setTranslationLanguagePreference} /> : null}
 
-        {Sefaria._uid && (props.module === Sefaria.LIBRARY_MODULE ? librarySavedIcon : sheetsNotificationsIcon)}
+        { Sefaria._uid && (props.module ===Sefaria.LIBRARY_MODULE ? librarySavedIcon : sheetsNotificationsIcon) }
 
-        <ModuleSwitcher />
+          <ModuleSwitcher />
 
-        {Sefaria._uid ?
-          <LoggedInDropdown module={props.module} />
-          : <LoggedOutDropdown module={props.module} />
-        }
+          { Sefaria._uid ?
+            <LoggedInDropdown module={props.module}/>
+            : <LoggedOutDropdown module={props.module}/>
+          }
 
-      </div>
-    </>
-  );
+        </div>
+      </>
+    );
 
-  const mobileHeaderContent = (
-    <>
-      <div>
-        <button onClick={props.onMobileMenuButtonClick} aria-label={Sefaria._("Menu")} className="menuButton">
-          <i className="fa fa-bars"></i>
-        </button>
-      </div>
+    const mobileHeaderContent = (
+      <>
+        <div>
+          <button onClick={props.onMobileMenuButtonClick} aria-label={Sefaria._("Menu")} className="menuButton">
+            <i className="fa fa-bars"></i>
+          </button>
+        </div>
 
-      <div className="mobileHeaderCenter">
-        {Sefaria._siteSettings.TORAH_SPECIFIC && logo}
-      </div>
+        <div className="mobileHeaderCenter">
+          { Sefaria._siteSettings.TORAH_SPECIFIC && logo }
+        </div>
 
-      {props.hasLanguageToggle ?
+        {props.hasLanguageToggle ?
         <div className={props.firstPanelLanguage + " mobileHeaderLanguageToggle"}>
           <LanguageToggleButton toggleLanguage={props.toggleLanguage} />
         </div> :
         <div></div>}
-    </>
-  );
+      </>
+    );
 
-  const headerClasses = classNames({ header: 1, mobile: !props.multiPanel });
-  const headerInnerClasses = classNames({
-    headerInner: 1,
-    boxShadow: props.hasBoxShadow,
-    mobile: !props.multiPanel
-  });
-  return (
-    <div className={headerClasses} role="banner" ref={headerRef}>
-      <div className={headerInnerClasses}>
-        {props.multiPanel ? headerContent : mobileHeaderContent}
-      </div>
+    const headerClasses = classNames({header: 1, mobile: !props.multiPanel});
+    const headerInnerClasses = classNames({
+      headerInner: 1,
+      boxShadow: props.hasBoxShadow,
+      mobile: !props.multiPanel
+    });
+    return (
+      <div className={headerClasses} role="banner" ref={headerRef}>
+        <div className={headerInnerClasses}>
+          {props.multiPanel ? headerContent : mobileHeaderContent}
+        </div>
 
-      {props.multiPanel ? null :
+        {props.multiPanel ? null :
         <MobileNavMenu
           visible={props.mobileNavMenuOpen}
           onRefClick={props.onRefClick}
@@ -349,238 +301,257 @@ const Header = (props) => {
           openURL={props.openURL}
           close={props.onMobileMenuButtonClick}
           module={props.module} />
-      }
-      <GlobalWarningMessage />
-    </div>
-  );
+        }
+        <GlobalWarningMessage />
+      </div>
+    );
 }
 
 Header.propTypes = {
-  multiPanel: PropTypes.bool.isRequired,
-  headerMode: PropTypes.bool.isRequired,
-  onRefClick: PropTypes.func.isRequired,
-  showSearch: PropTypes.func.isRequired,
-  openTopic: PropTypes.func.isRequired,
-  openURL: PropTypes.func.isRequired,
+  multiPanel:   PropTypes.bool.isRequired,
+  headerMode:   PropTypes.bool.isRequired,
+  onRefClick:   PropTypes.func.isRequired,
+  showSearch:   PropTypes.func.isRequired,
+  openTopic:    PropTypes.func.isRequired,
+  openURL:      PropTypes.func.isRequired,
   hasBoxShadow: PropTypes.bool.isRequired,
-  module: PropTypes.string.isRequired,
+  module:       PropTypes.string.isRequired,
 };
 
-const LoggedOutButtons = ({ mobile, loginOnly }) => {
+const LoggedOutButtons = ({mobile, loginOnly}) => {
   const [isClient, setIsClient] = useState(false);
-  const [next, setNext] = useState("/");
-  const [loginLink, setLoginLink] = useState("/login?next=/");
-  const [registerLink, setRegisterLink] = useState("/register?next=/");
-  useEffect(() => {
+  
+  const handleAuthClick = (e, path) => {
+    e.preventDefault();
+    const currentPath = encodeURIComponent(Sefaria.util.currentPath());
+    window.location.href = `${path}?next=${currentPath}`;
+  };
+
+  useEffect(()=>{
     setIsClient(true);
   }, []);
-  useEffect(() => {
-    if (isClient) {
-      setNext(encodeURIComponent(Sefaria.util.currentPath()));
-      setLoginLink("/login?next=" + next);
-      setRegisterLink("/register?next=" + next);
-    }
-  })
-  const classes = classNames({ accountLinks: !mobile, anon: !mobile });
+  const classes = classNames({accountLinks: !mobile, anon: !mobile});
   return (
     <div className={classes}>
-      {loginOnly && (
-        <a className="login loginLink" href={loginLink} key={`login${isClient}`}>
-          {mobile ? <img src="/static/icons/login.svg" alt={Sefaria._("Login")} /> : null}
-          <InterfaceText>Log in</InterfaceText>
-        </a>)}
+      { loginOnly && (
+      <a 
+        className="login loginLink" 
+        href="/login" 
+        onClick={(e) => handleAuthClick(e, '/login')}
+        key={`login${isClient}`}
+      >
+         {mobile ? <img src="/static/icons/login.svg" /> : null }
+         <InterfaceText>Log in</InterfaceText>
+       </a>)}
       {loginOnly ? null :
-        <span>
-          <a className="login signupLink" href={registerLink} key={`register${isClient}`}>
-            {mobile ? <img src="/static/icons/login.svg" alt={Sefaria._("Login")} /> : null}
-            <InterfaceText>Sign up</InterfaceText>
-          </a>
-          <a className="login loginLink" href={loginLink} key={`login${isClient}`}>
-            <InterfaceText>Log in</InterfaceText>
-          </a>
-        </span>}
+      <span>
+        <a 
+          className="login signupLink" 
+          href="/register" 
+          onClick={(e) => handleAuthClick(e, '/register')}
+          key={`register${isClient}`}
+        >
+          {mobile ? <img src="/static/icons/login.svg" /> : null }
+          <InterfaceText>Sign up</InterfaceText>
+        </a> 
+        <a 
+          className="login loginLink" 
+          href="/login" 
+          onClick={(e) => handleAuthClick(e, '/login')}
+          key={`login${isClient}`}
+        >
+          <InterfaceText>Log in</InterfaceText>
+        </a>
+      </span>}
 
     </div>
   );
 }
 
 
-const LoggedInButtons = ({ headerMode }) => {
+const LoggedInButtons = ({headerMode}) => {
   const [isClient, setIsClient] = useState(false);
   useEffect(() => {
-    if (headerMode) {
+    if(headerMode){
       setIsClient(true);
     }
   }, []);
   const unread = headerMode ? ((isClient && Sefaria.notificationCount > 0) ? 1 : 0) : Sefaria.notificationCount > 0 ? 1 : 0
-  const notificationsClasses = classNames({ notifications: 1, unread: unread });
+  const notificationsClasses = classNames({notifications: 1, unread: unread});
   return (
     <div className="loggedIn accountLinks">
       <a href="/texts/saved" aria-label="See My Saved Texts">
-        <img src="/static/icons/bookmarks.svg" alt={Sefaria._('Bookmarks')} />
+        <img src="/static/icons/bookmarks.svg" alt={Sefaria._('Bookmarks')}/>
       </a>
       <a href="/notifications" aria-label="See New Notifications" key={`notificationCount-C-${unread}`} className={notificationsClasses}>
         <img src="/static/icons/notification.svg" alt={Sefaria._('Notifications')} />
       </a>
-      {Sefaria._siteSettings.TORAH_SPECIFIC ? <HelpButton /> : null}
-      <ProfilePicMenu len={24} url={Sefaria.profile_pic_url} name={Sefaria.full_name} key={`profile-${isClient}-${Sefaria.full_name}`} />
+      { Sefaria._siteSettings.TORAH_SPECIFIC ? <HelpButton /> : null}
+      <ProfilePicMenu len={24} url={Sefaria.profile_pic_url} name={Sefaria.full_name} key={`profile-${isClient}-${Sefaria.full_name}`}/>
     </div>
   );
 }
 
-const MobileNavMenu = ({ onRefClick, showSearch, openTopic, openURL, close, visible, module }) => {
+const MobileNavMenu = ({onRefClick, showSearch, openTopic, openURL, close, visible, module}) => {
   const classes = classNames({
     mobileNavMenu: 1,
     closed: !visible,
   });
   return (
-    <nav className={classes} aria-label="Mobile navigation menu">
+    <div className={classes}>
       <div className="searchLine">
         <HeaderAutocomplete
-          onRefClick={onRefClick}
-          showSearch={showSearch}
-          openTopic={openTopic}
-          openURL={openURL}
-          onNavigate={close}
-          hideHebrewKeyboard={true}
+            onRefClick={onRefClick}
+            showSearch={showSearch}
+            openTopic={openTopic}
+            openURL={openURL}
+            onNavigate={close}
+            hideHebrewKeyboard={true}
         />
       </div>
-      {module === Sefaria.LIBRARY_MODULE &&
-        <>
-          <a href="/texts" onClick={close} className="textsPageLink">
-            <img src="/static/icons/book.svg" alt={Sefaria._("Texts")} />
-            <InterfaceText context="Header">Texts</InterfaceText>
-          </a>
-          <a href={"/topics"} onClick={close}>
-            <img src="/static/icons/topic.svg" alt={Sefaria._("Topics")} />
-            <InterfaceText context="Header">Explore</InterfaceText>
-          </a>
-          <a href="/calendars" onClick={close}>
-            <img src="/static/icons/calendar.svg" alt={Sefaria._("Learning Schedules")} />
-            <InterfaceText>Learning Schedules</InterfaceText>
-          </a>
-        </>
+      {module === Sefaria.LIBRARY_MODULE && 
+      <>
+        <a href="/texts" onClick={close} className="textsPageLink">
+          <img src="/static/icons/book.svg" />
+          <InterfaceText context="Header">Texts</InterfaceText>
+        </a>
+        <a href={"/topics"} onClick={close}>
+          <img src="/static/icons/topic.svg" />
+          <InterfaceText context="Header">Explore</InterfaceText>
+        </a>
+        <a href="/calendars" onClick={close}>
+          <img src="/static/icons/calendar.svg" />
+          <InterfaceText>Learning Schedules</InterfaceText>
+        </a>
+      </>  
       }
-      {module === Sefaria.VOICES_MODULE &&
-        <>
-          <a href="/topics" data-target-module={Sefaria.VOICES_MODULE} onClick={close}>
-            <img src="/static/icons/topic.svg" alt={Sefaria._("Topics")} />
-            <InterfaceText context="Header">Topics</InterfaceText>
-          </a>
-          <a href="/collections" onClick={close} className="textsPageLink" data-target-module={Sefaria.VOICES_MODULE}>
-            <img src="/static/icons/collection.svg" alt={Sefaria._("Collections")} />
-            <InterfaceText context="Header">Collections</InterfaceText>
-          </a>
-        </>
+      {module === Sefaria.SHEETS_MODULE && 
+      <>
+        <a href="/sheets/topics" data-target-module={Sefaria.SHEETS_MODULE} onClick={close}>
+        <img src="/static/icons/topic.svg" />
+        <InterfaceText context="Header">Topics</InterfaceText>
+        </a>
+        <a href="/sheets/collections" onClick={close} className="textsPageLink" data-target-module={Sefaria.SHEETS_MODULE}>
+        <img src="/static/icons/collection.svg" />
+        <InterfaceText context="Header">Collections</InterfaceText>
+      </a>
+      </>
       }
 
+
       <DonateLink classes={"blue"} source="MobileNavMenu">
-        <img src="/static/img/heart.png" alt={Sefaria._("donation icon")} />
+        <img src="/static/img/heart.png" alt="donation icon" />
         <InterfaceText>Donate</InterfaceText>
       </DonateLink>
 
       <div className="mobileAccountLinks">
 
         {Sefaria._uid &&
+        <>
+          {module === Sefaria.LIBRARY_MODULE && 
           <>
-            {module === Sefaria.LIBRARY_MODULE &&
-              <>
-                <a href="/texts/saved" onClick={close} data-target-module={Sefaria.LIBRARY_MODULE}>
-                  <img src="/static/icons/bookmarks.svg" alt={Sefaria._('Bookmarks')} />
-                  {<InterfaceText text={{ en: "Saved, History & Notes", he: "שמורים, היסטוריה והערות" }} />}
-                </a>
-              </>}
-            {module === Sefaria.VOICES_MODULE &&
-              <>
-                <a href={`/profile/${Sefaria.slug}`} onClick={close} data-target-module={Sefaria.VOICES_MODULE}>
-                  <div className="mobileProfileFlexContainer">
-                    <ProfilePic url={Sefaria.profile_pic_url} name={Sefaria.full_name} len={25} />
-                    <InterfaceText>Profile</InterfaceText>
-                  </div>
-                </a>
-                <a href="/saved" onClick={close} data-target-module={Sefaria.VOICES_MODULE}>
-                  <img src="/static/icons/bookmarks.svg" alt={Sefaria._('Bookmarks')} />
-                  {<InterfaceText text={{ en: "Saved & History", he: "שמורים והיסטוריה" }} />}
-                </a>
-                <a href="/notifications" onClick={close} data-target-module={Sefaria.VOICES_MODULE}>
-                  <img src="/static/icons/notification.svg" alt={Sefaria._("Notifications")} />
-                  <InterfaceText>Notifications</InterfaceText>
-                </a>
-              </>}
+            <a href="/texts/saved" onClick={close} data-target-module={Sefaria.LIBRARY_MODULE}>
+            <img src="/static/icons/bookmarks.svg" alt={Sefaria._('Bookmarks')} />
+            {<InterfaceText text={{en: "Saved, History & Notes", he: "שמורים, היסטוריה והערות"}} />}
+          </a>
           </>}
+          {module === Sefaria.SHEETS_MODULE && 
+          <>
+           <a href={`/sheets/profile/${Sefaria.slug}`} onClick={close} data-target-module={Sefaria.SHEETS_MODULE}>
+            <div className="mobileProfileFlexContainer">
+              <ProfilePic url={Sefaria.profile_pic_url} name={Sefaria.full_name} len={25}/>
+              <InterfaceText>Profile</InterfaceText>
+            </div>
+            </a>
+            <a href="/sheets/saved" onClick={close} data-target-module={Sefaria.SHEETS_MODULE}>
+            <img src="/static/icons/bookmarks.svg" alt={Sefaria._('Bookmarks')} />
+            {<InterfaceText text={{en: "Saved & History", he: "שמורים והיסטוריה"}} />}
+            <a href="/sheets/notifications" data-target-module={Sefaria.SHEETS_MODULE}>
+            <img src="/static/icons/notification.svg" />
+            <InterfaceText>Notifications</InterfaceText>
+            </a>
+          </a>
+          </>}
+        </>}
 
         {Sefaria._uid &&
           <>
             <a href="/settings/account" data-target-module={Sefaria.LIBRARY_MODULE}>
-              <img src="/static/icons/settings.svg" alt={Sefaria._("Settings")} />
-              <InterfaceText>Account Settings</InterfaceText>
-            </a>
+            <img src="/static/icons/settings.svg" />
+            <InterfaceText>Account Settings</InterfaceText>
+          </a>
           </>
         }
 
         <MobileInterfaceLanguageToggle />
 
-        <hr />
+        <hr/>
 
         <a href={Sefaria._v({
-          he: Sefaria._siteSettings.HELP_CENTER_URLS.HE,
+          he: Sefaria._siteSettings.HELP_CENTER_URLS.HE, 
           en: Sefaria._siteSettings.HELP_CENTER_URLS.EN_US
         })} target="_blank">
-          <img src="/static/icons/help.svg" alt={Sefaria._("Help")} />
+          <img src="/static/icons/help.svg" />
           <InterfaceText>Get Help</InterfaceText>
         </a>
 
         <a href="/mobile-about-menu">
-          <img src="/static/icons/info.svg" alt={Sefaria._("About")} />
+          <img src="/static/icons/info.svg" />
           <InterfaceText>About Sefaria</InterfaceText>
         </a>
 
         <hr />
+        
+        { module === Sefaria.LIBRARY_MODULE &&
+        <a href="/sheets/" data-target-module={Sefaria.SHEETS_MODULE}>
+          <img src="/static/icons/sheets-mobile-icon.svg" />
+          <InterfaceText>Sheets</InterfaceText>
+        </a>
+        } 
 
-        {module === Sefaria.LIBRARY_MODULE &&
-          <a href="/" data-target-module={Sefaria.VOICES_MODULE}>
-            <img src="/static/icons/sheets-mobile-icon.svg" alt={Sefaria._("Sheets")} />
-            <InterfaceText>Sheets</InterfaceText>
-          </a>
-        }
+      { module === Sefaria.SHEETS_MODULE &&
+        <a href="/texts" data-target-module={Sefaria.LIBRARY_MODULE}>
+          <img src="/static/icons/book.svg" />
+          <InterfaceText text={{en: "Sefaria Library", he: "ספריית ספריא"}} />
+        </a>
+        } 
 
-        {module === Sefaria.VOICES_MODULE &&
-          <a href="/texts" data-target-module={Sefaria.LIBRARY_MODULE}>
-            <img src="/static/icons/book.svg" alt={Sefaria._("Library")} />
-            <InterfaceText text={{ en: "Sefaria Library", he: "ספריית ספריא" }} />
-          </a>
-        }
-
-        <a href="https://developers.sefaria.org" target="_blank">
-          <img src="/static/icons/dev-portal-mobile-icon.svg" alt={Sefaria._("Developers")} />
-          <InterfaceText text={{ en: "Developers", he: "מפתחים" }} />
+        <a href="developers.sefaria.org" target="_blank">
+          <img src="/static/icons/dev-portal-mobile-icon.svg" />
+          <InterfaceText text={{en: "Developers", he: "מפתחים"}} />
         </a>
 
-        <a href="/products" data-target-module={Sefaria.LIBRARY_MODULE}>
-          <img src="/static/icons/products-icon.svg" alt={Sefaria._("Products")} />
-          <InterfaceText text={{ en: "All Products", he: "מוצרים" }} />
+        <a href="sefaria.org/products" target="_blank">
+          <img src="/static/icons/products-icon.svg" />
+          <InterfaceText text={{en: "All Products", he: "מוצרים"}} />
         </a>
 
         <hr />
 
         {Sefaria._uid ?
-          <a href={Sefaria.getLogoutUrl()} className="logout">
-            <img src="/static/icons/logout.svg" alt={Sefaria._("Logout")} />
-            <InterfaceText>Logout</InterfaceText>
-          </a>
-          :
-          <LoggedOutButtons mobile={true} loginOnly={false} />}
+        <a href={Sefaria.getLogoutUrl()} className="logout">
+          <img src="/static/icons/logout.svg" />
+          <InterfaceText>Logout</InterfaceText>
+        </a>
+        :
+        <LoggedOutButtons mobile={true} loginOnly={false}/> }
 
         <hr />
       </div>
-    </nav>
+    </div>
   );
 };
 
 
-const ProfilePicMenu = ({ len, url, name }) => {
+const ProfilePicMenu = ({len, url, name}) => {
   const [isOpen, setIsOpen] = useState(false);
   const wrapperRef = useRef(null);
+
+  const handleLanguageChange = (e, lang) => {
+    e.preventDefault();
+    const currentPath = encodeURIComponent(Sefaria.util.currentPath());
+    window.location.href = `/interface/${lang}?next=${currentPath}`;
+  };
 
   const menuClick = (e) => {
     var el = e.target;
@@ -605,8 +576,8 @@ const ProfilePicMenu = ({ len, url, name }) => {
   };
   const handleClickOutside = (event) => {
     if (
-      wrapperRef.current &&
-      !wrapperRef.current.contains(event.target)
+        wrapperRef.current &&
+        !wrapperRef.current.contains(event.target)
     ) {
       setIsOpen(false);
     }
@@ -622,64 +593,106 @@ const ProfilePicMenu = ({ len, url, name }) => {
   }, []);
   return (
     <div className="myProfileBox" ref={wrapperRef}>
-      <a href={`/profile/${Sefaria.slug}`} className="my-profile" onClick={profilePicClick} data-target-module={Sefaria.VOICES_MODULE}>
-        <ProfilePic len={len} url={url} name={name} />
-      </a>
-      <div className="interfaceLinks">
-        {isOpen ?
+        <a href={`/sheets/profile/${Sefaria.slug}`} className="my-profile" onClick={profilePicClick} data-target-module={Sefaria.SHEETS_MODULE}>
+          <ProfilePic len={len} url={url} name={name}/>
+        </a>
+        <div className="interfaceLinks">
+          {isOpen ?
           <div className="interfaceLinks-menu profile-menu" onClick={menuClick}>
             <div className="interfaceLinks-header profile-menu">{name}</div>
             <div className="profile-menu-middle">
-              <div><a className="interfaceLinks-row" id="my-profile-link" href={`/profile/${Sefaria.slug}`} data-target-module={Sefaria.VOICES_MODULE}>
+              <div><a className="interfaceLinks-row" id="my-profile-link" href={`/sheets/profile/${Sefaria.slug}`} data-target-module={Sefaria.SHEETS_MODULE}>
                 <InterfaceText>Profile</InterfaceText>
               </a></div>
-              <div><a className="interfaceLinks-row" id="new-sheet-link" href="/sheets/new" data-target-module={Sefaria.VOICES_MODULE}>
+              <div><a className="interfaceLinks-row" id="new-sheet-link" href="/sheets/new" data-target-module={Sefaria.SHEETS_MODULE}>
                 <InterfaceText>Create a New Sheet</InterfaceText>
               </a></div>
               <div><a className="interfaceLinks-row" id="account-settings-link" href="/settings/account" data-target-module={Sefaria.LIBRARY_MODULE}>
                 <InterfaceText>Account Settings</InterfaceText>
               </a></div>
               <div className="interfaceLinks-row languages">
-                <a className={`${(Sefaria.interfaceLang == 'hebrew') ? 'active' : ''}`} href={`/interface/hebrew?next=${getCurrentPage()}`} id="select-hebrew-interface-link">עברית</a>
-                <a className={`${(Sefaria.interfaceLang == 'english') ? 'active' : ''}`} href={`/interface/english?next=${getCurrentPage()}`} id="select-english-interface-link">English</a>
+                <a 
+                  className={`${(Sefaria.interfaceLang == 'hebrew') ? 'active':''}`} 
+                  href="/interface/hebrew" 
+                  onClick={(e) => handleLanguageChange(e, 'hebrew')}
+                  id="select-hebrew-interface-link"
+                >
+                  עברית
+                </a>
+                <a 
+                  className={`${(Sefaria.interfaceLang == 'english') ? 'active':''}`} 
+                  href="/interface/english" 
+                  onClick={(e) => handleLanguageChange(e, 'english')}
+                  id="select-english-interface-link"
+                >
+                  English
+                </a>
               </div>
               <div><a className="interfaceLinks-row bottom" id="help-link" href={Sefaria._v({
-                he: Sefaria._siteSettings.HELP_CENTER_URLS.HE,
+                he: Sefaria._siteSettings.HELP_CENTER_URLS.HE, 
                 en: Sefaria._siteSettings.HELP_CENTER_URLS.EN_US
               })} target="_blank">
                 <InterfaceText>Help</InterfaceText>
               </a></div>
             </div>
-            <hr className="interfaceLinks-hr" />
+            <hr className="interfaceLinks-hr"/>
             <div><a className="interfaceLinks-row logout" id="logout-link" href={Sefaria.getLogoutUrl()}>
               <InterfaceText>Logout</InterfaceText>
             </a></div>
           </div> : null}
-      </div>
+        </div>
     </div>
   );
 };
 
 
 const MobileInterfaceLanguageToggle = () => {
-  const currentURL = getCurrentPage();
+  const handleLanguageChange = (e, lang) => {
+    e.preventDefault();
+    const currentPath = encodeURIComponent(Sefaria.util.currentPath());
+    window.location.href = `/interface/${lang}?next=${currentPath}`;
+  };
 
   const links = Sefaria.interfaceLang == "hebrew" ?
     <>
-      <a href={"/interface/hebrew?next=" + currentURL} className="int-he">עברית</a>
+      <a 
+        href="/interface/hebrew" 
+        className="int-he"
+        onClick={(e) => handleLanguageChange(e, 'hebrew')}
+      >
+        עברית
+      </a>
       <span className="separator">•</span>
-      <a href={"/interface/english?next=" + currentURL} className="int-en inactive">English</a>
+      <a 
+        href="/interface/english" 
+        className="int-en inactive"
+        onClick={(e) => handleLanguageChange(e, 'english')}
+      >
+        English
+      </a>
     </>
     :
     <>
-      <a href={"/interface/english?next=" + currentURL} className="int-en">English</a>
+      <a 
+        href="/interface/english" 
+        className="int-en"
+        onClick={(e) => handleLanguageChange(e, 'english')}
+      >
+        English
+      </a>
       <span className="separator">•</span>
-      <a href={"/interface/hebrew?next=" + currentURL} className="int-he inactive">עברית</a>
+      <a 
+        href="/interface/hebrew" 
+        className="int-he inactive"
+        onClick={(e) => handleLanguageChange(e, 'hebrew')}
+      >
+        עברית
+      </a>
     </>;
 
   return (
     <div className="mobileInterfaceLanguageToggle">
-      <img src="/static/icons/globe-wire.svg" alt={Sefaria._("Language")} />
+      <img src="/static/icons/globe-wire.svg" />
       {links}
     </div>
   );
@@ -688,13 +701,13 @@ const MobileInterfaceLanguageToggle = () => {
 
 const HelpButton = () => {
   const url = Sefaria._v({
-    he: Sefaria._siteSettings.HELP_CENTER_URLS.HE,
+    he: Sefaria._siteSettings.HELP_CENTER_URLS.HE, 
     en: Sefaria._siteSettings.HELP_CENTER_URLS.EN_US
   });
   return (
     <div className="help">
-      <a href={url} data-target-module={Sefaria.VOICES_MODULE} target="_blank">
-        <img src="/static/img/help.svg" alt={Sefaria._("Help")} />
+      <a href={url} data-target-module={Sefaria.SHEETS_MODULE} target="_blank">
+        <img src="/static/img/help.svg" alt={Sefaria._("Help")}/>
       </a>
     </div>
   );
@@ -702,20 +715,23 @@ const HelpButton = () => {
 
 const SignUpButton = () => {
   return (
-    <Button href="/register" targetModule={Sefaria.LIBRARY_MODULE}>
-      <InterfaceText>Sign Up</InterfaceText>
+    <Button>
+      <a href="/register">
+        <InterfaceText>Sign Up</InterfaceText>
+      </a>
     </Button>
   )
 }
 
 const CreateButton = () => {
-
   return (
-    <Button className="small" href="/sheets/new" targetModule={Sefaria.VOICES_MODULE}>
-      <InterfaceText text={{ 'en': 'Create', 'he': 'דף חדש' }} />
+    <Button className="small">
+      <a href="/sheets/new" data-target-module={Sefaria.SHEETS_MODULE}>
+        <InterfaceText text={{'en': 'Create', 'he': 'דף חדש'}} /> 
+      </a>
     </Button>
   );
 };
 
 
-export { Header };
+export {Header};

--- a/static/js/Hooks.jsx
+++ b/static/js/Hooks.jsx
@@ -273,7 +273,6 @@ function usePaginatedLoad(fetchDataByPage, setter, identityElement, numPages, re
   }, [fetchPage]);
 }
 
-
 export {
   useScrollToLoad,
   usePaginatedScroll,

--- a/static/js/Misc.jsx
+++ b/static/js/Misc.jsx
@@ -4,7 +4,6 @@ import ReactDOM from 'react-dom';
 import $ from './sefaria/sefariaJquery';
 import {CollectionsModal} from "./CollectionsWidget";
 import Sefaria from './sefaria/sefaria';
-import Util from './sefaria/util';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import Component from 'react-class';
@@ -24,9 +23,12 @@ import {SourceEditor} from "./SourceEditor";
 import {EditTextInfo} from "./BookPage";
 import ReactMarkdown from 'react-markdown';
 import TrackG4 from "./sefaria/trackG4";
-import { ReaderApp } from './ReaderApp';
 import ReaderDisplayOptionsMenu from "./ReaderDisplayOptionsMenu";
-import {DropdownMenu, DropdownMenuItem, DropdownMenuItemWithIcon, DropdownMenuSeparator} from "./common/DropdownMenu";
+import {
+  DropdownLanguageToggle,
+  DropdownMenu,
+  DropdownMenuItemWithIcon,
+} from "./common/DropdownMenu";
 import Button from "./common/Button";
 
 function useOnceFullyVisible(onVisible, key) {
@@ -346,7 +348,12 @@ const FilterableList = ({
                 className={classNames({'sans-serif': 1, 'sort-option': 1, noselect: 1, active: sortOption === option})}
                 onClick={() => setSort(option)}
                 tabIndex="0"
-                onKeyDown={(e) => Util.handleKeyboardClick(e, () => setSort(option))}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault();
+                    e.target.click();
+                  }
+                }}
                 data-anl-event="sort_by:click"
                 data-anl-batch={JSON.stringify({
                   text: option, from: sortOption, to: option,
@@ -417,14 +424,6 @@ class TabView extends Component {
     }
     return tabIndex;
   }
-  onNavigate = (newIndex) => {
-    const newTab = this.props.tabs[newIndex];
-    if (this.props.setTab) {
-      this.props.setTab(newTab.id);
-    } else {
-      this.openTab(newIndex);
-    }
-  }
   onClickTab(e, clickTabOverride) {
     if (clickTabOverride) {
       clickTabOverride()
@@ -444,25 +443,8 @@ class TabView extends Component {
   }
   renderTab(tab, index) {
     const currTabIndex = this.getTabIndex();
-    const isActive = currTabIndex === index;
     return (
-      <div 
-        className={classNames({active: isActive, justifyright: tab.justifyright})} 
-        key={tab.id} 
-        data-tab-index={index} 
-        role="tab"
-        tabIndex={isActive ? "0" : "-1"}
-        aria-selected={isActive}
-        onClick={(e) => {this.onClickTab(e, tab.clickTabOverride)}}
-        onKeyDown={(e) => {
-          Util.handleTabKeyDown(e, {
-            currentIndex: index,
-            tabCount: this.props.tabs.length,
-            onNavigate: this.onNavigate,
-            onActivate: () => this.onClickTab(e, tab.clickTabOverride)
-          });
-        }}
-      >
+      <div className={classNames({active: currTabIndex === index, justifyright: tab.justifyright})} key={tab.id} data-tab-index={index} onClick={(e) => {this.onClickTab(e, tab.clickTabOverride)}}>
         {this.props.renderTab(tab, index)}
       </div>
     );
@@ -470,17 +452,12 @@ class TabView extends Component {
   render() {
     const currTabIndex = this.getTabIndex();
     const classes = classNames({"tab-view": 1, [this.props.containerClasses]: 1});
-    const currentTab = this.props.tabs[currTabIndex];
-    const ariaLabelledBy = currentTab && currentTab.id ? `tab-${currentTab.id}` : undefined;
-    
     return (
       <div className={classes}>
-        <div className="tab-list sans-serif" role="tablist">
+        <div className="tab-list sans-serif">
           {this.props.tabs.map(this.renderTab)}
         </div>
-        <div role="tabpanel" aria-labelledby={ariaLabelledBy}>
-          { React.Children.toArray(this.props.children)[currTabIndex] }
-        </div>
+        { React.Children.toArray(this.props.children)[currTabIndex] }
       </div>
     );
   }
@@ -535,9 +512,9 @@ DropdownOptionList.propTypes = {
 const DropdownButton = ({isOpen, toggle, enText, heText, buttonStyle}) => {
   const filterTextClasses = classNames({ "dropdown-button": 1, active: isOpen, buttonStyle });
   return (
-    <div className={ filterTextClasses } tabIndex="0" onClick={toggle} onKeyDown={(e) => Util.handleKeyboardClick(e, toggle)}>
+    <div className={ filterTextClasses } tabIndex="0" onClick={toggle} onKeyPress={(e) => {e.charCode == 13 ? toggle(e):null}}>
       <InterfaceText text={{en: enText, he: heText}} />
-      {isOpen ? <img src="/static/img/arrow-up.png" alt={Sefaria._("Collapse")} aria-hidden="true"/> : <img src="/static/img/arrow-down.png" alt={Sefaria._("Expand")} aria-hidden="true"/>}
+      {isOpen ? <img src="/static/img/arrow-up.png" alt=""/> : <img src="/static/img/arrow-down.png" alt=""/>}
     </div>
   );
 };
@@ -657,7 +634,7 @@ class TextBlockLink extends Component {
 
     if (sideColor) {
       return (
-        <a href={url} data-target-module={isSheet ? Sefaria.VOICES_MODULE : Sefaria.LIBRARY_MODULE} className={classes} data-ref={sref} data-ven={currVersions.en} data-vhe={currVersions.he} data-position={position}>
+        <a href={url} data-target-module={isSheet ? Sefaria.SHEETS_MODULE : Sefaria.LIBRARY_MODULE} className={classes} data-ref={sref} data-ven={currVersions.en} data-vhe={currVersions.he} data-position={position}>
           <div className="sideColorLeft" data-ref-child={true}>
             <div className="sideColor" data-ref-child={true} style={{backgroundColor: Sefaria.palette.categoryColor(category)}} />
             <div className="sideColorInner" data-ref-child={true}>
@@ -710,29 +687,16 @@ TextBlockLink.defaultProps = {
 };
 
 
-const getCurrentPage = () => {
-  return encodeURIComponent(Sefaria.util.currentPath());
-}
-
 class LanguageToggleButton extends Component {
-  constructor(props) {
-    super(props);
-    this.toggle = this.toggle.bind(this);
-  }
   toggle(e) {
     e.preventDefault();
     this.props.toggleLanguage();
   }
   render() {
     var url = this.props.url || "";
-    return (            <a
-              href={url}
-              className="languageToggle"
-              onClick={this.toggle}
-              onKeyDown={(e) => Util.handleKeyboardClick(e, this.toggle)}
-            >
-              <img className="en" src="/static/img/aleph.svg" alt={Sefaria._("Hebrew Language Toggle Icon")} />
-              <img className="he" src="/static/img/aye.svg" alt={Sefaria._("English Language Toggle Icon")} />
+    return (<a href={url} className="languageToggle" onClick={this.toggle}>
+              <img className="en" src="/static/img/aleph.svg" alt="Hebrew Language Toggle Icon" />
+              <img className="he" src="/static/img/aye.svg" alt="English Language Toggle Icon" />
             </a>);
   }
 }
@@ -806,7 +770,7 @@ class BlockLink extends Component {
     cn[linkClass] = 1;
     var classes = classNames(cn);
       return (<a className={classes} href={this.props.target}>
-              {this.props.image ? <img src={this.props.image} alt={this.props.title} /> : null}
+              {this.props.image ? <img src={this.props.image} alt="" /> : null}
               <span className={`${interfaceClass}en`}>{this.props.title}</span>
               <span className={`${interfaceClass}he`}>{this.props.heTitle}</span>
            </a>);
@@ -1037,16 +1001,7 @@ const CategoryHeader =  ({children, type, data = [], toggleButtonIDs = ["subcate
 const PencilSourceEditor = ({topic, text, classes}) => {
     const [addSource, toggleAddSource] = useEditToggle();
     return addSource ? <SourceEditor topic={topic} origData={text} close={toggleAddSource}/> :
-        <img 
-          className={classes} 
-          id={"editTopic"}
-          onClick={toggleAddSource}
-          src={"/static/icons/editing-pencil.svg"}
-          alt={Sefaria._("Edit topic")}
-          role="button"
-          tabIndex="0"
-          onKeyDown={(e) => Util.handleKeyboardClick(e, toggleAddSource)}
-        />;
+        <img className={classes} id={"editTopic"} onClick={toggleAddSource} src={"/static/icons/editing-pencil.svg"}/>;
 }
 
 const ReorderEditorWrapper = ({toggle, type, data}) => {
@@ -1193,7 +1148,7 @@ const CategoryAdderWrapper = ({toggle, data, type}) => {
 class SearchButton extends Component {
   render() {
     return (<span className="readerNavMenuSearchButton" onClick={this.props.onClick}>
-      <img src="/static/icons/iconmonstr-magnifier-2.svg" alt={Sefaria._("Search")} />
+      <img src="/static/icons/iconmonstr-magnifier-2.svg" />
     </span>);
   }
 }
@@ -1223,7 +1178,7 @@ class CloseButton extends Component {
     const { altText = Sefaria._("Close"), icon, url = "" } = this.props;
     
     if (icon == "circledX"){
-      var iconElement = <img src="/static/icons/circled-x.svg" alt={Sefaria._("Close")} aria-hidden="true"/>;
+      var iconElement = <img src="/static/icons/circled-x.svg" alt="" />;
     } else if (icon == "chevron") {
       var iconElement = <i className="fa fa-chevron-left"></i>
     } else {
@@ -1232,11 +1187,10 @@ class CloseButton extends Component {
     const classes = classNames({readerNavMenuCloseButton: 1, circledX: icon === "circledX"});
     
     return (
-      <a
-        href={url}
-        className={classes}
+      <a 
+        href={url} 
+        className={classes} 
         onClick={this.onClick}
-        onKeyDown={(e) => Util.handleKeyboardClick(e, this.onClick)}
         aria-label={altText}
         title={altText}
       >
@@ -1257,20 +1211,25 @@ class DisplaySettingsButton extends Component {
     if (Sefaria._siteSettings.TORAH_SPECIFIC) {
       icon =
         <InterfaceText>
-        <EnglishText> <img src="/static/img/lang_icon_english.svg" alt={Sefaria._("Toggle Reader Menu Display Settings")}/></EnglishText>
-        <HebrewText><img src="/static/img/lang_icon_hebrew.svg" alt={Sefaria._("Toggle Reader Menu Display Settings")}/></HebrewText>
+        <EnglishText> <img src="/static/img/lang_icon_english.svg" alt="Toggle Reader Menu Display Settings"/></EnglishText>
+        <HebrewText><img src="/static/img/lang_icon_hebrew.svg" alt="Toggle Reader Menu Display Settings"/></HebrewText>
         </InterfaceText>;
     } else {
       icon = <span className="textIcon">Aa</span>;
     }
     return (
-            <ToolTipped {...{ altText, classes, onClick: this.props.onClick, style}}>
-                <span
+            <ToolTipped {...{ altText, classes}}>
+                <a
                 className="readerOptions"
+                tabIndex="0"
+                role="button"
                 aria-haspopup="true"
-                tabIndex="-1">
+                aria-label="Toggle Reader Menu Display Settings"
+                style={style}
+                onClick={this.props.onClick}
+                onKeyPress={function(e) {e.charCode == 13 ? this.props.onClick(e):null}.bind(this)}>
                 {icon}
-              </span>
+              </a>
             </ToolTipped>
             );
   }
@@ -1281,13 +1240,7 @@ DisplaySettingsButton.propTypes = {
 };
 
 
-function InterfaceLanguageMenu({currentLang, translationLanguagePreference, setTranslationLanguagePreference}){
-
-  const [isOpen, setIsOpen] = useState(false);
-
-  const getCurrentPage = () => {
-    return isOpen ? (encodeURIComponent(Sefaria.util.currentPath())) : "/";
-  }
+function InterfaceLanguageMenu({translationLanguagePreference, setTranslationLanguagePreference}){
 
   const handleTransPrefResetClick = (e) => {
     e.stopPropagation();
@@ -1296,19 +1249,8 @@ function InterfaceLanguageMenu({currentLang, translationLanguagePreference, setT
 
   return (
     <DropdownMenu positioningClass="headerDropdownMenu" buttonComponent={<img src="/static/icons/globe-wire.svg" alt={Sefaria._('Toggle Interface Language Menu')}/>}>
-      <div className="dropdownLinks-options">
-        <div className="interfaceLinks interfaceLinks-menu interfaceLinks-header languageHeader">
-          <InterfaceText>Site Language</InterfaceText>
-        </div>
-        <DropdownMenuSeparator />
-        <div className='languageFlex'>
-          <DropdownMenuItem url={`/interface/hebrew?next=${getCurrentPage()}`} customCSS={`interfaceLinks-option int-bi ${(currentLang === 'hebrew') ? 'active':'inactive'}`}>
-            עברית
-          </DropdownMenuItem>
-          <DropdownMenuItem url={`/interface/english?next=${getCurrentPage()}`} customCSS={`interfaceLinks-option int-bi ${(currentLang === 'english') ? 'active' : 'inactive'}`}>
-            English
-          </DropdownMenuItem>
-        </div>
+      <div className="dropdownLinks-options globeLanguageToggle">
+        <DropdownLanguageToggle/>
       </div>
       { !!translationLanguagePreference ? (
             <>
@@ -1318,7 +1260,7 @@ function InterfaceLanguageMenu({currentLang, translationLanguagePreference, setT
               <div className="interfaceLinks-options trans-pref-header-container">
                 <InterfaceText>{Sefaria.translateISOLanguageCode(translationLanguagePreference, true)}</InterfaceText>
                 <a className="trans-pref-reset" onClick={handleTransPrefResetClick}>
-                  <img src="/static/img/circled-x.svg" className="reset-btn" alt={Sefaria._("Reset")} />
+                  <img src="/static/img/circled-x.svg" className="reset-btn" />
                   <span className="smallText">
                     <InterfaceText>Reset</InterfaceText>
                   </span>
@@ -1330,8 +1272,8 @@ function InterfaceLanguageMenu({currentLang, translationLanguagePreference, setT
   );
 }
 InterfaceLanguageMenu.propTypes = {
-  currentLang: PropTypes.string,
   translationLanguagePreference: PropTypes.string,
+  setTranslationLanguagePreference: PropTypes.func,
 };
 
 const isSaveButtonSelected = (historyObject) => !!Sefaria.getSavedItem(historyObject);
@@ -1361,7 +1303,7 @@ function SaveButton({historyObject, placeholder, tooltip, toggleSignUpModal}) {
   const style = placeholder ? {visibility: 'hidden'} : {};
   const classes = classNames({saveButton: 1, "tooltip-toggle": tooltip});
   const message = getSaveButtonMessage(selected);
-  const altText = placeholder ? 'Save button' : `${message} "${historyObject.sheet_title ?
+  const altText = placeholder ? '' : `${message} "${historyObject.sheet_title ?
           historyObject.sheet_title.stripHtml() : Sefaria._r(historyObject.ref)}"`;
 
   function onClick(event) {
@@ -1452,12 +1394,11 @@ ArrowButton.propTypes = {
 
 const ToolTipped = ({ altText, classes, style, onClick, children }) => {
   const analyticsContext = useContext(AdContext)
-  const handleClick = (e) => TrackG4.gtagClick(e, onClick, `ToolTipped`, {"classes": classes}, analyticsContext);
   return (
   <div aria-label={altText} tabIndex="0"
     className={classes} role="button"
-    style={style} onClick={handleClick}
-    onKeyDown={(e) => Util.handleKeyboardClick(e, handleClick)}>
+    style={style} onClick={e => TrackG4.gtagClick(e, onClick, `ToolTipped`, {"classes": classes}, analyticsContext)}
+    onKeyPress={e => {e.charCode == 13 ? onClick(e): null}}>
     { children }
   </div>
 )};
@@ -1487,7 +1428,7 @@ const AiInfoTooltip = () => {
           className="ai-info-icon"
           data-anl-event="ai_marker_hover:mouseover"
           src="/static/icons/ai-info.svg"
-          alt={Sefaria._("AI Info Icon")} onMouseEnter={() => setShowMessage(true)}
+          alt="AI Info Icon" onMouseEnter={() => setShowMessage(true)}
           onMouseLeave={() => setShowMessage(false)}
       />
     );
@@ -1596,14 +1537,9 @@ FollowButton.propTypes = {
 
 const SmallBlueButton = ({onClick, tabIndex, text}) => {
   return (
-    <div 
-      onClick={onClick} 
-      className="button extraSmall control-elem" 
-      tabIndex={tabIndex}
-      role="button"
-    >
-      <InterfaceText>{text}</InterfaceText>
-    </div>
+      <div onClick={onClick} className="button extraSmall blue control-elem" tabIndex={tabIndex} role="button">
+        <InterfaceText>{text}</InterfaceText>
+      </div>
   );
 };
 
@@ -1630,7 +1566,7 @@ class ProfileListing extends Component {
     return (
       <div className={"authorByLine sans-serif" + (smallfonts ? " small" : "")}>
         <div className="authorByLineImage">
-          <a href={url} data-target-module={Sefaria.VOICES_MODULE}>
+          <a href={url} data-target-module={Sefaria.SHEETS_MODULE}>
             <ProfilePic
               len={smallfonts ? 30 : 40}
               url={image}
@@ -1736,7 +1672,7 @@ const SheetListing = ({
   const sheetInfo = hideAuthor ? null :
       <div className="sheetInfo">
         <div className="sheetUser">
-          <a href={sheet.ownerProfileUrl} target={openInNewTab ? "_blank" : "_self"} data-target-module={Sefaria.VOICES_MODULE}>
+          <a href={sheet.ownerProfileUrl} target={openInNewTab ? "_blank" : "_self"} data-target-module={Sefaria.SHEETS_MODULE}>
             <ProfilePic
               outerStyle={{display: "inline-block"}}
               name={sheet.ownerName}
@@ -1744,7 +1680,7 @@ const SheetListing = ({
               len={26}
             />
           </a>
-          <a href={sheet.ownerProfileUrl} data-target-module={Sefaria.VOICES_MODULE} target={openInNewTab ? "_blank" : "_self"} className="sheetAuthor" onClick={handleSheetOwnerClick}>{sheet.ownerName}</a>
+          <a href={sheet.ownerProfileUrl} data-target-module={Sefaria.SHEETS_MODULE} target={openInNewTab ? "_blank" : "_self"} className="sheetAuthor" onClick={handleSheetOwnerClick}>{sheet.ownerName}</a>
         </div>
         {viewsIcon}
       </div>
@@ -1756,10 +1692,10 @@ const SheetListing = ({
   const collections = collectionsList.map((collection, i) => {
     const separator = i == collectionsList.length -1 ? null : <span className="separator">,</span>;
     return (
-      <a href={`/collections/${collection.slug}`}
+      <a href={`/sheets/collections/${collection.slug}`}
         target={openInNewTab ? "_blank" : "_self"}
         className="sheetTag"
-        data-target-module={Sefaria.VOICES_MODULE}
+        data-target-module={Sefaria.SHEETS_MODULE}
         key={i}
       >
         {collection.name}
@@ -1770,12 +1706,12 @@ const SheetListing = ({
   const topics = sheet.topics.map((topic, i) => {
     const separator = i !== sheet.topics.length -1 && <span className="separator">,</span>;
     return (
-      <a href={`/topics/${topic.slug}`}
+      <a href={`/sheets/topics/${topic.slug}`}
         target={openInNewTab ? "_blank" : "_self"}
         className="sheetTag"
         key={i}
         onClick={handleTopicClick.bind(null, topic.slug)}
-        data-target-module={Sefaria.VOICES_MODULE}
+        data-target-module={Sefaria.SHEETS_MODULE}
       >
         <InterfaceText text={topic} />
         {separator}
@@ -1784,8 +1720,8 @@ const SheetListing = ({
   });
   const created = Sefaria.util.localeDate(sheet.created);
   const underInfo = infoUnderneath ? [
-      sheet.status !== 'public' ? (<span className="unlisted"><img src="/static/img/eye-slash.svg" alt={Sefaria._("Not published")}/><span>{Sefaria._("Not Published")}</span></span>) : undefined,
-      showAuthorUnderneath ? (<a href={sheet.ownerProfileUrl} data-target-module={Sefaria.VOICES_MODULE} target={openInNewTab ? "_blank" : "_self"}>{sheet.ownerName}</a>) : undefined,
+      sheet.status !== 'public' ? (<span className="unlisted"><img src="/static/img/eye-slash.svg"/><span>{Sefaria._("Not Published")}</span></span>) : undefined,
+      showAuthorUnderneath ? (<a href={sheet.ownerProfileUrl} data-target-module={Sefaria.SHEETS_MODULE} target={openInNewTab ? "_blank" : "_self"}>{sheet.ownerName}</a>) : undefined,
       views,
       created,
       collections.length ? collections : undefined,
@@ -1795,13 +1731,13 @@ const SheetListing = ({
   const pinButtonClasses = classNames({sheetListingPinButton: 1, pinned: pinned, active: pinnable});
   const pinMessage = pinned && pinnable ? Sefaria._("Pinned Sheet - click to unpin") :
                     pinned ? Sefaria._("Pinned Sheet") : Sefaria._("Pin Sheet");
-  const pinButton = <img src="/static/img/pin.svg" className={pinButtonClasses} title={pinMessage} onClick={pinnable ? pinSheet : null} alt={pinMessage} />
+  const pinButton = <img src="/static/img/pin.svg" className={pinButtonClasses} title={pinMessage} onClick={pinnable ? pinSheet : null} />
 
   return (
     <div className="sheet" key={sheet.sheetUrl}>
       <div className="sheetLeft">
         {sheetInfo}
-        <a href={sheet.sheetUrl} data-target-module={Sefaria.VOICES_MODULE} target={openInNewTab ? "_blank" : "_self"} className="sheetTitle" onClick={handleSheetClickLocal}>
+        <a href={sheet.sheetUrl} data-target-module={Sefaria.SHEETS_MODULE} target={openInNewTab ? "_blank" : "_self"} className="sheetTitle" onClick={handleSheetClickLocal}>
           <span className="sheetTitleText">{title}</span>
         </a>
         {sheetSummary}
@@ -1819,12 +1755,12 @@ const SheetListing = ({
       <div className="sheetRight">
         {
           collectable ?
-            <img src="/static/icons/collection.svg" onClick={toggleCollectionsModal} title={Sefaria._("Add to Collection")} alt={Sefaria._("Add to Collection")} />
+            <img src="/static/icons/collection.svg" onClick={toggleCollectionsModal} title={Sefaria._("Add to Collection")} />
             : null
         }
         {
           deletable ?
-            <img src="/static/icons/circled-x.svg" onClick={handleSheetDeleteClick} title={Sefaria._("Delete")} alt={Sefaria._("Delete")} />
+            <img src="/static/icons/circled-x.svg" onClick={handleSheetDeleteClick} title={Sefaria._("Delete")} />
             : null
         }
         {
@@ -1851,20 +1787,20 @@ const SheetListing = ({
 
 const CollectionListing = ({data}) => {
   const imageUrl = "/static/icons/collection.svg";
-  const collectionUrl = "/collections/" + data.slug;
+  const collectionUrl = "/sheets/collections/" + data.slug;
   return (
     <div className="collectionListing">
       <div className="left-content">
         <div className="collectionListingText">
 
-          <a href={collectionUrl} className="collectionListingName" data-target-module={Sefaria.VOICES_MODULE}>
+          <a href={collectionUrl} className="collectionListingName" data-target-module={Sefaria.SHEETS_MODULE}>
             {data.name}
           </a>
 
           <div className="collectionListingDetails">
             {data.listed ? null :
               (<span className="unlisted">
-                <img src="/static/img/eye-slash.svg" alt={Sefaria._("Unlisted")}/>
+                <img src="/static/img/eye-slash.svg"/>
                 <InterfaceText>Unlisted</InterfaceText>
               </span>) }
 
@@ -1896,23 +1832,16 @@ class Note extends Component {
   // Public or private note in the Sidebar.
   render() {
     var authorInfo = this.props.ownerName && !this.props.isMyNote ?
-        (<div className="noteAuthorInfo">
-          <a href={this.props.ownerProfileUrl} data-target-module={Sefaria.VOICES_MODULE}>
-            <img className="noteAuthorImg" src={this.props.ownerImageUrl} alt={Sefaria._("Note author profile picture")} />
+        (        <div className="noteAuthorInfo">
+          <a href={this.props.ownerProfileUrl} data-target-module={Sefaria.SHEETS_MODULE}>
+            <img className="noteAuthorImg" src={this.props.ownerImageUrl} />
           </a>
-          <a href={this.props.ownerProfileUrl} className="noteAuthor" data-target-module={Sefaria.VOICES_MODULE}>{this.props.ownerName}</a>
+          <a href={this.props.ownerProfileUrl} className="noteAuthor" data-target-module={Sefaria.SHEETS_MODULE}>{this.props.ownerName}</a>
         </div>) : null;
 
       var buttons = this.props.isMyNote ?
                     (<div className="noteButtons">
-                      <i
-                        className="editNoteButton fa fa-pencil"
-                        title="Edit Note"
-                        onClick={this.props.editNote}
-                        role="button"
-                        tabIndex="0"
-                        onKeyDown={(e) => Util.handleKeyboardClick(e, this.props.editNote)}
-                      ></i>
+                      <i className="editNoteButton fa fa-pencil" title="Edit Note" onClick={this.props.editNote} ></i>
                     </div>) : null;
 
       var text = Sefaria.util.linkify(this.props.text);
@@ -1978,22 +1907,14 @@ class SignUpModal extends Component {
       this.props.show ? <div id="interruptingMessageBox" className="sefariaModalBox">
         <div id="interruptingMessageOverlay" onClick={this.props.onClose}></div>
         <div id="interruptingMessage" className="sefariaModalContentBox">
-          <div 
-            id="interruptingMessageClose"
-            className="sefariaModalClose"
-            role="button"
-            tabIndex="0"
-            aria-label={Sefaria._("Close")}
-            onClick={this.props.onClose}
-            onKeyDown={(e) => Util.handleKeyboardClick(e, this.props.onClose)}
-          >×</div>
+          <div id="interruptingMessageClose" className="sefariaModalClose" onClick={this.props.onClose}>×</div>
           <div className="sefariaModalContent">
             <h2 className="serif sans-serif-in-hebrew">
               <InterfaceText text={modalContent.h2} />
             </h2>
-            {modalContent.h3 && <h3>
+            <h3>
               <InterfaceText text={modalContent.h3} />
-            </h3>}
+            </h3>
             <div className="sefariaModalInnerContent">
               { innerContent }
             </div>
@@ -2067,18 +1988,12 @@ const transformValues = (obj, callback) => {
   return newObj;
 };
 
-// Use optional parameter with destructuring
-export const replaceNewLinesWithLinebreaks = (content, options = {}) => {
-  const { mode = "standard" } = options ?? {};
-
-  if (mode === "strapi") {
-    // Strapi needs to have all the newslines in markdown replaced with &nbsp; entities, extra space at the end for good measure
-    return transformValues(content, (s) => s.replace(/\n/gi, "&nbsp; \n") + "&nbsp; \n&nbsp; \n");
-  }
-
-  // Replace single newlines only, preserving double newlines (paragraph breaks)
-  return transformValues(content, (s) => s.replace(/\n(?!\n)/g, " \n"));
-};
+export const replaceNewLinesWithLinebreaks = (content) => {
+  return transformValues(
+    content,
+    (s) => s.replace(/\n(?!\n)/g, "  \n")
+  );
+}
 
 const InterruptingMessage = ({
                                onClose,
@@ -2197,13 +2112,9 @@ const InterruptingMessage = ({
             <div id="interruptingMessageContentBox" className="hasColorLine">
               <div
                 id="interruptingMessageClose"
-                role="button"
-                tabIndex="0"
-                aria-label={Sefaria._("Close")}
                 onClick={() => {
                   closeModal("close_clicked");
                 }}
-                onKeyDown={(e) => Util.handleKeyboardClick(e, () => closeModal("close_clicked"))}
               >
                 ×
               </div>
@@ -2218,8 +2129,7 @@ const InterruptingMessage = ({
                   <div id="defaultModalBody" className="line-break">
                     <InterfaceText
                       markdown={replaceNewLinesWithLinebreaks(
-                        strapi.modal.modalText,
-                        { mode: "strapi" }
+                        strapi.modal.modalText
                       )}
                     />
                   </div>
@@ -2383,8 +2293,7 @@ const Banner = ({ onClose }) => {
             <div id="bannerTextBox">
               <InterfaceText
                 markdown={replaceNewLinesWithLinebreaks(
-                  strapi.banner.bannerText,
-                  { mode: 'strapi' }
+                  strapi.banner.bannerText
                 )}
               />
             </div>
@@ -2504,11 +2413,8 @@ class Dropdown extends Component {
     super(props);
     this.state = {
       optionsOpen: false,
-      selected: null,
-      focusedIndex: -1
+      selected: null
     };
-    this.listboxRef = null;
-    this.triggerRef = null;
   }
 
   componentDidMount() {
@@ -2519,89 +2425,28 @@ class Dropdown extends Component {
   }
 
   select(option) {
-    this.setState({selected: option, optionsOpen: false, focusedIndex: -1});
+    this.setState({selected: option, optionsOpen: false});
     const event = {target: {name: this.props.name, value: option.value}}
     this.props.onChange && this.props.onChange(event);
   }
   toggle() {
-    const opening = !this.state.optionsOpen;
-    this.setState({
-      optionsOpen: opening,
-      focusedIndex: opening ? 0 : -1
-    });
-  }
-  onNavigate = (newIndex) => {
-    this.setState({ focusedIndex: newIndex });
-  }
-  onSelect = () => {
-    if (this.state.focusedIndex >= 0 && this.props.options[this.state.focusedIndex]) {
-      this.select(this.props.options[this.state.focusedIndex]);
-    }
-  }
-  onClose = () => {
-    this.setState({ optionsOpen: false });
-  }
-  componentDidUpdate(prevProps, prevState) {
-    // Move focus to the listbox when opened, back to trigger when closed
-    if (!prevState.optionsOpen && this.state.optionsOpen && this.listboxRef) {
-      this.listboxRef.focus();
-    } else if (prevState.optionsOpen && !this.state.optionsOpen && this.triggerRef) {
-      this.triggerRef.focus();
-    }
+    this.setState({optionsOpen: !this.state.optionsOpen});
   }
   render() {
     return (
         <div className="dropdown sans-serif">
-          <div
-            className={`dropdownMain noselect${this.state.selected ? " selected":""}`}
-            onClick={this.toggle}
-            role="button"
-            tabIndex="0"
-            aria-haspopup="listbox"
-            aria-expanded={this.state.optionsOpen}
-            aria-controls={`${this.props.name}-listbox`}
-            ref={(el) => { this.triggerRef = el; }}
-            onKeyDown={(e) => Util.handleDropdownTriggerKeyDown(e, {
-              onToggle: this.toggle,
-              isOpen: this.state.optionsOpen
-            })}
-          >
+          <div className={`dropdownMain noselect${this.state.selected ? " selected":""}`} onClick={this.toggle}>
             <span>{this.state.selected ? this.state.selected.label : this.props.placeholder}</span>
-            <img src="/static/icons/chevron-down.svg" className="dropdownOpenButton noselect fa fa-caret-down" alt={Sefaria._("Open dropdown")}/>
+            <img src="/static/icons/chevron-down.svg" className="dropdownOpenButton noselect fa fa-caret-down"/>
 
           </div>
           {this.state.optionsOpen ?
             <div className="dropdownListBox noselect">
-              <div
-                className="dropdownList noselect"
-                tabIndex="0"
-                role="listbox"
-                aria-label={this.props.placeholder}
-                id={`${this.props.name}-listbox`}
-                ref={(el) => { this.listboxRef = el; }}
-                onKeyDown={(e) => Util.handleListboxKeyDown(e, {
-                  currentIndex: this.state.focusedIndex,
-                  maxIndex: this.props.options.length - 1,
-                  onNavigate: this.onNavigate,
-                  onSelect: this.onSelect,
-                  onClose: this.onClose,
-                  triggerRef: this.triggerRef
-                })}
-              >
-                {this.props.options.map(function(option, index) {
+              <div className="dropdownList noselect">
+                {this.props.options.map(function(option) {
                   const onClick = this.select.bind(null, option);
-                  const isSelected = this.state.selected && this.state.selected.value == option.value;
-                  const isFocused = this.state.focusedIndex === index;
-                  const classes = classNames({dropdownOption: 1, selected: isSelected, focused: isFocused});
-                  return <div 
-                    className={classes} 
-                    onClick={onClick} 
-                    key={option.value} 
-                    role="option" 
-                    aria-selected={!!isSelected}
-                    data-index={index}
-                    style={isFocused ? {outline: `2px solid ${getComputedStyle(document.documentElement).getPropertyValue('--focus-blue')}`, outlineOffset: '2px'} : {}}
-                  >{option.label}</div>
+                  const classes = classNames({dropdownOption: 1, selected: this.state.selected && this.state.selected.value == option.value});
+                  return <div className={classes} onClick={onClick} key={option.value}>{option.label}</div>
                 }.bind(this))}
               </div>
             </div>
@@ -2623,7 +2468,7 @@ class LoadingMessage extends Component {
     var message = this.props.message || "Loading...";
     var heMessage = this.props.heMessage || "טוען מידע...";
     var classes = "loadingMessage sans-serif " + (this.props.className || "");
-    return (<div className={classes} aria-live="polite" aria-label={Sefaria._("Loading status")}>
+    return (<div className={classes}>
               <InterfaceText>
                 <EnglishText>{message}</EnglishText>
                 <HebrewText>{heMessage}</HebrewText>
@@ -2661,7 +2506,7 @@ class SheetTopicLink extends Component {
   render() {
     const { slug, en, he } = this.props.topic;
     return (
-      <a href={`/topics/${slug}`} onClick={this.handleTagClick} data-target-module={Sefaria.VOICES_MODULE}>
+      <a href={`/sheets/topics/${slug}`} onClick={this.handleTagClick} data-target-module={Sefaria.SHEETS_MODULE}>
         <InterfaceText text={{en:en, he:he}} />
       </a>
     );
@@ -2758,7 +2603,7 @@ class FeedbackBox extends Component {
             <p className="int-he">אנחנו מעוניינים במשוב ממך</p>
 
             {this.state.alertmsg ?
-                <div role="alert" aria-live="assertive">
+                <div>
                     <p className="int-en">{this.state.alertmsg}</p>
                     <p className="int-he">{this.state.alertmsg}</p>
                 </div>
@@ -2786,17 +2631,10 @@ class FeedbackBox extends Component {
                 <div><input className="sidebarInput noselect" placeholder={Sefaria._("Email Address")} id="feedbackEmail" /></div>
                 : null }
 
-            <div
-              className="button"
-              aria-label={Sefaria._("Send Feedback")}
-              onClick={() => this.sendFeedback()}
-              onKeyDown={(e) => Util.handleKeyboardClick(e, () => this.sendFeedback())}
-              role="button"
-              tabIndex="0"
-            >
+             <div className="button" role="button" onClick={() => this.sendFeedback()}>
                  <span className="int-en">Submit</span>
                  <span className="int-he">שליחה</span>
-            </div>
+             </div>
         </div>
     );
   }
@@ -2821,20 +2659,8 @@ class ReaderMessage extends Component {
       <div className="readerMessageBox">
         <div className="readerMessage">
           <div className="int-en">{this.props.message}</div>
-          <div
-            className="button small"
-            onClick={() => this.setFeedback('Like')}
-            onKeyDown={(e) => Util.handleKeyboardClick(e, () => this.setFeedback('Like'))}
-            role="button"
-            tabIndex="0"
-          >{this.props.buttonLikeText}</div>
-          <div
-            className="button small"
-            onClick={() => this.setFeedback('Dislike')}
-            onKeyDown={(e) => Util.handleKeyboardClick(e, () => this.setFeedback('Dislike'))}
-            role="button"
-            tabIndex="0"
-          >{this.props.buttonDislikeText}</div>
+          <div className="button small" role="button" onClick={() => this.setFeedback('Like')}>{this.props.buttonLikeText}</div>
+          <div className="button small" role="button" onClick={() => this.setFeedback('Dislike')}>{this.props.buttonDislikeText}</div>
         </div>
       </div>);
   }
@@ -2876,14 +2702,14 @@ class CookiesNotification extends Component {
       <div className="cookiesNotification">
 
           <span className="int-en">
-            <span>We use cookies to give you the best experience possible on our site. Click OK to continue using Sefaria. <a href="/privacy-policy">Learn More</a>.</span>
-            <div className="button small white int-en" onClick={this.setCookie} onKeyDown={(e) => Util.handleKeyboardClick(e, this.setCookie)} role="button" tabIndex="0">OK</div>
+            <span>We use cookies to give you the best experience possible on our site. Click OK to continue using Sefaria. <a href={privacyPolicyLink} data-target-module={Sefaria.LIBRARY_MODULE}>Learn More</a>.</span>
+            <span className='int-en button small white' onClick={this.setCookie}>OK</span>
           </span>
           <span className="int-he">
             <span>אנחנו משתמשים ב"עוגיות" כדי לתת למשתמשים את חוויית השימוש הטובה ביותר.
               <a href={privacyPolicyLink} data-target-module={Sefaria.LIBRARY_MODULE}>קראו עוד בנושא</a>
             </span>
-            <div className="button small white int-he" onClick={this.setCookie} onKeyDown={(e) => Util.handleKeyboardClick(e, this.setCookie)} role="button" tabIndex="0">לחצו כאן לאישור</div>
+            <span className='int-he button small white' onClick={this.setCookie}>לחצו כאן לאישור</span>
           </span>
 
        </div>
@@ -2986,11 +2812,11 @@ const CollectionStatement = ({name, slug, image, children}) => (
   slug ?
     <div className="collectionStatement sans-serif" contentEditable={false} style={{ userSelect: 'none' }}>
       <div className="collectionListingImageBox imageBox">
-        <a href={"/collections/" + slug} data-target-module={Sefaria.VOICES_MODULE}>
-          <img className={classNames({collectionListingImage:1, "img-circle": 1, default: !image})} src={image || "/static/icons/collection.svg"} alt={Sefaria._("Collection Logo")}/>
+        <a href={"/sheets/collections/" + slug} data-target-module={Sefaria.SHEETS_MODULE}>
+          <img className={classNames({collectionListingImage:1, "img-circle": 1, default: !image})} src={image || "/static/icons/collection.svg"} alt="Collection Logo"/>
         </a>
       </div>
-      <a href={"/collections/" + slug} data-target-module={Sefaria.VOICES_MODULE}>{children ? children : name}</a>
+      <a href={"/sheets/collections/" + slug} data-target-module={Sefaria.SHEETS_MODULE}>{children ? children : name}</a>
     </div>
     :
     <div className="collectionStatement sans-serif" contentEditable={false} style={{ userSelect: 'none', display: 'none' }}>
@@ -3007,10 +2833,10 @@ const AdminToolHeader = function({title, validate, close}) {
                 <InterfaceText>{title}</InterfaceText>
               </h1>
               <div className="end">
-                <div onClick={close} onKeyDown={(e) => Util.handleKeyboardClick(e, close)} className="button small transparent control-elem" id="cancel" role="button" tabIndex="0">
+                <a onClick={close} id="cancel" className="button small transparent control-elem">
                   <InterfaceText>Cancel</InterfaceText>
-                </div>
-                <div onClick={validate} onKeyDown={(e) => Util.handleKeyboardClick(e, validate)} className="button small control-elem" id="saveAccountSettings" tabIndex="0" role="button">
+                </a>
+                <div onClick={validate} id="saveAccountSettings" className="button small blue control-elem" tabIndex="0" role="button">
                   <InterfaceText>Save</InterfaceText>
                 </div>
               </div>
@@ -3110,20 +2936,19 @@ const TitleVariants = function({titles, update, options}) {
                     allowNew={true}
                     tags={titles}
                     onDelete={options?.onTitleDelete ? options.onTitleDelete : onTitleDelete}
-                    placeholderText={Sefaria._("Add a title and press 'enter'.")}
-                    delimiters={["Enter"]}
+                    placeholderText={Sefaria._("Add a title and press 'enter' or 'tab'.")}
+                    delimiters={["Enter", "Tab"]}
                     onAddition={options?.onTitleAddition ? options.onTitleAddition : onTitleAddition}
                     onValidate={options?.onTitleValidate ? options.onTitleValidate : onTitleValidate}
                   />
          </div>
 }
-const SheetMetaDataBox = ({title, summary, sheetOptions, editable, titleCallback, summaryCallback, showGuide}) => {
+const SheetMetaDataBox = ({title, summary, sheetOptions, editable, titleCallback, summaryCallback}) => {
   const languageToggle = <DropdownMenu positioningClass="readerDropdownMenu marginInlineIndent" buttonComponent={<DisplaySettingsButton/>}><ReaderDisplayOptionsMenu/></DropdownMenu>;
   return <div className="sheetMetaDataBox">
     <div className={`sidebarLayout`}>
       <SheetMetaDataBoxSegment text={title} className="title" editable={editable} blurCallback={titleCallback}/>
       <div className="items">
-        {showGuide && <GuideButton onShowGuide={showGuide} />}
         {languageToggle}
         {sheetOptions}
       </div>
@@ -3687,7 +3512,6 @@ export {
   LangSelectInterface,
   PencilSourceEditor,
   SmallBlueButton,
-  getCurrentPage,
   GuideButton,
   ArrowButton as Arrow,
   transformValues,

--- a/static/js/common/DropdownMenu.jsx
+++ b/static/js/common/DropdownMenu.jsx
@@ -1,8 +1,7 @@
 import React, {useEffect, useRef, useState} from 'react';
 import PropTypes from "prop-types";
-import { InterfaceText, getCurrentPage } from '../Misc';
+import { InterfaceText } from '../Misc';
 import Sefaria from '../sefaria/sefaria';
-import Util from '../sefaria/util';
 
 const DropdownMenuSeparator = () => {
 
@@ -25,9 +24,7 @@ const DropdownMenuItem = ({url, children, newTab, customCSS = null, preventClose
     <a className={cssClasses}
        href={fullURL}
        target={newTab ? '_blank' : null}
-       data-prevent-close={preventClose}
-       onKeyDown={(e) => Util.handleKeyboardClick(e)}
-    >
+       data-prevent-close={preventClose}>
       {children}
     </a>
 
@@ -43,9 +40,7 @@ const DropdownMenuItemLink = ({url, children, newTab, preventClose = false}) => 
     <a className={`interfaceLinks-option int-bi dropdownItem`}
        href={url}
        target={newTab ? '_blank' : null}
-       data-prevent-close={preventClose}
-       onKeyDown={(e) => Util.handleKeyboardClick(e)}
-    >
+       data-prevent-close={preventClose}>
       {children}
     </a>
   );
@@ -53,14 +48,7 @@ const DropdownMenuItemLink = ({url, children, newTab, preventClose = false}) => 
 
 const DropdownMenuItemWithCallback = ({onClick, children, preventClose = false}) => {
   return (
-    <div
-      className={'interfaceLinks-option int-bi dropdownItem'}
-      onClick={onClick}
-      data-prevent-close={preventClose}
-      role="button"
-      tabIndex="0"
-      onKeyDown={(e) => Util.handleKeyboardClick(e, onClick)}
-    >
+    <div className={'interfaceLinks-option int-bi dropdownItem'} onClick={onClick} data-prevent-close={preventClose}>
         {children}
     </div>
   );
@@ -70,7 +58,7 @@ const DropdownMenuItemWithIcon = ({icon, textEn='', descEn='', descHe=''}) => {
   return (
     <>
       <div className="dropdownHeader">
-        <img src={icon} alt={Sefaria._("Menu icon")} />
+        <img src={icon} />
         <span className='dropdownHeaderText'>
           <InterfaceText>{textEn}</InterfaceText>
         </span>
@@ -83,57 +71,6 @@ const DropdownMenuItemWithIcon = ({icon, textEn='', descEn='', descHe=''}) => {
   </>
   );
 }
-
-/**
- * DropdownModuleItem - A dropdown menu item for module navigation with a colored dot indicator
- *
- * Used primarily in the module switcher to allow navigation between different Sefaria modules
- * (Library, Voices, Developers). Displays a colored dot and bilingual text.
- *
- * @param {string} url - The destination URL for the link
- * @param {boolean} newTab - Whether to open the link in a new tab
- * @param {string} [targetModule] - The target module identifier (e.g., Sefaria.LIBRARY_MODULE).
- *                                  If provided, the URL will be constructed using Sefaria.util.fullURL
- * @param {string} dotColor - CSS variable name for the colored dot (e.g., '--sefaria-blue', '--sheets-green')
- * @param {Object} text - Bilingual text object with 'en' and 'he' keys
- * @param {string} text.en - English text to display
- * @param {string} text.he - Hebrew text to display
- *
- * @example
- * <DropdownModuleItem
- *   url={"/"}
- *   newTab={false}
- *   targetModule={Sefaria.LIBRARY_MODULE}
- *   dotColor={'--sefaria-blue'}
- *   text={{ en: "Library", he: "ספריה" }}
- * />
- */
-const DropdownModuleItem = ({url, newTab, targetModule, dotColor, text}) => {
-  const fullURL = targetModule ? Sefaria.util.fullURL(url, targetModule) : url;
-  return (
-    <a className="interfaceLinks-option int-bi dropdownItem dropdownModuleItem"
-       href={fullURL}
-       onKeyDown={(e) => Util.handleKeyboardClick(e)}
-       target={newTab ? '_blank' : null}>
-      <div className="dropdownHeader">
-        <span className="dropdownDot" style={{backgroundColor: `var(${dotColor})`}}></span>
-        <span className='dropdownHeaderText'>
-          <InterfaceText text={text}/>
-        </span>
-      </div>
-    </a>
-  );
-}
-DropdownModuleItem.propTypes = {
-  url: PropTypes.string.isRequired,
-  newTab: PropTypes.bool.isRequired,
-  targetModule: PropTypes.string,
-  dotColor: PropTypes.string.isRequired,
-  text: PropTypes.shape({
-    en: PropTypes.string.isRequired,
-    he: PropTypes.string.isRequired
-  }).isRequired
-};
 
 const DropdownMenu = ({children, buttonComponent, positioningClass}) => {
     /**
@@ -148,9 +85,7 @@ const DropdownMenu = ({children, buttonComponent, positioningClass}) => {
      */
 
     const [isOpen, setIsOpen] = useState(false);
-    const menuRef = useRef(null);
     const wrapperRef = useRef(null);
-    const buttonRef = useRef(null);
 
     const handleButtonClick = (e) => {
       e.stopPropagation();
@@ -187,49 +122,12 @@ const DropdownMenu = ({children, buttonComponent, positioningClass}) => {
         };
     }, []);
 
-    useEffect(() => {
-        if (isOpen && menuRef.current) {
-            Util.focusFirstElement(menuRef.current);
-        }
-    }, [isOpen]);
-
-    const handleMenuKeyDown = (e) => {
-        Util.trapFocusWithTab(e, {
-            container: menuRef.current,
-            onClose: () => setIsOpen(false),
-            returnFocusRef: buttonRef.current
-        });
-    };
-
     return (
         <div className={positioningClass} ref={wrapperRef}>
-           <div
-             className="dropdownLinks-button"
-           >
-              {/* 
-                Using React.cloneElement to inject dropdown behavior into the button.
-                We receive a pre-created React element (e.g., <DisplaySettingsButton/>) and need to add:
-                - onClick: toggle the dropdown
-                - ref: manage focus for keyboard navigation
-                - tabIndex & onKeyDown: ensure keyboard accessibility (Space/Enter to activate)
-                
-                This approach allows parent components to pass any button element they want,
-                while DropdownMenu handles the dropdown logic without the parent needing to know
-                the implementation details.
-              */}
-              {React.cloneElement(buttonComponent, {
-                onClick: handleButtonClick,
-                ref: buttonRef,
-                tabIndex: 0,
-                onKeyDown: (e) => Util.handleKeyboardClick(e, handleButtonClick)
-              })}
+           <div className="dropdownLinks-button" onClick={handleButtonClick}>
+              {buttonComponent}
           </div>
-          <div 
-            className={`dropdownLinks-menu ${ isOpen ? "open" : "closed"}`} 
-            onClick={handleContentsClick}
-            ref={menuRef}
-            onKeyDown={handleMenuKeyDown}
-          >
+          <div className={`dropdownLinks-menu ${ isOpen ? "open" : "closed"}`} onClick={handleContentsClick}>
               {children}
           </div>
         </div>
@@ -241,10 +139,14 @@ const DropdownMenu = ({children, buttonComponent, positioningClass}) => {
   };
 
 
-
 const DropdownLanguageToggle = () => {
-  const englishLink = Sefaria.util.fullURL(`/interface/english?next=${getCurrentPage()}`);
-  const hebrewLink = Sefaria.util.fullURL(`/interface/hebrew?next=${getCurrentPage()}`);
+  const handleLanguageChange = (e, lang) => {
+    e.preventDefault();
+    const currentPath = encodeURIComponent(Sefaria.util.currentPath());
+    const targetUrl = Sefaria.util.fullURL(`/interface/${lang}?next=${currentPath}`);
+    window.location.href = targetUrl;
+  };
+
   return (
     <>
       <div className="languageHeader">
@@ -252,16 +154,27 @@ const DropdownLanguageToggle = () => {
       </div>
       <div className='dropdownLanguageToggle'>
       <span className='englishLanguageButton'>
-        <a className="englishLanguageLink" href={englishLink}>
+        <a 
+          className={`englishLanguageLink ${(Sefaria.interfaceLang === 'english') ? 'active': ''}`} 
+          href="/interface/english"
+          onClick={(e) => handleLanguageChange(e, 'english')}
+        >
           English
         </a>
       </span>
-      <a className="hebrewLanguageLink" href={hebrewLink}>
+      <a 
+        className={`hebrewLanguageLink ${(Sefaria.interfaceLang === 'hebrew') ? 'active': ''}`} 
+        href="/interface/hebrew"
+        onClick={(e) => handleLanguageChange(e, 'hebrew')}
+      >
         עברית
       </a>
       </div>
     </>
   )
+}
+DropdownLanguageToggle.propTypes = {
+    currentLang: PropTypes.string,
 }
 
   export {
@@ -269,8 +182,7 @@ const DropdownLanguageToggle = () => {
     DropdownMenuSeparator,
     DropdownMenuItemWithIcon,
     DropdownMenuItemLink,
-    DropdownMenuItem,
+    DropdownMenuItem, 
     DropdownMenuItemWithCallback,
-    DropdownModuleItem,
     DropdownLanguageToggle
   };


### PR DESCRIPTION
…ect hook

Replace the problematic useCurrentPath hook (which caused constant re-renders due to no dependency array) with onClick handlers that calculate the current path at click-time.

Changes:
- DropdownLanguageToggle: Remove useCurrentPath, add handleLanguageChange onClick
- ProfilePicMenu: Remove useCurrentPath, add handleLanguageChange onClick for language links
- MobileInterfaceLanguageToggle: Add handleLanguageChange onClick handlers
- LoggedOutDropdown: Add handleAuthClick for login/register links with dynamic next param
- LoggedOutButtons: Add handleAuthClick for login/register links
- Footer: Add handleLanguageChange method that also tracks analytics
- Hooks.jsx: Remove useCurrentPath hook entirely (no longer needed)
- Header.jsx: Remove useCurrentPath import

Benefits:
- No unnecessary re-renders
- Always gets fresh current URL at click-time
- Simpler, more maintainable code
- Better performance
- No race conditions

This implements the onClick approach suggested in the Slack discussion as a cleaner alternative to either constant re-renders (Option 1) or history API patching (Option 2).
