### PR TITLE
Fix/nginx redirect

### DIFF
--- a/helm-chart/sefaria/conf/nginx.template.conf.tpl
+++ b/helm-chart/sefaria/conf/nginx.template.conf.tpl
@@ -176,7 +176,7 @@ http {
     {{- $subdomain := printf "%s.%s" $subdomain $rootDomain }}
     {{- range .redirects }}
     location ~ ^/{{ . }}(/.*|$) {
-        return 307 https://{{ $subdomain }}$1;
+        return 307 https://{{ $subdomain }}/{{ . }}$1;
     }
     {{- end }}
     {{- end }}


### PR DESCRIPTION
[sc-37592]
## Description
Updated nginx redirect configuration to properly handle specific path routing from main domain to subdomain while preserving URL structure and slugs.

## Code Changes
The following changes were made to the files below:

**`helm-chart/sefaria/conf/nginx.template.conf.tpl`** (lines 177-180):
- Modified the redirect location block regex pattern to explicitly include the path name in the redirect URL
- Changed from generic `return 307 https://{{ $subdomain }}$1;` to `return 307 https://{{ $subdomain }}/{{ . }}$1;`
- This ensures that paths like `/collections`, `/profile`, `/sheets`, and `/topics` redirect to the correct subdomain URLs with the path preserved

## Notes
- The regex pattern `^/{{ . }}(/.*|$)` matches both exact paths (e.g., `/collections`) and paths with slugs (e.g., `/collections/my-collection`)
- The `{{ . }}` template variable represents the redirect path name (collections, profile, sheets, topics)
- This change ensures proper routing from `sefaria.org/collections` → `voices.sefaria.org/collections` and `sefaria.org/collections/slug` → `voices.sefaria.org/collections/slug`
- Uses 307 (Temporary Redirect) status code to maintain SEO best practices
- Generic implementation works for all redirect paths defined in the configuration