### PR TITLE
Add ISO code for Turkish

### DIFF
--- a/static/js/sefaria/sefaria.js
+++ b/static/js/sefaria/sefaria.js
@@ -741,6 +741,7 @@ Sefaria = extend(Sefaria, {
     "pl": {"name": "Polish", "nativeName": "Polski", "showTranslations": 1, "title": "Teksty żydowskie w języku polskim"},
     "pt": {"name": "Portuguese", "nativeName": "Português", "showTranslations": 1, "title": "Textos judaicos em portugues"},
     "ru": {"name": "Russian", "nativeName": "Pусский", "showTranslations": 1, "title": "Еврейские тексты на русском языке"},
+    "tr": {"name": "Turkish", "nativeName": "Türkçe", "showTranslations": 1, "title": "Türkçe Yahudi Metinleri"},
     "yi": {"name": "Yiddish", "nativeName": "יידיש", "showTranslations": 1, "title": "יידישע טעקסטן אויף יידיש"},
     "jrb": {"name": "Judeo-Arabic", "nativeName": "Arabia Yehudia", "showTranslations": 0},  // nativeName in English because hard to determine correct native name
   },

--- a/static/js/sefaria/strings.js
+++ b/static/js/sefaria/strings.js
@@ -409,6 +409,7 @@ const Strings = {
     "Italian": "איטלקית",
     "Polish": "פולנית",
     "Russian": "רוסית",
+    "Turkish": "טורקית",
     "Esperanto": "אספרנטו",
     "Persian": "פרסית",
     "Ladino" : "לאדינו",


### PR DESCRIPTION
## Description
Adding the ISO code for Turkish

## Code Changes
1. `static/js/sefaria/sefaria.js`

  Added Turkish to the ISOMap object in alphabetical order (between Russian and Yiddish):
  `"tr": {"name": "Turkish", "nativeName": "Türkçe", "showTranslations": 1, "title": "Türkçe Yahudi Metinleri"}`

  2. `static/js/sefaria/strings.js`

  Added Turkish translation entry:
  `"Turkish": "טורקית"`

## Notes
The extended title text was done via Google Translate, let me know if another formulation would be preferred. 