### PR TITLE
Fix Topics Infinite Load in Voices

### DIFF
--- a/reader/views.py
+++ b/reader/views.py
@@ -3179,7 +3179,7 @@ def topics_list_api(request):
     API used by the topics A-Z page.
     """
     limit = int(request.GET.get("limit", 1000))
-    all_topics = get_all_topics(limit, activeModule=request.active_module)
+    all_topics = get_all_topics(limit, active_module=request.active_module)
     all_topics_json = []
     for topic in all_topics:
         topic_json = topic.contents(minify=True, with_html=True)


### PR DESCRIPTION
## Description
In the 'voices' module, the 'All Topics A-Z' was loading infinitely. This PR fixes a small syntax error which resolves the bug. 

## Code Changes
1. In `reader/views.py` - switch the parameter from camelCase to snake_case: `active_module` 

## Notes
I'm struggling to test locally because of some unresolved topic pool issues on my machine, @stevekaplan123 pulled and tested locally very successfully. 