### PR TITLE
Fix Module And Language Changes

### DIFF
--- a/sefaria/utils/util.py
+++ b/sefaria/utils/util.py
@@ -529,6 +529,23 @@ def get_language_specific_domain_modules(interfaceLang):
     language_specific_domain_modules = settings.DOMAIN_MODULES.get(interface_lang_code, settings.DOMAIN_MODULES['en'])
     return language_specific_domain_modules
 
+def get_module_aware_domain(target_language, current_module):
+    """
+    Get the target domain for a specific language and module combination.
+    :param target_language: 'english' or 'hebrew'
+    :param current_module: 'library' or 'voices'
+    :return: Full domain URL for the target language/module combination
+    """
+    target_lang_code = get_short_lang(target_language)
+    
+    if target_lang_code in settings.DOMAIN_MODULES:
+        module_domains = settings.DOMAIN_MODULES[target_lang_code]
+        if current_module in module_domains:
+            return module_domains[current_module]
+    
+    # Fallback to English library if not found
+    return settings.DOMAIN_MODULES.get('en', {}).get('library', '/')
+
 def get_short_lang(language):
     """
     Converts a language to a code.


### PR DESCRIPTION
## Description

Fixes domain routing and module switching issues where language changes didn't preserve the current module context (library vs voices). Previously, switching from Hebrew chiburim to English would incorrectly redirect to English library instead of English voices, and switching from English library to Hebrew would append `/texts` incorrectly.

## Code Changes

The following changes were made to the files below:

### `sefaria/utils/util.py`
- **Added `get_module_aware_domain()` function**: New helper function that resolves target domains based on current module (library/voices) and target language, using the nested DOMAIN_MODULES configuration structure.

### `reader/views.py` 
- **Enhanced `interface_language_redirect()` function**: 
  - Added module context detection using `request.active_module` with fallback to `ModuleMiddleware._set_active_module()`
  - Implemented module-aware domain resolution to preserve current module when switching languages
  - Added path cleanup logic to handle `/texts` paths correctly for different modules (voices gets `/`, library preserves `/texts`)

### `sefaria/system/middleware.py`
- **Updated `LanguageSettingsMiddleware.process_request()`**: 
  - Replaced old domain lookup logic with module-aware domain resolution
  - Ensures language switching preserves current module context instead of always defaulting to library module

## Notes

**Issues Fixed:**
- Hebrew chiburim → English now correctly goes to English voices (preserves voices module)
- English library → Hebrew now correctly goes to Hebrew library without extra `/texts` path
- Module switching maintains context across language changes