### PR TITLE
chore: syntax error

### DIFF
--- a/static/js/sefaria/sefaria.js
+++ b/static/js/sefaria/sefaria.js
@@ -3313,7 +3313,7 @@ _media: {},
       return typeof ref === "string" ? parseInt(ref.split(" ")[1]) : parseInt(ref[0].split(" ")[1]);
     },
     getSheetTitle: function(title) {
-      // Returns a sheet's title with fallback to "Untitled" 
+      // Useful for displaying sheet titles in the UI without HTML tags and handling null or empty values by falling back to "Untitled"
       return title?.stripHtml() || Sefaria._("Untitled");
     }
   },


### PR DESCRIPTION
## Description
getSheetTitle expects a sheet object with a title as a string but all usages of it pass it a title as a string.  I changed the function so that it now simply handles strings.  This makes sense because in many contexts its usage is not aware of the sheet object.