### PR TITLE
fix(SheetsHomePage): Extract topic from holiday API response

### DIFF
--- a/static/js/sheets/SheetsHomePageTopicsTOC.jsx
+++ b/static/js/sheets/SheetsHomePageTopicsTOC.jsx
@@ -41,7 +41,7 @@ const SheetsHoliday = ({handleClick}) => {
   useEffect(() => {
     Sefaria.getUpcomingDay('holiday').then(data => {setHoliday(data?.topic || null)});
   }, []);
-  if (Object.keys(holiday).length === 0) {
+  if (Object.keys(holiday || {}).length === 0) {
     return <div className="navBlock">Loading...</div>
   }
   return <TopicTOCCard topic={holiday} setTopic={handleClick} showDescription={true}/>;


### PR DESCRIPTION
Fixed the getUpcomingDay function to deal with the nested structure of the data.
I'm not sure what broke now!
