### PR TITLE
chore(workflows): remove unnecessary 'actions_variables' permission

### DIFF
--- a/.github/workflows/production-deploy.yaml
+++ b/.github/workflows/production-deploy.yaml
@@ -161,7 +161,6 @@ jobs:
     permissions:
       contents: 'read'
       id-token: 'write'
-      actions_variables: 'write'
     needs:
       - build-derived
       - workflow-check


### PR DESCRIPTION
## Description
Fix GitHub Actions workflow parsing error by removing invalid `actions_variables` permission from production deployment workflow.

## Code Changes
The following changes were made to the files below:

**`.github/workflows/production-deploy.yaml`**
- Removed invalid `actions_variables: 'write'` permission from the `prod-deploy` job permissions block (line 164)
- Retained valid permissions: `contents: 'read'` and `id-token: 'write'`

## Notes
- This fixes the workflow parsing error: "Unexpected value 'actions_variables'" that was preventing the release workflow from running
- The `actions_variables` permission is not a recognized GitHub Actions workflow permission
- The workflow functionality remains intact as the GitHub API call to update repository variables uses `${{ secrets.GITHUB_TOKEN }}` which has sufficient default permissions
- No breaking changes - this is purely a bug fix to resolve workflow syntax validation