### PR TITLE
fix(values.yaml): remove 'community' from redirects in domains

### DIFF
--- a/helm-chart/sefaria/values.yaml
+++ b/helm-chart/sefaria/values.yaml
@@ -248,7 +248,7 @@ domains:
         he: chiburim
       redirects:
         - sheets
-        - collection
+        - collections
         - profile
 
 nginx:


### PR DESCRIPTION
Based on the redirects table - community should be handled in django.