### PR TITLE
Fixed saving saved alignment in Heb interface

### DIFF
--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -9621,9 +9621,6 @@ body.interface-english .publishBox .react-tags__suggestions ul {
   background: white;
   padding: 3px;
 }
-
-.editorSaveStateIndicator.tooltip-toggle{
-}
 .interface-english .editorSaveStateIndicator.tooltip-toggle::before{
   margin-inline-start: 75px;
 }
@@ -9636,15 +9633,6 @@ body.interface-english .publishBox .react-tags__suggestions ul {
 .editorSaveStateIndicator .saveStateMessage a{
   font-family: Roboto;
   color: #18345D;
-}
-.interface-hebrew .editorSaveStateIndicator .saveStateMessage{
-  direction: rtl;
-}
-.interface-hebrew .editorSaveStateIndicator {
-  flex-direction: row-reverse;
-}
-.interface-hebrew .sheetContentSidebar .editorSaveStateIndicator {
-  direction: ltr;
 }
 .interface-hebrew .sheetContentSidebar .editorSaveStateIndicator.tooltip-toggle::before {
   left: auto;


### PR DESCRIPTION
Removed some CSS that was causing the problem and add `left: auto;` for the tooltip