### PR TITLE
fix(cronjob): Standardize backup schedule for PostgreSQL and MongoDB

### DIFF
--- a/helm-chart/sefaria/templates/cronjob/sync-mongo-production-data.yaml
+++ b/helm-chart/sefaria/templates/cronjob/sync-mongo-production-data.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     {{- include "sefaria.labels" . | nindent 4 }}
 spec:
-  schedule: {{ .Values.restore.schedule | quote }}
+  schedule: "0 2 * * 0"  # Every week on Sunday at 2 AM
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:

--- a/helm-chart/sefaria/templates/cronjob/sync-postgres-production-data.yaml
+++ b/helm-chart/sefaria/templates/cronjob/sync-postgres-production-data.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     {{- include "sefaria.labels" . | nindent 4 }}
 spec:
-  schedule: {{ .Values.postgres.schedule | quote }}
+  schedule: "0 2 * * 0"  # Every week on Sunday at 2 AM
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:

--- a/helm-chart/sefaria/values.yaml
+++ b/helm-chart/sefaria/values.yaml
@@ -73,7 +73,6 @@ postgres:
   db: "sefaria_auth"
   restore: false
   sync: false
-  schedule: "0 2 * * 0"  # Every week on Sunday at 2 AM
 
 
 web:


### PR DESCRIPTION

- Removed the PostgreSQL backup schedule from values.yaml.
- Updated sync-mongo-production-data and sync-postgres-production-data cronjob templates to use a consistent backup schedule of "0 2 * * 0" (every Sunday at 2 AM).