### PR TITLE
Fix bilingual layouts in editor

### DIFF
--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -12161,7 +12161,10 @@ cursor: pointer;
 }
 
 .bilingual.heRight .sheetContent .sheetItem .SheetSource.segment {
-  flex-direction: row-reverse;
+  direction: rtl;
+}
+.bilingual.heLeft .sheetContent .sheetItem .SheetSource.segment {
+  direction: ltr;
 }
 
 .boxedSheetItem + .spacer {


### PR DESCRIPTION
## Description
Have explicit direction according to the selected layout.
Explanation - here the classname tells us the explicit direction, so we should have explicit direction in css, rather than using `reverse` (using `reverse` depends also on the interface language).

## Notes
Unfortunately we have different implementations for section in library text, sheet viewer and sheet editor. It seems that sheet editor is the best (with flexbox), so I didn't change the implementation is this PR.