### PR TITLE
fix(Mobile menu): Fix alignment on More from Sefaria in the dropdown

### DIFF
--- a/static/js/Header.jsx
+++ b/static/js/Header.jsx
@@ -534,7 +534,7 @@ const MobileNavMenu = ({ onRefClick, showSearch, openTopic, openURL, close, visi
           <InterfaceText>Developers on Sefaria</InterfaceText>
         </a>
 
-        <a href="/products" className="mobileModuleSwitcher" data-target-module={Sefaria.LIBRARY_MODULE}>
+        <a href="/products" data-target-module={Sefaria.LIBRARY_MODULE}>
           <img className="chevron" src="/static/icons/chevron-right.svg"/>
           <InterfaceText>More from Sefaria</InterfaceText>
         </a>


### PR DESCRIPTION
Removing the CSS from the `More on Sefaria` to un-do the alignment fixes. 