### PR TITLE
Fix the skip in infinit scroll of history

### DIFF
--- a/static/js/Hooks.jsx
+++ b/static/js/Hooks.jsx
@@ -59,7 +59,7 @@ function useScrollToLoad({scrollableRef, url, setter, itemsPreLoaded=0, pageSize
   // `itemsPreLoaded` counts the number of items already loaded, e.g. when some data was already available
   // in the JS cache.  If `itemsPreLoaded` > 0, no initial API is made
   // call will be made until scroll occurs, otherwise the size page is requeste immediately.
-  const [skip, setSkip] = useState(itemsPreLoaded);
+  const [skip, setSkip] = useState(0); // It is set to pageSize before the first load
   const [loading, setLoading] = useState(false);
   const [loadedToEnd, setLoadedToEnd] = useState(false);
   const isFirstRender = useRef(true);


### PR DESCRIPTION
What I did:
Set initial value of `skip` to `0`

why:
The infinit scroll would skip history items 20-40.
Init history load was 20 and then load would start from 40.

The problem was that the `skip` param initiated to `20` but it was updated before the load was triggered (the change in `skip` triggers the load).
Typically you would want it to update with `+=theAmountToLoad` (in the code `size`). But in the first run that brought us to 40.

