### PR TITLE
chore: make itag finder run once

### DIFF
--- a/sefaria/helper/normalization.py
+++ b/sefaria/helper/normalization.py
@@ -169,15 +169,13 @@ class ITagNormalizer(AbstractNormalizer):
         from sefaria.model.text import AbstractTextRecord
 
         all_itags = []
-        soup = BeautifulSoup(f"<root>{s}</root>", 'lxml')
-        itag_list = soup.find_all(ITagNormalizer._find_itags)
+        soup, itag_list = AbstractTextRecord.find_all_itags(s)
         for itag in itag_list:
-            all_itags += [itag]
-            try:
-                if AbstractTextRecord._itag_is_footnote(itag):
-                    all_itags += [itag.next_sibling]  # it's a footnote
-            except AttributeError:
-                pass  # it's an inline commentator
+            all_itags.append(itag)
+            if AbstractTextRecord._itag_is_footnote(itag):
+                sibling = itag.next_sibling
+                if isinstance(sibling, Tag):
+                    all_itags.append(sibling)  # it's a footnote
         return all_itags, soup
 
     @staticmethod


### PR DESCRIPTION
Restricted BeautifulSoup traversal to just the sup/i tags we ever care about and moved the predicate logic inline, so we’re no longer calling _find_itags on every node in the document; _itag_is_footnote now short-circuits on non-sup tags and _is_tanakh_end_sup isolates the extra JPS case, keeping the return values identical while cutting the hot path work (sefaria/model/text.py (lines 1218-1258)). ITagNormalizer now reuses AbstractTextRecord.find_all_itags, so it gets the same speedup instead of instantiating its own soup walk