### PR TITLE
Use base_text_titles as context in linker

### DIFF
--- a/sefaria/model/linker/ref_resolver.py
+++ b/sefaria/model/linker/ref_resolver.py
@@ -414,10 +414,14 @@ class RefResolver:
     def get_unrefined_ref_part_matches(self, book_context_ref: Optional[text.Ref], raw_ref: RawRef) -> List[
             'ResolvedRef']:
         context_free_matches = self._get_unrefined_ref_part_matches_recursive(raw_ref, ref_parts=raw_ref.parts_to_match)
-        contexts = [(book_context_ref, ContextType.CURRENT_BOOK)] + [(text.Ref(base_text_title), ContextType.CURRENT_BOOK) for
-                                                                     base_text_title in
-                                                                     book_context_ref.index.base_text_titles] + [
-                       (ibid_ref, ContextType.IBID) for ibid_ref in self._ibid_history.last_refs]
+        contexts = []
+        if book_context_ref:
+            contexts += [(book_context_ref, ContextType.CURRENT_BOOK)]
+            contexts += [
+                (text.Ref(base_text_title), ContextType.CURRENT_BOOK)
+                for base_text_title in (book_context_ref.index.base_text_titles or [])
+            ]
+        contexts += [(ibid_ref, ContextType.IBID) for ibid_ref in self._ibid_history.last_refs]
         matches = context_free_matches
         if len(matches) == 0:
             context_full_matches = []

--- a/sefaria/model/linker/tests/linker_test.py
+++ b/sefaria/model/linker/tests/linker_test.py
@@ -213,6 +213,7 @@ def test_multiple_ambiguities():
     [crrd(["@Job"], lang='en', prev_trefs=['Job 1:1']), ("Job",)],  # don't use ibid context if there's a match that uses all input
     [crrd(["#28", "^-", "#30"], lang='en', context_tref='Leviticus 15:13'), ("Leviticus 15:28-30",)],  # ibid range
     [crrd(["#30"], lang='en', context_tref='Leviticus 15:13-17'), ("Leviticus 15:30",)],  # range in context ref
+    [crrd(["#סימן תצ״ג"], lang='he', context_tref='Mishnah Berurah 494:1'), ("Mishnah Berurah 493", "Shulchan Arukh, Orach Chayim 493")],  # use base_titles to infer possible links from book_ref context
 
     # Relative (e.g. Lekaman)
     [crrd(["@תוס'", "<לקמן", "#ד ע\"ב", "*ד\"ה דאר\"י"], "Gilyon HaShas on Berakhot 2a:2"), ("Tosafot on Berakhot 4b:6:1",)],  # likaman + abbrev in DH


### PR DESCRIPTION
This pull request enhances the reference resolution logic in the linker by improving how context is used to infer possible links, especially when base text titles are available in the book context. It also adds a new test case to verify that multiple possible links can be inferred using base text titles from the book context.

Improvements to reference resolution logic:

* Updated the `resolve_raw_ref_using_ref_instantiation` method in `ref_resolver.py` to include base text titles from the book context as additional context options when resolving references. This allows for more accurate linking when the context reference has associated base text titles.

Test coverage enhancements:

* Added a test case to `linker_test.py` that verifies multiple possible links are inferred from base text titles in the book context, improving confidence in the new resolution logic.## Description
_A brief description of the PR_

## Code Changes
_The following changes were made to the files below_

## Notes
_Any additional notes go here_