### PR TITLE
Rework module switcher tests to account for new logic. 

### DIFF
--- a/static/js/HeaderAutocomplete.jsx
+++ b/static/js/HeaderAutocomplete.jsx
@@ -359,13 +359,17 @@ const SuggestionsGroup = ({ suggestions, initialIndexForGroup, getItemProps, hig
 export const HeaderAutocomplete = ({onRefClick, showSearch, openTopic, openURL, onNavigate, hideHebrewKeyboard = false}) => {
     const [searchFocused, setSearchFocused] = useState(false);
 
+    const MODULE_AUTOCOMPLETE_TYPES = {
+      [Sefaria.LIBRARY_MODULE]: ['Topic', 'ref', 'TocCategory', 'Collection', 'Term'],
+      [Sefaria.VOICES_MODULE]: ['Topic', 'User', 'Collection']
+    };
 
     const fetchSuggestions = async (inputValue) => {
         if (inputValue.length < 3){
           return[];
         }
         try {
-        let types = Sefaria.activeModule === Sefaria.VOICES_MODULE ? ['Topic', 'User', 'Collection'] : undefined;
+        const types = MODULE_AUTOCOMPLETE_TYPES[Sefaria.activeModule];
         const topic_pool = Sefaria.getTopicPoolNameForModule(Sefaria.activeModule);
         const d = await Sefaria.getName(inputValue, undefined, types, topic_pool);
 

--- a/static/js/Hooks.jsx
+++ b/static/js/Hooks.jsx
@@ -59,7 +59,7 @@ function useScrollToLoad({scrollableRef, url, setter, itemsPreLoaded=0, pageSize
   // `itemsPreLoaded` counts the number of items already loaded, e.g. when some data was already available
   // in the JS cache.  If `itemsPreLoaded` > 0, no initial API is made
   // call will be made until scroll occurs, otherwise the size page is requeste immediately.
-  const [skip, setSkip] = useState(itemsPreLoaded);
+  const [skip, setSkip] = useState(0); // It is set to pageSize before the first load
   const [loading, setLoading] = useState(false);
   const [loadedToEnd, setLoadedToEnd] = useState(false);
   const isFirstRender = useRef(true);


### PR DESCRIPTION
## Description
Reworking the tests to accommodate for the new logic. 
1. In conjunction with @yitzhakc - decided not to move to testing the cookie set on the subdomain with module switching, and remove module switching tests from the code
2. 4 language switching tests for the 3 environments, cauldron, staging and prod. These test that the middleware doesn't redirect but the language cookie is retained. 

## Note
All tests are currently passing. 