### PR TITLE
Removing the ref_resolver_context_swaps key from the optional_param_keys list

### DIFF
--- a/sefaria/model/schema.py
+++ b/sefaria/model/schema.py
@@ -1217,7 +1217,7 @@ class SchemaNode(TitledTreeNode):
 
     """
     is_virtual = False
-    optional_param_keys = ["match_templates", "numeric_equivalent", "ref_resolver_context_swaps", "ref_resolver_context_mutations", 'referenceable']
+    optional_param_keys = ["match_templates", "numeric_equivalent", "ref_resolver_context_mutations", 'referenceable']
 
     def __init__(self, serial=None, **kwargs):
         """


### PR DESCRIPTION
This pull request makes a small update to the `SchemaNode` class in `sefaria/model/schema.py` by removing the `ref_resolver_context_swaps` key from the `optional_param_keys` list, likely as part of a cleanup or deprecation.

* Removed `ref_resolver_context_swaps` from the `optional_param_keys` list in the `SchemaNode` class.## Description
_A brief description of the PR_

## Code Changes
_The following changes were made to the files below_

## Notes
_Any additional notes go here_