### PR TITLE
Fix targeting topic category pages by keyword for sidebar ads

### DIFF
--- a/static/js/ReaderApp.jsx
+++ b/static/js/ReaderApp.jsx
@@ -2097,7 +2097,17 @@ toggleSignUpModal(modalContentKind = SignUpModalKind.Default) {
       }
 
     }
-    const refs = this.state.panels.map(panel => panel.currentlyVisibleRef || panel.bookRef || returnNullIfEmpty(panel.navigationCategories) || panel.navigationTopic).flat();
+    
+    const refs = this.state.panels
+      .map(
+        (panel) =>
+          panel.currentlyVisibleRef ||
+          panel.bookRef ||
+          returnNullIfEmpty(panel.navigationCategories) ||
+          panel.navigationTopic ||
+          panel.navigationTopicCategory
+      )
+      .flat();
     const books = refs.map(ref => Sefaria.parseRef(ref).book);
     const triggers = refs.map(ref => Sefaria.refCategories(ref))
           .concat(books)


### PR DESCRIPTION
## Description
There is a desire to target sidebar ads on specific topic category pages. Text category pages and topic pages were previously included. The keywords from topic category pages were previously missing from the references used to trigger sidebar ads.

## Code Changes
* The panel state that includes the current topic categories is now included in the user context's keywords for triggering sidebar ads