### PR TITLE
Remove stripping of vowels and punctuation for non-Hebrew texts

### DIFF
--- a/static/js/TextRange.jsx
+++ b/static/js/TextRange.jsx
@@ -278,8 +278,8 @@ class TextRange extends Component {
 
     // [\.\!\?\:\,\u05F4]+                                                                      # Match (and remove) one or more punctuation or gershayim
     //    (?![\u0591-\u05bd\u05bf-\u05c5\u05c7\u200d\u05d0-\u05eA](?:[\.\!\?\:\,\u05F4\s]|$))   # So long as it's not immediately followed by one letter (followed by space, punctuation, endline, etc.)
-    // |—\s;                                                                                    # OR match (and remove) an mdash followed by a space
-    const punctuationre = /[\.\!\?\:\,\u05F4]+(?![\u0591-\u05bd\u05bf-\u05c5\u05c7\u200d\u05d0-\u05eA](?:[\.\!\?\:\,\u05F4\s]|$))|—\s/g;
+    // |[—–]\s;                                                                                 # OR match (and remove) an em/en dash followed by a space
+    const punctuationre = /[\.\!\?\:\,\u05F4]+(?![\u0591-\u05bd\u05bf-\u05c5\u05c7\u200d\u05d0-\u05eA](?:[\.\!\?\:\,\u05F4\s]|$))|[—–]\s/g;
 
     const strip_punctuation_re = (this.props.settings?.language === "hebrew" || this.props.settings?.language === "bilingual") && this.props.settings?.punctuationTalmud === "punctuationOff" && data?.type === "Talmud" ? punctuationre : null;
     const nre = /[\u0591-\u05af\u05bd\u05bf\u05c0\u05c4\u05c5\u200d]/g; // cantillation


### PR DESCRIPTION
## Description
Punctuation stripping of en texts was possible when binlingual mode was on, which caused an issue with citations.
It turns out that the punctuation stripping of non-hebrew texts should not be enabled anyway
<img width="1432" height="728" alt="image" src="https://github.com/user-attachments/assets/9c429eb3-b7b8-472e-a92e-8f3ed871d631" />


## Code Changes
_The following changes were made to the files below_

## Notes
_Any additional notes go here_