### PR TITLE
chore: add celery results ttl

### DIFF
--- a/sefaria/celery_setup/app.py
+++ b/sefaria/celery_setup/app.py
@@ -2,5 +2,5 @@ from celery import Celery
 from sefaria.celery_setup.config import generate_config_from_env
 
 app = Celery('sefaria')
-app.conf.update(**generate_config_from_env())
+app.conf.update(**generate_config_from_env(), result_expires=1800)
 app.autodiscover_tasks(packages=['sefaria.helper.llm', 'sefaria.helper.linker'])


### PR DESCRIPTION
This pull request makes a minor configuration update to the Celery application. The change sets the `result_expires` parameter to 1800 seconds (30 minutes), which controls how long Celery stores task results.

- Celery configuration: Set `result_expires=1800` in `app.conf.update()` within `sefaria/celery_setup/app.py` to limit how long task results are kept.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Set Celery `result_expires` to 1800 seconds in `sefaria/celery_setup/app.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9eb623e57d61c9c5b1859e30c82710520b758e1c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->