### PR TITLE
chore(gitignore): returned /playwright-profile/ that was missing afte…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,7 +141,7 @@ e2e-tests/e2e-test-logs/
 /test-results/
 /playwright-report/
 /playwright/.cache/
-/test-results/
+/playwright-profile/
 
 # Storybook #
 *storybook.log


### PR DESCRIPTION
Returned a line to `.gitignore` that is missing after a big merge