### PR TITLE
feat: capture object memory snapshot

### DIFF
--- a/sefaria/urls.py
+++ b/sefaria/urls.py
@@ -444,6 +444,7 @@ urlpatterns += [
     url(r'^admin/rebuild/shared-cache', sefaria_views.rebuild_shared_cache),
     url(r'^admin/delete/citation-links/(?P<title>.+)$', sefaria_views.delete_citation_links),
     url(r'^admin/cache/stats', sefaria_views.cache_stats),
+    url(r'^admin/memory/summary', sefaria_views.memory_summary),
     url(r'^admin/cache/dump', sefaria_views.cache_dump),
     url(r'^admin/run/tests', sefaria_views.run_tests),
     url(r'^admin/export/all', sefaria_views.export_all),


### PR DESCRIPTION
This pull request adds a new admin endpoint to provide a summary of memory usage using the `pympler` library. This feature is intended to help staff members monitor memory consumption by object type in the application.

New admin memory summary endpoint:

* Added a new URL pattern `/admin/memory/summary` in `sefaria/urls.py` to route requests to the new memory summary view.
* Implemented the `memory_summary` view in `sefaria/views.py`, which returns a JSON summary of memory usage by object type. The endpoint supports an optional `limit` query parameter and handles errors such as missing dependencies or invalid parameters.