### PR TITLE
fix-mutc-sanitize

### DIFF
--- a/sefaria/model/linker_output.py
+++ b/sefaria/model/linker_output.py
@@ -62,6 +62,12 @@ class LinkerOutput(AbstractMongoRecord):
         }
     }
 
+    def _sanitize(self):
+        # No sanitization needed. The span text comes from the Version's text,
+        # which has already been sanitized. Other fields (ref, versionTitle, language)
+        # are metadata and should not be HTML-escaped.
+        pass
+
 
 class LinkerOutputSet(AbstractMongoSet):
     recordClass = LinkerOutput

--- a/sefaria/model/marked_up_text_chunk.py
+++ b/sefaria/model/marked_up_text_chunk.py
@@ -95,6 +95,12 @@ class MarkedUpTextChunk(AbstractMongoRecord):
 
         return True
 
+    def _sanitize(self):
+        # No sanitization needed. The span text comes from the Version's text,
+        # which has already been sanitized. Other fields (ref, versionTitle, language)
+        # are metadata and should not be HTML-escaped.
+        pass
+    
     def __str__(self):
         return "TextSpan: {}".format(self.ref)
     


### PR DESCRIPTION
This pull request overrides `AbstractMongoRecord._sanitize` which by default bleach cleans all fields on a mongo record to prevent XSS attacks. We override this method  on both the `LinkerOutput` and `MarkedUpTextChunk` models. The method is intentionally left as a no-op, with comments explaining that sanitization is unnecessary because the relevant fields are either already sanitized or are metadata.