### PR TITLE
chore: up memory limit

### DIFF
--- a/build/ci/production-values.yaml
+++ b/build/ci/production-values.yaml
@@ -34,10 +34,10 @@ web:
       gunicornThreadCount: 5
       resources:
         requests:
-          memory: "12Gi"
+          memory: "14Gi"
           cpu: "1500m"
         limits:
-          memory: "14Gi"
+          memory: "18Gi"
           cpu: "2"
   secrets:
     googleClient:


### PR DESCRIPTION
This pull request increases the memory allocation for the `web` service in the production deployment configuration. Both the requested and maximum memory limits have been raised to better support application performance under load.

- Resource allocation updates:
  * Increased the `requests.memory` value for the `web` service from `12Gi` to `14Gi` in `build/ci/production-values.yaml`
  * Increased the `limits.memory` value for the `web` service from `14Gi` to `18Gi` in `build/ci/production-values.yaml`