### PR TITLE
fix(sheets): Fix bug with no suffix

### DIFF
--- a/static/js/sefaria/sefaria.js
+++ b/static/js/sefaria/sefaria.js
@@ -3605,9 +3605,6 @@ _media: {},
           voices: "Sheets from Voices on Sefaria",
           library: "Texts from the Sefaria Library"
         },
-        collections: {
-          voices: "Voices on Sefaria"
-        },
         collection: {
           voices: "Voices on Sefaria Collection"
         },
@@ -3622,7 +3619,8 @@ _media: {},
         baseTitle = "Untitled";
       }
 
-      if (!pageType) {
+      // If no page tye, or a page type with a default suffix
+      if (!pageType || pageType === "sheet" || pageType === "collections") {
         pageType = "default";
       }
   


### PR DESCRIPTION
Account for `pageType` of `sheet` in the suffix page title generation logic. 