### PR TITLE
feat(redirects): Add redirect from /sheets/ to /getstarted/ endpoint

### DIFF
--- a/reader/views.py
+++ b/reader/views.py
@@ -962,6 +962,13 @@ def topics_redirect(request):
     return redirect("/topics", permanent=True)
 
 
+def sheets_redirect_to_getstarted(request):
+    """
+    Redirect /sheets/ to /getstarted/
+    """
+    return redirect("/getstarted/", permanent=True)
+
+
 @sanitize_get_params
 def collection_page(request, slug):
     """

--- a/sefaria/urls_sheets.py
+++ b/sefaria/urls_sheets.py
@@ -21,6 +21,7 @@ urlpatterns = [
     url(r'^collections/(?P<slug>[^.]+)$', reader_views.collection_page),
 
     url(r'^getstarted/?$', reader_views.serve_static, {'page': 'sheets'}, name='sheets'),
+    url(r'^sheets/?$', reader_views.sheets_redirect_to_getstarted),
     url(r'^sheets/new/?$', sheets_views.new_sheet),
     url(r'^sheets/(?P<sheet_id>\d+)$', sheets_views.view_sheet),
     url(r'^sheets/visual/(?P<sheet_id>\d+)$', sheets_views.view_visual_sheet),


### PR DESCRIPTION
## Description
Adds a permanent redirect from `/sheets/` to `/getstarted/` to route users to the get started page.

## Code Changes
- **`reader/views.py`**
  - Added `sheets_redirect_to_getstarted()` to handle the redirect with a permanent (301) redirect

- **`sefaria/urls_sheets.py`**
  - Added URL pattern `url(r'^sheets/?$', reader_views.sheets_redirect_to_getstarted)` on line 24
  - Placed before other sheets patterns (like `/sheets/new/` and `/sheets/{id}`) so it matches the base `/sheets/` path first

## Notes
- Uses a permanent (301) redirect
- Pattern matches both `/sheets` and `/sheets/` (trailing slash optional)
- Positioned before other sheets URL patterns to ensure correct matching precedence
- Existing sheets functionality (creating new sheets, viewing specific sheets) remains unchanged