### PR TITLE
Fix API Reference link in README

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -4,7 +4,7 @@
 
 
 ## Getting Started
-Visit our [Developer Portal](https://developers.sefaria.org/) to read our [docs](https://developers.sefaria.org/docs/getting-started-1), play with our interactive [API Reference](https://developers.sefaria.org/reference/getting-started-with-your-api) and to learn more about Sefaria's open source data and technology.  There, you can also find tutorials, installation instructions, and all of the most up-to-date information about our technology.
+Visit our [Developer Portal](https://developers.sefaria.org/) to read our [docs](https://developers.sefaria.org/docs/getting-started-1), play with our interactive [API Reference](https://developers.sefaria.org/reference/getting-started) and to learn more about Sefaria's open source data and technology.  There, you can also find tutorials, installation instructions, and all of the most up-to-date information about our technology.
 
 Interested developers can join the [sefaria-dev mailing list](https://groups.google.com/forum/#!forum/sefaria-dev).
 


### PR DESCRIPTION
Updated API Reference link to the latest version.

the previous one is broken 💔 