### PR TITLE
fix: white screen on side panel options in modularization main

### DIFF
--- a/static/js/ConnectionsPanelHeader.jsx
+++ b/static/js/ConnectionsPanelHeader.jsx
@@ -49,7 +49,7 @@ class ConnectionsPanelHeader extends Component {
     const excludedModes = ["Resources", "ConnectionsList"];
     if (!excludedModes.includes(this.props.connectionsMode)) {
       // Only modes were there's an actual source-text get the dropdown.
-      return <DropdownMenu buttonContent={<DisplaySettingsButton/>} context={ReaderPanelContext}><ReaderDisplayOptionsMenu/></DropdownMenu>;
+      return <DropdownMenu buttonComponent={<DisplaySettingsButton/>} context={ReaderPanelContext}><ReaderDisplayOptionsMenu/></DropdownMenu>;
     }
     if (this.props.interfaceLang !== "english") {
       // if interface is Hebrew and we're not viewing actual source text in the sidebar, language switcher is turned off.

--- a/static/js/common/DropdownMenu.jsx
+++ b/static/js/common/DropdownMenu.jsx
@@ -235,7 +235,7 @@ const DropdownMenu = ({children, buttonComponent, positioningClass}) => {
                 while DropdownMenu handles the dropdown logic without the parent needing to know
                 the implementation details.
               */}
-              {buttonComponent && React.cloneElement(buttonComponent, {
+              {React.cloneElement(buttonComponent, {
                 onClick: handleButtonClick,
                 ref: buttonRef,
                 tabIndex: 0,


### PR DESCRIPTION
## Description
This PR fixes a bug on `modularization-main`, where upon clicking on an option in the sidebar, a white screen appeared. 

## Code Changes
In `static/js/common/DropdownMenu.jsx` add a conditional check for `buttonComponent` before attempting to `React.cloneElement`.