### PR TITLE
feat(cronjob): Update MongoDB backup sync to download the latest priv…

### DIFF
--- a/helm-chart/sefaria/templates/cronjob/sync-mongo-production-data.yaml
+++ b/helm-chart/sefaria/templates/cronjob/sync-mongo-production-data.yaml
@@ -30,9 +30,26 @@ spec:
                 - -c
                 - |
                   set -e
-                  echo "Downloading latest backup from production..."
-                  gsutil -q cp gs://sefaria-mongo-backup/dump.tar.gz /storage/dump.tar.gz
-                  echo "Backup downloaded successfully"
+                  echo "Finding latest MongoDB private dump from production..."
+                  
+                  # List all private dump files and find the latest one by timestamp
+                  echo "Listing available private dumps..."
+                  # Use GCS timestamps for reliable sorting (column 2 is the timestamp)
+                  latest_backup=$(gsutil ls -l gs://sefaria-mongo-backup/ | \
+                    grep 'private_dump_.*\.tar\.gz' | \
+                    sort -k2 | \
+                    tail -1 | \
+                    awk '{print $3}')
+                  
+                  if [ -z "$latest_backup" ]; then
+                    echo "ERROR: No private dump files found in bucket"
+                    exit 1
+                  fi
+                  
+                  echo "Found latest private dump: $latest_backup"
+                  echo "Downloading backup..."
+                  gsutil cp "$latest_backup" /storage/dump.tar.gz
+                  echo "Private dump downloaded successfully"
           containers:
             - name: sync-mongo-production-data
               image: mongo:4.4


### PR DESCRIPTION
## Description
Update MongoDB production data sync to use latest private dump instead of hardcoded backup file. The cronjob now dynamically discovers and downloads the most recent private dump file (e.g., `private_dump_26.11.25.tar.gz`) using timestamp-based sorting, similar to the existing Postgres sync logic.

## Code Changes
**`helm-chart/sefaria/templates/cronjob/sync-mongo-production-data.yaml`**
- Replaced hardcoded `dump.tar.gz` download with dynamic backup discovery logic
- Added `gsutil ls -l` command to list all private dump files with timestamps
- Implemented grep pattern matching for `private_dump_*.tar.gz` files
- Added timestamp-based sorting (`sort -k2`) to find the most recent backup
- Included error handling to verify backup file exists before download
- Enhanced logging to show which specific backup file is being used
- Maintained same download path (`/storage/dump.tar.gz`) for compatibility with restore process

## Notes
- This change ensures staging/development environments always sync with the latest private production data
- The logic mirrors the existing Postgres sync job pattern for consistency
- Private dumps include sensitive collections like sheets that are excluded from public dumps
- No changes to the restore process - only the backup discovery and download logic
- Cronjob continues to run weekly on Sundays at 2 AM as configured