### PR TITLE
fix(HeaderAutocomplete): Added a catch for ref searches in voices to …

### DIFF
--- a/static/js/HeaderAutocomplete.jsx
+++ b/static/js/HeaderAutocomplete.jsx
@@ -29,7 +29,7 @@ const type_title_map = {
 };
 
 const MODULE_ALLOWED_SEARCH_TYPES = {
-  [Sefaria.LIBRARY_MODULE]: ['Topic', 'ref', 'TocCategory', 'Collection', 'Term'],
+  [Sefaria.LIBRARY_MODULE]: ['Topic', 'ref', 'TocCategory', 'Term'],
   [Sefaria.VOICES_MODULE]: ['Topic', 'User', 'Collection']
 };
 


### PR DESCRIPTION
Blocking searching for refs in the voices module
Code changes:
1. Moved `MODULE_AUTOCOMPLETE_TYPES` to be global and renamed to `MODULE_ALLOWED_SEARCH_TYPES`
2. Added a filter inside `getQueryObj` to only return for `is_ref` if `ref` is inside the active module allowed search list