### PR TITLE
fix: rename "Explore" to "Topics" in Library mobile menu

### DIFF
--- a/static/js/Header.jsx
+++ b/static/js/Header.jsx
@@ -428,7 +428,7 @@ const MobileNavMenu = ({ onRefClick, showSearch, openTopic, openURL, close, visi
           </a>
           <a href={"/topics"} onClick={close}>
             <img src="/static/icons/topic.svg" alt={Sefaria._("Topics")} />
-            <InterfaceText context="Header">Explore</InterfaceText>
+            <InterfaceText context="Header">Topics</InterfaceText>
           </a>
           <a href="/calendars" onClick={close}>
             <img src="/static/icons/calendar.svg" alt={Sefaria._("Learning Schedules")} />

--- a/static/js/sefaria/strings.js
+++ b/static/js/sefaria/strings.js
@@ -792,7 +792,6 @@ const Strings = {
     },
     "Header": {
       "Texts": "מקורות",
-      "Explore": "נושאים",
     },
     "RecentlyPublished": {
       "Load More": "דפי מקורות נוספים",


### PR DESCRIPTION
Change the string from "Explore" to "Topics"
removed the unused string from `strings.js`
