### PR TITLE
feat: Hide ToC language toggle on narrow screens

### DIFF
--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -1328,6 +1328,12 @@ a.interfaceLinks-option.active, a.interfaceLinks-option.inactive {
   align-items: center;
   justify-content: center;
 }
+/* Hide ToC language toggle on narrow screens where mobile header shows its own toggle */
+@media (max-width: 842px) {
+  .navTitle .languageToggle {
+    display: none;
+  }
+}
 .navTitleTab {
   margin-inline-end: 26px;
   color: var(--medium-grey-legacy);

--- a/static/js/TextsPage.jsx
+++ b/static/js/TextsPage.jsx
@@ -78,7 +78,7 @@ const TextsPage = ({categories, settings, setCategories, onCompareBack, openSear
         <CategoryHeader type="cats" toggleButtonIDs={["subcategory", "reorder"]}>
             <h1><InterfaceText>Browse the Library</InterfaceText></h1>
         </CategoryHeader>
-      { multiPanel && Sefaria.interfaceLang !== "hebrew" && Sefaria._siteSettings.TORAH_SPECIFIC ?
+      { Sefaria.interfaceLang !== "hebrew" && Sefaria._siteSettings.TORAH_SPECIFIC ?
       <LanguageToggleButton toggleLanguage={toggleLanguage} /> : null }
     </div>
 


### PR DESCRIPTION
## Description
Hid the `.languageToggle` from the ToC page on narrow screens because it appears in the header

## Code Changes
* Added in S2 that not to display the component on narrow screens
* Removed the old JS filter on `multiPanel`

## Notes
1. I tried to implement this in the header SCSS using the existing breakpoint vars, but S2 loads after Header.css so it wasn't working
2. I thought making a new SCSS file just for this was overkill for a 2 point task and didn't have other ideas how to avoid hardcoding the breakpoint