### PR TITLE
fix: "TopicTOCCard handles a relative path"

### DIFF
--- a/static/js/common/TopicTOCCard.jsx
+++ b/static/js/common/TopicTOCCard.jsx
@@ -16,8 +16,7 @@ export const TopicTOCCard = ({topic, setTopic, setNavTopic=null, showDescription
   let {en, he} = topic.primaryTitle;
   en = en.replace(/^Parashat /, "");  // Torah Portions have "Parashat" in their titles, which we do want to display on topic pages, but not in the TOC
   he = he.replace(/^פרשת /, "");
-  const href = `topics/${children ? 'category/' : ''}${slug}`;
-
+  const href = `/topics/${children ? 'category/' : ''}${slug}`;
   return <Card cardTitleHref={href}
                cardTitle={{en, he}}
                cardText={showDescription ? description : ""}


### PR DESCRIPTION
## Description
URL path was specified as if it were relative to the current URL when it should be relative to the domain.  It needed a "/" prepended.