### PR TITLE
chore: use en instead of primaryTitle

### DIFF
--- a/static/js/CollectionPage.jsx
+++ b/static/js/CollectionPage.jsx
@@ -124,7 +124,7 @@ class CollectionPage extends Component {
     filter = n(filter);
     
     //title and each topic in he and en
-    let filterableData  = sheet.topics.map(topic => [n(topic.en), n(topic.he), n(topic.asTyped)]).flat();
+    const filterableData  = sheet.topics.map(topic => [n(topic.en), n(topic.he), n(topic.asTyped)]).flat();
     filterableData.push(n(sheet.title.stripHtml()));
     
     //this may be confusing- in the exact case, "includes" is an array func and returns if any of the above match filter exactly, 


### PR DESCRIPTION
## Description
Collections for Nechama Leibowitz couldn't be navigated.

## Code Changes
Changed `topic.primaryTitle.en` to `topic.en`.  Normally our pattern is `topic.primaryTitle.en` because `topic.contents()` returns the structure `topic.primaryTitle.en`.  However, sheet topics are actually stored in our database in the sheets collection with the structure `topic.en` or `topic.he`, so we should use this instead.
