### PR TITLE
Fix reader app from crashing during improper setups

### DIFF
--- a/static/js/ReaderPanel.jsx
+++ b/static/js/ReaderPanel.jsx
@@ -940,7 +940,7 @@ class ReaderPanel extends Component {
                     currVersions={this.state.currVersions}
                     settingsLanguage={this.state.settings.language == "hebrew"?"he":"en"}
                     toggleLanguage={this.toggleLanguage}
-                    category={Sefaria.index(this.state.bookRef).primary_category}
+                    category={Sefaria.index(this.state.bookRef)?.primary_category || "Other"}
                     currentRef={this.state.bookRef}
                     compare={this.state.compare}
                     onCompareBack={onCompareBack}

--- a/static/js/Story.jsx
+++ b/static/js/Story.jsx
@@ -158,7 +158,7 @@ const TopicStoryDescBlock = ({title, tref}) =>
     (
       <div className="topicStoryDescBlock">
             <StoryTitleBlock en={title.en} he={title.he}></StoryTitleBlock>
-        <div>{Sefaria._(Sefaria.index(Sefaria.parseRef(tref).index).primary_category).toUpperCase()}</div>
+        <div>{Sefaria._(Sefaria.index(Sefaria.parseRef(tref)?.index)?.primary_category || "Other").toUpperCase()}</div>
       </div>
 )
 

--- a/static/js/TextColumn.jsx
+++ b/static/js/TextColumn.jsx
@@ -34,11 +34,14 @@ class TextColumn extends Component {
     // Set on mount, so placeholders aren't rendered server side to prevent intial layout shift
     this.setState({showScrollPlaceholders: true});
 
-       const params = {
-         content_type: Sefaria.index(this.props.bookTitle).primary_category,
-         item_id: this.props.bookTitle
-       }
-      gtag("event", "select_content", params)
+    const index = this.props.bookTitle ? Sefaria.index(this.props.bookTitle) : null;
+    if (index) {
+      const params = {
+        content_type: index.primary_category,
+        item_id: this.props.bookTitle
+      };
+      gtag("event", "select_content", params);
+    }
 
     this.node.addEventListener("scroll", this.handleScroll);
   }


### PR DESCRIPTION
This fixes a bug with rendering that can happen during local development and defends against faulty data.

## Description
I don't always run the node server for server-side rendering during local development. Client-side rendering should still work even if the node server isn't used. When server-side rendering isn't properly setup to rebuild the cache to prepopulate the data, ReaderApp can crash. This can happen during local development. `bookTitle` might be null or undefined during the first render when the dependent React components mount. `Sefaria.parseRef` and/or `Sefaria.index` when using that `bookTitle` can return null or undefined for an uncached book.

## Code Changes
Optional chaining and null checks were added to prevent components from crashing during rendering dependent on `bookTitle`.