### PR TITLE
fix(CollectionPage): added optional chaining to avoid error when topi…

### DIFF
--- a/static/js/CollectionPage.jsx
+++ b/static/js/CollectionPage.jsx
@@ -124,7 +124,7 @@ class CollectionPage extends Component {
     filter = n(filter);
     
     //title and each topic in he and en
-    let filterableData  = sheet.topics.map(topic => [n(topic.primaryTitle.en), n(topic.primaryTitle.he), n(topic.asTyped)]).flat();
+    let filterableData  = sheet.topics.map(topic => [n(topic.primaryTitle?.en || ''), n(topic.primaryTitle?.he || ''), n(topic.asTyped || '')]).flat();
     filterableData.push(n(sheet.title.stripHtml()));
     
     //this may be confusing- in the exact case, "includes" is an array func and returns if any of the above match filter exactly, 


### PR DESCRIPTION
Problem:
The bug was that we had empty `topic.primaryTitle` and then we got an error when trying to access `topic.primaryTitle.en`
Solution:
Added safety catches for cases where `topic.primaryTitle` or `topic.asTyped` are empty

Story details: https://app.shortcut.com/sefaria/story/39659