### PR TITLE
fix: auto-set renderStatic for non-SSR views in render_template

### DIFF
--- a/reader/views.py
+++ b/reader/views.py
@@ -2388,7 +2388,7 @@ def visualize_parasha_colors(request):
 def visualize_links_through_rashi(request):
     level = request.GET.get("level", 1)
     json_file = "../static/files/torah_rashi_torah.json" if level == 1 else "../static/files/tanach_rashi_tanach.json"
-    return render_template(request,'visualize_links_through_rashi.html', None, {"json_file": json_file, "renderStatic": True})
+    return render_template(request,'visualize_links_through_rashi.html', None, {"json_file": json_file})
 
 def talmudic_relationships(request):
     json_file = "../static/files/talmudic_relationships_data.json"
@@ -4113,7 +4113,6 @@ def edit_profile(request):
       'user': request.user,
       'profile': profile,
       'sheets': sheets,
-      "renderStatic": True
     })
 
 
@@ -4260,7 +4259,6 @@ def dashboard(request):
 
     return render_template(request,'dashboard.html', None, {
         "states": states,
-        "renderStatic": True
     })
 
 
@@ -4273,7 +4271,6 @@ def metrics(request):
     metrics_json = dumps(metrics)
     return render_template(request,'metrics.html', None,{
         "metrics_json": metrics_json,
-        "renderStatic": True
     })
 
 

--- a/sefaria/views.py
+++ b/sefaria/views.py
@@ -1138,7 +1138,7 @@ def delete_user_by_email(request):
     from sefaria.utils.user import delete_user_account
     if request.method == 'GET':
         form = SefariaDeleteUserForm()
-        return render_template(request, "registration/delete_user_account.html", None, {'form': form, 'next': next, "renderStatic": True})
+        return render_template(request, "registration/delete_user_account.html", None, {'form': form, 'next': next})
     elif request.method == 'POST':
         user = User.objects.get(id=request.user.id)
         email = request.POST.get("email")
@@ -1166,7 +1166,7 @@ def delete_sheet_by_id(request):
     from sefaria.utils.user import delete_user_account
     if request.method == 'GET':
         form = SefariaDeleteSheet()
-        return render_template(request, "delete-sheet.html", None, {'form': form, 'next': next, "renderStatic": True})
+        return render_template(request, "delete-sheet.html", None, {'form': form, 'next': next})
     elif request.method == 'POST':
         user = User.objects.get(id=request.user.id)
         sheet_id = request.POST.get("sid")


### PR DESCRIPTION
I am unfamiliar with this code. I did my best to understand the problem and make sure this is a correct solution but am still not confident.

## Summary

Fixes white screen on `/explore` and other visualization pages (sc-39610).

## Problem

Commit `1752753b` changed `base.html` from `{% if not html %}` to `{% if renderStatic %}` for rendering `{% block content %}`. This broke all views that pass `app_props=None` (visualizations, activity, metrics, etc.) because they never set `renderStatic: True`.

## Solution

Auto-set `renderStatic = True` in `render_template()` when `app_props` is not provided:

```python
if app_props:
    html = render_react_component(...)
else:
    template_context["renderStatic"] = True
```

Also removes 6 now-redundant explicit `renderStatic: True` flags from views.
