### PR TITLE
fix(ConnectionPanel): Fixed the conditional render to check if `count…

### DIFF
--- a/static/js/ConnectionsPanel.jsx
+++ b/static/js/ConnectionsPanel.jsx
@@ -1046,7 +1046,7 @@ const ToolsButton = ({ en, he, onClick, urlConnectionsMode = null, icon, image,
         {iconElem}
         <span className="toolsButtonText">
           {control === "interface" ? <InterfaceText text={{ en: en, he: he }} /> : <ContentText text={{ en: en, he: he }} />}
-          {count && (<span className="connectionsCount">({count})</span>)}
+          {count > 0 && (<span className="connectionsCount">({count})</span>)}
           {experiment && <span className="experimentLabel">Experiment</span>}
         </span>
         {children}


### PR DESCRIPTION
Fixed the conditional render to check if `count > 0` instead of just checking `count` is falsy because react returns the first falsy operand when there is an && and not false