### PR TITLE
Fix: 500 error in newsletter signup: add missing mailing_lists parameter

### DIFF
--- a/sefaria/helper/crm/crm_connection_manager.py
+++ b/sefaria/helper/crm/crm_connection_manager.py
@@ -38,7 +38,7 @@ class CrmConnectionManager(object):
         """
         pass
 
-    def subscribe_to_lists(self, email, first_name=None, last_name=None, educator=False, lang="en"):
+    def subscribe_to_lists(self, email, first_name=None, last_name=None, educator=False, lang="en", mailing_lists=None):
         CrmConnectionManager.validate_email(email)
         CrmConnectionManager.validate_name(first_name)
         CrmConnectionManager.validate_name(last_name)

--- a/sefaria/helper/crm/dummy_crm.py
+++ b/sefaria/helper/crm/dummy_crm.py
@@ -21,8 +21,8 @@ class DummyConnectionManager(CrmConnectionManager):
     def change_user_email(self, uid, new_email):
         return True
 
-    def subscribe_to_lists(self, email, first_name=None, last_name=None, educator=False, lang="en"):
-        CrmConnectionManager.subscribe_to_lists(self, email, first_name, last_name, educator, lang)
+    def subscribe_to_lists(self, email, first_name=None, last_name=None, educator=False, lang="en", mailing_lists=None):
+        CrmConnectionManager.subscribe_to_lists(self, email, first_name, last_name, educator, lang, mailing_lists)
         return True
 
     def find_crm_id(self, email=None):

--- a/sefaria/helper/crm/nationbuilder.py
+++ b/sefaria/helper/crm/nationbuilder.py
@@ -70,8 +70,8 @@ class NationbuilderConnectionManager(CrmConnectionManager):
 
         return True
 
-    def subscribe_to_lists(self, email, first_name=None, last_name=None, lang="en", educator=False):
-        CrmConnectionManager.subscribe_to_lists(self,email, first_name, last_name, lang, educator)
+    def subscribe_to_lists(self, email, first_name=None, last_name=None, educator=False, lang="en", mailing_lists=None):
+        CrmConnectionManager.subscribe_to_lists(self, email, first_name, last_name, educator, lang, mailing_lists)
         return self.add_user_to_crm(email, first_name, last_name, lang, educator, signup=False)
 
     def nationbuilder_get_all(self, endpoint_func, args=[]):


### PR DESCRIPTION
The issue is a signature mismatch between the CRM implementations.

`CrmMediator.subscribe_to_lists` passes `mailing_lists` to underlying CRM connections, but `DummyConnectionManager` and `NationbuilderConnectionManager` didn't accept this parameter, causing "takes from 2 to 6 positional arguments but 7 were given" error.

Also fixes parameter order in `NationbuilderConnectionManager` (educator/lang were swapped vs base class).


Story details: https://app.shortcut.com/sefaria/story/39803