### PR TITLE
Update MODULE_SWITCHER_LEARN_MORE_PATH to support localization

### DIFF
--- a/sites/sefaria/site_settings.py
+++ b/sites/sefaria/site_settings.py
@@ -25,7 +25,10 @@ SITE_SETTINGS = {
 		"en": "/sheets/674324",
 		"he": "/sheets/674327"
 	},
-	"MODULE_SWITCHER_LEARN_MORE_PATH": "/sheets/689609",
+	"MODULE_SWITCHER_LEARN_MORE_PATH": { 
+		"en": "/sheets/689609", 
+		"he": "/sheets/689610" 
+	},
 	"HELP_CENTER_REDIRECTS": { 
 	"en": {
 		"215584": "https://help.sefaria.org/hc/en-us/sections/12756520483868-Text-Formatting-Accessibility",

--- a/static/js/ModuleSwitcherPopover.jsx
+++ b/static/js/ModuleSwitcherPopover.jsx
@@ -71,6 +71,8 @@ const ModuleSwitcherPopover = ({ children }) => {
     }
   };
 
+  const learnMorePath = Sefaria._v(Sefaria._siteSettings.MODULE_SWITCHER_LEARN_MORE_PATH);
+
   return (
     <Popover open={isOpen} handleOpen={handleOpenChange}>
       {/* Trigger: The element that the popover points to (module switcher button) */}
@@ -94,8 +96,7 @@ const ModuleSwitcherPopover = ({ children }) => {
             {/* External link to learn more */}
             <Button
               className="learn-more accessible-touch-target"
-              href={Sefaria.util.fullURL(Sefaria._siteSettings?.MODULE_SWITCHER_LEARN_MORE_PATH, Sefaria.VOICES_MODULE)}
-              target="_blank"
+              href={learnMorePath}
               targetModule={Sefaria.VOICES_MODULE}
             >
               <InterfaceText context="ModuleSwitcherPopover">{STRINGS.LEARN_MORE}</InterfaceText>


### PR DESCRIPTION
## Description
Add Hebrew support for the module switcher "Learn More" link and align navigation behavior with other Voices links.

## Code Changes
- **sites/sefaria/site_settings.py**
  - Convert `MODULE_SWITCHER_LEARN_MORE_PATH` from a string to a bilingual object (`en`/`he`), matching `WHAT_ARE_VOICES_PATHS`

- **static/js/ModuleSwitcherPopover.jsx**
  - Add `learnMorePath` using `Sefaria._v()` for localization
  - Replace `Sefaria.util.fullURL()` with the localized path variable
  - Remove `target="_blank"` to navigate in the same tab
  - Keep `targetModule={Sefaria.VOICES_MODULE}` for module context

## Notes
- Aligns with the bilingual pattern used in `NavSidebar.jsx` for `WHAT_ARE_VOICES_PATHS`
- Changes navigation from new tab to same tab for consistency