### PR TITLE
Fix: 403 CSRF error on newsletter signup forms

### DIFF
--- a/reader/views.py
+++ b/reader/views.py
@@ -931,6 +931,7 @@ def search(request):
         "noindex": True
     })
 
+@ensure_csrf_cookie
 def public_collections(request):
     props = base_props(request)
     props.update({
@@ -977,6 +978,7 @@ def sheets_redirect_to_getstarted(request):
     return redirect("/getstarted/", permanent=True)
 
 
+@ensure_csrf_cookie
 @sanitize_get_params
 def collection_page(request, slug):
     """
@@ -3192,6 +3194,7 @@ def texts_history_api(request, tref, lang=None, version=None):
     return jsonResponse(summary, callback=request.GET.get("callback", None))
 
 
+@ensure_csrf_cookie
 @sanitize_get_params
 def topics_page(request):
     """
@@ -3211,6 +3214,7 @@ def topics_page(request):
 def topic_page_b(request, slug):
     return topic_page(request, slug, test_version="b")
 
+@ensure_csrf_cookie
 @sanitize_get_params
 def topic_page(request, slug, test_version=None):
     """

--- a/sourcesheets/views.py
+++ b/sourcesheets/views.py
@@ -64,6 +64,8 @@ def annotate_user_links(sources):
 
 from django.utils.translation import ugettext as _
 from reader.views import menu_page
+
+@ensure_csrf_cookie
 def sheets_home_page(request):
     title = get_page_title("", module=request.active_module, page_type=PageTypes.HOME)
     desc  = _("Mix and match sources from Sefaria's library of Jewish texts, and add your comments, images and videos.")


### PR DESCRIPTION
## Summary
Add `@ensure_csrf_cookie` decorator to 5 entry point views that have newsletter signup forms, fixes 403 CSRF error when users land directly on Voices Collections or Library Topics pages