### PR TITLE
Feature/sc 39874/fix mongo production sync

### DIFF
--- a/helm-chart/sefaria/templates/cronjob/sync-mongo-production-data.yaml
+++ b/helm-chart/sefaria/templates/cronjob/sync-mongo-production-data.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     {{- include "sefaria.labels" . | nindent 4 }}
 spec:
-  schedule: "30 12 * * *"  # 12:30 PM daily (temporary for testing)
+  schedule: "0 2 * * 0"  # Every week on Sunday at 2 AM
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:


### PR DESCRIPTION
## Description
Adds pod eviction protection to the MongoDB sync cronjob to prevent Cluster Autoscaler from evicting pods during job execution.

## Code Changes

### `helm-chart/sefaria/templates/cronjob/sync-mongo-production-data.yaml`
- **Added** `cluster-autoscaler.kubernetes.io/safe-to-evict: "false"` annotation to the pod template metadata
- Annotation is placed under `spec.jobTemplate.spec.template.metadata.annotations` (not on the CronJob's own metadata)
- Ensures pods created by this CronJob will not be evicted by Cluster Autoscaler while the MongoDB restore operation is running

## Notes
- The annotation prevents Cluster Autoscaler from evicting pods during long-running MongoDB restore operations, ensuring jobs complete successfully
- The annotation is correctly placed on the Pod template (not the CronJob metadata), so it applies to all pods created by this CronJob
- This is particularly important for restore operations that may take significant time to complete