### PR TITLE
feat: add GitHub Actions workflow for modularization main branch

### DIFF
--- a/.github/workflows/modularization-main.yaml
+++ b/.github/workflows/modularization-main.yaml
@@ -1,0 +1,25 @@
+name: Modularization Main
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+    branches:
+      - modularization-main
+
+jobs:
+  check-testing-status:
+    name: "Check Testing Status"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if merging is allowed
+        run: |
+          if [ "${{ vars.TESTING }}" != "true" ]; then
+            echo "::error::Merging is blocked - testing in progress. Set the TESTING variable to 'true' to allow merges."
+            exit 1
+          fi
+          echo "Merging is allowed - no testing in progress."
+


### PR DESCRIPTION
## Description
Adds a new GitHub Actions workflow to control merging to the `modularization-main` branch. The workflow checks a repository variable `TESTING` and blocks merges when testing is in progress, providing a simple gate mechanism for the modularization branch.

## Code Changes
**`.github/workflows/modularization-main.yaml`** (new file)
- Created new GitHub Actions workflow named "Modularization Main"
- Triggers on pull request events (`opened`, `reopened`, `synchronize`, `ready_for_review`) targeting the `modularization-main` branch
- Added `check-testing-status` job that:
  - Checks if repository variable `vars.TESTING` equals `true`
  - Fails with an error message if `TESTING` is not `true`, blocking the merge
  - Succeeds silently when merging is allowed

## Notes
- **Required Setup**: Before this workflow functions correctly, you must:
  1. Create a repository variable named `TESTING` with value `true` (Settings → Secrets and variables → Actions → Variables)
  2. Add `Check Testing Status` as a required status check in branch protection rules for `modularization-main`
- Set `TESTING` to `false` when you want to block all merges to `modularization-main` (e.g., during active testing)
- Set `TESTING` back to `true` to allow merges again