### PR TITLE
feat(remoteConfig): add client remote config logic

### DIFF
--- a/reader/views.py
+++ b/reader/views.py
@@ -35,7 +35,7 @@ from django.utils import timezone
 from django.utils.html import strip_tags
 from bson.objectid import ObjectId
 
-from remote_config.keys import ENABLE_WEBPAGES
+from remote_config.keys import CLIENT_REMOTE_CONFIG_JSON, ENABLE_WEBPAGES
 from remote_config import remoteConfigCache
 
 from sefaria.model import *
@@ -116,6 +116,7 @@ def render_template(request, template_name='base.html', app_props=None, template
     template_context = template_context if template_context else {}
     props = base_props(request)
     props.update(app_props)
+    props["remoteConfig"] = remoteConfigCache.get(CLIENT_REMOTE_CONFIG_JSON, {})
     propsJSON = json.dumps(props, ensure_ascii=False)
     template_context["propsJSON"] = propsJSON
     if app_props: # We are rendering the ReaderApp in Node, otherwise its jsut a Django template view with ReaderApp set to headerMode

--- a/remote_config/keys.py
+++ b/remote_config/keys.py
@@ -1,3 +1,4 @@
 CURRENT_LINKER_VERSION = "feature.linker.current_version"
 REF_CACHE_LIMIT_KEY = "feature.text.ref_cache_limit"
 ENABLE_WEBPAGES = "feature.webpages.enable"
+CLIENT_REMOTE_CONFIG_JSON = "feature.client.remote_config_json"

--- a/static/js/client.jsx
+++ b/static/js/client.jsx
@@ -17,9 +17,10 @@ $(function() {
         new Sentry.BrowserTracing(),
         new Sentry.Replay(),
       ],
-      tracesSampleRate: 0.0,
-      replaysSessionSampleRate: 0.01, // This sets the sample rate at 10%. You may want to change it to 100% while in development and then sample at a lower rate in production.
-      replaysOnErrorSampleRate: 0.01, // If you're not already sampling the entire session, change the sample rate to 100% when sampling sessions where errors occur.
+      tracesSampleRate: remoteConfig?.sentry?.tracesSampleRate || 0.0,
+      sampleRate: remoteConfig?.sentry?.sampleRate || 0.0,
+      replaysSessionSampleRate: remoteConfig?.sentry?.replaysSessionSampleRate || 0.0,
+      replaysOnErrorSampleRate: remoteConfig?.sentry?.replaysOnErrorSampleRate || 0.0,
     });
   }
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -252,6 +252,9 @@
         static_url:    {{ STATIC_PREFIX }},
       };
 
+      // Make remote config available globally
+      window.remoteConfig = DJANGO_VARS.props?.remoteConfig || {};
+
       {% if STRAPI_LOCATION and STRAPI_PORT %}
           var STRAPI_INSTANCE =  "{{ STRAPI_LOCATION }}:{{ STRAPI_PORT }}";
       {% else %}


### PR DESCRIPTION
This pull request introduces support for passing remote configuration values from the backend to the frontend, allowing client-side features to be dynamically controlled via remote config. The main focus is on making `remoteConfig` available globally and updating Sentry initialization to use values from this config.

Backend changes for remote config:

* Added a new key `CLIENT_REMOTE_CONFIG_JSON` to `remote_config/keys.py` for client-specific remote config data.
* Updated `reader/views.py` to fetch `CLIENT_REMOTE_CONFIG_JSON` from the cache and inject it into the React app props for use on the frontend. [[1]](diffhunk://#diff-26c40bdd3eeaef442340754126fdbcb1ed9e451eb3bb31c02cb78053f5702eaaL38-R38) [[2]](diffhunk://#diff-26c40bdd3eeaef442340754126fdbcb1ed9e451eb3bb31c02cb78053f5702eaaR119)

Frontend changes for remote config usage:

* Made `remoteConfig` available globally on `window` in the base template, so it can be accessed by client-side scripts.
* Updated Sentry initialization in `static/js/client.jsx` to pull sampling rates and other values from `remoteConfig`, allowing these settings to be controlled remotely.