### PR TITLE
Revert "fix: [sc-39906] Add csrfexmpt to all newsletter subscription apis"

### DIFF
--- a/sefaria/helper/crm/crm_connection_manager.py
+++ b/sefaria/helper/crm/crm_connection_manager.py
@@ -38,7 +38,7 @@ class CrmConnectionManager(object):
         """
         pass
 
-    def subscribe_to_lists(self, email, first_name=None, last_name=None, educator=False, lang="en", mailing_lists=None):
+    def subscribe_to_lists(self, email, first_name=None, last_name=None, educator=False, lang="en"):
         CrmConnectionManager.validate_email(email)
         CrmConnectionManager.validate_name(first_name)
         CrmConnectionManager.validate_name(last_name)

--- a/sefaria/helper/crm/dummy_crm.py
+++ b/sefaria/helper/crm/dummy_crm.py
@@ -21,8 +21,8 @@ class DummyConnectionManager(CrmConnectionManager):
     def change_user_email(self, uid, new_email):
         return True
 
-    def subscribe_to_lists(self, email, first_name=None, last_name=None, educator=False, lang="en", mailing_lists=None):
-        CrmConnectionManager.subscribe_to_lists(self, email, first_name, last_name, educator, lang, mailing_lists)
+    def subscribe_to_lists(self, email, first_name=None, last_name=None, educator=False, lang="en"):
+        CrmConnectionManager.subscribe_to_lists(self, email, first_name, last_name, educator, lang)
         return True
 
     def find_crm_id(self, email=None):

--- a/sefaria/helper/crm/nationbuilder.py
+++ b/sefaria/helper/crm/nationbuilder.py
@@ -70,8 +70,8 @@ class NationbuilderConnectionManager(CrmConnectionManager):
 
         return True
 
-    def subscribe_to_lists(self, email, first_name=None, last_name=None, educator=False, lang="en", mailing_lists=None):
-        CrmConnectionManager.subscribe_to_lists(self, email, first_name, last_name, educator, lang, mailing_lists)
+    def subscribe_to_lists(self, email, first_name=None, last_name=None, lang="en", educator=False):
+        CrmConnectionManager.subscribe_to_lists(self,email, first_name, last_name, lang, educator)
         return self.add_user_to_crm(email, first_name, last_name, lang, educator, signup=False)
 
     def nationbuilder_get_all(self, endpoint_func, args=[]):

--- a/sefaria/views.py
+++ b/sefaria/views.py
@@ -181,7 +181,6 @@ def accounts(request):
     })
 
 
-@csrf_exempt
 def generic_subscribe_to_newsletter_api(request, org, email):
     """
     Generic view for subscribing a user to a newsletter
@@ -209,7 +208,6 @@ def generic_subscribe_to_newsletter_api(request, org, email):
         return jsonResponse({"error": _("Sorry, there was an error.")})
 
 
-@csrf_exempt
 def subscribe_sefaria_newsletter_view(request, email):
     return generic_subscribe_to_newsletter_api(request, 'sefaria', email)
 


### PR DESCRIPTION
The problem solved itself on prod

This reverts PR #2973 (merge commit 1e47523e9).

Original PR: https://github.com/Sefaria/Sefaria-Project/pull/2973

## Summary
Reverting the changes that:
- Added `@csrf_exempt` to newsletter subscription endpoints
- Fixed expected params in `DummyConnectionManager` and `NationbuilderConnectionManager`