### PR TITLE
chore: change modalContent to modalContentKind

### DIFF
--- a/static/js/Misc.jsx
+++ b/static/js/Misc.jsx
@@ -2001,7 +2001,7 @@ class SignUpModal extends Component {
 SignUpModal.propTypes = {
   show: PropTypes.bool,
   onClose: PropTypes.func.isRequired,
-  modalContent: PropTypes.object.isRequired,
+  modalContentKind: PropTypes.symbol,
 };
 
   /**


### PR DESCRIPTION
The prop passed is not what is required by the component SignUpModal.
It also doesn't need to be isRequired as the component explicitly handles an undefined value for modalContentKind
