### PR TITLE
implement Elasticsearch reindexing cronjob

### DIFF
--- a/sefaria/search.py
+++ b/sefaria/search.py
@@ -913,12 +913,12 @@ def index_sheets_by_timestamp(timestamp):
     failed = []
     total = len(ids)
 
-    for i, id in enumerate(ids):
-        did_succeed = index_sheet(curr_index_name, id)
+    for i, _id in enumerate(ids):
+        did_succeed = index_sheet(curr_index_name, _id)
         if did_succeed:
-            succeeded.append(id)
+            succeeded.append(_id)
         else:
-            failed.append(id)
+            failed.append(_id)
         
     # Only log if there are failures
     if len(failed) > 0:
@@ -983,7 +983,7 @@ def clear_index(index_name):
         else:
             logger.debug(f"Index does not exist, nothing to delete - index_name: {index_name}")
     except NotFoundError:
-        # Index doesn't exist (race condition or double-check), which is fine
+        # Index doesn't exist - handle race condition where index is deleted between exists() check and delete() call
         logger.debug(f"Index not found when attempting to delete - index_name: {index_name}")
     except Exception as e:
         logger.error(f"Error deleting Elasticsearch index - index_name: {index_name} - error: {str(e)}")


### PR DESCRIPTION
## Description
Implement a centralized logging system for Elasticsearch reindexing that toggles between `INFO` and `DEBUG` levels via a CLI flag, and refactor the reindexing cronjob for better reliability and visibility.

## Code Changes

### `Sefaria-Project/sefaria/search.py`
* Added `setup_logging(debug=False)` utility to centralize `logging.basicConfig` configuration.
* Replaced `structlog` and `print` statements with standard `logging` calls.
* Moved verbose operational logs (index creation, mapping application, version priority mapping) to `DEBUG` level.
* Added detailed failure tracking to `TextIndexer` class for improved reporting.
* Improved error handling and null-safety during sheet and text indexing.

### `Sefaria-Project/scripts/scheduled/reindex_elasticsearch_cronjob.py`
* Added `argparse` support with a `-d/--debug` flag to trigger detailed logging.
* Implemented `ReindexingResult` class to track and report detailed successes, failures, and warnings.
* Refactored main execution flow into discrete steps (PageSheetRank, Full Index, Sheet Catch-up) with individual error handling.
* Moved non-essential progress logs to `DEBUG` level, keeping `INFO` output clean and milestone-focused.
* Added pre-flight checks for Elasticsearch connectivity and index states.

## Notes
* The new logging system uses `logging.basicConfig(force=True)` to ensure configuration consistency across the project when `search.py` is imported.
* Operational output is significantly quieter by default, focusing only on major milestones and summary reports.