### PR TITLE
chore: add ensure_csrf_cookie to texts_list view

### DIFF
--- a/reader/views.py
+++ b/reader/views.py
@@ -1128,6 +1128,7 @@ def _get_user_calendar_params(request):
     return {"diaspora": request.diaspora, "custom": custom}
 
 
+@ensure_csrf_cookie
 def texts_list(request):
     title = get_page_title("", module=request.active_module, page_type=PageTypes.HOME)
     desc  = _("The largest free library of Jewish texts available to read online in Hebrew and English including Torah, Tanakh, Talmud, Mishnah, Midrash, commentaries and more.")


### PR DESCRIPTION
## Description
Add `ensure_csrf_cookie` decorator to `texts_list` view to head off csrftoken errors

## Code Changes
Added the decorator to `texts_list` view in `reader/views.py`

## Notes
`texts_list` view is the view called upon initial browse to the library module