### PR TITLE
fix(sheets): Slugless topics prevent sheet loading

### DIFF
--- a/sefaria/sheets.py
+++ b/sefaria/sheets.py
@@ -1022,13 +1022,21 @@ def add_langs_to_topics(topic_list: list, use_as_typed=True, backwards_compat_la
 	topic_map = library.get_topic_mapping()
 	if len(topic_list) > 0:
 		for topic in topic_list:
-			# DEBUG: Check if topic has required 'slug' field
+			# TEMPORARY FIX (2026-01-13): Check if topic has required 'slug' field
+			# WARNING: This is a workaround to prevent KeyError crashes when topics are saved without slugs.
+			# Root cause: Frontend allows users to create custom topics via ReactTags (allowNew=true) which
+			# creates tags without slugs. These bypass update_sheet_topics() when saving via POST /api/sheets/.
+			# TODO: Proper fix needed:
+			#   1. Fix frontend to filter out tags without slugs before sending, OR
+			#   2. Always run topics through update_sheet_topics() which adds slugs, OR
+			#   3. Add migration to fix existing sheets with slugless topics
+			# See: topic_slug_issue_analysis.md for full analysis
 			if 'slug' not in topic:
 				import logging
 				logger = logging.getLogger(__name__)
-				logger.error(f"DEBUG: Topic missing 'slug' field. Topic data: {topic}")
-				print(f"DEBUG: Topic missing 'slug' field. Topic data: {topic}")
-				# Skip this malformed topic
+				logger.error(f"Topic missing 'slug' field. Sheet topic data: {topic}")
+				print(f"Topic missing 'slug' field. Sheet topic data: {topic}")
+				# Skip this malformed topic to prevent crash
 				continue
 			# Fall back on `asTyped` if no data is in mapping yet. If neither `asTyped` nor mapping data is availble fail safe by reconstructing a title from a slug (HACK currently affecting trending topics if a new topic isn't in cache yet)
 			default_title = topic['asTyped'] if use_as_typed else topic['slug'].replace("-", " ").title()


### PR DESCRIPTION
This pull request introduces a temporary fix to prevent backend crashes caused by malformed topic data when saving sheets. Specifically, it adds a safeguard to skip any topic objects missing the required `slug` field, which can occur due to frontend behavior. The change includes logging for easier debugging and highlights the need for a more permanent solution.

**Bug prevention and diagnostics:**

* Added a check in `add_langs_to_topics` (in `sefaria/sheets.py`) to skip topics missing the `slug` field, preventing KeyError crashes when saving sheets with custom topics created via the frontend. This includes error logging and a printed warning for easier diagnosis.

**Documentation and future work:**

* Included detailed comments outlining the root cause, temporary nature of the fix, and suggestions for a proper long-term solution, with reference to an external analysis document for further context.## Description
_A brief description of the PR_

## Code Changes
_The following changes were made to the files below_

## Notes
_Any additional notes go here_