### PR TITLE
fix: Calendar topics landing page in library text overlap

### DIFF
--- a/static/js/TopicLandingPage/TopicLandingCalendar.jsx
+++ b/static/js/TopicLandingPage/TopicLandingCalendar.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {InterfaceText} from "../Misc";
 import {Card} from "../common/Card";
-import { TopicLandingSeasonal } from './TopicLandingSeasonal';
 
 
 export const TopicLandingCalendar = ({ header, title, description, link, children }) => {


### PR DESCRIPTION
## Description
This fixes text overlap in the library topics homepage calendar via CSS. 

## Code Changes
1. `static/css/s2.css` - Removed the absolute positioning of the `seasonal-bottom-section` div

Screenshot of fix:

<img width="366" height="457" alt="Screenshot 2026-01-14 at 10 22 54" src="https://github.com/user-attachments/assets/73dd4795-a440-428d-96db-2711ab1ee9c2" />

