### PR TITLE
feat(tracing): put sentry into server

### DIFF
--- a/helm-chart/sefaria/templates/configmap/local-settings-file.yaml
+++ b/helm-chart/sefaria/templates/configmap/local-settings-file.yaml
@@ -267,6 +267,11 @@ data:
     SENTRY_CODE_VERSION = os.getenv("SENTRY_CODE_VERSION", "unknown")
     SENTRY_ENVIRONMENT = os.getenv("SENTRY_ENVIRONMENT", "unknown")
 
+    if SENTRY_DSN:
+        from sefaria.settings_utils import init_sentry
+        
+        init_sentry(SENTRY_DSN, SENTRY_CODE_VERSION, SENTRY_ENVIRONMENT)
+
     # TODO: Make the logging format more configurable based on specific objects being defined.
     # LOGGING = {
     #     'version': 1,

--- a/requirements.txt
+++ b/requirements.txt
@@ -63,7 +63,7 @@ regex==2020.10.23
 requests
 roman==3.3
 selenium==3.141.0
-# sentry-sdk==1.26.0
+sentry-sdk==1.26.0
 tqdm==4.51.0
 ua-parser==0.10.0
 undecorated==0.3.0

--- a/sefaria/settings_utils.py
+++ b/sefaria/settings_utils.py
@@ -1,35 +1,35 @@
-# from http.client import HTTPException
-# import sentry_sdk
-# from sentry_sdk.integrations.django import DjangoIntegration
-# import os
+from http.client import HTTPException
+import sentry_sdk
+from sentry_sdk.integrations.django import DjangoIntegration
+import os
 
-# def init_sentry(sentry_dsn, sentry_code_version, sentry_environment):
+def init_sentry(sentry_dsn, sentry_code_version, sentry_environment):
 
-#     def before_send(event, hint):
-#         # Check if the event has an exception
-#         if 'exc_info' in hint:
-#             exc_type, exc_value, tb = hint['exc_info']
-#             # If it is not an HTTP 500 error, drop the event
-#             if isinstance(exc_value, HTTPException) and exc_value.code != 500:
-#                 return None
+    def before_send(event, hint):
+        # Check if the event has an exception
+        if 'exc_info' in hint:
+            exc_type, exc_value, tb = hint['exc_info']
+            # If it is not an HTTP 500 error, drop the event
+            if isinstance(exc_value, HTTPException) and exc_value.code != 500:
+                return None
 
-#         # If there is no exception, drop the event
-#         if 'exception' not in event:
-#             return None
+        # If there is no exception, drop the event
+        if 'exception' not in event:
+            return None
 
-#         return event
+        return event
 
-#     sentry_sdk.init(
-#         dsn=sentry_dsn,
-#         environment=sentry_environment,
-#         integrations=[DjangoIntegration()],
-#         traces_sample_rate=0.01,
-#         profiles_sample_rate=0.01,
-#         send_default_pii=False,
-#         before_send=before_send,
-#         max_breadcrumbs=30,
-#         release=sentry_code_version,
-#         _experiments={
-#             "continuous_profiling_auto_start": True,
-#         },
-#     )
+    sentry_sdk.init(
+        dsn=sentry_dsn,
+        environment=sentry_environment,
+        integrations=[DjangoIntegration()],
+        traces_sample_rate=0.01,
+        profiles_sample_rate=0.01,
+        send_default_pii=False,
+        before_send=before_send,
+        max_breadcrumbs=30,
+        release=sentry_code_version,
+        _experiments={
+            "continuous_profiling_auto_start": True,
+        },
+    )


### PR DESCRIPTION
This pull request introduces Sentry error tracking to the project by implementing a production-ready Sentry initialization function and integrating it into the configuration. The main focus is on enabling Sentry reporting only for HTTP 500 errors and filtering out less critical exceptions.

**Sentry integration and error filtering:**

* Added a new `init_sentry` function in `sefaria/settings_utils.py` that initializes Sentry with Django integration, custom sampling rates, and a `before_send` filter to only report HTTP 500 errors and drop other exceptions.
* Updated the configuration in `helm-chart/sefaria/templates/configmap/local-settings-file.yaml` to call `init_sentry` with the appropriate environment variables if `SENTRY_DSN` is present.