### PR TITLE
fix-add-all-unknown-cerberus

### DIFF
--- a/sefaria/model/abstract.py
+++ b/sefaria/model/abstract.py
@@ -226,12 +226,12 @@ class AbstractMongoRecord(object):
         """
         is_root = schema is None
         schema = schema or self.attr_schemas
-        if not is_root and schema['type'] == 'dict':
+        if not is_root and schema.get('type') == 'dict':
             schema['allow_unknown'] = schema.get('allow_unknown', False)
         for key in schema:
             if isinstance(schema[key], dict):
                 if 'schema' in schema[key]:
-                    self.__set_allow_unknown_false(schema[key]['schema'])
+                    self.__set_allow_unknown_false(schema[key])
  
     def _validate(self):
         """


### PR DESCRIPTION
## Description
We walk the Cerberus schema to disallow unknown fields. We can't set the global disallow unknown fields because we allow unknown fields at the root (these are fields that haven't been specified in Cerberus). This PR fixes how we walk the schema.

## Code Changes
_The following changes were made to the files below_

## Notes
_Any additional notes go here_