### PR TITLE
Strip links from topic descriptions on voices

### DIFF
--- a/static/js/TopicPage.jsx
+++ b/static/js/TopicPage.jsx
@@ -392,7 +392,7 @@ const TopicHeader = ({ topic, topicData, topicTitle, multiPanel, isCat, setNavTo
   const tpTopImg = !multiPanel && topicImage ? <TopicImage photoLink={topicImage.image_uri} caption={topicImage.image_caption}/> : null;
   const actionButtons = getTopicHeaderAdminActionButtons(topic, topicData.refs?.about?.refs);
   const hasAiContentLinks = getLinksWithAiContent(topicData.refs?.about?.refs).length != 0;
-  const disallowedMarkdownElements = (Sefaria.activeModule === Sefaria.LIBRARY_MODULE) ? ['p'] : ['p', 'a'];
+  const disallowedMarkdownElements = (Sefaria.activeModule === Sefaria.VOICES_MODULE) ? ['p', 'a'] : ['p'];
 
 return (
     <div>


### PR DESCRIPTION
## Description
Our links are stored in mongo with library subdomain, so they links to library also in voices.
For new the decision is to strip them in voices, so I did it in the simplest way on the client side.