### PR TITLE
Fix delete note from notes page

### DIFF
--- a/static/js/NoteListing.jsx
+++ b/static/js/NoteListing.jsx
@@ -62,11 +62,11 @@ NoteListing.propTypes = {
   onDeleteNote: PropTypes.func,
 };
 
-const NotesList = ({notes}) => {  
+const NotesList = ({notes, onDeleteNote}) => {
   return (
-    notes && notes.length ? 
+    notes && notes.length ?
       notes.map((item, i) => (
-        <NoteListing data={item} key={i} />
+        <NoteListing data={item} key={i} onDeleteNote={() => onDeleteNote(item._id)} />
       ))
     : <LoadingMessage message="You haven't written any notes yet." heMessage="טרם הוספת רשומות משלך" />)};
 

--- a/static/js/UserHistoryPanel.jsx
+++ b/static/js/UserHistoryPanel.jsx
@@ -88,7 +88,7 @@ const UserHistoryPanel = ({menuOpen, toggleLanguage, openDisplaySettings, openNa
               <LanguageToggleButton toggleLanguage={toggleLanguage} />}
             </div>
             { menuOpen === 'notes' ?
-                  <NotesList notes={notes} />
+                  <NotesList notes={notes} onDeleteNote={(noteId) => setNotes(notes.filter(n => n._id !== noteId))} />
                  :
                   <UserHistoryList
                     store={store}


### PR DESCRIPTION
## Code Changes
1. In `UserHistoryPanel` avoid removing node's `_id` for being able to delete it (deletion is done by id).
2. Pass `onDeleteNote` from `UserHistoryPanel` via `NotesList` to `NoteListing` for triggering `setNotes` on deletion.