### PR TITLE
chore(client): replace jQuery DOM ready with vanilla JavaScript

### DIFF
--- a/static/js/client.jsx
+++ b/static/js/client.jsx
@@ -1,6 +1,5 @@
 import "core-js/stable";
 import "regenerator-runtime/runtime";
-import $ from './sefaria/sefariaJquery';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import DjangoCSRF from './lib/django-csrf';
@@ -8,7 +7,7 @@ const SefariaReact = require('./ReaderApp');
 import * as Sentry from "@sentry/react";
 
 
-$(function() {
+document.addEventListener('DOMContentLoaded', () => {
   // Initialize Sentry, sentryDSN is defined in base.html
   if (sentryDSN) {
     Sentry.init({
@@ -42,7 +41,7 @@ $(function() {
   } else {
     // Rendering the Header only on top of a static page
     let staticProps = {
-      multiPanel: $(window).width() > 600,
+      multiPanel: window.innerWidth > 600,
       headerMode: true,
     };
 
@@ -54,7 +53,7 @@ $(function() {
 
   // Handle template-specific component rendering (for pages that don't use ReaderApp)
   if (DJANGO_VARS.containerId && DJANGO_VARS.reactComponentName) {
-    // Render a specific component to a container    
+    // Render a specific component to a container
     container = document.getElementById(DJANGO_VARS.containerId);
     component = React.createElement(SefariaReact[DJANGO_VARS.reactComponentName], DJANGO_VARS.props);
     renderFunc(component, container);


### PR DESCRIPTION
## Summary
- Removed jQuery dependency from `client.jsx`
- Replaced jQuery DOM ready callback `$(function() {...})` with `document.addEventListener('DOMContentLoaded', ...)`
- Replaced `$(window).width()` with `window.innerWidth`

## Context
Resolves technical cleanup issue SC-998: "Why is client.jsx main method being called through jQuery?"

The entire client.jsx was wrapped in a jQuery DOM ready callback, which was unnecessary overhead. This change modernizes the code to use vanilla JavaScript equivalents.

## Test plan
- [x] Build completed successfully with `npm run build`
- [ ] Manual testing: verify the app loads correctly in browser
- [ ] Manual testing: verify static pages render header correctly (uses window.innerWidth logic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)