### PR TITLE
feat(dev): add file-based caching for library objects during development

### DIFF
--- a/reader/management/commands/clear_dev_cache.py
+++ b/reader/management/commands/clear_dev_cache.py
@@ -1,0 +1,55 @@
+"""
+Management command to clear the development file cache.
+
+Usage:
+    python manage.py clear_dev_cache           # Clear all cache entries
+    python manage.py clear_dev_cache --list    # List all cache entries
+    python manage.py clear_dev_cache --name full_auto_completer  # Clear specific entry
+"""
+from django.core.management.base import BaseCommand
+from sefaria.system.cache import clear_dev_file_cache, list_dev_file_cache, is_dev_file_cache_enabled
+
+
+class Command(BaseCommand):
+    help = 'Clear the development file cache used for persisting library objects across server reloads'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--name',
+            type=str,
+            help='Clear a specific cache entry by name (e.g., full_auto_completer, linker_he)',
+        )
+        parser.add_argument(
+            '--list',
+            action='store_true',
+            help='List all cache entries instead of clearing',
+        )
+
+    def handle(self, *args, **options):
+        if not is_dev_file_cache_enabled():
+            self.stdout.write(
+                self.style.WARNING(
+                    'Dev file cache is not enabled. Set USE_DEV_FILE_CACHE = True in local_settings.py'
+                )
+            )
+
+        if options['list']:
+            entries = list_dev_file_cache()
+            if entries:
+                self.stdout.write('Dev file cache entries:')
+                for entry in entries:
+                    self.stdout.write(f'  - {entry}')
+            else:
+                self.stdout.write('No cache entries found.')
+            return
+
+        name = options.get('name')
+        deleted = clear_dev_file_cache(name)
+
+        if name:
+            if deleted:
+                self.stdout.write(self.style.SUCCESS(f'Cleared cache entry: {name}'))
+            else:
+                self.stdout.write(self.style.WARNING(f'Cache entry not found: {name}'))
+        else:
+            self.stdout.write(self.style.SUCCESS(f'Cleared {deleted} cache entries'))

--- a/sefaria/local_settings_example.py
+++ b/sefaria/local_settings_example.py
@@ -220,6 +220,13 @@ DISABLE_AUTOCOMPLETER = False
 # Turns on loading of machine learning models to run linker
 ENABLE_LINKER = False
 
+# File-based caching for library objects (AutoCompleter, Linker) during development.
+# When enabled, these expensive objects are serialized to disk after first build
+# and loaded from disk on subsequent server reloads, significantly speeding up
+# development iteration. Should NOT be used in production.
+USE_DEV_FILE_CACHE = False
+DEV_FILE_CACHE_DIR = "/tmp/sefaria_dev_cache"
+
 # Caching with Cloudflare
 CLOUDFLARE_ZONE = ""
 CLOUDFLARE_EMAIL = ""

--- a/sefaria/settings.py
+++ b/sefaria/settings.py
@@ -310,6 +310,11 @@ CACHES = {
 }
 
 
+# Default values for settings that may be overridden in local_settings.
+# These ensure the application works even if local_settings doesn't define them.
+USE_DEV_FILE_CACHE = False
+DEV_FILE_CACHE_DIR = "/tmp/sefaria_dev_cache"
+
 # Grab environment specific settings from a file which
 # is left out of the repo.
 try:


### PR DESCRIPTION
Add optional file-based caching for expensive library objects (AutoCompleter, Linker, topic pools) that persist across Django server reloads during development. This significantly speeds up the development iteration cycle by avoiding re-initialization of these objects on every code change.

New settings:
- USE_DEV_FILE_CACHE: Enable/disable the feature (default: False)
- DEV_FILE_CACHE_DIR: Cache directory (default: /tmp/sefaria_dev_cache)

Modified methods to use file cache:
- Library.build_full_auto_completer()
- Library.build_lexicon_auto_completers()
- Library.build_cross_lexicon_auto_completer()
- Library.build_linker()
- TopicManager.build_slug_to_pools_cache()

Added management command:
- python manage.py clear_dev_cache

## Description
_A brief description of the PR_

## Code Changes
_The following changes were made to the files below_

## Notes
_Any additional notes go here_