### PR TITLE
Add missing routes for Strapi banner/modal endpoints back

### DIFF
--- a/sefaria/urls_shared.py
+++ b/sefaria/urls_shared.py
@@ -205,6 +205,9 @@ shared_patterns = [
     url(r'^api/subscribe/(?P<email>.+)$', sefaria_views.subscribe_sefaria_newsletter_view),
     url(r'^api/newsletter_mailing_lists/?$', sefaria_views.get_available_newsletter_mailing_lists),
 
+    url(r'^api/strapi/graphql-cache$', sefaria_views.strapi_graphql_cache),
+    url(r'^api/strapi/cache-invalidate$', sefaria_views.strapi_cache_invalidate),
+
     url(r'^api/stats/library-stats', sefaria_views.library_stats),
     url(r'^api/stats/core-link-stats', sefaria_views.core_link_stats),
 


### PR DESCRIPTION
## Description
Adds back the routes for Strapi banner/modals that were defined here: https://github.com/Sefaria/Sefaria-Project/pull/2585/changes#diff-2ec2353562d79cc6a3e9b4d4f3e23d7384da02e486f3c3d2cc391e6dff3d4194R419

## Code Changes
The routes were added to the new file for shared routes between modules `urls_shared.py`