### PR TITLE
chore: upgrade regex

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -60,7 +60,7 @@ python-bidi
 pytz
 pyyaml==6.0.1
 rauth==0.7.3
-regex==2025.11.3
+regex==2026.1.15
 requests
 roman==3.3
 selenium==3.141.0


### PR DESCRIPTION
## Description
Python regex library is 5 years out of date.   I've been updating manually to get rid of compatibility warnings.  Not aware of any breaking changes. 

## Code Changes
_The following changes were made to the files below_

## Notes
_Any additional notes go here_