### PR TITLE
chore: enclose the STATIC_PREFIX variable in a string

### DIFF
--- a/templates/compare.html
+++ b/templates/compare.html
@@ -112,7 +112,7 @@
     {% autoescape off %}
       var JSON_PROPS = {{ JSON_PROPS }}
       var DJANGO_VARS = {
-            static_url: {{ STATIC_PREFIX }},
+            static_url: "{{ STATIC_PREFIX }}",
             props:    {{ propsJSON|default:"null" }},
 
         };

--- a/templates/edit_text.html
+++ b/templates/edit_text.html
@@ -213,7 +213,7 @@
     contentLang: "{{ contentLang }}",
     interfaceLang: "{{ interfaceLang }}",
     inReaderApp: false,
-    static_url: {{ STATIC_PREFIX }}
+    static_url: "{{ STATIC_PREFIX }}"
   };
   {% endautoescape %}
 </script>


### PR DESCRIPTION
## Description
Ensure that the places where `STATIC_PREFIX` is injected in Django templates as a Javascript string are encapsulated as strings.

## Notes
Should fix the error with `edit_text.html` in #3041 