### PR TITLE
Add default values to OpenAPI spec

### DIFF
--- a/docs/openAPI.json
+++ b/docs/openAPI.json
@@ -977,7 +977,8 @@
           "name": "tref",
           "description": "A Sefaria-specific reference, `Ref`. This should be a segment `Ref` (the most specific reference possible), or bottom level section `Ref` (i.e.  a section of text one level up. A section is an array of segments). If a `Ref` which is not a segment or bottom level section is passed, the response will be to the first bottom level section `Ref` (e.g. `Genesis` will resolve to the bottom level section `Ref` of `Genesis 1`)",
           "schema": {
-            "type": "string"
+            "type": "string",
+            "default": "Esther 1.1"
           },
           "in": "path",
           "required": true
@@ -1214,7 +1215,10 @@
             "name": "tref",
             "description": "A valid textual `Ref` to a Sefaria text.",
             "schema": {
-              "$ref": "#/components/schemas/ref"
+              "allOf": [
+                { "$ref": "#/components/schemas/ref" }
+              ],
+              "default": "Kohelet 5:10"
             },
             "in": "path",
             "required": true
@@ -1327,7 +1331,10 @@
           "name": "tref",
           "description": "A valid textual `Ref` to a Sefaria text.",
           "schema": {
-            "$ref": "#/components/schemas/ref"
+            "allOf": [
+              { "$ref": "#/components/schemas/ref" }
+            ],
+            "default": "Kohelet 5:10"
           },
           "in": "path",
           "required": true
@@ -1485,7 +1492,8 @@
           "name": "index",
           "description": "A valid Sefaria Index",
           "schema": {
-            "type": "string"
+            "type": "string",
+            "default": "Mishnah Berakhot"
           },
           "in": "path",
           "required": true
@@ -1608,7 +1616,8 @@
           "name": "lang",
           "description": "An ISO 639-1 language code.",
           "schema": {
-            "type": "string"
+            "type": "string",
+            "default": "en"
           },
           "in": "path",
           "required": true
@@ -1635,7 +1644,8 @@
             "name": "tref",
             "description": "The `tref` parameter must a valid Sefaria ref to a text.",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "default": "Numbers 12.1"
             },
             "in": "path",
             "required": true
@@ -1714,7 +1724,8 @@
           "name": "tref",
           "description": "A valid Sefaria ref",
           "schema": {
-            "type": "string"
+            "type": "string",
+            "default": "Numbers.17.2"
           },
           "in": "path",
           "required": true
@@ -2448,7 +2459,8 @@
           "name": "index_title",
           "description": "A title of a valid Sefaria `Index`. For a complete list of works in the [Sefaria](sefaria.org) library, as well as their index titles, query the [api/index](https://www.sefaria.org/api/index/) endpoint. ",
           "schema": {
-            "type": "string"
+            "type": "string",
+            "default": "Genesis"
           },
           "in": "path",
           "required": true
@@ -2930,7 +2942,8 @@
               "name": "title",
               "description": "The title of a valid Sefaria `Index`, or the path of a valid Sefaria category. ",
               "schema": {
-                  "type": "string"
+                  "type": "string",
+                  "default": "Jonah"
               },
               "in": "path",
               "required": true
@@ -3502,7 +3515,10 @@
           "name": "tref",
           "description": "A valid Sefaria textual `Ref`. ",
           "schema": {
-            "$ref": "#/components/schemas/ref"
+            "allOf": [
+              { "$ref": "#/components/schemas/ref" }
+            ],
+            "default": "Deuteronomy 1.1"
           },
           "in": "path",
           "required": true
@@ -3569,7 +3585,10 @@
           "name": "tref",
           "description": "A valid Sefaria textual `Ref`.",
           "schema": {
-            "$ref": "#/components/schemas/ref"
+            "allOf": [
+              { "$ref": "#/components/schemas/ref" }
+            ],
+            "default": "Obadiah 1.2"
           },
           "in": "path",
           "required": true
@@ -3656,7 +3675,10 @@
           "name": "tref",
           "description": "A valid Sefaria textual `Ref`",
           "schema": {
-            "$ref": "#/components/schemas/ref"
+            "allOf": [
+              { "$ref": "#/components/schemas/ref" }
+            ],
+            "default": "Judges 12"
           },
           "in": "path",
           "required": true
@@ -3817,7 +3839,8 @@
                 "Matot-Masei",
                 "Nitzavim-Vayeilech"
               ],
-              "type": "string"
+              "type": "string",
+              "default": "Bereshit"
             },
             "in": "path",
             "required": true
@@ -3857,7 +3880,8 @@
           "name": "parasha",
           "description": "The _Parasha_ for which you'd like to generate relevant metadata, most notably the schedule of when it is next read. \n\n*Note*: The _Parasha_ must be in English written with a capitalized first letter, so `Noach` is valid, but `noach` will return an empty array. Any parshiyot with special characters (i.e. apostrophes, or spaces) should have those special characters percent url encoded. ",
           "schema": {
-            "type": "string"
+            "type": "string",
+            "default": "Devarim"
           },
           "in": "path",
           "required": true
@@ -3948,7 +3972,8 @@
           "name": "word",
           "description": "The word or phrase to search for in the lexicons.",
           "schema": {
-            "type": "string"
+            "type": "string",
+            "default": "תורה"
           },
           "in": "path",
           "required": true
@@ -3995,7 +4020,8 @@
             "name": "lexicon",
             "description": "An optional text string matching the name of one of Sefaria's lexicons to limit the search.",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "default": "Klein Dictionary"
             },
             "in": "path",
             "required": true
@@ -4082,7 +4108,8 @@
           "name": "word",
           "description": "An arbitrary text string to match against Sefaria's lexicon collections.",
           "schema": {
-            "type": "string"
+            "type": "string",
+            "default": "תורה"
           },
           "in": "path",
           "required": true
@@ -4261,7 +4288,8 @@
           "name": "topic_slug",
           "description": "The slug of the desired topic",
           "schema": {
-            "type": "string"
+            "type": "string",
+            "default": "moses"
           },
           "in": "path",
           "required": true
@@ -4449,7 +4477,8 @@
           "name": "topic_slug",
           "description": "The slug of a topic in the Sefaria system. (To find all of the slugs, you can run `api/topics` without a path parameter to see the data for each topic in our database).",
           "schema": {
-            "type": "string"
+            "type": "string",
+            "default": "rosh-hashanah"
           },
           "in": "path",
           "required": true
@@ -5035,7 +5064,8 @@
           "name": "topic_slug",
           "description": "A valid Sefaria slug for a topic in the database. ",
           "schema": {
-            "type": "string"
+            "type": "string",
+            "default": "moses"
           },
           "in": "path",
           "required": true
@@ -5074,7 +5104,8 @@
             "name": "ref_list",
             "description": "List of strings separated by '+'",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "default": "Genesis 50+Mishnah Peah 3"
             },
             "in": "path",
             "required": true
@@ -5266,7 +5297,8 @@
           "name": "name",
           "description": "The English name of a valid Sefaria term. ",
           "schema": {
-            "type": "string"
+            "type": "string",
+            "default": "Noah"
           },
           "in": "path",
           "required": true
@@ -5326,7 +5358,8 @@
           "name": "name",
           "description": "An arbitrary text string to match against Sefaria's data collections.",
           "schema": {
-            "type": "string"
+            "type": "string",
+            "default": "Genesis"
           },
           "in": "path",
           "required": true
@@ -5385,6 +5418,19 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/SearchPOSTData"
+              },
+              "examples": {
+                "Text Search": {
+                  "value": {
+                    "query": "love",
+                    "type": "text",
+                    "field": "naive_lemmatizer",
+                    "size": 10,
+                    "slop": 10,
+                    "sort_method": "score",
+                    "sort_fields": ["pagesheetrank"]
+                  }
+                }
               }
             }
           },
@@ -5491,7 +5537,10 @@
           "name": "tref",
           "description": "A valid Sefaria textual `Ref`.",
           "schema": {
-            "$ref": "#/components/schemas/ref"
+            "allOf": [
+              { "$ref": "#/components/schemas/ref" }
+            ],
+            "default": "Esther 1.1"
           },
           "in": "path",
           "required": true
@@ -5557,7 +5606,8 @@
           "name": "category_path",
           "description": "A valid Sefaria Category path",
           "schema": {
-            "type": "string"
+            "type": "string",
+            "default": "Tanakh/Torah"
           },
           "in": "path",
           "required": true
@@ -13594,7 +13644,8 @@
           },
           "field": {
             "description": "The field you want to query. Common fields to query are `exact` or `naive_lemmatizer` for the `text` and `merged` indices. For querying the `sheet` index, commonly you'll query the `content` field",
-            "type": "string"
+            "type": "string",
+            "default": "naive_lemmatizer"
           },
           "filter_fields": {
             "description": "Must be the same length as `filters`. Each entry specifies the field to apply the corresponding filter in `filters`. For queries of type `text` this has no effect since there's only one field to filter text queries on (`path`. this field is explained in `filters`). For `sheet` queries, the following fields can appear in `filter_fields`: `collections` (corresponds to the collections that the sheet is in), `topics_en` (corresponds to the topics for this sheet, translated into English), `topics_he` (corresponds to the topics for this sheet, translated into Hebrew).",
@@ -13608,24 +13659,28 @@
           },
           "query": {
             "description": "Your search query.",
-            "type": "string"
+            "type": "string",
+            "default": "love"
           },
           "size": {
             "format": "int32",
             "description": "For paginating results. The total number of results to return, starting from `start`",
-            "type": "integer"
+            "type": "integer",
+            "default": 10
           },
           "slop": {
             "format": "int32",
             "description": "The maximum distance between each query word in the resulting document. `0` means an exact match must be found",
-            "type": "integer"
+            "type": "integer",
+            "default": 10
           },
           "sort_fields": {
             "description": "List of fields to sort on. If `sort_method = 'score'` this list should have exactly one item. Common fields to sort on are `comp_date` (which list results from titles published chronologically), `order` (which list results based on Sefaria's table of contents structure), `pagesheetrank` (most relevant results based on the Sheet Rank algorithm), `dateCreated` (for sheet results returned chronologically), `views` (for sheet results based on popularity).",
             "type": "array",
             "items": {
               "type": "string"
-            }
+            },
+            "default": ["pagesheetrank"]
           },
           "sort_method": {
             "description": "How to sort results. If sort, the values are sorted according to `sort_fields`. If `score`, the value in `sort_fields` is multiplied with the default ElasticSearch score.",
@@ -13633,7 +13688,8 @@
               "sort",
               "score"
             ],
-            "type": "string"
+            "type": "string",
+            "default": "score"
           },
           "sort_reverse": {
             "description": "Whether or not to reverse the sort applied on `sort_fields`",
@@ -13654,7 +13710,8 @@
               "text",
               "sheet"
             ],
-            "type": "string"
+            "type": "string",
+            "default": "text"
           }
         },
         "example": {


### PR DESCRIPTION
## Description
Add default values to the OpenAPI spec to enable tight integration with ReadMe's platform, so when users hit "try me" the examples are pre-filled and makes for a smoother UX. 

## Notes
1. Since search is a POST request, the best I could get the UI is to have a drop down for an example. If users don't see that, they will get a 500 error. Anyone who takes a few minutes to read the docs will figure it out fairly quickly. 
2. Due to what seems like a small bug with ref-topics-links, there will also be a 404 there. Bug has been pointed out to @yitzhakc. 
3. This file has been tested in a test env in ReadMe, and linted with our [Spectral OpenAPI linter](https://github.com/Sefaria/Sefaria-Project/blob/master/docs/.spectral.yaml). 