### PR TITLE
fix: Pass active_module to template context for favicon rendering

### DIFF
--- a/reader/views.py
+++ b/reader/views.py
@@ -202,6 +202,7 @@ def render_template(request, template_name='base.html', app_props=None, template
     props["remoteConfig"] = remoteConfigCache.get(CLIENT_REMOTE_CONFIG_JSON, {})
     propsJSON = json.dumps(props, ensure_ascii=False)
     template_context["propsJSON"] = propsJSON
+    template_context["active_module"] = getattr(request, "active_module", LIBRARY_MODULE)
     if app_props: # We are rendering the ReaderApp in Node, otherwise its jsut a Django template view with ReaderApp set to headerMode
         html = render_react_component("ReaderApp", propsJSON)
         template_context["html"] = html


### PR DESCRIPTION
The favicon links in base.html use {{ active_module }} to construct paths like /static/icons/{{ active_module }}/favicon.ico. However, render_template() was not passing active_module to the template context, causing the favicon path to be incomplete on pages using this function.

This resulted in bookmarks of the homepage showing a default globe icon instead of the Sefaria samech favicon.

https://claude.ai/code/session_01B8CFbT8vgvTWyjXAHrpDRp

## Description
_A brief description of the PR_

## Code Changes
_The following changes were made to the files below_

## Notes
_Any additional notes go here_