### PR TITLE
Bug/sc 41138/restore he and en keys to topic toc json object

### DIFF
--- a/sefaria/model/topic.py
+++ b/sefaria/model/topic.py
@@ -504,8 +504,8 @@ class Topic(abst.SluggedAbstractMongoRecord, AbstractTitledObject):
         """
         d = {'primaryTitle': {}}
         for lang in ('en', 'he'):
-            d[lang] = self.get_primary_title(lang=lang, with_disambiguation=kwargs.get('with_disambiguation', True))
-            d['primaryTitle'][lang] = d[lang]   # we use 'en' and 'he' for backwards compatibility with mobile app but our desktop app uses 'primaryTitle'
+            d['primaryTitle'][lang] = self.get_primary_title(lang=lang, with_disambiguation=kwargs.get('with_disambiguation', True))
+            d[lang] = d['primaryTitle'][lang]   # we are currently using 'en' and 'he' for backwards compatibility with mobile app but our desktop app is using 'primaryTitle'
         if not kwargs.get("with_html"):
             for k, v in d.get("description", {}).items():
                 d["description"][k] = re.sub("<[^>]+>", "", v or "")


### PR DESCRIPTION
## Description
Minor change for backwards compatibility: use 'en' and 'he' and 'primaryTitles'.
