### PR TITLE
fix(score sheet): fall gracefully when tasks pod or llm pod are missing.

### DIFF
--- a/sefaria/helper/llm/sheet_scoring_tools.py
+++ b/sefaria/helper/llm/sheet_scoring_tools.py
@@ -59,6 +59,8 @@ def _dispatch(sheet: Dict[str, Any]) -> None:
             logger.info("Queued scoring task id=%s", res.id)
         elif isinstance(res, bool):
             logger.info("Synchronous scoring result: %s", "OK" if res else "FAIL")
+        elif res is None:
+            logger.info('No scoring task dispatched: LLM or tasks pod may be missing.')
         else:
             logger.debug("Dispatched scoring (no return value)")
     except Exception as e:


### PR DESCRIPTION
## Code Changes
1. get values from `CELERY_QUEUES` safely.
2. if no values (i.e.) no pods do not assign tasks.
3. log it in `_dispatch`.