### PR TITLE
Import relative_to_abs_path directly from sefaria.settings

### DIFF
--- a/sefaria/client/util.py
+++ b/sefaria/client/util.py
@@ -6,7 +6,7 @@ from django.http import HttpResponse
 from django.core.mail import EmailMultiAlternatives
 from webpack_loader import utils as webpack_utils
 
-from django.conf import settings as sls
+from sefaria.settings import relative_to_abs_path
 # from sefaria.model.user_profile import UserProfile
 
 
@@ -54,6 +54,6 @@ def send_email(subject, message_html, from_email, to_email):
 
 def read_webpack_bundle(config_name):
     webpack_files = webpack_utils.get_files('main', config=config_name)
-    bundle_path = sls.relative_to_abs_path('..' + webpack_files[0]["url"])
+    bundle_path = relative_to_abs_path('..' + webpack_files[0]["url"])
     with open(bundle_path, 'r') as file:
         return file.read()


### PR DESCRIPTION
## Description
Refactored the import statement in `sefaria/client/util.py` to import `relative_to_abs_path` directly from `sefaria.settings` instead of importing the entire settings module as `sls`. This improves code clarity and reduces unnecessary module aliasing.

## Code Changes
- Replaced `from django.conf import settings as sls` with `from sefaria.settings import relative_to_abs_path`
- Updated the function call from `sls.relative_to_abs_path()` to `relative_to_abs_path()` in the `read_webpack_bundle()` function

## Notes
This change makes the code more explicit about its dependencies and follows the principle of importing only what is needed. The functionality remains unchanged.

https://claude.ai/code/session_01Jda7TZznrFuWx3DuhnXEzq