### PR TITLE
Prevent duplicate submissions in the NewsletterSignUpForm component

### DIFF
--- a/static/js/NewsletterSignUpForm.jsx
+++ b/static/js/NewsletterSignUpForm.jsx
@@ -73,7 +73,7 @@ export function NewsletterSignUpForm({
             onChange={e => setEmail(e.target.value)}
             onKeyUp={(e) => Util.handleEnterKey(e, handleSubscribe)}/>
       </span>
-            {!showNameInputs && !isSubscribed ? <img src="/static/img/circled-arrow-right.svg" alt={Sefaria._("Submit")} onClick={handleSubscribe}/> : null}
+            {!showNameInputs && !isFormDisabled ? <img src="/static/img/circled-arrow-right.svg" alt={Sefaria._("Submit")} onClick={handleSubscribe}/> : null}
             {showNameInputs ?
                 <><span className="int-en">
         <input
@@ -122,7 +122,7 @@ export function NewsletterSignUpForm({
       </span>
                     {includeEducatorOption ?
                         <EducatorCheckbox educatorCheck={educatorCheck} setEducatorCheck={setEducatorCheck} disabled={isFormDisabled}/> : null}
-                    {!isSubscribed && <img src="/static/img/circled-arrow-right.svg" alt={Sefaria._("Submit")} onClick={handleSubscribe}/>}
+                    {!isFormDisabled && <img src="/static/img/circled-arrow-right.svg" alt={Sefaria._("Submit")} onClick={handleSubscribe}/>}
                 </>
                 : null}
             {subscribeMessage ?


### PR DESCRIPTION
## Description
Once the NewsletterSignUpForm is populated with the submitter's information and the submission completes successfully, the submitter should be prevented from submitting again. Doing so will prevent duplicate submissions from being entered into Salesforce and ActiveCampaign

## Code Changes
* State variable added based on whether the user's submission has successfully gone through
* disabled property added to each of the text input fields
*  Conditionally render the submission icon based on that same state variable