### PR TITLE
Fix read_webpack_bundle to handle full URLs from STATIC_URL

### DIFF
--- a/sefaria/client/util.py
+++ b/sefaria/client/util.py
@@ -1,6 +1,7 @@
 
 import json
 from datetime import datetime
+from urllib.parse import urlparse
 
 from django.http import HttpResponse
 from django.core.mail import EmailMultiAlternatives
@@ -54,6 +55,12 @@ def send_email(subject, message_html, from_email, to_email):
 
 def read_webpack_bundle(config_name):
     webpack_files = webpack_utils.get_files('main', config=config_name)
-    bundle_path = relative_to_abs_path('..' + webpack_files[0]["url"])
+    url = webpack_files[0]["url"]
+    # Handle both relative paths and full URLs
+    # In production, STATIC_URL can be a full URL like https://www.sefaria.org/static/
+    # which makes webpack_files return full URLs instead of relative paths
+    parsed = urlparse(url)
+    path = parsed.path if parsed.scheme else url
+    bundle_path = relative_to_abs_path('..' + path)
     with open(bundle_path, 'r') as file:
         return file.read()


### PR DESCRIPTION
When FRONT_END_URL is set in production, STATIC_URL becomes a full URL (e.g., https://www.sefaria.org/static/) which causes webpack_files to return full URLs instead of relative paths. The code was concatenating '..' with the full URL, resulting in invalid paths like: '/app/sefaria/..<https://www.sefaria.org/static/bundles/linker.v3/linker.v3.js>'

Use urlparse to extract just the path portion when dealing with full URLs.

https://claude.ai/code/session_01Q48JEBe416fLKFsuYiva8o

## Description
_A brief description of the PR_

## Code Changes
_The following changes were made to the files below_

## Notes
_Any additional notes go here_