### PR TITLE
chore: remove null param

### DIFF
--- a/static/js/ReaderPanel.jsx
+++ b/static/js/ReaderPanel.jsx
@@ -200,7 +200,7 @@ class ReaderPanel extends Component {
      * depending on whether we're in multi-panel mode
      */
     if (this.props.multiPanel) {
-      this.props.openConnectionsPanel(ref, null, additionalState);
+      this.props.openConnectionsPanel(ref, additionalState);
     } else {
       this.openConnectionsInPanel(ref, additionalState);
     }


### PR DESCRIPTION
## Description
"Go to Translations" bug did not open Translations in the ConnectionsPanel

## Code Changes
As Claude suggested, the only issue was the modularization re-factor of the `openTextListAt` function.  We removed a parameter in that re-factor.  `openTextListAt` is passed down to the ReaderPanel as `openConnectionsPanel` so I had to remove an unnecessary parameter from being passed down.  This may seem like a big change, but actually it is an obscure bug because ReaderPanel's openConnectionsPanel function doesn't seem to get called anywhere in our code except by ReaderControls in the single case of dealing with translations.