### PR TITLE
Fire modswitch_close analytics event only when it's really closed.

### DIFF
--- a/static/js/common/DropdownMenu.jsx
+++ b/static/js/common/DropdownMenu.jsx
@@ -179,6 +179,8 @@ const DropdownMenu = ({children, buttonComponent, positioningClass, analyticsFea
     const menuRef = useRef(null);
     const wrapperRef = useRef(null);
     const buttonRef = useRef(null);
+    const isOpenRef = useRef(false);
+    isOpenRef.current = isOpen;
 
     const handleButtonClick = (e) => {
       e.stopPropagation();
@@ -213,7 +215,7 @@ const DropdownMenu = ({children, buttonComponent, positioningClass, analyticsFea
             wrapperRef.current &&
             !wrapperRef.current.contains(event.target)
         ) {
-            if (isOpen) {onClose?.({ type: 'passive' });}
+            if (isOpenRef.current) {onClose?.({ type: 'passive' });}
             setIsOpen(false);
         }
     };


### PR DESCRIPTION
## Description
Call `onClose` only if `isOpen`, so it won't be called when clicking outside and the menu is not open.
Do it before setting `isOpen` to false.