### PR TITLE
Fix social media link previews on static pages

### DIFF
--- a/reader/templatetags/sefaria_tags.py
+++ b/reader/templatetags/sefaria_tags.py
@@ -15,6 +15,7 @@ from django import template
 from django.conf import settings
 from django.template.defaultfilters import stringfilter
 from django.utils.safestring import mark_safe
+from django.utils.html import conditional_escape
 from django.core.serializers import serialize
 from django.db.models.query import QuerySet
 from django.contrib.sites.models import Site
@@ -42,6 +43,48 @@ logger = structlog.get_logger(__name__)
 register = template.Library()
 
 domain = SimpleLazyObject(lambda: Site.objects.get_current().domain)
+
+
+class MetaTitleNode(template.Node):
+    """Renders {% meta_title %}...{% endmeta_title %} as synchronized title + og:title + twitter:title tags."""
+    def __init__(self, nodelist):
+        self.nodelist = nodelist
+
+    def render(self, context):
+        content = conditional_escape(self.nodelist.render(context).strip())
+        return mark_safe(
+            f'<title>{content}</title>\n'
+            f'    <meta property="og:title" content="{content}"/>\n'
+            f'    <meta name="twitter:title" content="{content}"/>'
+        )
+
+
+@register.tag('meta_title')
+def meta_title_tag(parser, token):
+    nodelist = parser.parse(('endmeta_title',))
+    parser.delete_first_token()
+    return MetaTitleNode(nodelist)
+
+
+class MetaDescNode(template.Node):
+    """Renders {% meta_desc %}...{% endmeta_desc %} as synchronized description + og:description + twitter:description tags."""
+    def __init__(self, nodelist):
+        self.nodelist = nodelist
+
+    def render(self, context):
+        content = conditional_escape(self.nodelist.render(context).strip())
+        return mark_safe(
+            f'<meta name="description" content="{content}"/>\n'
+            f'    <meta property="og:description" content="{content}"/>\n'
+            f'    <meta name="twitter:description" content="{content}"/>'
+        )
+
+
+@register.tag('meta_desc')
+def meta_desc_tag(parser, token):
+    nodelist = parser.parse(('endmeta_desc',))
+    parser.delete_first_token()
+    return MetaDescNode(nodelist)
 
 
 def get_static_file_hash(path):
@@ -560,3 +603,5 @@ def date_string_to_date(dateString):
 def sheet_via_absolute_link(sheet_id):
     return mark_safe(absolute_link(
 		'<a href="/sheets/{}">a sheet</a>'.format(sheet_id)))
+
+

--- a/reader/templatetags/sefaria_tags.py
+++ b/reader/templatetags/sefaria_tags.py
@@ -45,18 +45,37 @@ register = template.Library()
 domain = SimpleLazyObject(lambda: Site.objects.get_current().domain)
 
 
-class MetaTitleNode(template.Node):
-    """Renders {% meta_title %}...{% endmeta_title %} as synchronized title + og:title + twitter:title tags."""
+class SyncedMetaTagNode(template.Node):
+    """
+    Base node that renders content into synchronized regular, OpenGraph, and Twitter meta tags.
+    Subclasses provide a format_template that receives the escaped content via {content}.
+    """
+    format_template = ""
+
     def __init__(self, nodelist):
         self.nodelist = nodelist
 
     def render(self, context):
         content = conditional_escape(self.nodelist.render(context).strip())
-        return mark_safe(
-            f'<title>{content}</title>\n'
-            f'    <meta property="og:title" content="{content}"/>\n'
-            f'    <meta name="twitter:title" content="{content}"/>'
-        )
+        return mark_safe(self.format_template.format(content=content))
+
+
+class MetaTitleNode(SyncedMetaTagNode):
+    """Renders {% meta_title %}...{% endmeta_title %} as synchronized title + og:title + twitter:title tags."""
+    format_template = (
+        '<title>{content}</title>\n'
+        '    <meta property="og:title" content="{content}"/>\n'
+        '    <meta name="twitter:title" content="{content}"/>'
+    )
+
+
+class MetaDescNode(SyncedMetaTagNode):
+    """Renders {% meta_desc %}...{% endmeta_desc %} as synchronized description + og:description + twitter:description tags."""
+    format_template = (
+        '<meta name="description" content="{content}"/>\n'
+        '    <meta property="og:description" content="{content}"/>\n'
+        '    <meta name="twitter:description" content="{content}"/>'
+    )
 
 
 @register.tag('meta_title')
@@ -64,20 +83,6 @@ def meta_title_tag(parser, token):
     nodelist = parser.parse(('endmeta_title',))
     parser.delete_first_token()
     return MetaTitleNode(nodelist)
-
-
-class MetaDescNode(template.Node):
-    """Renders {% meta_desc %}...{% endmeta_desc %} as synchronized description + og:description + twitter:description tags."""
-    def __init__(self, nodelist):
-        self.nodelist = nodelist
-
-    def render(self, context):
-        content = conditional_escape(self.nodelist.render(context).strip())
-        return mark_safe(
-            f'<meta name="description" content="{content}"/>\n'
-            f'    <meta property="og:description" content="{content}"/>\n'
-            f'    <meta name="twitter:description" content="{content}"/>'
-        )
 
 
 @register.tag('meta_desc')

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,7 +1,8 @@
 {% extends "base.html" %}
 {% load i18n %}
+{% load sefaria_tags %}
 
-{% block title %}{% trans "Page Not Found | Sefaria" %}{% endblock %}
+{% block meta_title %}{% meta_title %}{% trans "Page Not Found | Sefaria" %}{% endmeta_title %}{% endblock %}
 
 {% block content %}
 

--- a/templates/500.html
+++ b/templates/500.html
@@ -1,7 +1,8 @@
 {% extends "base.html" %}
 {% load i18n %}
+{% load sefaria_tags %}
 
-{% block title %}{% trans "Internal Server Error" %}{% endblock %}
+{% block meta_title %}{% meta_title %}{% trans "Internal Server Error" %}{% endmeta_title %}{% endblock %}
 
 {% block content %}
 <div id="errorPage" class="biReady container error static">

--- a/templates/activity.html
+++ b/templates/activity.html
@@ -2,25 +2,21 @@
 {% load i18n cache humanize sefaria_tags static %}
 
 
-{% block title %}
-	{% if single %}
+{% block meta_title %}{% meta_title %}{% if single %}
 {% trans "Revision History of" %} {{ ref }} ({{ version }})
 	{% elif for_user %}
 {{ profile.full_name }} | {% trans "Sefaria Activity" %}
 	{% else %}
 {% trans "Sefaria Activity" %}
-	{% endif %}
-{% endblock %}
+	{% endif %}{% endmeta_title %}{% endblock %}
 
-{% block description %}
-	{% if single %}
+{% block meta_description %}{% meta_desc %}{% if single %}
 {% trans "View the complete revision hisotry of this text on Sefaria." %}
 	{% elif for_user %}
 {% trans "View a user's acitvitiy history on Sefaria, including published source sheets, and text translations, edits or additions." %}
 	{% else %}
 {% trans "View the complete log of public activity on Sefaria, including published source sheets, and text translations, edits or additions. " %}
-	{% endif %}
-{% endblock %}
+	{% endif %}{% endmeta_desc %}{% endblock %}
 
 {% block head %}
     <meta name="robots" content="noindex">

--- a/templates/base.html
+++ b/templates/base.html
@@ -7,9 +7,9 @@
 <!DOCTYPE html>
 <html lang="{{ request.LANGUAGE_CODE }}">
 <head>
-    <title>{% block title %}{{ title|striptags }}{% endblock %}</title>
+    {% block meta_title %}{% meta_title %}{{ title|striptags }}{% endmeta_title %}{% endblock %}
     <meta charset="utf-8"/>
-    <meta name="description" content="{% block description %}{{ desc|striptags }}{% endblock %}"/>
+    {% block meta_description %}{% meta_desc %}{{ desc|striptags }}{% endmeta_desc %}{% endblock %}
 
     {% if noindex or DEBUG %}
         <meta name="robots" content="noindex, nofollow">
@@ -31,21 +31,17 @@
     {% endblock %}
 
     {% block ogimage %}
-        <meta property="og:description" content="{% block fb_description %}{{ desc|striptags }}{% endblock %}"/>
         <meta property="og:image" content="https://{{ request.get_host }}/api/img-gen{{ request.path }}?lang={{request.GET.lang}}&platform=facebook&ven={{request.GET.ven}}&vhe={{request.GET.vhe}}" />
         <meta property="og:image:type" content="image/png" />
         <meta property="og:image:width" content="1200" />
         <meta property="og:image:height" content="630" />
     {% endblock %}
 
-    <meta property="og:title" content="{{title|striptags}}" />
     <meta property="og:url" content="https://{{ request.get_host }}{{ request.get_full_path }}" />
 
     <meta name="twitter:card" content="summary_large_image" />
     {# Sefaria is stopping use of its Twitter account. However, according to Twitter dev docs, an account to reference as an attribute is still necessary for cards usage #}
     <meta name="twitter:site" content="@sefariaproject" />
-    <meta name="twitter:title" content="{{title|striptags}}" />
-    <meta name="twitter:description" content="{% block soc_description %}{{ desc|striptags }}{% endblock %}" />
     <meta name="twitter:image" content="https://{{ request.get_host }}/api/img-gen{{ request.path }}?lang={{request.GET.lang}}&platform=twitter&ven={{request.GET.ven}}&vhe={{request.GET.vhe}}" />
 
     <meta name="apple-mobile-web-app-capable" content="yes">

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -5,7 +5,7 @@
 {% load cache %}
 
 
-{% block title %}Sefaria Dashboard{% endblock %}
+{% block meta_title %}{% meta_title %}Sefaria Dashboard{% endmeta_title %}{% endblock %}
 {% block head %}
 {% endblock %}
 

--- a/templates/edit_profile.html
+++ b/templates/edit_profile.html
@@ -2,7 +2,7 @@
 {% load sefaria_tags %}
 {% load i18n static %}
 
-{% block title %}{% trans "Edit Your Profile on Sefaria" %}{% endblock %}
+{% block meta_title %}{% meta_title %}{% trans "Edit Your Profile on Sefaria" %}{% endmeta_title %}{% endblock %}
 
 {% block content %}
 <div id="editProfilePage" class="static biReady">

--- a/templates/edit_term.html
+++ b/templates/edit_term.html
@@ -4,7 +4,7 @@
 {% load humanize %}
 {% load static %}
 
-{% block title %}Edit Term: {{ term.name }}{% endblock %}
+{% block meta_title %}{% meta_title %}Edit Term: {{ term.name }}{% endmeta_title %}{% endblock %}
 
 {% block css %}
 	#jsonEditor input {

--- a/templates/edit_text_info.html
+++ b/templates/edit_text_info.html
@@ -3,7 +3,7 @@
 {% load sefaria_tags %}
 {% load humanize %}
 
-{% block title %}Edit Text Info for {{ title }}{% endblock %}
+{% block meta_title %}{% meta_title %}Edit Text Info for {{ title }}{% endmeta_title %}{% endblock %}
 
 {% block content %}
 

--- a/templates/explore.html
+++ b/templates/explore.html
@@ -1,15 +1,16 @@
 {% extends "base.html" %}
 {% load i18n static %}
+{% load sefaria_tags %}
 
-{% block title %}{% if urlRoot == "/explore" %}{% blocktrans %}Link Explorer - Visualized Connections Between Talmud and Tanakh | Sefaria{% endblocktrans %}{% else %}{% blocktrans %}Link Explorer - Visualized Connections Between {{ bottomCatTitle }} and {{ topCatTitle}} | Sefaria{% endblocktrans %}{% endif %}{% endblock %}
+{% block meta_title %}{% meta_title %}{% if urlRoot == "/explore" %}{% blocktrans %}Link Explorer - Visualized Connections Between Talmud and Tanakh | Sefaria{% endblocktrans %}{% else %}{% blocktrans %}Link Explorer - Visualized Connections Between {{ bottomCatTitle }} and {{ topCatTitle}} | Sefaria{% endblocktrans %}{% endif %}{% endmeta_title %}{% endblock %}
 
-{% block description %}{% if urlRoot == "/explore" %}{% blocktrans %}Explore over 30,000 examples of the Talmud quoting a verse from Tanakh. Zoom in to particular books either above or below to explore deeper.{% endblocktrans %}{% else %}{% blocktrans %}Visually explore quotations and connections between {{ bottomCatTitle }} and {{ topCatTitle}}. Zoom in to particular books either above or below to explore deeper.{% endblocktrans %}{% endif %}{% endblock %}
+{% block meta_description %}{% meta_desc %}{% if urlRoot == "/explore" %}{% blocktrans %}Explore over 30,000 examples of the Talmud quoting a verse from Tanakh. Zoom in to particular books either above or below to explore deeper.{% endblocktrans %}{% else %}{% blocktrans %}Visually explore quotations and connections between {{ bottomCatTitle }} and {{ topCatTitle}}. Zoom in to particular books either above or below to explore deeper.{% endblocktrans %}{% endif %}{% endmeta_desc %}{% endblock %}
 
-{% block ogimage %}<meta property="og:image" content="{%  static "img/explorer.png" %}" />{% endblock %}
+{% block ogimage %}<meta property="og:image" content="{% static "img/explorer.png" %}" />{% endblock %}
 
 {% block head %}
 <script src="https://d3js.org/d3.v3.min.js"></script>
-{%  endblock %}
+{% endblock %}
 
 {% block css %}
 

--- a/templates/leaderboard.html
+++ b/templates/leaderboard.html
@@ -1,9 +1,10 @@
 {% extends "base.html" %}
 {% load i18n cache %}
+{% load sefaria_tags %}
 
-{% block title %}{% trans "Top Contributors | Sefaria" %}{% endblock %}
+{% block meta_title %}{% meta_title %}{% trans "Top Contributors | Sefaria" %}{% endmeta_title %}{% endblock %}
 
-{% block description %}{% trans "See who has been contributing most to Sefaria in terms of texts, translations, and source sheet." %}{% endblock %}
+{% block meta_description %}{% meta_desc %}{% trans "See who has been contributing most to Sefaria in terms of texts, translations, and source sheet." %}{% endmeta_desc %}{% endblock %}
 
 {% block css %}
 

--- a/templates/metrics.html
+++ b/templates/metrics.html
@@ -2,9 +2,9 @@
 {% load i18n cache humanize sefaria_tags %}
 {% load i18n %}
 {% load static %}
-{% block title %}{% trans "Sefaria Metrics" %}{% endblock %}
+{% block meta_title %}{% meta_title %}{% trans "Sefaria Metrics" %}{% endmeta_title %}{% endblock %}
 
-{% block description %}{% trans "See graphs charting Sefaria's progress since 2013 across metrics including word counts, number of links and number of source sheets." %}{% endblock %}
+{% block meta_description %}{% meta_desc %}{% trans "See graphs charting Sefaria's progress since 2013 across metrics including word counts, number of links and number of source sheets." %}{% endmeta_desc %}{% endblock %}
 
 {% block content %}
 <div class="superAbout">

--- a/templates/random.html
+++ b/templates/random.html
@@ -3,7 +3,7 @@
 {% load sefaria_tags %}
 {% load humanize %}
 
-{% block title %}Random Text | Sefaria.org{% endblock %}
+{% block meta_title %}{% meta_title %}Random Text | Sefaria.org{% endmeta_title %}{% endblock %}
 
 {% block content %}
 

--- a/templates/registration/login.html
+++ b/templates/registration/login.html
@@ -1,9 +1,9 @@
 {% extends "base.html" %}
 {% load i18n sefaria_tags %}
 
-{% block title %}{% trans "Log in to Sefaria" %}{% endblock %}
+{% block meta_title %}{% meta_title %}{% trans "Log in to Sefaria" %}{% endmeta_title %}{% endblock %}
 
-{% block description %}{% trans "Log in to your Sefaria account to make source sheets, write notes, and follow other Sefaria users." %}{% endblock %}
+{% block meta_description %}{% meta_desc %}{% trans "Log in to your Sefaria account to make source sheets, write notes, and follow other Sefaria users." %}{% endmeta_desc %}{% endblock %}
 
 {% block content %}
 

--- a/templates/registration/password_reset_form.html
+++ b/templates/registration/password_reset_form.html
@@ -1,9 +1,9 @@
 {% extends "base.html" %}
 {% load i18n sefaria_tags %}
 
-{% block title %}{% trans "Forgot your Password" %} | {% trans "Sefaria" %}{% endblock %}
+{% block meta_title %}{% meta_title %}{% trans "Forgot your Password" %} | {% trans "Sefaria" %}{% endmeta_title %}{% endblock %}
 
-{% block description %}{% trans "Request a link to change your Sefaria password if you've forgotten it." %}{% endblock %}
+{% block meta_description %}{% meta_desc %}{% trans "Request a link to change your Sefaria password if you've forgotten it." %}{% endmeta_desc %}{% endblock %}
 
 {% block content %}
 

--- a/templates/registration/register.html
+++ b/templates/registration/register.html
@@ -1,9 +1,9 @@
 {% extends "base.html" %}
 {% load i18n sefaria_tags %}
 
-{% block title %}{% trans "Create an Account" %} | {% trans "Sefaria" %}{% endblock %}
+{% block meta_title %}{% meta_title %}{% trans "Create an Account" %} | {% trans "Sefaria" %}{% endmeta_title %}{% endblock %}
 
-{% block description %}{% trans "Create an account on Sefaria to make source sheets, take notes and follow other people." %}{% endblock %}
+{% block meta_description %}{% meta_desc %}{% trans "Create an account on Sefaria to make source sheets, take notes and follow other people." %}{% endmeta_desc %}{% endblock %}
 
 {% block content %}
 <div id="register" class="biReady registrationContent static">

--- a/templates/sefer_hachinukh_mitzvot.html
+++ b/templates/sefer_hachinukh_mitzvot.html
@@ -4,9 +4,9 @@
 {% load sefaria_tags %}
 {% load i18n %}
 
-{% block title %}{% trans "Sefer HaChinukh Visualization" %}{% endblock %}
+{% block meta_title %}{% meta_title %}{% trans "Sefer HaChinukh Visualization" %}{% endmeta_title %}{% endblock %}
 
-{% block description %}{% trans "Explore how different categories of Mitzvot connect to one another through this parallel sets chart." %}{% endblock %}
+{% block meta_description %}{% meta_desc %}{% trans "Explore how different categories of Mitzvot connect to one another through this parallel sets chart." %}{% endmeta_desc %}{% endblock %}
 
 {% block ogimage %}<meta property="og:image" content="/static/img/sefer-hachinukh-mitzvot.png"/>{% endblock %}
 {% block head %}

--- a/templates/sheets.html
+++ b/templates/sheets.html
@@ -4,10 +4,9 @@
 {% load static %}
 {% load i18n %}
 
-{% block title %}{% if title %}{{ title }} | {% trans "Sefaria" %}{% else %}{% trans "Start a New Sheet - Sefaria Source Sheet Builder" %}{% endif %}{% endblock %}
+{% block meta_title %}{% meta_title %}{% if title %}{{ title }} | {% trans "Sefaria" %}{% else %}{% trans "Start a New Sheet - Sefaria Source Sheet Builder" %}{% endif %}{% endmeta_title %}{% endblock %}
 
-{% block description %}{% if sheet.owner %}{% trans "A source sheet created with Sefaria's Source Sheet Builder." %}{% else %}{% trans "Create your own source sheet with Sefaria's Source Sheet Builder." %}{% endif %}{% endblock %}
-{% block soc_description %}{% if sheet.owner %}{% trans "A source sheet created with Sefaria's Source Sheet Builder." %}{% else %}{% trans "Create your own source sheet with Sefaria's Source Sheet Builder." %}{% endif %}{% endblock %}
+{% block meta_description %}{% meta_desc %}{% if sheet.owner %}{% trans "A source sheet created with Sefaria's Source Sheet Builder." %}{% else %}{% trans "Create your own source sheet with Sefaria's Source Sheet Builder." %}{% endif %}{% endmeta_desc %}{% endblock %}
 
 {% block head %}
     <link rel="stylesheet" type="text/css" href="{% static 'css/tooltipster.css' %}" />
@@ -925,7 +924,7 @@
 	<div id="printFooter">
 		<img src="{% static 'img/samekh.png' %}">
 		<div>
-            {% trans "Made with the Sefaria Source Sheet Builder"  %}
+            {% trans "Made with the Sefaria Source Sheet Builder" %}
 			<br/>
             sheets.sefaria.org/sheets
 		</div>
@@ -1473,7 +1472,7 @@
 </div> <!-- end sheetContent -->
 {% endblock %}
 
-{% block js  %}
+{% block js %}
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.8.1/jquery.js"></script>
 <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.9.2/jquery-ui.min.js"></script>
 <script>{% include "js/django-csrf.js" %}</script>

--- a/templates/sheets_visual.html
+++ b/templates/sheets_visual.html
@@ -1,9 +1,9 @@
 {% extends "base.html" %}
 {% load i18n cache humanize sefaria_tags static%}
 
-{% block title %}{% if title %}{{ title|striptags|strip_html_entities }} | {% trans "Visualized" %} | {% trans "Sefaria Source Sheet Builder" %}{% else %}{% trans "Start a New Sheet - Sefaria Source Sheet Builder" %}{% endif %}{% endblock %}
+{% block meta_title %}{% meta_title %}{% if title %}{{ title|striptags|strip_html_entities }} | {% trans "Visualized" %} | {% trans "Sefaria Source Sheet Builder" %}{% else %}{% trans "Start a New Sheet - Sefaria Source Sheet Builder" %}{% endif %}{% endmeta_title %}{% endblock %}
 
-{% block description %}{% if sheet.owner %}{% blocktrans %}Visual layout of a source sheet by {{ sheet.owner|user_name }} created with Sefaria's Source Sheet Builder.{% endblocktrans %}{% else %}{% trans "Create your own source sheet with Sefaria's Source Sheet Builder." %}{% endif %}{% endblock %}
+{% block meta_description %}{% meta_desc %}{% if sheet.owner %}{% blocktrans %}Visual layout of a source sheet by {{ sheet.owner|user_name }} created with Sefaria's Source Sheet Builder.{% endblocktrans %}{% else %}{% trans "Create your own source sheet with Sefaria's Source Sheet Builder." %}{% endif %}{% endmeta_desc %}{% endblock %}
 
 {% block head %}
     <link rel="stylesheet" type="text/css" href="{% static 'css/tooltipster.css' %}" />
@@ -45,7 +45,7 @@
 {% endblock %}
 
 
-{% block js  %}
+{% block js %}
 <script src="{% static 'js/lib/jquery.ui.touch-punch.min.js' %}"></script>
 <script type="text/javascript" src="{% static 'js/lib/jquery.scrollTo-1.4.2-min.js' %}"></script>
 <script type="text/javascript" src="{% static 'js/lib/jquery.easing.1.3.js' %}"></script>

--- a/templates/static/adin-even-israel-steinsaltz.html
+++ b/templates/static/adin-even-israel-steinsaltz.html
@@ -1,7 +1,8 @@
 {% extends "base.html" %}
 {% load i18n %}
+{% load sefaria_tags %}
 
-{% block title %}Rabbi Adin Even-Israel Steinsaltz{% endblock %}
+{% block meta_title %}{% meta_title %}Rabbi Adin Even-Israel Steinsaltz{% endmeta_title %}{% endblock %}
 
 {% block css %}
 	#steinsaltz p {

--- a/templates/static/ai.html
+++ b/templates/static/ai.html
@@ -1,8 +1,9 @@
 {% extends "base.html" %}
 {% load static %}
 {% load i18n %}
-{% block title %}{% trans "AI on Sefaria" %}{% endblock %}
-{% block description %}{% trans "Sefaria is a nonprofit organization dedicated to building the future of Jewish learning in an open and participatory way." %}{% endblock %}
+{% load sefaria_tags %}
+{% block meta_title %}{% meta_title %}{% trans "AI on Sefaria" %}{% endmeta_title %}{% endblock %}
+{% block meta_description %}{% meta_desc %}{% trans "Sefaria is a nonprofit organization dedicated to building the future of Jewish learning in an open and participatory way." %}{% endmeta_desc %}{% endblock %}
 
 {% block css %}
     #top #languageToggle {

--- a/templates/static/app.html
+++ b/templates/static/app.html
@@ -1,9 +1,10 @@
 {% extends "base.html" %}
 {% load i18n static %}
+{% load sefaria_tags %}
 
-{% block title %}{% trans "Sefaria App" %}{% endblock %}
+{% block meta_title %}{% meta_title %}{% trans "Sefaria App" %}{% endmeta_title %}{% endblock %}
 
-{% block description %}{% trans "Download the free Sefaria App for iOS and Android." %}{% endblock %}
+{% block meta_description %}{% meta_desc %}{% trans "Download the free Sefaria App for iOS and Android." %}{% endmeta_desc %}{% endblock %}
 
 {% block css %}
 
@@ -342,7 +343,7 @@
 
 {% endblock %}
 
-{% block js  %}
+{% block js %}
     <script>
     $(function() {
         // Set tracking links to app stores

--- a/templates/static/aramaic-translation-contest.html
+++ b/templates/static/aramaic-translation-contest.html
@@ -1,9 +1,9 @@
 {% extends "base.html" %}
 {% load i18n cache humanize sefaria_tags static %}
 
-{% block title %}{% trans "Sefaria: a Living Library of Jewish Texts Online" %}{% endblock %}
+{% block meta_title %}{% meta_title %}{% trans "Sefaria: a Living Library of Jewish Texts Online" %}{% endmeta_title %}{% endblock %}
 
-{% block description %}{% trans "The largest free library of Jewish texts available to read online in Hebrew and English including Torah, Tanakh, Talmud, Mishnah, Midrash, commentaries and more." %}{% endblock %}
+{% block meta_description %}{% meta_desc %}{% trans "The largest free library of Jewish texts available to read online in Hebrew and English including Torah, Tanakh, Talmud, Mishnah, Midrash, commentaries and more." %}{% endmeta_desc %}{% endblock %}
 
 {% block head %}
 {% endblock %}
@@ -169,7 +169,7 @@
     </div>
 {% endblock %}
 
-{% block js  %}
+{% block js %}
     <script>
     $(function() {
         // Email List

--- a/templates/static/coming-soon.html
+++ b/templates/static/coming-soon.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
+{% load sefaria_tags %}
 
-{% block title %}Coming Soon{% endblock %}
+{% block meta_title %}{% meta_title %}Coming Soon{% endmeta_title %}{% endblock %}
 
 {% block content %}
 <div id="iosPage" class="static">

--- a/templates/static/contest.html
+++ b/templates/static/contest.html
@@ -1,9 +1,10 @@
 {% extends "base.html" %}
 {% load i18n static %}
+{% load sefaria_tags %}
 
-{% block title %}{% trans "Powered by Sefaria Contest" %}{% endblock %}
+{% block meta_title %}{% meta_title %}{% trans "Powered by Sefaria Contest" %}{% endmeta_title %}{% endblock %}
 
-{% block description %}{% trans "Powered by Sefaria Contest" %}{% endblock %}
+{% block meta_description %}{% meta_desc %}{% trans "Powered by Sefaria Contest" %}{% endmeta_desc %}{% endblock %}
 
 {% block css %}
 {% endblock %}

--- a/templates/static/contributed-to-sefaria.html
+++ b/templates/static/contributed-to-sefaria.html
@@ -1,9 +1,10 @@
 {% extends "base.html" %}
 {% load i18n %}
+{% load sefaria_tags %}
 
-{% block title %}{% trans "Texts Contributed to Sefaria" %}{% endblock %}
+{% block meta_title %}{% meta_title %}{% trans "Texts Contributed to Sefaria" %}{% endmeta_title %}{% endblock %}
 
-{% block description %}{% trans "Texts on Sefaria that list this page as their source were contributed directly to Sefaria and have not yet been published elsewhere in print or on the web." %}{% endblock %}
+{% block meta_description %}{% meta_desc %}{% trans "Texts on Sefaria that list this page as their source were contributed directly to Sefaria and have not yet been published elsewhere in print or on the web." %}{% endmeta_desc %}{% endblock %}
 
 {% block content %}
 

--- a/templates/static/daf-yomi.html
+++ b/templates/static/daf-yomi.html
@@ -1,9 +1,10 @@
 {% extends "base.html" %}
 {% load i18n static %}
+{% load sefaria_tags %}
 
-{% block title %}{% trans "Daf Yomi | Sefaria" %}{% endblock %}
+{% block meta_title %}{% meta_title %}{% trans "Daf Yomi | Sefaria" %}{% endmeta_title %}{% endblock %}
 
-{% block description %}{% trans "Learn the Talmud each day with Daf Yomi on Sefaria." %}{% endblock %}
+{% block meta_description %}{% meta_desc %}{% trans "Learn the Talmud each day with Daf Yomi on Sefaria." %}{% endmeta_desc %}{% endblock %}
 
 {% block css %}
 

--- a/templates/static/dicta-thanks.html
+++ b/templates/static/dicta-thanks.html
@@ -1,9 +1,10 @@
 {% extends "base.html" %}
 {% load i18n static %}
+{% load sefaria_tags %}
 
-{% block title %}{% trans "Dicta Thanks" %}{% endblock %}
+{% block meta_title %}{% meta_title %}{% trans "Dicta Thanks" %}{% endmeta_title %}{% endblock %}
 
-{% block description %}{% trans "Sefaria thanks Dicta for all of their help." %}{% endblock %}
+{% block meta_description %}{% meta_desc %}{% trans "Sefaria thanks Dicta for all of their help." %}{% endmeta_desc %}{% endblock %}
 
 {% block content %}
 <main id="dictaThanksPage" class="biReady container static">

--- a/templates/static/digitized-by-sefaria.html
+++ b/templates/static/digitized-by-sefaria.html
@@ -1,9 +1,8 @@
 {% extends "base.html" %}
 {% load i18n sefaria_tags %}
 
-{% block title %}{% trans "Texts Digitized by Sefaria" %}{% endblock %}
+{% block meta_title %}{% meta_title %}{% trans "Texts Digitized by Sefaria" %}{% endmeta_title %}{% endblock %}
 
-{% block description %}{% endblock %}
 
 {% block content %}
 

--- a/templates/static/educators.html
+++ b/templates/static/educators.html
@@ -1,9 +1,10 @@
 {% extends "base.html" %}
 {% load i18n static %}
+{% load sefaria_tags %}
 
-{% block title %}{% trans "Teach with Sefaria" %}{% endblock %}
+{% block meta_title %}{% meta_title %}{% trans "Teach with Sefaria" %}{% endmeta_title %}{% endblock %}
 
-{% block description %}{% trans "Teach with Sefaria" %}{% endblock %}
+{% block meta_description %}{% meta_desc %}{% trans "Teach with Sefaria" %}{% endmeta_desc %}{% endblock %}
 
 {% block css %}
 {% endblock %}

--- a/templates/static/en/about.html
+++ b/templates/static/en/about.html
@@ -1,8 +1,9 @@
 {% extends "base.html" %}
 {% load static %}
 {% load i18n %}
-{% block title %}{% trans "About Sefaria" %}{% endblock %}
-{% block description %}{% trans "Sefaria is a nonprofit organization dedicated to building the future of Jewish learning in an open and participatory way." %}{% endblock %}
+{% load sefaria_tags %}
+{% block meta_title %}{% meta_title %}{% trans "About Sefaria" %}{% endmeta_title %}{% endblock %}
+{% block meta_description %}{% meta_desc %}{% trans "Sefaria is a nonprofit organization dedicated to building the future of Jewish learning in an open and participatory way." %}{% endmeta_desc %}{% endblock %}
 
 {% block css %}
     #top #languageToggle {

--- a/templates/static/en/ways-to-give.html
+++ b/templates/static/en/ways-to-give.html
@@ -1,9 +1,10 @@
 {% extends "base.html" %}
 {% load i18n static %}
+{% load sefaria_tags %}
 
-{% block title %}{% trans "Donate to Sefaria" %}{% endblock %}
+{% block meta_title %}{% meta_title %}{% trans "Donate to Sefaria" %}{% endmeta_title %}{% endblock %}
 
-{% block description %}{% trans "Support Sefaria by making a tax-deductible donation online or by check or wire transfer." %}{% endblock %}
+{% block meta_description %}{% meta_desc %}{% trans "Support Sefaria by making a tax-deductible donation online or by check or wire transfer." %}{% endmeta_desc %}{% endblock %}
 
 {% block css %}
 {% endblock %}

--- a/templates/static/generic.html
+++ b/templates/static/generic.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
+{% load sefaria_tags %}
 
-{% block title %}{{ title }}{% endblock %}
+{% block meta_title %}{% meta_title %}{{ title }}{% endmeta_title %}{% endblock %}
 
-{% block description %}{% endblock %}
 
 {% block content %}
 	<div class="container doc">

--- a/templates/static/he/about.html
+++ b/templates/static/he/about.html
@@ -1,9 +1,10 @@
 {% extends "base.html" %}
 {% load i18n %}
 {% load static %}
-{% block title %}{% trans "About Sefaria" %}{% endblock %}
+{% load sefaria_tags %}
+{% block meta_title %}{% meta_title %}{% trans "About Sefaria" %}{% endmeta_title %}{% endblock %}
 
-{% block description %}{% trans "Sefaria is a nonprofit organization dedicated to building the future of Jewish learning in an open and participatory way." %}{% endblock %}
+{% block meta_description %}{% meta_desc %}{% trans "Sefaria is a nonprofit organization dedicated to building the future of Jewish learning in an open and participatory way." %}{% endmeta_desc %}{% endblock %}
 
 {% block css %}
     #top #languageToggle {

--- a/templates/static/he/ways-to-give.html
+++ b/templates/static/he/ways-to-give.html
@@ -1,10 +1,11 @@
 {% extends "base.html" %}
 {% load i18n %}
 {% load static %}
+{% load sefaria_tags %}
 
-{% block title %}{% trans "Donate to Sefaria" %}{% endblock %}
+{% block meta_title %}{% meta_title %}{% trans "Donate to Sefaria" %}{% endmeta_title %}{% endblock %}
 
-{% block description %}{% trans "Support Sefaria by making a tax-deductible donation online or by check or wire transfer." %}{% endblock %}
+{% block meta_description %}{% meta_desc %}{% trans "Support Sefaria by making a tax-deductible donation online or by check or wire transfer." %}{% endmeta_desc %}{% endblock %}
 
 {% block content %}
 

--- a/templates/static/henry-and-julia-koschitzky-apps.html
+++ b/templates/static/henry-and-julia-koschitzky-apps.html
@@ -1,7 +1,8 @@
 {% extends "base.html" %}
 {% load i18n %}
+{% load sefaria_tags %}
 
-{% block title %}Sefaria App Dedication{% endblock %}
+{% block meta_title %}{% meta_title %}Sefaria App Dedication{% endmeta_title %}{% endblock %}
 
 {% block css %}
     #koschitzky p {

--- a/templates/static/ios.html
+++ b/templates/static/ios.html
@@ -1,9 +1,9 @@
 {% extends "base.html" %}
 {% load i18n %}
+{% load sefaria_tags %}
 
-{% block title %}{% trans "Sefaria iOS" %}{% endblock %}
+{% block meta_title %}{% meta_title %}{% trans "Sefaria iOS" %}{% endmeta_title %}{% endblock %}
 
-{% block description %}{% endblock %}
 
 {% block content %}
 <div id="iosPage" class="static biReady">

--- a/templates/static/jobs.html
+++ b/templates/static/jobs.html
@@ -1,9 +1,10 @@
 {% extends "base.html" %}
 {% load i18n %}
 {% load static %}
-{% block title %}{% trans "Jobs at Sefaria" %}{% endblock %}
+{% load sefaria_tags %}
+{% block meta_title %}{% meta_title %}{% trans "Jobs at Sefaria" %}{% endmeta_title %}{% endblock %}
 
-{% block description %}{% trans "Job openings at Sefaria, a nonprofit technology organization dedicated to building the Jewish future." %}{% endblock %}
+{% block meta_description %}{% meta_desc %}{% trans "Job openings at Sefaria, a nonprofit technology organization dedicated to building the Jewish future." %}{% endmeta_desc %}{% endblock %}
 
 {% block js %}
 <script>

--- a/templates/static/link-to-annual-report.html
+++ b/templates/static/link-to-annual-report.html
@@ -1,7 +1,8 @@
 {% extends "base.html" %}
 {% load i18n %}
 {% load static %}
-{% block title %}{% trans "Annual Report" %}{% endblock %}
+{% load sefaria_tags %}
+{% block meta_title %}{% meta_title %}{% trans "Annual Report" %}{% endmeta_title %}{% endblock %}
 
 
 {% block content %}

--- a/templates/static/linker.html
+++ b/templates/static/linker.html
@@ -1,9 +1,10 @@
 {% extends "base.html" %}
 {% load i18n static %}
+{% load sefaria_tags %}
 
-{% block title %}{% trans "Linker Plugin" %} | {% trans "Sefaria" %}{% endblock %}
+{% block meta_title %}{% meta_title %}{% trans "Linker Plugin" %} | {% trans "Sefaria" %}{% endmeta_title %}{% endblock %}
 
-{% block description %}{% trans "Automatically turn citations on your website into links or dynamic popups with the full text from Sefaria." %}{% endblock %}
+{% block meta_description %}{% meta_desc %}{% trans "Automatically turn citations on your website into links or dynamic popups with the full text from Sefaria." %}{% endmeta_desc %}{% endblock %}
 
 {% block content %}
 <div id="linkerPage" class="container static">

--- a/templates/static/mobile.html
+++ b/templates/static/mobile.html
@@ -1,9 +1,10 @@
 {% extends "base.html" %}
 {% load i18n static %}
+{% load sefaria_tags %}
 
-{% block title %}{% trans "Sefaria Mobile Apps" %}{% endblock %}
+{% block meta_title %}{% meta_title %}{% trans "Sefaria Mobile Apps" %}{% endmeta_title %}{% endblock %}
 
-{% block description %}{% trans "Download the free Sefaria Apps for iOS and Android." %}{% endblock %}
+{% block meta_description %}{% meta_desc %}{% trans "Download the free Sefaria Apps for iOS and Android." %}{% endmeta_desc %}{% endblock %}
 
 {% block css %}
 
@@ -347,7 +348,7 @@
 
 {% endblock %}
 
-{% block js  %}
+{% block js %}
     <script>
     $(function() {
         // Set tracking links to app stores

--- a/templates/static/nash-bravmann-collection.html
+++ b/templates/static/nash-bravmann-collection.html
@@ -1,9 +1,10 @@
 {% extends "base.html" %}
 {% load i18n static %}
+{% load sefaria_tags %}
 
-{% block title %}The Nash-Bravmann Collection{% endblock %}
+{% block meta_title %}{% meta_title %}The Nash-Bravmann Collection{% endmeta_title %}{% endblock %}
 
-{% block description %}The Jack Nash and Ludwig Bravmann Collection is a free, online library of Rabbi Adin Steinsaltz's major commentaries in Hebrew and English. Interlinked to Sefaria’s vast and ever-growing corpus of Jewish text, The Nash-Bravmann collection will further integrate Rabbi Steinsaltz’s Torah into the Jewish library, while also bringing these already-renowned commentaries to an even wider global audience. This exciting partnership was made possible by a generous donation by the Pershing Square Foundation in honor of Jack Nash and Ludwig (Lou) Bravmann, two pioneering Jewish philanthropists whose lifelong support of Rabbi Steinsaltz was essential to his outsized output and impact.{% endblock %}
+{% block meta_description %}{% meta_desc %}The Jack Nash and Ludwig Bravmann Collection is a free, online library of Rabbi Adin Steinsaltz's major commentaries in Hebrew and English. Interlinked to Sefaria’s vast and ever-growing corpus of Jewish text, The Nash-Bravmann collection will further integrate Rabbi Steinsaltz’s Torah into the Jewish library, while also bringing these already-renowned commentaries to an even wider global audience. This exciting partnership was made possible by a generous donation by the Pershing Square Foundation in honor of Jack Nash and Ludwig (Lou) Bravmann, two pioneering Jewish philanthropists whose lifelong support of Rabbi Steinsaltz was essential to his outsized output and impact.{% endmeta_desc %}{% endblock %}
 
 {% block css %}
 #nashBravemannCollection {

--- a/templates/static/newsletter.html
+++ b/templates/static/newsletter.html
@@ -1,9 +1,10 @@
 {% extends "base.html" %}
 {% load i18n static %}
+{% load sefaria_tags %}
 
-{% block title %}{% trans "Sign up for Sefaria's Newsletter" %}{% endblock %}
+{% block meta_title %}{% meta_title %}{% trans "Sign up for Sefaria's Newsletter" %}{% endmeta_title %}{% endblock %}
 
-{% block description %}{% trans "Sign up for Sefaria's Newsletter" %}{% endblock %}
+{% block meta_description %}{% meta_desc %}{% trans "Sign up for Sefaria's Newsletter" %}{% endmeta_desc %}{% endblock %}
 
 {% block js %}
 <script>

--- a/templates/static/pioneers.html
+++ b/templates/static/pioneers.html
@@ -1,9 +1,10 @@
 {% extends "base.html" %}
 {% load i18n static %}
+{% load sefaria_tags %}
 
-{% block title %}{% trans "Pioneers | Sefaria" %}{% endblock %}
+{% block meta_title %}{% meta_title %}{% trans "Pioneers | Sefaria" %}{% endmeta_title %}{% endblock %}
 
-{% block description %}{% trans "Sefaria Pioneers" %}{% endblock %}
+{% block meta_description %}{% meta_desc %}{% trans "Sefaria Pioneers" %}{% endmeta_desc %}{% endblock %}
 
 {% block css %}
 

--- a/templates/static/powered-by-sefaria-contest-2020.html
+++ b/templates/static/powered-by-sefaria-contest-2020.html
@@ -1,9 +1,10 @@
 {% extends "base.html" %}
 {% load i18n static %}
+{% load sefaria_tags %}
 
-{% block title %}{% trans "Powered by Sefaria Contest 2020" %}{% endblock %}
+{% block meta_title %}{% meta_title %}{% trans "Powered by Sefaria Contest 2020" %}{% endmeta_title %}{% endblock %}
 
-{% block description %}{% trans "Powered by Sefaria Contest 2020" %}{% endblock %}
+{% block meta_description %}{% meta_desc %}{% trans "Powered by Sefaria Contest 2020" %}{% endmeta_desc %}{% endblock %}
 
 {% block css %}
 {% endblock %}

--- a/templates/static/powered-by-sefaria-contest-2021.html
+++ b/templates/static/powered-by-sefaria-contest-2021.html
@@ -1,9 +1,10 @@
 {% extends "base.html" %}
 {% load i18n static %}
+{% load sefaria_tags %}
 
-{% block title %}{% trans "Powered by Sefaria Contest 2021" %}{% endblock %}
+{% block meta_title %}{% meta_title %}{% trans "Powered by Sefaria Contest 2021" %}{% endmeta_title %}{% endblock %}
 
-{% block description %}{% trans "Powered by Sefaria Contest 2021" %}{% endblock %}
+{% block meta_description %}{% meta_desc %}{% trans "Powered by Sefaria Contest 2021" %}{% endmeta_desc %}{% endblock %}
 
 {% block css %}
 {% endblock %}

--- a/templates/static/powered-by.html
+++ b/templates/static/powered-by.html
@@ -1,9 +1,10 @@
 {% extends "base.html" %}
 {% load i18n static %}
+{% load sefaria_tags %}
 
-{% block title %}{% trans "Powered by Sefaria" %}{% endblock %}
+{% block meta_title %}{% meta_title %}{% trans "Powered by Sefaria" %}{% endmeta_title %}{% endblock %}
 
-{% block description %}{% trans "Sefaria’s open data and API can be used by anyone.  You can find it all for free in our GitHub repository!" %}{% endblock %}
+{% block meta_description %}{% meta_desc %}{% trans "Sefaria’s open data and API can be used by anyone.  You can find it all for free in our GitHub repository!" %}{% endmeta_desc %}{% endblock %}
 
 {% block css %}
 .staticPage .staticPageHeader {

--- a/templates/static/privacy-policy.html
+++ b/templates/static/privacy-policy.html
@@ -1,9 +1,9 @@
 {% extends "base.html" %}
 {% load i18n %}
 {% load static %}
-{% block title %}{% trans "Privacy Policy" %} | {% trans "Sefaria" %}{% endblock %}
+{% load sefaria_tags %}
+{% block meta_title %}{% meta_title %}{% trans "Privacy Policy" %} | {% trans "Sefaria" %}{% endmeta_title %}{% endblock %}
 
-{% block description %}{% endblock %}
 
 {% block content %}
 <div class="superAbout">

--- a/templates/static/products.html
+++ b/templates/static/products.html
@@ -1,10 +1,11 @@
 
 {% extends "base.html" %}
 {% load i18n static %}
+{% load sefaria_tags %}
 
-{% block title %}{% trans "Products" %}{% endblock %}
+{% block meta_title %}{% meta_title %}{% trans "Products" %}{% endmeta_title %}{% endblock %}
 
-{% block description %}{% trans "A catalogue of Sefaria's products and experiments" %}{% endblock %}
+{% block meta_description %}{% meta_desc %}{% trans "A catalogue of Sefaria's products and experiments" %}{% endmeta_desc %}{% endblock %}
 
 {% block js %}
 <script>

--- a/templates/static/ramban-sponsorships.html
+++ b/templates/static/ramban-sponsorships.html
@@ -1,9 +1,10 @@
 {% extends "base.html" %}
 {% load i18n static %}
+{% load sefaria_tags %}
 
-{% block title %}{% trans "Ramban on Torah - Thank you to our Sponsors" %}{% endblock %}
+{% block meta_title %}{% meta_title %}{% trans "Ramban on Torah - Thank you to our Sponsors" %}{% endmeta_title %}{% endblock %}
 
-{% block description %}{% trans "Ramban on Torah - Thank you to our Sponsors" %}{% endblock %}
+{% block meta_description %}{% meta_desc %}{% trans "Ramban on Torah - Thank you to our Sponsors" %}{% endmeta_desc %}{% endblock %}
 
 {% block css %}
 {% endblock %}

--- a/templates/static/sefaria-community-translation.html
+++ b/templates/static/sefaria-community-translation.html
@@ -1,9 +1,10 @@
 {% extends "base.html" %}
 {% load i18n %}
+{% load sefaria_tags %}
 
-{% block title %}{% trans "About Sefaria Community Translations" %}{% endblock %}
+{% block meta_title %}{% meta_title %}{% trans "About Sefaria Community Translations" %}{% endmeta_title %}{% endblock %}
 
-{% block description %}{% trans "Sefaria Community Translations are open, crowd-sourced translations of texts available in the Sefaria Library." %}{% endblock %}
+{% block meta_description %}{% meta_desc %}{% trans "Sefaria Community Translations are open, crowd-sourced translations of texts available in the Sefaria Library." %}{% endmeta_desc %}{% endblock %}
 
 {% block content %}
 

--- a/templates/static/sefaria-edition.html
+++ b/templates/static/sefaria-edition.html
@@ -1,9 +1,10 @@
 {% extends "base.html" %}
 {% load i18n %}
+{% load sefaria_tags %}
 
-{% block title %}{% trans "About Sefaria Editions" %}{% endblock %}
+{% block meta_title %}{% meta_title %}{% trans "About Sefaria Editions" %}{% endmeta_title %}{% endblock %}
 
-{% block description %}{% trans "The Sefaria Edition is a Sefaria commissioned translation created by professional translators." %}{% endblock %}
+{% block meta_description %}{% meta_desc %}{% trans "The Sefaria Edition is a Sefaria commissioned translation created by professional translators." %}{% endmeta_desc %}{% endblock %}
 
 {% block content %}
 

--- a/templates/static/sheets.html
+++ b/templates/static/sheets.html
@@ -1,9 +1,10 @@
 {% extends "base.html" %}
 {% load i18n static %}
+{% load sefaria_tags %}
 
-{% block title %}{% trans "Sheets on Sefaria" %}{% endblock %}
+{% block meta_title %}{% meta_title %}{% trans "Sheets on Sefaria" %}{% endmeta_title %}{% endblock %}
 
-{% block description %}{% trans "Mix and match sources from Sefaria’s library of Jewish texts, and add your comments, images and videos." %}{% endblock %}
+{% block meta_description %}{% meta_desc %}{% trans "Mix and match sources from Sefaria’s library of Jewish texts, and add your comments, images and videos." %}{% endmeta_desc %}{% endblock %}
 
 {% block css %}
 {% endblock %}

--- a/templates/static/shraga-silverstein.html
+++ b/templates/static/shraga-silverstein.html
@@ -1,9 +1,9 @@
 {% extends "base.html" %}
 {% load i18n static %}
+{% load sefaria_tags %}
 
-{% block title %}{% trans "In Memory of Rabbi Shraga Silverstein" %}{% endblock %}
+{% block meta_title %}{% meta_title %}{% trans "In Memory of Rabbi Shraga Silverstein" %}{% endmeta_title %}{% endblock %}
 
-{% block description %}{% endblock %}
 
 {% block css %}
     #shraga h3 {

--- a/templates/static/strategy.html
+++ b/templates/static/strategy.html
@@ -1,7 +1,8 @@
 {% extends "base.html" %}
 {% load i18n static %}
+{% load sefaria_tags %}
 
-{% block title %}{% trans "Sefaria Strategy" %}{% endblock %}
+{% block meta_title %}{% meta_title %}{% trans "Sefaria Strategy" %}{% endmeta_title %}{% endblock %}
 
 {% block css %}
   html, body {

--- a/templates/static/supporters.html
+++ b/templates/static/supporters.html
@@ -1,10 +1,11 @@
 {% extends "base.html" %}
 {% load i18n %}
 {% load static %}
+{% load sefaria_tags %}
 
-{% block title %}{% trans "Sefaria's Supporters" %}{% endblock %}
+{% block meta_title %}{% meta_title %}{% trans "Sefaria's Supporters" %}{% endmeta_title %}{% endblock %}
 
-{% block description %}{% trans "Sefaria gratefully acknowledges the following donors whose generosity and leadership are making Sefaria possible." %}{% endblock %}
+{% block meta_description %}{% meta_desc %}{% trans "Sefaria gratefully acknowledges the following donors whose generosity and leadership are making Sefaria possible." %}{% endmeta_desc %}{% endblock %}
 
 
 {% block content %}

--- a/templates/static/team.html
+++ b/templates/static/team.html
@@ -1,10 +1,11 @@
 
 {% extends "base.html" %}
 {% load i18n static %}
+{% load sefaria_tags %}
 
-{% block title %}{% trans "The Sefaria Team" %}{% endblock %}
+{% block meta_title %}{% meta_title %}{% trans "The Sefaria Team" %}{% endmeta_title %}{% endblock %}
 
-{% block description %}{% trans "Sefaria's team is working to create the Jewish future." %}{% endblock %}
+{% block meta_description %}{% meta_desc %}{% trans "Sefaria's team is working to create the Jewish future." %}{% endmeta_desc %}{% endblock %}
 
 {% block js %}
 <script>

--- a/templates/static/terms.html
+++ b/templates/static/terms.html
@@ -1,10 +1,10 @@
 {% extends "base.html" %}
 {% load i18n %}
 {% load static %}
+{% load sefaria_tags %}
 
-{% block title %}{% trans "Terms of Use" %} | {% trans "Sefaria" %}{% endblock %}
+{% block meta_title %}{% meta_title %}{% trans "Terms of Use" %} | {% trans "Sefaria" %}{% endmeta_title %}{% endblock %}
 
-{% block description %}{% endblock %}
 
 {% block content %}
 <div class="superAbout">

--- a/templates/static/testimonials.html
+++ b/templates/static/testimonials.html
@@ -1,9 +1,10 @@
 {% extends "base.html" %}
 {% load i18n static %}
+{% load sefaria_tags %}
 
-{% block title %}{% trans "Sefaria Testimonials" %}{% endblock %}
+{% block meta_title %}{% meta_title %}{% trans "Sefaria Testimonials" %}{% endmeta_title %}{% endblock %}
 
-{% block description %}{% trans "Sefaria’s Impact – Reflections and Insights from Users" %}{% endblock %}
+{% block meta_description %}{% meta_desc %}{% trans "Sefaria’s Impact – Reflections and Insights from Users" %}{% endmeta_desc %}{% endblock %}
 
 {% block css %}
     #top #languageToggle {

--- a/templates/static/the-sefaria-story.html
+++ b/templates/static/the-sefaria-story.html
@@ -1,9 +1,10 @@
 {% extends "base.html" %}
 {% load i18n %}
+{% load sefaria_tags %}
 
-{% block title %}{% trans "The Sefaria Story" %}{% endblock %}
+{% block meta_title %}{% meta_title %}{% trans "The Sefaria Story" %}{% endmeta_title %}{% endblock %}
 
-{% block description %}{% trans "Watch a video about the story of Sefaria." %}{% endblock %}
+{% block meta_description %}{% meta_desc %}{% trans "Watch a video about the story of Sefaria." %}{% endmeta_desc %}{% endblock %}
 
 {% block css %}
 .static h1 {

--- a/templates/static/torah-tab.html
+++ b/templates/static/torah-tab.html
@@ -1,10 +1,11 @@
 {% extends "base.html" %}
 {% load i18n static %}
+{% load sefaria_tags %}
 
 
-{% block title %}{% trans "Sefaria Torah Tab" %}{% endblock %}
+{% block meta_title %}{% meta_title %}{% trans "Sefaria Torah Tab" %}{% endmeta_title %}{% endblock %}
 
-{% block description %}{% trans "Install the free Sefaria Torah Tab for your web browser." %}{% endblock %}
+{% block meta_description %}{% meta_desc %}{% trans "Install the free Sefaria Torah Tab for your web browser." %}{% endmeta_desc %}{% endblock %}
 
 {% block head %}
     <meta property="og:type" content="website"/>

--- a/templates/static/updates.html
+++ b/templates/static/updates.html
@@ -1,10 +1,11 @@
 {% extends "base.html" %}
 {% load i18n %}
 {% load static %}
+{% load sefaria_tags %}
 
-{% block title %}{% trans "New Additions to the Sefaria Library" %}{% endblock %}
+{% block meta_title %}{% meta_title %}{% trans "New Additions to the Sefaria Library" %}{% endmeta_title %}{% endblock %}
 
-{% block description %}{% trans "See texts, translations and connections that have been recently added to Sefaria." %}{% endblock %}
+{% block meta_description %}{% meta_desc %}{% trans "See texts, translations and connections that have been recently added to Sefaria." %}{% endmeta_desc %}{% endblock %}
 
 {% block js %}
 <script>

--- a/templates/static/visualizations.html
+++ b/templates/static/visualizations.html
@@ -1,9 +1,10 @@
 {% extends "base.html" %}
 {% load i18n static %}
+{% load sefaria_tags %}
 
-{% block title %}{% trans "Visualizations" %} | {% trans "Sefaria" %}{% endblock %}
+{% block meta_title %}{% meta_title %}{% trans "Visualizations" %} | {% trans "Sefaria" %}{% endmeta_title %}{% endblock %}
 
-{% block description %}{% trans "Projects which have been created to make interactive visualizations of the texts and connections in the Sefaria Library of Torah texts." %}{% endblock %}
+{% block meta_description %}{% meta_desc %}{% trans "Projects which have been created to make interactive visualizations of the texts and connections in the Sefaria Library of Torah texts." %}{% endmeta_desc %}{% endblock %}
 
 {% block content %}
 <div id="visualizationsPage" class="static">

--- a/templates/static/william-davidson-talmud.html
+++ b/templates/static/william-davidson-talmud.html
@@ -1,9 +1,10 @@
 {% extends "base.html" %}
 {% load i18n static %}
+{% load sefaria_tags %}
 
-{% block title %}{% trans "The William Davidson Talmud" %}{% endblock %}
+{% block meta_title %}{% meta_title %}{% trans "The William Davidson Talmud" %}{% endmeta_title %}{% endblock %}
 
-{% block description %}{% trans "The William Davidson Talmud is a free digital edition of the Babylonian Talmud with parallel translations, interlinked to major commentaries, biblical citations, Midrash, Halakhah, and an ever-growing library of Jewish texts." %}{% endblock %}
+{% block meta_description %}{% meta_desc %}{% trans "The William Davidson Talmud is a free digital edition of the Babylonian Talmud with parallel translations, interlinked to major commentaries, biblical citations, Midrash, Halakhah, and an ever-growing library of Jewish texts." %}{% endmeta_desc %}{% endblock %}
 
 {% block css %}
     #davidsonTalmud {

--- a/templates/static/word-by-word.html
+++ b/templates/static/word-by-word.html
@@ -1,9 +1,10 @@
 {% extends "base.html" %}
 {% load i18n static %}
+{% load sefaria_tags %}
 
-{% block title %}{% trans "Word by Word: A Jewish Women's Writing Circle" %}{% endblock %}
+{% block meta_title %}{% meta_title %}{% trans "Word by Word: A Jewish Women's Writing Circle" %}{% endmeta_title %}{% endblock %}
 
-{% block description %}{% trans "Word by Word: A Jewish Women's Writing Circle will provide up to 20 Jewish women writers engaged in serious torah scholarship the support and guidance to produce publishable books." %}{% endblock %}
+{% block meta_description %}{% meta_desc %}{% trans "Word by Word: A Jewish Women's Writing Circle will provide up to 20 Jewish women writers engaged in serious torah scholarship the support and guidance to produce publishable books." %}{% endmeta_desc %}{% endblock %}
 
 {% block css %}
 {% endblock %}

--- a/templates/talmudic_relationships.html
+++ b/templates/talmudic_relationships.html
@@ -21,9 +21,9 @@ Ideas:
 {% load sefaria_tags %}
 {% load i18n %}
 
-{% block title %}{% trans "Student-Teacher Relationships in the Talmud" %}{% endblock %}
+{% block meta_title %}{% meta_title %}{% trans "Student-Teacher Relationships in the Talmud" %}{% endmeta_title %}{% endblock %}
 
-{% block description %}{% trans "Student-Teacher Relationships in the Talmud" %}{% endblock %}
+{% block meta_description %}{% meta_desc %}{% trans "Student-Teacher Relationships in the Talmud" %}{% endmeta_desc %}{% endblock %}
 
 {% block ogimage %}<meta property="og:image" content="/static/img/talmud-rabbis-visualization.png"/>{% endblock %}
 {% block head %}
@@ -47,7 +47,7 @@ Ideas:
     to set up a python environment at a specific port
     to run it, then ran it at said port. -->
       <script src="//d3js.org/d3.v3.min.js"></script>
-{%  endblock %}
+{% endblock %}
 
 {% block css %}
 

--- a/templates/timeline.html
+++ b/templates/timeline.html
@@ -1,15 +1,16 @@
 {% extends "base.html" %}
 {% load i18n static %}
+{% load sefaria_tags %}
 
-{% block title %}{% trans "Timeline" %}{% endblock %}
+{% block meta_title %}{% meta_title %}{% trans "Timeline" %}{% endmeta_title %}{% endblock %}
 
-{% block description %}{% trans "Timeline" %}{% endblock %}
+{% block meta_description %}{% meta_desc %}{% trans "Timeline" %}{% endmeta_desc %}{% endblock %}
 
-{% block ogimage %}<meta property="og:image" content="{%  static "img/explorer.png" %}" />{% endblock %}
+{% block ogimage %}<meta property="og:image" content="{% static "img/explorer.png" %}" />{% endblock %}
 
 {% block head %}
 <script src="https://d3js.org/d3.v5.min.js"></script>
-{%  endblock %}
+{% endblock %}
 
 {% block css %}
     #textBox {

--- a/templates/unique_words_viz.html
+++ b/templates/unique_words_viz.html
@@ -4,9 +4,9 @@
 {% load sefaria_tags %}
 {% load i18n %}
 
-{% block title %}{% trans "Unique Words used by Biblical Commentators" %}{% endblock %}
+{% block meta_title %}{% meta_title %}{% trans "Unique Words used by Biblical Commentators" %}{% endmeta_title %}{% endblock %}
 
-{% block description %}{% trans "Explore how unique and verbose biblical commentators were." %}{% endblock %}
+{% block meta_description %}{% meta_desc %}{% trans "Explore how unique and verbose biblical commentators were." %}{% endmeta_desc %}{% endblock %}
 
 {% block ogimage %}<meta property="og:image" content="/static/img/sefer-hachinukh-mitzvot.png"/>{% endblock %}
 {% block head %}
@@ -25,7 +25,7 @@
     {% endif %}
 
 
-{%  endblock %}
+{% endblock %}
 
 {% block css %}
 

--- a/templates/visual_library.html
+++ b/templates/visual_library.html
@@ -1,9 +1,9 @@
 {% extends "base.html" %}
 {% load i18n sefaria_tags static %}
 
-{% block title %}{% trans "Visualizing the Sefaria Library" %} {% if lang %} ({{ lang }}){% endif %}{% endblock %}
+{% block meta_title %}{% meta_title %}{% trans "Visualizing the Sefaria Library" %} {% if lang %} ({{ lang }}){% endif %}{% endmeta_title %}{% endblock %}
 
-{% block description %}{% trans "How big is Torah compared to Talmud? This sunburst diagram lets you see the number of words in the texts and categories of Sefaria's library (which is growing every day!)." %}{% endblock %}
+{% block meta_description %}{% meta_desc %}{% trans "How big is Torah compared to Talmud? This sunburst diagram lets you see the number of words in the texts and categories of Sefaria's library (which is growing every day!)." %}{% endmeta_desc %}{% endblock %}
 
 
 {% block ogimage %}<meta property="og:image" content="{% static 'img/sunburst.png' %}"/>{% endblock %}
@@ -21,7 +21,7 @@
     </script>
     {% endif %}
     <script src="https://d3js.org/d3.v3.js"></script>
-{%  endblock %}
+{% endblock %}
 
 {% block css %}
     #controls {

--- a/templates/visual_parasha_colors.html
+++ b/templates/visual_parasha_colors.html
@@ -3,7 +3,7 @@
 {% load sefaria_tags %}
 {% load i18n static %}
 
-{% block title %}{% trans "Visualizing the Parshiot" %}{% endblock %}
+{% block meta_title %}{% meta_title %}{% trans "Visualizing the Parshiot" %}{% endmeta_title %}{% endblock %}
 {% block ogimage %}<meta property="og:image" content="{% static 'img/sunburst.png' %}"/>{% endblock %}
 {% block head %}
     {% if not OFFLINE %}
@@ -19,7 +19,7 @@
     </script>
     {% endif %}
     <script src="https://d3js.org/d3.v3.js"></script>
-{%  endblock %}
+{% endblock %}
 
 {% block css %}
   #languageToggle {

--- a/templates/visual_toc.html
+++ b/templates/visual_toc.html
@@ -2,7 +2,7 @@
 
 {% load sefaria_tags static %}
 
-{% block title %}Visualizing the Sefaria Table of Contents{% if lang %} ({{ lang }}){% endif %}{% endblock %}
+{% block meta_title %}{% meta_title %}Visualizing the Sefaria Table of Contents{% if lang %} ({{ lang }}){% endif %}{% endmeta_title %}{% endblock %}
 {% block ogimage %}<meta property="og:image" content="{% static 'img/sunburst.png' %}"/>{% endblock %}
 {% block head %}
     {% if not OFFLINE %}
@@ -18,7 +18,7 @@
     </script>
     {% endif %}
     <script src="https://d3js.org/d3.v3.js"></script>
-{%  endblock %}
+{% endblock %}
 
 {% block css %}
   #languageToggle {

--- a/templates/visualize_links_through_rashi.html
+++ b/templates/visualize_links_through_rashi.html
@@ -3,9 +3,9 @@
 {% load sefaria_tags %}
 {% load i18n static %}
 
-{% block title %}{% trans "Visualizing Torah Connections through Rashi's Commentary" %}{% endblock %}
+{% block meta_title %}{% meta_title %}{% trans "Visualizing Torah Connections through Rashi's Commentary" %}{% endmeta_title %}{% endblock %}
 
-{% block description %}{% trans "Explore how Rashi connects verses of Torah to one another when he quotes one verse in his commentary on another." %}{% endblock %}
+{% block meta_description %}{% meta_desc %}{% trans "Explore how Rashi connects verses of Torah to one another when he quotes one verse in his commentary on another." %}{% endmeta_desc %}{% endblock %}
 
 {% block ogimage %}<meta property="og:image" content="{% static 'img/links-through-rashi.png' %}"/>{% endblock %}
 {% block head %}
@@ -22,7 +22,7 @@
     </script>
     {% endif %}
     <script src="https://d3js.org/d3.v3.js"></script>
-{%  endblock %}
+{% endblock %}
 
 {% block css %}
 #rashiLinksContainer {


### PR DESCRIPTION
## Description

When sharing Sefaria static pages (like `/jobs`, `/team`, `/educators`, `/about`) on social media platforms and messaging apps (LinkedIn, Facebook, Slack, iMessage), the link preview description would sometimes display "Skip to main content" instead of the page's actual description. The link preview title could also appear blank.

This happened because the OpenGraph and Twitter meta tags (`og:description`, `og:title`, `twitter:description`, `twitter:title`) were empty for static pages.  When social media scrapers encounter empty OpenGraph tags, they fall back to extracting the first visible text from the page body or, if none is present, the page title. That first text could either be blank or come from a React accessibility skip link rendered during server-side rendering ("Skip to main content").

The root cause was an architectural mismatch in `base.html`. The regular `<meta name="description">` tag and the OpenGraph `<meta property="og:description">` tag were controlled by separate, independent Django template blocks (`{% block description %}` and `{% block fb_description %}`). Static page templates only overrode `{% block description %}`, leaving the OpenGraph block to fall back to a Python variable (`desc`) that the `serve_static` view never set. The same problem affected titles — `og:title` and `twitter:title` used the Python variable `title` directly without any block mechanism at all.

A secondary bug was also present: the `og:description` tag was nested inside `{% block ogimage %}`. Several visualization pages (`/explore`, `/visualize/library`, etc.) overrode this block to set a custom preview image, which inadvertently removed their `og:description` tag entirely.

## Design Decisions

### Why custom template tags instead of a capture variable

I considered two approaches:

1. **Capture approach**: Add a `{% capture as page_desc %}` custom tag that renders a block's output into a variable, then reuse that variable for all three meta tags. This would require zero changes to static page templates but introduces indirection. Future developers (or my coding agent friends) would need to understand that the OG description is fed by a captured variable from a different block.

2. **Grouped block approach** (chosen): Create `{% meta_title %}` and `{% meta_desc %}` template tags that each take a single content value and output all three synchronized meta tags (regular, OpenGraph, and Twitter). Group these inside `{% block meta_title %}` and `{% block meta_description %}` blocks that child templates can override.

I chose the grouped block approach because:

- **It makes it impossible for the tags to get out of sync.** The three meta tags are generated from a single source of truth by the custom tag. With the capture approach, they would still be in separate locations linked by a variable, which a future change could accidentally break.
- **No indirection.** Each template explicitly declares its description, and the tag handles the rest. There is no need to trace how a variable flows from one block to another.
- **It fixes the `ogimage` secondary bug.** Moving `og:description` out of `{% block ogimage %}` means visualization pages that override `ogimage` for a custom image no longer accidentally lose their description.
- **Simpler for template authors.** Adding a new static page only requires writing `{% block meta_description %}{% meta_desc %}Your description here{% endmeta_desc %}{% endblock %}` — one block, one concept.

The trade-off is that this approach requires updating many child templates.

### Why block-style tags instead of simple tags

The custom tags use a block-style syntax (`{% meta_desc %}...{% endmeta_desc %}`) rather than a simple argument syntax (`{% meta_desc "some text" %}`). This allows arbitrary Django template expressions inside the tag, including `{% trans %}`, `{% blocktrans %}`, `{% if %}` conditionals, and variable references like `{{ desc|striptags }}`, without needing first to capture the value into a variable, without needing first to capture the value into a variable.

## Code Changes

### Custom template tags (`reader/templatetags/sefaria_tags.py`)

Added two new template tags:

- `{% meta_title %}...{% endmeta_title %}` — renders its content into synchronized `<title>`, `<meta property="og:title">`, and `<meta name="twitter:title">` tags.
- `{% meta_desc %}...{% endmeta_desc %}` — renders its content into synchronized `<meta name="description">`, `<meta property="og:description">`, and `<meta name="twitter:description">` tags.

Both tags use `conditional_escape` to safely handle special characters in the content, preventing potential XSS if descriptions contain quotes or HTML characters.

### Base template (`templates/base.html`)

- Replaced the old separate blocks (`{% block title %}`, `{% block description %}`, `{% block fb_description %}`, `{% block soc_description %}`) with two grouped blocks: `{% block meta_title %}` and `{% block meta_description %}`.
- Moved `og:description` out of `{% block ogimage %}` so that templates overriding the image block no longer accidentally drop their description.
- Removed standalone `og:title` and `twitter:title` tags that previously used the Python variable directly with no block override mechanism.

### Child templates (with live routes)

Updated all templates that extend `base.html` to use the new block names and custom tags. 

## Notes

- Pages that don't use child templates (text reader pages like `/Genesis.1`, topic pages, profile pages) are unaffected. Their views pass `desc` and `title` as Python context variables, which the base template's default `{% meta_desc %}{{ desc|striptags }}{% endmeta_desc %}` handles correctly.
- `templates/edit_text.html` has its own standalone `<meta name="description">` but does not extend `base.html`, so it is not affected by these changes.
- There are orphan templates with no live URL routes. Those should be removed at a future time.
