### PR TITLE
fix: don't queryselectorall using exact string

### DIFF
--- a/static/js/TextRange.jsx
+++ b/static/js/TextRange.jsx
@@ -135,9 +135,12 @@ class TextRange extends Component {
     this.conditionalPlaceSegmentNumbers();
     this.props.onTextLoad && this.props.onTextLoad(data.ref);
 
-    const connectionsPanelRefElement = document.querySelectorAll(`[data-ref='${this.props.filterRef}']`);
-    if (connectionsPanelRefElement.length > 0) {
-      connectionsPanelRefElement[0].scrollIntoView();
+    const filterRef = this.props.filterRef;
+    if (filterRef) {
+      const connectionsPanelRefElement = Array.from(
+        document.querySelectorAll("[data-ref]")
+      ).find((node) => node.getAttribute("data-ref") === filterRef);
+      connectionsPanelRefElement?.scrollIntoView();
     }
   }
   _prefetchLinksAndNotes(data) {


### PR DESCRIPTION
## Description
When users open up refs with apostrophes in their titles (like "Kitzur Ba'al HaTurim on Numbers 10:34:1"), we were querying for the title using apostrophes, thus causing a white screen.

## Code Changes
Previously, we called querySelectorAll looking for the exact div where 'data-ref' equals "Kitzur Ba'al HaTurim on Numbers 10:34:1" for example.  Instead of querying for the exact string, this fix first queries for all TextRange elements and then filters out the one that matches the exact ref we're looking for.   We could have solved this by escaping the apostrophes but I think this is more elegant as it doesn't tie us to a specific ref format.  We simply grab the elements on the screen with a 'data-ref' (which is not usually more than 10) and look for the one with the exact string match to the ref the user requested.