### PR TITLE
fix(healthz): add 5s timeout to Node.js health check

### DIFF
--- a/reader/views.py
+++ b/reader/views.py
@@ -5140,7 +5140,7 @@ def application_health_api(request):
     def isNodeJsReachable():
         url = NODE_HOST + "/healthz"
         try:
-            statusCode = urllib.request.urlopen(url).status
+            statusCode = urllib.request.urlopen(url, timeout=5).status
             return statusCode == 200
         except Exception as e:
             logger.warn(f"Failed node healthcheck. Error: {e}")


### PR DESCRIPTION
## Summary
- `/healthz` calls `urllib.request.urlopen(NODE_HOST + "/healthz")` with no timeout
- On staging (1 gunicorn worker/thread), if Node.js is slow the single thread blocks indefinitely
- Liveness/readiness probes then time out → pod restart → intermittent 504s from envoy
- Adding `timeout=5` makes the check fail fast instead of hanging

## Root cause trace
1. Envoy logs show `response_flags: "UT"` (upstream timeout, 15s) for all paths including `/`
2. `kubectl describe pod` shows liveness probe `context deadline exceeded` every ~7 min
3. `ps aux` in the pod: `--threads 1 --workers 1` (staging default, no override in `envs/staging/`)
4. One hung `/healthz` → Node.js call blocks the single thread → everything queues → 504

## Test plan
- [ ] Deploy to staging and confirm pod no longer restarts every ~7 minutes
- [ ] Confirm `/healthz` returns quickly even when Node.js is degraded (returns `nodejsReady: false` instead of hanging)

🤖 Generated with [Claude Code](https://claude.com/claude-code)