### PR TITLE
chore(staging): bump gunicorn workers to 2

### DIFF
--- a/envs/staging/helmrelease.yaml
+++ b/envs/staging/helmrelease.yaml
@@ -33,6 +33,7 @@ spec:
         tag: "v6.88.0"
       resources:
         web:
+          gunicornWorkerCount: 2
           resources:
             requests:
               memory: "8Gi"


### PR DESCRIPTION
Raises staging gunicorn worker count from default (1) to 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)