### PR TITLE
chore: guard texts_api against whole-book commentary+pad=0 requests

### DIFF
--- a/reader/views.py
+++ b/reader/views.py
@@ -1578,7 +1578,7 @@ def texts_api(request, tref):
         # Guard against pathologically expensive link-expansion requests.
         # e.g. /api/texts/Deuteronomy?commentary=1&pad=0 fetches every link in the book.
         if commentary and not pad and oref.is_book_level():
-            return {"error": "commentary=1 and pad=0 is not supported for whole-book refs. Request a specific section or segment.", "ref": oref.normal()}
+            return jsonResponse({"error": "commentary=1 and pad=0 is not supported for whole-book refs. Request a specific section or segment.", "ref": oref.normal()}, cb, 400)
 
         def _get_text(oref, versionEn=versionEn, versionHe=versionHe, commentary=commentary, context=context, pad=pad,
                       alts=alts, wrapLinks=wrapLinks, layer_name=layer_name):

--- a/reader/views.py
+++ b/reader/views.py
@@ -1575,6 +1575,11 @@ def texts_api(request, tref):
         translationLanguagePreference = request.GET.get("transLangPref", None)  # as opposed to vlangPref, this refers to the actual lang of the text
         fallbackOnDefaultVersion = bool(int(request.GET.get("fallbackOnDefaultVersion", False)))
 
+        # Guard against pathologically expensive link-expansion requests.
+        # e.g. /api/texts/Deuteronomy?commentary=1&pad=0 fetches every link in the book.
+        if commentary and not pad and oref.is_book_level():
+            return {"error": "commentary=1 and pad=0 is not supported for whole-book refs. Request a specific section or segment.", "ref": oref.normal()}
+
         def _get_text(oref, versionEn=versionEn, versionHe=versionHe, commentary=commentary, context=context, pad=pad,
                       alts=alts, wrapLinks=wrapLinks, layer_name=layer_name):
             text_family_kwargs = dict(version=versionEn, lang="en", version2=versionHe, lang2="he",


### PR DESCRIPTION
Reject /api/texts/<book>?commentary=1&pad=0 for book-level refs, which would otherwise expand links across the entire book.

