### PR TITLE
fix: update calendar API to include language parameter in URL because…

### DIFF
--- a/reader/views.py
+++ b/reader/views.py
@@ -3582,7 +3582,7 @@ def topic_ref_bulk_api(request):
 def seasonal_topic_api(request):
     from django_topics.models import SeasonalTopic
 
-    lang = request.LANGUAGE_CODE
+    lang = request.GET.get("lang")
     cb = request.GET.get("callback", None)
     diaspora = request.GET.get("diaspora", False)
 

--- a/static/js/sefaria/sefaria.js
+++ b/static/js/sefaria/sefaria.js
@@ -2963,7 +2963,7 @@ _media: {},
         throw new Error('Invalid day. Expected "holiday" or "parasha".');
       }
       return this._cachedApiPromise({
-          url:   `${this.apiHost}/api/calendars/topics/${day}`,
+          url:   `${this.apiHost}/api/calendars/topics/${day}?lang=${Sefaria.interfaceLang.slice(0, 2)}`,
           key:   day + new Date().toLocaleDateString(),
           store: this._upcomingDay,
      });


### PR DESCRIPTION
… request.LANGUAGE_CODE is always "en" for APIs

## Description
_A brief description of the PR_

## Code Changes
_The following changes were made to the files below_

## Notes
_Any additional notes go here_