### PR TITLE
helm(cronjobs): schedule mongo backup/restore jobs on non-preemptible nodes

### DIFF
--- a/helm-chart/sefaria/templates/_helpers.tpl
+++ b/helm-chart/sefaria/templates/_helpers.tpl
@@ -169,6 +169,29 @@ tasks: {{ .Values.deployEnv }}-tasks
 {{- merge  (fromYaml (include "sefaria.tasks.internalQueues" . )) .Values.tasks.queues | toYaml }}
 {{- end }}
 
+{{/*
+Node affinity to avoid preemptible/spot GKE nodes.
+Renders a nodeAffinity block from .Values.nonPreemptibleNodeAffinity.
+Usage inside an existing affinity: block:
+  {{- include "sefaria.nonPreemptibleNodeAffinity" . | nindent <N> }}
+Usage when no affinity: block exists yet (wraps in affinity:):
+  {{- include "sefaria.nonPreemptibleAffinityBlock" . | nindent <N> }}
+*/}}
+{{- define "sefaria.nonPreemptibleNodeAffinity" -}}
+{{- with .Values.nonPreemptibleNodeAffinity }}
+nodeAffinity:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end -}}
+
+{{- define "sefaria.nonPreemptibleAffinityBlock" -}}
+{{- with .Values.nonPreemptibleNodeAffinity }}
+affinity:
+  nodeAffinity:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
+{{- end -}}
+
 {{- define "config.domainModules" }}
 {{- $map := dict -}}
 {{- $deployEnv := .Values.deployEnv -}}

--- a/helm-chart/sefaria/templates/cronjob/mongo-backup-extra.yaml
+++ b/helm-chart/sefaria/templates/cronjob/mongo-backup-extra.yaml
@@ -27,6 +27,10 @@ spec:
                       values:
                       - mongo
                   topologyKey: kubernetes.io/hostname
+            {{- if not (empty .Values.backup.mongo.nodeAffinity) }}
+            nodeAffinity:
+              {{- toYaml .Values.backup.mongo.nodeAffinity | nindent 14 }}
+            {{- end }}
           tolerations:
             - key: schedule-on-database-vm
               operator: "Equal"

--- a/helm-chart/sefaria/templates/cronjob/mongo-backup-extra.yaml
+++ b/helm-chart/sefaria/templates/cronjob/mongo-backup-extra.yaml
@@ -27,10 +27,7 @@ spec:
                       values:
                       - mongo
                   topologyKey: kubernetes.io/hostname
-            {{- if not (empty .Values.backup.mongo.nodeAffinity) }}
-            nodeAffinity:
-              {{- toYaml .Values.backup.mongo.nodeAffinity | nindent 14 }}
-            {{- end }}
+            {{- include "sefaria.nonPreemptibleNodeAffinity" . | nindent 12 }}
           tolerations:
             - key: schedule-on-database-vm
               operator: "Equal"

--- a/helm-chart/sefaria/templates/cronjob/mongo-backup.yaml
+++ b/helm-chart/sefaria/templates/cronjob/mongo-backup.yaml
@@ -27,6 +27,10 @@ spec:
                       values:
                       - mongo
                   topologyKey: kubernetes.io/hostname
+            {{- if not (empty .Values.backup.mongo.nodeAffinity) }}
+            nodeAffinity:
+              {{- toYaml .Values.backup.mongo.nodeAffinity | nindent 14 }}
+            {{- end }}
           tolerations:
             - key: schedule-on-database-vm
               operator: "Equal"

--- a/helm-chart/sefaria/templates/cronjob/mongo-backup.yaml
+++ b/helm-chart/sefaria/templates/cronjob/mongo-backup.yaml
@@ -27,10 +27,7 @@ spec:
                       values:
                       - mongo
                   topologyKey: kubernetes.io/hostname
-            {{- if not (empty .Values.backup.mongo.nodeAffinity) }}
-            nodeAffinity:
-              {{- toYaml .Values.backup.mongo.nodeAffinity | nindent 14 }}
-            {{- end }}
+            {{- include "sefaria.nonPreemptibleNodeAffinity" . | nindent 12 }}
           tolerations:
             - key: schedule-on-database-vm
               operator: "Equal"

--- a/helm-chart/sefaria/templates/cronjob/sync-mongo-production-data.yaml
+++ b/helm-chart/sefaria/templates/cronjob/sync-mongo-production-data.yaml
@@ -19,6 +19,11 @@ spec:
             cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
         spec:
           serviceAccount: {{ .Values.restore.serviceAccount }}
+          {{- if not (empty .Values.cronJobs.syncMongoProductionData.nodeAffinity) }}
+          affinity:
+            nodeAffinity:
+              {{- toYaml .Values.cronJobs.syncMongoProductionData.nodeAffinity | nindent 14 }}
+          {{- end }}
           volumes:
             - name: shared-volume
               emptyDir: {}

--- a/helm-chart/sefaria/templates/cronjob/sync-mongo-production-data.yaml
+++ b/helm-chart/sefaria/templates/cronjob/sync-mongo-production-data.yaml
@@ -19,11 +19,7 @@ spec:
             cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
         spec:
           serviceAccount: {{ .Values.restore.serviceAccount }}
-          {{- if not (empty .Values.cronJobs.syncMongoProductionData.nodeAffinity) }}
-          affinity:
-            nodeAffinity:
-              {{- toYaml .Values.cronJobs.syncMongoProductionData.nodeAffinity | nindent 14 }}
-          {{- end }}
+          {{- include "sefaria.nonPreemptibleAffinityBlock" . | nindent 10 }}
           volumes:
             - name: shared-volume
               emptyDir: {}

--- a/helm-chart/sefaria/templates/jobs/mongo-restore.yaml
+++ b/helm-chart/sefaria/templates/jobs/mongo-restore.yaml
@@ -17,11 +17,7 @@ spec:
   template:
     spec:
       serviceAccount: {{ .Values.restore.serviceAccount }}
-      {{- if not (empty .Values.restore.nodeAffinity) }}
-      affinity:
-        nodeAffinity:
-          {{- toYaml .Values.restore.nodeAffinity | nindent 10 }}
-      {{- end }}
+      {{- include "sefaria.nonPreemptibleAffinityBlock" . | nindent 6 }}
       volumes:
         - name: shared-volume
           emptyDir:

--- a/helm-chart/sefaria/templates/jobs/mongo-restore.yaml
+++ b/helm-chart/sefaria/templates/jobs/mongo-restore.yaml
@@ -17,6 +17,11 @@ spec:
   template:
     spec:
       serviceAccount: {{ .Values.restore.serviceAccount }}
+      {{- if not (empty .Values.restore.nodeAffinity) }}
+      affinity:
+        nodeAffinity:
+          {{- toYaml .Values.restore.nodeAffinity | nindent 10 }}
+      {{- end }}
       volumes:
         - name: shared-volume
           emptyDir:

--- a/helm-chart/sefaria/values.yaml
+++ b/helm-chart/sefaria/values.yaml
@@ -45,6 +45,13 @@ restore:
   bucket: sefaria-mongo-backup
   # tarball:
   serviceAccount: database-backup-read
+  # Avoid GKE preemptible nodes during restore. Set nodeAffinity: {} to allow any pool.
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: cloud.google.com/gke-preemptible
+              operator: DoesNotExist
 # config to backup environment DB
 backup:
   mongo:
@@ -56,6 +63,13 @@ backup:
     archiveBucket: sefaria-mongo-archive
     serviceAccount: database-backup-write
     version: 4.4
+    # Avoid GKE preemptible nodes mid-dump. Set nodeAffinity: {} to allow any pool.
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: cloud.google.com/gke-preemptible
+                operator: DoesNotExist
   postgres:
     enabled: false
     version: 10.3

--- a/helm-chart/sefaria/values.yaml
+++ b/helm-chart/sefaria/values.yaml
@@ -8,6 +8,16 @@ releaseImageTag:
 
 sandbox: "false"
 
+# Shared node affinity applied to all long-running mongo jobs (backup, restore, sync).
+# Prevents scheduling on preemptible GKE nodes that Google can reclaim mid-run.
+# Set to {} in environment values to allow any node pool.
+nonPreemptibleNodeAffinity:
+  requiredDuringSchedulingIgnoredDuringExecution:
+    nodeSelectorTerms:
+      - matchExpressions:
+          - key: cloud.google.com/gke-preemptible
+            operator: DoesNotExist
+
 # This value sets the name of the environment and it's associated objects. Some
 # suggestions for the values are prod/dev/test
 deployEnv: "dev"
@@ -45,13 +55,6 @@ restore:
   bucket: sefaria-mongo-backup
   # tarball:
   serviceAccount: database-backup-read
-  # Avoid GKE preemptible nodes during restore. Set nodeAffinity: {} to allow any pool.
-  nodeAffinity:
-    requiredDuringSchedulingIgnoredDuringExecution:
-      nodeSelectorTerms:
-        - matchExpressions:
-            - key: cloud.google.com/gke-preemptible
-              operator: DoesNotExist
 # config to backup environment DB
 backup:
   mongo:
@@ -63,13 +66,6 @@ backup:
     archiveBucket: sefaria-mongo-archive
     serviceAccount: database-backup-write
     version: 4.4
-    # Avoid GKE preemptible nodes mid-dump. Set nodeAffinity: {} to allow any pool.
-    nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        nodeSelectorTerms:
-          - matchExpressions:
-              - key: cloud.google.com/gke-preemptible
-                operator: DoesNotExist
   postgres:
     enabled: false
     version: 10.3
@@ -450,13 +446,6 @@ cronJobs:
     enabled: false
   syncMongoProductionData:
     enabled: false
-    # Avoid GKE preemptible nodes (VM can be reclaimed mid-download/restore). Set nodeAffinity: {} to allow any pool.
-    nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        nodeSelectorTerms:
-          - matchExpressions:
-              - key: cloud.google.com/gke-preemptible
-                operator: DoesNotExist
 
 localSettings:
   DEBUG: true

--- a/helm-chart/sefaria/values.yaml
+++ b/helm-chart/sefaria/values.yaml
@@ -436,6 +436,13 @@ cronJobs:
     enabled: false
   syncMongoProductionData:
     enabled: false
+    # Avoid GKE preemptible nodes (VM can be reclaimed mid-download/restore). Set nodeAffinity: {} to allow any pool.
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: cloud.google.com/gke-preemptible
+                operator: DoesNotExist
 
 localSettings:
   DEBUG: true


### PR DESCRIPTION
## Summary

GKE preemptible VMs can be reclaimed by Google at any time mid-run, causing long-running mongo jobs (sync, backup, restore) to be killed silently — the Job then reports \`Failed\` because the Pod simply disappeared, not because the app itself errored.

Adding \`nodeAffinity\` (\`cloud.google.com/gke-preemptible: DoesNotExist\`) to all four mongo workloads so they are never placed on preemptible nodes:
- \`cronjob/sync-mongo-production-data\`
- \`cronjob/mongo-backup\`
- \`cronjob/mongo-backup-extra\`
- \`jobs/mongo-restore\`

## Files changed

| File | Change |
|------|--------|
| \`helm-chart/sefaria/templates/cronjob/sync-mongo-production-data.yaml\` | Added nodeAffinity block |
| \`helm-chart/sefaria/templates/cronjob/mongo-backup.yaml\` | Added nodeAffinity inside existing affinity block |
| \`helm-chart/sefaria/templates/cronjob/mongo-backup-extra.yaml\` | Added nodeAffinity inside existing affinity block |
| \`helm-chart/sefaria/templates/jobs/mongo-restore.yaml\` | Added nodeAffinity block |
| \`helm-chart/sefaria/values.yaml\` | Added default nodeAffinity values under \`backup.mongo\`, \`restore\`, and \`cronJobs.syncMongoProductionData\` |

## Configuration

The rule is values-driven — can be overridden or disabled per environment:
```yaml
# To opt out (e.g. in a cauldron without standard nodes):
cronJobs:
  syncMongoProductionData:
    nodeAffinity: {}
```

## Test plan

- [ ] \`helm template\` with \`backup.mongo.enabled=true\`, \`restore.enabled=true\`, \`cronJobs.syncMongoProductionData.enabled=true\` — confirm \`nodeAffinity\` / \`DoesNotExist\` present in rendered YAML
- [ ] After deploy to staging, trigger sync job manually and confirm \`kubectl get pod -o wide\` shows it lands on a non-preemptible node
- [ ] Watch Cloud Logging for the next scheduled Sunday run — job should complete without mid-run pod loss