### PR TITLE
feat(staging): enable Datadog observability

### DIFF
--- a/envs/staging/helmrelease.yaml
+++ b/envs/staging/helmrelease.yaml
@@ -81,6 +81,8 @@ spec:
       containerImage:
         imageRegistry: us-east1-docker.pkg.dev/production-deployment/containers/sefaria-web
         tag: "v6.89.4"
+    datadog:
+      enabled: true
     tasks:
       enabled: false
     postgres:

--- a/helm-chart/sefaria/Chart.yaml
+++ b/helm-chart/sefaria/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: sefaria
-# Dummy value, will be populated by release action automtically.
+# Dummy value, will be populated by release action automatically.
 version: 0.0.0
 description: Chart to deploy complete Sefaria environment
 icon: https://raw.githubusercontent.com/Sefaria/Sefaria-Project/e757b59968adbc0d6845eaa1b420f934ad864d32/static/img/logo/icon.svg


### PR DESCRIPTION
## Summary

- Sets `datadog.enabled: true` in `envs/staging/helmrelease.yaml` to opt the staging cauldron into the Datadog observability stack introduced in #3217

## Test plan

- [ ] Verify pod annotations and Unified Service Tagging labels appear on staging rollout pods
- [ ] Verify logs appear in Datadog UI with trace correlation

🤖 Generated with [Claude Code](https://claude.com/claude-code)