### PR TITLE
fix(gateway): add 2-minute timeout for /api/texts/ to prevent 504s

### DIFF
--- a/helm-chart/sefaria/templates/gateway/httproute.yaml
+++ b/helm-chart/sefaria/templates/gateway/httproute.yaml
@@ -27,6 +27,16 @@ spec:
     {{- end }}
     {{- end }}
   rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api/texts/
+      timeouts:
+        request: 2m
+        backendRequest: 90s
+      backendRefs:
+        - name: nginx-{{ $.Values.deployEnv }}
+          port: 80
     - backendRefs:
         - name: nginx-{{ $.Values.deployEnv }}
           port: 80


### PR DESCRIPTION
## Summary
- Adds a path-specific HTTPRoute rule for \`/api/texts/\` with:
  - \`request: 2m\` — total wall-clock cap from first byte to last byte
  - \`backendRequest: 90s\` — time the backend has to respond after receiving the full POST body
- Prevents 504 timeouts for internal users editing large text nodes
- Envoy rule inserted before wildcard \`/\` rule so it takes precedence

## Why
An internal user was getting 504s when posting an entire node via \`/api/texts/\`. The default Envoy timeout was too short. Per Envoy best practices, \`backendRequest\` is set separately from \`request\` so the backend has a clear window to respond after upload completes.

No Varnish changes needed: the VCL \`backend default\` block already sets \`.first_byte_timeout = 900s\`.

## Test plan
- [ ] Deploy to staging and attempt to edit a large text node
- [ ] Confirm no 504 within 2 minutes
- [ ] Verify other routes are unaffected (wildcard rule still applies)

Closes SC-43508

🤖 Generated with [Claude Code](https://claude.com/claude-code)