### PR TITLE
fix(httproute): add timeout for /edit/ routes to prevent 504 errors

### DIFF
--- a/helm-chart/sefaria/templates/gateway/httproute.yaml
+++ b/helm-chart/sefaria/templates/gateway/httproute.yaml
@@ -37,6 +37,16 @@ spec:
       backendRefs:
         - name: nginx-{{ $.Values.deployEnv }}
           port: 80
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /edit/
+      timeouts:
+        request: 2m
+        backendRequest: 90s
+      backendRefs:
+        - name: nginx-{{ $.Values.deployEnv }}
+          port: 80
     - backendRefs:
         - name: nginx-{{ $.Values.deployEnv }}
           port: 80


### PR DESCRIPTION
## Description
Adds a 2-minute timeout rule for `/edit/` routes in the HTTPRoute config, mirroring the same fix applied for `/api/texts/` in #3224.

## Code Changes
- `helm-chart/sefaria/templates/gateway/httproute.yaml`: Added PathPrefix match for `/edit/` with `request: 2m` and `backendRequest: 90s` timeouts

## Notes
The URL `https://www.sefaria.org.il/edit/Mishneh%20Torah%2C%20Negative%20Mitzvot%20355/...` was returning 504 because Envoy Gateway applies a default timeout shorter than the backend needs to render the edit page. No pod restart needed — the Envoy controller pushes this config change via xDS API.