### PR TITLE
helm(prod): enable Datadog observability for production rollouts

### DIFF
--- a/envs/prod/helmrelease.yaml
+++ b/envs/prod/helmrelease.yaml
@@ -230,6 +230,8 @@ spec:
       enabled: false
       otelEndpoint: "http://otel-collector-collector.monitoring:4317"
       jaegerEndpoint: "jaeger-agent-dev.monitoring.svc.cluster.local:6831"
+    datadog:
+      enabled: true
     localSettings:
       DEBUG: false
       OFFLINE: false

--- a/helm-chart/sefaria/templates/rollout/nginx.yaml
+++ b/helm-chart/sefaria/templates/rollout/nginx.yaml
@@ -37,6 +37,16 @@ spec:
         deployEnv: "{{ .Values.deployEnv }}"
         stackRole: nginx
         releaseRevision: "{{ .Release.Revision }}"
+        {{- if .Values.datadog.enabled }}
+        tags.datadoghq.com/env: {{ .Values.deployEnv | quote }}
+        tags.datadoghq.com/service: "nginx"
+        tags.datadoghq.com/version: {{ .Values.nginx.containerImage.tag | quote }}
+        admission.datadoghq.com/enabled: "true"
+        {{- end }}
+      {{- if .Values.datadog.enabled }}
+      annotations:
+        ad.datadoghq.com/nginx.logs: '[{"source":"nginx","service":"{{ .Values.deployEnv }}-nginx"}]'
+      {{- end }}
     spec:
       affinity:
         podAntiAffinity:

--- a/helm-chart/sefaria/templates/rollout/nodejs.yaml
+++ b/helm-chart/sefaria/templates/rollout/nodejs.yaml
@@ -36,6 +36,17 @@ spec:
         {{- if .Values.instrumentation.enabled }}
         instrumentation.opentelemetry.io/inject-nodejs: "true"
         {{- end }}
+        {{- if .Values.datadog.enabled }}
+        tags.datadoghq.com/env: {{ .Values.deployEnv | quote }}
+        tags.datadoghq.com/service: "node"
+        tags.datadoghq.com/version: {{ .Values.nodejs.containerImage.tag | quote }}
+        admission.datadoghq.com/enabled: "true"
+        {{- end }}
+      {{- if .Values.datadog.enabled }}
+      annotations:
+        ad.datadoghq.com/node.logs: '[{"source":"nodejs","service":"{{ .Values.deployEnv }}-node"}]'
+        admission.datadoghq.com/js-lib.version: "v5.97.0"
+      {{- end }}
     spec:
       affinity:
         podAntiAffinity:
@@ -66,6 +77,10 @@ spec:
             value: {{ .Values.localSettings.DEBUG | quote }}
           - name: NODE_OPTIONS
             value: "--max-old-space-size={{ .Values.nodejs.heapSize }}"
+          {{- if .Values.datadog.enabled }}
+          - name: DD_LOGS_INJECTION
+            value: "true"
+          {{- end }}
           {{- if .Values.mongo.enabled }}
           - name: MONGO_HOST
             value: {{ .Values.deployEnv }}-mongo

--- a/helm-chart/sefaria/templates/rollout/task.yaml
+++ b/helm-chart/sefaria/templates/rollout/task.yaml
@@ -42,6 +42,17 @@ spec:
         deployEnv: "{{ .Values.deployEnv }}"
         stackRole: celery
         releaseRevision: "{{ .Release.Revision }}"
+        {{- if .Values.datadog.enabled }}
+        tags.datadoghq.com/env: {{ .Values.deployEnv | quote }}
+        tags.datadoghq.com/service: "tasks"
+        tags.datadoghq.com/version: {{ .Values.web.containerImage.tag | quote }}
+        admission.datadoghq.com/enabled: "true"
+        {{- end }}
+      {{- if .Values.datadog.enabled }}
+      annotations:
+        ad.datadoghq.com/tasks.logs: '[{"source":"python","service":"{{ .Values.deployEnv }}-tasks"}]'
+        admission.datadoghq.com/python-lib.version: "v4.7.1"
+      {{- end }}
     spec:
       affinity:
         podAntiAffinity:
@@ -84,6 +95,10 @@ spec:
             value: "varnish-{{ .Values.deployEnv }}-{{ .Release.Revision }}"
           - name: HELM_REVISION
             value: "{{ .Release.Revision }}"
+          {{- if .Values.datadog.enabled }}
+          - name: DD_LOGS_INJECTION
+            value: "true"
+          {{- end }}
           {{- with .Values.gpuServer }}
           - name: GPU_SERVER_HOST
             value: "{{ . }}"

--- a/helm-chart/sefaria/templates/rollout/web.yaml
+++ b/helm-chart/sefaria/templates/rollout/web.yaml
@@ -54,6 +54,17 @@ spec:
         deployEnv: "{{ .Values.deployEnv }}"
         stackRole: django
         releaseRevision: "{{ .Release.Revision }}"
+        {{- if .Values.datadog.enabled }}
+        tags.datadoghq.com/env: {{ .Values.deployEnv | quote }}
+        tags.datadoghq.com/service: "web"
+        tags.datadoghq.com/version: {{ .Values.web.containerImage.tag | quote }}
+        admission.datadoghq.com/enabled: "true"
+        {{- end }}
+      {{- if .Values.datadog.enabled }}
+      annotations:
+        ad.datadoghq.com/web.logs: '[{"source":"python","service":"{{ .Values.deployEnv }}-web"}]'
+        admission.datadoghq.com/python-lib.version: "v4.7.1"
+      {{- end }}
     spec:
       affinity:
         podAntiAffinity:
@@ -91,6 +102,10 @@ spec:
             value: "{{ .Values.deployEnv }}"
           - name: STACK_COMPONENT
             value: web
+          {{- if .Values.datadog.enabled }}
+          - name: DD_LOGS_INJECTION
+            value: "true"
+          {{- end }}
           - name: REDIS_HOST
             value: "redis-{{ .Values.deployEnv }}"
           - name: NODEJS_HOST

--- a/helm-chart/sefaria/values.yaml
+++ b/helm-chart/sefaria/values.yaml
@@ -469,3 +469,6 @@ instrumentation:
   enabled: false
   otelEndpoint: ""
   jaegerEndpoint: ""
+
+datadog:
+  enabled: false


### PR DESCRIPTION
## Summary

Hotfix branched from `prod`. Adds opt-in Datadog labels/log annotations to Argo Rollout templates behind `datadog.enabled`, sets `datadog.enabled: true` in `envs/prod/helmrelease.yaml`, and defaults `datadog.enabled: false` in chart `values.yaml`.

## Commits

- `feat(helm): add Datadog pod annotations and labels for per-cauldron observability`
- `helm(prod): enable Datadog in production HelmRelease values`

## Testing

- [ ] `helm template` with prod-style values / `datadog.enabled` toggles

Replaces the broader #3229 (feature branch included unrelated history).

Made with [Cursor](https://cursor.com)