### PR TITLE
feat(datadog): enable continuous profiling for web and tasks

### DIFF
--- a/envs/prod/helmrelease.yaml
+++ b/envs/prod/helmrelease.yaml
@@ -232,6 +232,8 @@ spec:
       jaegerEndpoint: "jaeger-agent-dev.monitoring.svc.cluster.local:6831"
     datadog:
       enabled: true
+      profiling:
+        enabled: true
     localSettings:
       DEBUG: false
       OFFLINE: false

--- a/helm-chart/sefaria/templates/rollout/task.yaml
+++ b/helm-chart/sefaria/templates/rollout/task.yaml
@@ -98,6 +98,10 @@ spec:
           {{- if .Values.datadog.enabled }}
           - name: DD_LOGS_INJECTION
             value: "true"
+          {{- if .Values.datadog.profiling.enabled }}
+          - name: DD_PROFILING_ENABLED
+            value: "true"
+          {{- end }}
           {{- end }}
           {{- with .Values.gpuServer }}
           - name: GPU_SERVER_HOST

--- a/helm-chart/sefaria/templates/rollout/web.yaml
+++ b/helm-chart/sefaria/templates/rollout/web.yaml
@@ -105,6 +105,10 @@ spec:
           {{- if .Values.datadog.enabled }}
           - name: DD_LOGS_INJECTION
             value: "true"
+          {{- if .Values.datadog.profiling.enabled }}
+          - name: DD_PROFILING_ENABLED
+            value: "true"
+          {{- end }}
           {{- end }}
           - name: REDIS_HOST
             value: "redis-{{ .Values.deployEnv }}"

--- a/helm-chart/sefaria/values.yaml
+++ b/helm-chart/sefaria/values.yaml
@@ -482,3 +482,5 @@ instrumentation:
 
 datadog:
   enabled: false
+  profiling:
+    enabled: false


### PR DESCRIPTION
## Summary

- Adds `datadog.profiling.enabled` flag (default `false`) to the Helm chart values
- Sets `DD_PROFILING_ENABLED=true` on web and tasks pods when the flag is on
- Enables profiling for production via `envs/prod/helmrelease.yaml`

The Datadog Operator Admission Controller already injects the `ddtrace` library into pods (via `admission.datadoghq.com/python-lib.version: "v4.7.1"`), so no changes to `requirements.txt` are needed. This PR only wires the env var that activates the profiler.

## Changes

- `helm-chart/sefaria/values.yaml` — add `datadog.profiling.enabled: false`
- `helm-chart/sefaria/templates/rollout/web.yaml` — emit `DD_PROFILING_ENABLED=true` when flag is set
- `helm-chart/sefaria/templates/rollout/task.yaml` — same for Celery tasks pods
- `envs/prod/helmrelease.yaml` — set `datadog.profiling.enabled: true`

## Companion PR

Infra repo: https://github.com/Sefaria/infrastructure/pull/new/feat/datadog-profiling (enables the `profiling` feature in the `DatadogAgent` CRD)

## Test plan

- [ ] Verify `DD_PROFILING_ENABLED=true` is present on web pods in staging after merge
- [ ] Confirm profiles appear in [Datadog Continuous Profiler](https://us5.datadoghq.com/profiling) under `service:web`
- [ ] Check no memory/CPU regression in the rollout window

Made with [Cursor](https://cursor.com)