### PR TITLE
helm(datadog): enable continuous profiler for web pods

### DIFF
--- a/helm-chart/sefaria/templates/configmap/gunicorn.yaml
+++ b/helm-chart/sefaria/templates/configmap/gunicorn.yaml
@@ -39,6 +39,9 @@ data:
         {{- if .Values.instrumentation.enabled }}
         from opentelemetry.instrumentation.auto_instrumentation import sitecustomize
         {{- end }}
+        {{- if .Values.datadog.enabled }}
+        import ddtrace.profiling.auto  # Profiler threads die on fork; reimport restarts them in each worker
+        {{- end }}
 
     def on_starting(server):
         from reader.startup import init_library_cache

--- a/helm-chart/sefaria/templates/rollout/web.yaml
+++ b/helm-chart/sefaria/templates/rollout/web.yaml
@@ -107,6 +107,8 @@ spec:
             value: "true"
           - name: DD_PROFILING_ENABLED
             value: "true"
+          - name: DD_RUNTIME_METRICS_ENABLED
+            value: "true"
           {{- end }}
           - name: REDIS_HOST
             value: "redis-{{ .Values.deployEnv }}"

--- a/helm-chart/sefaria/templates/rollout/web.yaml
+++ b/helm-chart/sefaria/templates/rollout/web.yaml
@@ -105,6 +105,8 @@ spec:
           {{- if .Values.datadog.enabled }}
           - name: DD_LOGS_INJECTION
             value: "true"
+          - name: DD_PROFILING_ENABLED
+            value: "true"
           {{- end }}
           - name: REDIS_HOST
             value: "redis-{{ .Values.deployEnv }}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,7 @@ djangorestframework @ https://github.com/encode/django-rest-framework/archive/3.
 djangorestframework_simplejwt==3.3.0
 django-hosts==7.0.0
 dnspython~=2.5.0
+ddtrace==4.7.1
 elasticsearch==8.8.2
 geojson==2.5.0
 geopy==2.3.0


### PR DESCRIPTION
## Summary

Enables the Datadog Continuous Profiler for web pods in all environments where `datadog.enabled: true`. Fixes a critical gap where gunicorn's prefork model (`preload_app=True`) killed profiler background threads after forking workers, meaning profiling data was never actually collected.

## Changes

- **`helm-chart/sefaria/templates/rollout/web.yaml`** — add `DD_RUNTIME_METRICS_ENABLED=true` alongside the existing `DD_PROFILING_ENABLED=true` to surface memory, GC, and thread metrics correlated with profiles in the Datadog UI
- **`helm-chart/sefaria/templates/configmap/gunicorn.yaml`** — add `import ddtrace.profiling.auto` in `post_fork` hook (gated on `datadog.enabled`) to restart profiler threads in each worker after gunicorn forks
- **`requirements.txt`** — pin `ddtrace==4.7.1` to match the version already injected by the Datadog Admission Controller annotation (`admission.datadoghq.com/python-lib.version: v4.7.1`)

## Testing

- [x] Verified `ddtrace==4.7.1` is importable in the live production pod (`production-web-dd-profiling`)
- [x] Verified `import ddtrace.profiling.auto` completes without error in the production container environment
- [x] Admission controller init containers (`datadog-lib-python-init`, `datadog-init-apm-inject`) confirmed running
- [x] `DD_PROFILING_ENABLED`, `DD_ENV`, `DD_SERVICE` confirmed present in pod env
- [x] Pod serving real production traffic for 20+ minutes with no regressions

## Notes

Profiles will appear at [app.us5.datadoghq.com/profiling](https://app.us5.datadoghq.com/profiling) a couple of minutes after the next rollout. The `production-web-dd-profiling` diagnostic pod can be removed once this is deployed to prod via the Helm chart.

Made with [Cursor](https://cursor.com)