### PR TITLE
Fix save button and add tests

### DIFF
--- a/e2e-tests/tests/edit-text.spec.ts
+++ b/e2e-tests/tests/edit-text.spec.ts
@@ -1,7 +1,11 @@
 import { test, expect } from "@playwright/test";
 
-const TRANSPARENT = "rgba(0, 0, 0, 0)";
 const EDIT_URL = "/edit/Genesis.1";
+
+const isTransparent = (color: string): boolean => {
+  if (color === "transparent") return true;
+  return color.replace(/\s/g, "") === "rgba(0,0,0,0)";
+};
 
 test.describe("edit_text page CSS rendering", () => {
 
@@ -19,16 +23,21 @@ test.describe("edit_text page CSS rendering", () => {
     await page.goto(EDIT_URL);
     await page.waitForLoadState("load");
 
-    const bgColor = await page.evaluate(() => {
+    await page.evaluate(() => {
       const editButtons = document.getElementById("editButtons");
       if (editButtons) editButtons.style.display = "block";
-      const save = document.getElementById("addVersionSave");
-      return save ? getComputedStyle(save).backgroundColor : null;
     });
-    expect(bgColor).not.toBe(TRANSPARENT);
+
+    const saveButton = page.locator("#addVersionSave");
+    await expect(saveButton).toBeAttached();
+
+    const bgColor = await saveButton.evaluate(el =>
+      getComputedStyle(el).backgroundColor
+    );
+    expect(isTransparent(bgColor)).toBe(false);
   });
 
-  test("Save button text is visible", async ({ page }) => {
+  test("Save button has correct text", async ({ page }) => {
     await page.goto(EDIT_URL);
     await page.waitForLoadState("load");
 
@@ -37,7 +46,9 @@ test.describe("edit_text page CSS rendering", () => {
       if (el) el.style.display = "block";
     });
 
-    await expect(page.locator("#addVersionSave")).toContainText("Save");
+    const saveButton = page.locator("#addVersionSave");
+    await expect(saveButton).toBeAttached();
+    await expect(saveButton).toContainText("Save");
   });
 
   test("Add a New Text modal: Cancel button has a non-transparent background", async ({ page }) => {
@@ -52,7 +63,7 @@ test.describe("edit_text page CSS rendering", () => {
     const bgColor = await page.locator("#newTextCancel").evaluate(el =>
       getComputedStyle(el).backgroundColor
     );
-    expect(bgColor).not.toBe(TRANSPARENT);
+    expect(isTransparent(bgColor)).toBe(false);
   });
 
   test("Add a New Text modal: Add button has a non-transparent background when active", async ({ page }) => {
@@ -62,7 +73,6 @@ test.describe("edit_text page CSS rendering", () => {
     await page.evaluate(() => {
       const el = document.getElementById("newTextModal");
       if (el) el.style.display = "block";
-      // Simulate the JS activating the Add button after a valid ref is entered
       const ok = document.getElementById("newTextOK");
       if (ok) ok.classList.remove("inactive");
     });
@@ -70,7 +80,7 @@ test.describe("edit_text page CSS rendering", () => {
     const bgColor = await page.locator("#newTextOK").evaluate(el =>
       getComputedStyle(el).backgroundColor
     );
-    expect(bgColor).not.toBe(TRANSPARENT);
+    expect(isTransparent(bgColor)).toBe(false);
   });
 
 });

--- a/e2e-tests/tests/edit-text.spec.ts
+++ b/e2e-tests/tests/edit-text.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect } from "@playwright/test";
+
+const TRANSPARENT = "rgba(0, 0, 0, 0)";
+const EDIT_URL = "/edit/Genesis.1";
+
+test.describe("edit_text page CSS rendering", () => {
+
+  test("color-palette CSS variables are defined", async ({ page }) => {
+    await page.goto(EDIT_URL);
+    await page.waitForLoadState("load");
+
+    const sefariaBlue = await page.evaluate(() =>
+      getComputedStyle(document.documentElement).getPropertyValue("--sefaria-blue").trim()
+    );
+    expect(sefariaBlue).not.toBe("");
+  });
+
+  test("Save button has a non-transparent background", async ({ page }) => {
+    await page.goto(EDIT_URL);
+    await page.waitForLoadState("load");
+
+    const bgColor = await page.evaluate(() => {
+      const editButtons = document.getElementById("editButtons");
+      if (editButtons) editButtons.style.display = "block";
+      const save = document.getElementById("addVersionSave");
+      return save ? getComputedStyle(save).backgroundColor : null;
+    });
+    expect(bgColor).not.toBe(TRANSPARENT);
+  });
+
+  test("Save button text is visible", async ({ page }) => {
+    await page.goto(EDIT_URL);
+    await page.waitForLoadState("load");
+
+    await page.evaluate(() => {
+      const el = document.getElementById("editButtons");
+      if (el) el.style.display = "block";
+    });
+
+    await expect(page.locator("#addVersionSave")).toContainText("Save");
+  });
+
+  test("Add a New Text modal: Cancel button has a non-transparent background", async ({ page }) => {
+    await page.goto(EDIT_URL);
+    await page.waitForLoadState("load");
+
+    await page.evaluate(() => {
+      const el = document.getElementById("newTextModal");
+      if (el) el.style.display = "block";
+    });
+
+    const bgColor = await page.locator("#newTextCancel").evaluate(el =>
+      getComputedStyle(el).backgroundColor
+    );
+    expect(bgColor).not.toBe(TRANSPARENT);
+  });
+
+  test("Add a New Text modal: Add button has a non-transparent background when active", async ({ page }) => {
+    await page.goto(EDIT_URL);
+    await page.waitForLoadState("load");
+
+    await page.evaluate(() => {
+      const el = document.getElementById("newTextModal");
+      if (el) el.style.display = "block";
+      // Simulate the JS activating the Add button after a valid ref is entered
+      const ok = document.getElementById("newTextOK");
+      if (ok) ok.classList.remove("inactive");
+    });
+
+    const bgColor = await page.locator("#newTextOK").evaluate(el =>
+      getComputedStyle(el).backgroundColor
+    );
+    expect(bgColor).not.toBe(TRANSPARENT);
+  });
+
+});

--- a/templates/edit_text.html
+++ b/templates/edit_text.html
@@ -12,6 +12,7 @@
 	<meta name="apple-mobile-web-app-capable" content="yes">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 	<link rel="stylesheet" href="{% static 'js/lib/jquery-ui/css/smoothness/jquery-ui-1.8.22.custom.css' %}">
+	<link rel="stylesheet" href="{% static 'css/color-palette.css' %}">
 	<link rel="stylesheet" href="{% static 'css/reader.css' %}">
     <link rel="stylesheet" href="{% static 'font-awesome/css/font-awesome.css' %}">
 	<link rel="stylesheet" href="{% static 'css/common.css' %}">


### PR DESCRIPTION
## Description
Fixes the rendering of the save button on adding a new text and adding a new section. 

## Code Changes
1. `templates/edit_text.html` - was missing the link to the color-palette.css, so was missing the --sefaria-blue variable definition it was calling. This links it in. 
2. `e2e-tests/tests/edit-text.spec.ts` - test coverage, tests all pass. 