### PR TITLE
Track registration funnel with GA4 events

### DIFF
--- a/sefaria/views.py
+++ b/sefaria/views.py
@@ -9,7 +9,7 @@ import requests
 from datetime import datetime, timedelta
 from typing import Optional, Union, List, Any
 from dataclasses import asdict
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlencode, parse_qsl, urlunparse
 from collections import defaultdict
 from random import choice
 from celery.result import AsyncResult
@@ -198,30 +198,29 @@ def register(request):
     if request.user.is_authenticated:
         return redirect("login")
 
-    next = request.GET.get('next', '')
+    next_url = request.GET.get('next', '')
 
     if request.method == 'POST':
         errors, _, form = process_register_form(request)
         if len(errors) == 0:
-            if "noredirect" in request.POST:
-                return HttpResponse("ok")
-            elif "new?assignment=" in request.POST.get("next",""):
-                next = request.POST.get("next", "")
-                return HttpResponseRedirect(next)
+            if "new?assignment=" in request.POST.get("next", ""):
+                next_url = request.POST.get("next", "")
             else:
-                next = request.POST.get("next", "/")
-                if "?" in next:
-                    next += "&welcome=to-sefaria"
-                else:
-                    next += "?welcome=to-sefaria"
-                return HttpResponseRedirect(next)
+                next_url = request.POST.get("next", "/")
+                parsed = urlparse(next_url)
+                next_url = urlunparse(parsed._replace(query=urlencode(parse_qsl(parsed.query) + [('welcome', 'to-sefaria')])))
+            if "noredirect" in request.POST:
+                return jsonResponse({"redirect": next_url})
+            return HttpResponseRedirect(next_url)
+        elif "noredirect" in request.POST:
+            return jsonResponse(errors)
     else:
         if request.GET.get('educator', ''):
             form = SefariaNewUserForm(initial={'subscribe_educator': True})
         else:
             form = SefariaNewUserForm()
 
-    return render_template(request, "registration/register.html", {"headerMode": True}, {'form': form, 'next': next, "renderStatic": True})
+    return render_template(request, "registration/register.html", {"headerMode": True}, {'form': form, 'next': next_url, "renderStatic": True})
 
 
 def maintenance_message(request):

--- a/templates/registration/register.html
+++ b/templates/registration/register.html
@@ -173,7 +173,9 @@
         // Only restore if no other script has patched pushState after us;
         // if they have, leave their patch in place — our listener is removed so the
         // dispatched 'pushstate' event becomes harmless.
-        if (history.pushState === patchedPushState) { history.pushState = originalPushState; }
+        if (history.pushState === patchedPushState) {
+            history.pushState = originalPushState;
+        }
         window.removeEventListener('pushstate', fireFormEnd);
         window.removeEventListener('popstate', fireFormEnd);
         window.removeEventListener('beforeunload', fireFormEnd);

--- a/templates/registration/register.html
+++ b/templates/registration/register.html
@@ -173,9 +173,7 @@
         // Only restore if no other script has patched pushState after us;
         // if they have, leave their patch in place — our listener is removed so the
         // dispatched 'pushstate' event becomes harmless.
-        if (history.pushState === patchedPushState) {
-            history.pushState = originalPushState;
-        }
+        if (history.pushState === patchedPushState) { history.pushState = originalPushState; }
         window.removeEventListener('pushstate', fireFormEnd);
         window.removeEventListener('popstate', fireFormEnd);
         window.removeEventListener('beforeunload', fireFormEnd);

--- a/templates/registration/register.html
+++ b/templates/registration/register.html
@@ -35,3 +35,154 @@
     </div>
 </div>
 {% endblock %}
+
+{% block js %}
+<script>
+(function registrationAnalytics() {
+    // Tracks the 4 GA4 funnel events for the registration form:
+    // form_start (first field focus), form_submit (submit click),
+    // form_submit_result (success/failure via AJAX), form_end (page leave).
+    // flow_id ties all 4 events to the same page visit; from comes from ?from= on the URL.
+    const flowId    = crypto.randomUUID();
+    const fromParam = new URLSearchParams(window.location.search).get('from') || undefined;
+    const form      = document.getElementById('register-form');
+
+    const BASE_PARAMS = {
+        project:      'site_registration',
+        feature_name: 'site_registration_form',
+        flow_id:      flowId,
+        from:         fromParam,
+    };
+
+    function getFilledFields() {
+        const filled = ['email', 'first_name', 'last_name', 'password1'].filter(f => {
+            const el = document.getElementById('id_' + f);
+            return el && el.value.length > 0;
+        });
+        return filled.length ? filled.join('|') : null;
+    }
+
+    /**
+     * Safe wrapper around gtag(). Merges BASE_PARAMS and text automatically.
+     * Uses transport_type: 'beacon' for all events — GA defaults to XHR and batches events
+     * during normal page activity, so events fired just before navigation get dropped.
+     * Beacon forces immediate per-event dispatch regardless of page state.
+     * GA can be undefined when blocked by an ad blocker or a content policy. Without the
+     * typeof guard, a thrown exception in the success branch would prevent window.location.href
+     * from running, leaving the user stuck after account creation.
+     */
+    function fireEvent(name, extraParams) {
+        if (typeof gtag !== 'function') { return; }
+        gtag('event', name, { ...BASE_PARAMS, text: getFilledFields(), transport_type: 'beacon', ...extraParams });
+    }
+
+    function fireFormSubmitResult(status, error) {
+        fireEvent('form_submit_result', { status, ...(error && { error }) });
+    }
+
+    function displayErrors(errors) {
+        form.querySelectorAll('.errorlist').forEach(el => el.remove());
+        Object.entries(errors).forEach(([field, message]) => {
+            const ul = document.createElement('ul');
+            ul.className = 'errorlist' + (field === '__all__' ? ' nonfield' : '');
+            const li = document.createElement('li');
+            li.textContent = message;
+            ul.appendChild(li);
+            if (field === '__all__') {
+                form.prepend(ul);
+            } else {
+                document.getElementById('id_' + field)?.closest('p')?.prepend(ul);
+            }
+        });
+    }
+
+    // form_start — fires once on first focus of any input
+    const onFirstFocus = () => {
+        fireEvent('form_start');
+        form.querySelectorAll('input').forEach(input => input.removeEventListener('focus', onFirstFocus));
+    };
+    form.querySelectorAll('input').forEach(input => input.addEventListener('focus', onFirstFocus));
+
+    // form_submit — fires on submit button click or Enter key in a single-line input
+    // Also resets the browser validation flag so each attempt is tracked independently
+    let browserValidationFailed = false;
+    function onSubmitAttempt() {
+        browserValidationFailed = false;
+        fireEvent('form_submit');
+    }
+    form.querySelector('[type="submit"]').addEventListener('click', onSubmitAttempt);
+    form.addEventListener('keydown', e => {
+        if (e.key === 'Enter' && e.target.tagName === 'INPUT') { onSubmitAttempt(); }
+    });
+
+    // form_submit_result:failure — browser validation blocked the submit
+    // `invalid` fires per-field; the flag collapses multiple fields into one event per attempt
+    form.addEventListener('invalid', () => {
+        if (!browserValidationFailed) {
+            browserValidationFailed = true;
+            fireFormSubmitResult('failure', 'browser_validation');
+        }
+    }, true); // capture phase: `invalid` doesn't bubble
+
+    // AJAX submission + form_submit_result
+    let registrationStatus = 'failure';
+
+    form.addEventListener('submit', e => {
+        e.preventDefault();
+
+        const formData = new FormData(form);
+        formData.append('noredirect', '1');
+
+        fetch(form.action, { method: 'POST', body: formData })
+            .then(r => r.json())
+            .then(data => {
+                if (data.redirect) {
+                    registrationStatus = 'success';
+                    fireFormSubmitResult('success');
+                    window.location.href = data.redirect;
+                } else {
+                    const errorSummary = Object.entries(data).map(([k, v]) => `${k}: ${v}`).join(' | ');
+                                        fireFormSubmitResult('failure', errorSummary);
+                    displayErrors(data);
+                }
+            })
+            .catch(() => {
+                // Network or JSON parse error — fall back to a standard form submission
+                form.submit();
+            });
+    });
+
+    // form_end — fires when user navigates away (React SPA or full-page)
+    // Guard: multiple listeners (pushstate, popstate, beforeunload) could fire on the same navigation
+    let formEndFired = false;
+
+    // React Router uses history.pushState for client-side navigation.
+    // We dispatch a custom 'pushstate' event to avoid putting logic directly in the patched function.
+    const originalPushState = history.pushState;
+    const patchedPushState = function(...args) {
+        const result = originalPushState.apply(this, args);
+        window.dispatchEvent(new Event('pushstate'));
+        return result;
+    };
+    history.pushState = patchedPushState;
+
+    function fireFormEnd() {
+        if (formEndFired) { return; }
+        formEndFired = true;
+        fireEvent('form_end', { status: registrationStatus });
+        // Only restore if no other script has patched pushState after us;
+        // if they have, leave their patch in place — our listener is removed so the
+        // dispatched 'pushstate' event becomes harmless.
+        if (history.pushState === patchedPushState) { history.pushState = originalPushState; }
+        window.removeEventListener('pushstate', fireFormEnd);
+        window.removeEventListener('popstate', fireFormEnd);
+        window.removeEventListener('beforeunload', fireFormEnd);
+    }
+    window.addEventListener('pushstate', fireFormEnd);
+    window.addEventListener('popstate', fireFormEnd);
+
+    // Full-page navigation and tab close
+    window.addEventListener('beforeunload', fireFormEnd);
+})();
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary

Adds GA4 analytics tracking to the `/registration` page as part of the registration funnel data collection initiative. Tracking is implemented via direct `gtag()` calls (not `AnalyticsEventTracker` data attributes) since all parameters are dynamic.

### 4 tracked events

| Event | Trigger |
|---|---|
| `form_start` | First focus on any input field |
| `form_submit` | Submit button click (fires regardless of validation outcome) |
| `form_submit_result` | After each submission attempt — success, server-side failure, or browser validation failure |
| `form_end` | User navigates away (SPA or full-page) |

### Parameters sent with every event
- `project`: `site_registration`
- `feature_name`: `site_registration_form`
- `flow_id`: UUID generated on page load, ties all 4 events to the same visit
- `from`: value of `?from=` query param (to be set by entry point CTAs)
- `text`: pipe-separated list of fields the user had filled at the time of the event (e.g. `email|first_name`)

### Implementation details

**AJAX submission** — the form is submitted via `fetch` with `noredirect=1` so `form_submit_result` can fire before the browser navigates away. The Django view now returns `{"redirect": url}` on success or `{"field": "error message"}` on failure. On network error, falls back to a standard form submit.

**Browser validation failures** — tracked via the `invalid` event (capture phase) rather than `checkValidity()`, so the browser's own validation is not duplicated. A flag collapses multiple per-field `invalid` events into a single `form_submit_result` per attempt, reset on each new click.

**`form_end` navigation coverage** — covers three navigation paths:
- React Router (SPA): `history.pushState` is patched to dispatch a custom `pushstate` event; logic lives in the listener, not the patch
- Browser back/forward: `popstate`
- Full-page navigation / tab close: `beforeunload`

A guard flag ensures `form_end` fires at most once. Uses `transport_type: 'beacon'` so the request is guaranteed to be sent during unload.

**Error display** — on server-side validation failure, errors from the JSON response are injected directly into the DOM using Django's `errorlist` markup, so no page reload is needed.

### Backend changes (`sefaria/views.py`)
- `register()` renamed `next` → `next_url` (avoid shadowing built-in)
- URL construction uses `urllib.parse` instead of string concatenation
- Returns `jsonResponse({"redirect": url})` on success with `noredirect`
- Returns `jsonResponse(errors)` on failure with `noredirect`

### New custom GA4 dimensions required
- `flow_id`
- `status`
- `error`
