### PR TITLE
chore(prod): reduce tasks pod replicas from 12 to 6

### DIFF
--- a/envs/prod/helmrelease.yaml
+++ b/envs/prod/helmrelease.yaml
@@ -121,7 +121,7 @@ spec:
         limits:
           memory: "6Gi"
           cpu: "1000m"
-      replicaCount: 12
+      replicaCount: 6
       redis:
         url: ""
         port: "26379"


### PR DESCRIPTION
## Summary
- Reduce tasks pod `replicaCount` from 12 to 6 in prod HelmRelease

## Changes
- `envs/prod/helmrelease.yaml`: `tasks.replicaCount` 12 → 6

## Testing Checklist
- [ ] Verify tasks pods scale down to 6 after merge and Flux reconciliation
- [ ] Monitor task queue processing to ensure no degradation