### PR TITLE
Documenting Endpoints

### DIFF
--- a/docs/decisions/documented_endpoints.md
+++ b/docs/decisions/documented_endpoints.md
@@ -17,7 +17,7 @@ A complete inventory of every Sefaria API endpoint and the decision on whether t
 | Skipped — auth flow (login / register / JWT) | 4 |
 | Skipped — forms / telemetry / subscribe | 5 |
 | Skipped — duplicates or version-status helpers | ~12 |
-| Skipped — broken / unreliable | 2 |
+| Skipped — broken / unreliable | 3 |
 | **Total** | **~152** |
 
 (Counts use ~ because a few endpoints serve multiple regex patterns; the totals jiggle by 1–3 depending on how you count.)
@@ -35,11 +35,11 @@ An endpoint is skipped from public documentation if any of the following apply:
 
 When a future engineer adds a new endpoint, the rubric above is the contract: if it fits a skip bucket, it stays out of `openAPI.json` unless we explicitly revisit.
 
-## In scope — newly documented (31 endpoints)
+## In scope — newly documented (29 endpoints)
 
 All endpoints are served from `https://www.sefaria.org`. Sheets are *viewed* at `voices.sefaria.org`, but their API endpoints live at `www.sefaria.org` like everything else.
 
-### Sheets (12)
+### Sheets (13)
 
 | Endpoint | Description | Notes |
 |---|---|---|
@@ -74,17 +74,17 @@ All endpoints are served from `https://www.sefaria.org`. Sheets are *viewed* at 
 
 (`GET /api/texts/parashat_hashavua` was originally in scope but moved to "broken / unreliable" — see below — after consistent 504s during capture on 2026-05-05.)
 
-### Index (6, including Authors fold-in)
+### Index (7, including Authors fold-in)
 
 | Endpoint | Description |
 |---|---|
-| `GET /api/index/titles/` | All index titles. |
+| `GET /api/index/titles` | All index titles. |
 | `GET /api/index/{title}` | Index metadata. |
 | `GET /api/v2/index/{title}` | v2 index metadata. |
 | `GET /api/counts/{title}` | Word/segment counts for a title. |
 | `GET /api/counts/links/{cat1}/{cat2}` | Link counts between two categories. |
 | `GET /api/counts/words/{title}/{version}/{language}` | Word counts for a specific version. |
-| `GET /api/authors/{author_slug}/indexes/` | List of indexes by an author. (author_slug lookup recipe.) |
+| `GET /api/authors/{author_slug}/indexes` | List of indexes by an author. (author_slug lookup recipe.) |
 
 ### Related (1)
 
@@ -96,8 +96,8 @@ All endpoints are served from `https://www.sefaria.org`. Sheets are *viewed* at 
 
 | Endpoint | Description | Notes |
 |---|---|---|
-| `GET /api/calendars/topics/parasha/` | Topic info for current parasha. | — |
-| `GET /api/calendars/topics/holiday/` | Topic info for current holiday. | Returns 404 when no holiday is active; example uses a fixed canonical holiday date |
+| `GET /api/calendars/topics/parasha` | Topic info for current parasha. | — |
+| `GET /api/calendars/topics/holiday` | Topic info for current holiday. | Returns 404 when no holiday is active; example uses a fixed canonical holiday date |
 
 ### Misc (1, including Profile fold-in)
 
@@ -232,13 +232,13 @@ Endpoints group into the following sidebar folders (= OpenAPI `tags`):
 
 | Tag | Endpoint count | Net change |
 |---|---|---|
-| Text | 8 | +3 |
-| Index | 11 | +7 (incl. Authors fold-in) |
+| Text | 9 | +2 |
+| Index | 10 | +7 (incl. Authors fold-in) |
 | Related | 5 | +1 |
 | Calendars | 4 | +2 |
 | Lexicon | 3 | unchanged |
 | Topic | 5 | unchanged |
 | Term | 1 | unchanged |
-| Sheets *(new)* | 12 | +12 |
+| Sheets *(new)* | 13 | +13 |
 | Collections *(new)* | 3 | +3 |
 | Misc | 7 | +1 (Profile fold-in) |

--- a/docs/decisions/documented_endpoints.md
+++ b/docs/decisions/documented_endpoints.md
@@ -49,8 +49,8 @@ All endpoints are served from `https://www.sefaria.org`. Sheets are *viewed* at 
 | `GET /api/sheets/user/{user_id}` | List a user's public sheets. | Split path; user_id recipe; public-only caveat |
 | `GET /api/sheets/user/{user_id}/{sort_by}/{limiter}/{offset}` | Same, paginated and sorted. | Same as above |
 | `GET /api/v2/sheets/bulk/{sheet_id_list}` | Fetch many sheets at once via piped ID list. | sheet_id recipe |
-| `GET /api/sheets/trending-tags/` | Currently trending sheet tags. | — |
-| `GET /api/sheets/tag-list/` | All sheet tags, sorted by count. | — |
+| `GET /api/sheets/trending-tags` | Currently trending sheet tags. | — |
+| `GET /api/sheets/tag-list` | All sheet tags, sorted by count. | — |
 | `GET /api/sheets/tag-list/{sort_by}` | All sheet tags with chosen sort order. | — |
 | `GET /api/sheets/tag-list/user/{user_id}` | Tags used on a specific user's sheets. | user_id recipe |
 | `GET /api/sheets/ref/{ref}` | Public sheets that cite a given ref. | — |

--- a/docs/decisions/documented_endpoints.md
+++ b/docs/decisions/documented_endpoints.md
@@ -10,7 +10,7 @@ A complete inventory of every Sefaria API endpoint and the decision on whether t
 | Bucket | Count |
 |---|---|
 | Already documented in `openAPI.json` | 30 |
-| Newly added in the 2026-05 documentation pass | 29 |
+| Newly added in the 2026-05 documentation pass | 28 |
 | Skipped — login-required (per-user data) | ~38 |
 | Skipped — staff-only (admin / moderation) | ~22 |
 | Skipped — internal infrastructure | ~8 |
@@ -39,12 +39,11 @@ When a future engineer adds a new endpoint, the rubric above is the contract: if
 
 All endpoints are served from `https://www.sefaria.org`. Sheets are *viewed* at `voices.sefaria.org`, but their API endpoints live at `www.sefaria.org` like everything else.
 
-### Sheets (13)
+### Sheets (11)
 
 | Endpoint | Description | Notes |
 |---|---|---|
 | `GET /api/sheets/{sheet_id}` | Fetch a single sheet by ID. | sheet_id lookup recipe |
-| `GET /api/sheets/{sheet_id}/likers` | List users who have liked a sheet. | sheet_id lookup recipe |
 | `GET /api/sheets/modified/{sheet_id}/{timestamp}` | Check whether a sheet has been modified since a timestamp. | sheet_id lookup recipe |
 | `GET /api/sheets/user/{user_id}` | List a user's public sheets. | Split path; user_id recipe; public-only caveat |
 | `GET /api/sheets/user/{user_id}/{sort_by}/{limiter}/{offset}` | Same, paginated and sorted. | Same as above |
@@ -55,7 +54,6 @@ All endpoints are served from `https://www.sefaria.org`. Sheets are *viewed* at 
 | `GET /api/sheets/tag-list/user/{user_id}` | Tags used on a specific user's sheets. | user_id recipe |
 | `GET /api/sheets/ref/{ref}` | Public sheets that cite a given ref. | — |
 | `GET /api/sheets/all-sheets/{limiter}/{offset}` | Paginated list of all public sheets. | — |
-| `GET /api/sheets/{parasha}/get_aliyot` | Aliyot ranges for a parasha (sheet builder helper). | — |
 
 ### Collections (3)
 
@@ -92,12 +90,13 @@ All endpoints are served from `https://www.sefaria.org`. Sheets are *viewed* at 
 |---|---|
 | `GET /api/link-summary/{ref}` | Summary of links by category. |
 
-### Calendars (2)
+### Calendars (3)
 
 | Endpoint | Description | Notes |
 |---|---|---|
 | `GET /api/calendars/topics/parasha` | Topic info for current parasha. | — |
 | `GET /api/calendars/topics/holiday` | Topic info for current holiday. | Returns 404 when no holiday is active; example uses a fixed canonical holiday date |
+| `GET /api/sheets/{parasha}/get_aliyot` | Aliyot ranges for a parasha. | Moved to Calendars tag (URL is under /api/sheets/ for historical reasons) |
 
 ### Misc (1, including Profile fold-in)
 
@@ -202,6 +201,12 @@ CSRF-form-shaped endpoints, not API-shaped consumer endpoints.
 - `GET /api/newsletter_mailing_lists/`
 - `POST /api/find-refs/report/`
 
+## Removed after initial documentation
+
+Endpoints that were documented then removed on review.
+
+- `GET /api/sheets/{id}/likers` — removed 2026-05-07; not useful enough to external developers to warrant public documentation.
+
 ## Out of scope — duplicates or version-status helpers
 
 Alternate shapes of already-documented endpoints, or admin-dashboard helpers.
@@ -235,10 +240,10 @@ Endpoints group into the following sidebar folders (= OpenAPI `tags`):
 | Text | 9 | +2 |
 | Index | 10 | +7 (incl. Authors fold-in) |
 | Related | 5 | +1 |
-| Calendars | 4 | +2 |
+| Calendars | 5 | +3 (incl. Aliyot fold-in) |
 | Lexicon | 3 | unchanged |
 | Topic | 5 | unchanged |
 | Term | 1 | unchanged |
-| Sheets *(new)* | 13 | +13 |
+| Sheets *(new)* | 11 | +11 |
 | Collections *(new)* | 3 | +3 |
 | Misc | 7 | +1 (Profile fold-in) |

--- a/docs/decisions/documented_endpoints.md
+++ b/docs/decisions/documented_endpoints.md
@@ -1,0 +1,244 @@
+# API Endpoint Documentation Audit
+
+A complete inventory of every Sefaria API endpoint and the decision on whether to publish it in [`docs/openAPI.json`](../openAPI.json) (which is what becomes the public reference at developers.sefaria.org via ReadMe).
+
+**Last reviewed:** 2026-05-04
+**Scope:** Every `api/` and `_api/` route declared in [`sefaria/urls_shared.py`](../../sefaria/urls_shared.py) and [`sefaria/urls_library.py`](../../sefaria/urls_library.py). (`urls_sheets.py` adds no API routes; it pulls in `shared_patterns`.)
+
+## Summary
+
+| Bucket | Count |
+|---|---|
+| Already documented in `openAPI.json` | 30 |
+| Newly added in the 2026-05 documentation pass | 29 |
+| Skipped — login-required (per-user data) | ~38 |
+| Skipped — staff-only (admin / moderation) | ~22 |
+| Skipped — internal infrastructure | ~8 |
+| Skipped — auth flow (login / register / JWT) | 4 |
+| Skipped — forms / telemetry / subscribe | 5 |
+| Skipped — duplicates or version-status helpers | ~12 |
+| Skipped — broken / unreliable | 2 |
+| **Total** | **~152** |
+
+(Counts use ~ because a few endpoints serve multiple regex patterns; the totals jiggle by 1–3 depending on how you count.)
+
+## Skip rubric
+
+An endpoint is skipped from public documentation if any of the following apply:
+
+- **Auth-gated** — requires `@login_required` or `@staff_member_required`. We do not distribute API keys, so external developers cannot call these.
+- **Internal-only shape** — built for our own services (Strapi cache, remote-config, async polling, opensearch suggestions, linker telemetry).
+- **Auth flow** — `/api/login`, `/api/login/refresh`, `/api/register`, `/api/account/delete`. Worth documenting later as a dedicated authentication sub-project.
+- **Form / telemetry** — newsletter subscribes, feedback submission, linker tracking.
+- **Duplicate / legacy redirect** — alternate shapes of an already-documented endpoint, or legacy redirects to current versions.
+- **Broken** — endpoint returns 504 / 5xx under normal load.
+
+When a future engineer adds a new endpoint, the rubric above is the contract: if it fits a skip bucket, it stays out of `openAPI.json` unless we explicitly revisit.
+
+## In scope — newly documented (31 endpoints)
+
+All endpoints are served from `https://www.sefaria.org`. Sheets are *viewed* at `voices.sefaria.org`, but their API endpoints live at `www.sefaria.org` like everything else.
+
+### Sheets (12)
+
+| Endpoint | Description | Notes |
+|---|---|---|
+| `GET /api/sheets/{sheet_id}` | Fetch a single sheet by ID. | sheet_id lookup recipe |
+| `GET /api/sheets/{sheet_id}/likers` | List users who have liked a sheet. | sheet_id lookup recipe |
+| `GET /api/sheets/modified/{sheet_id}/{timestamp}` | Check whether a sheet has been modified since a timestamp. | sheet_id lookup recipe |
+| `GET /api/sheets/user/{user_id}` | List a user's public sheets. | Split path; user_id recipe; public-only caveat |
+| `GET /api/sheets/user/{user_id}/{sort_by}/{limiter}/{offset}` | Same, paginated and sorted. | Same as above |
+| `GET /api/v2/sheets/bulk/{sheet_id_list}` | Fetch many sheets at once via piped ID list. | sheet_id recipe |
+| `GET /api/sheets/trending-tags/` | Currently trending sheet tags. | — |
+| `GET /api/sheets/tag-list/` | All sheet tags, sorted by count. | — |
+| `GET /api/sheets/tag-list/{sort_by}` | All sheet tags with chosen sort order. | — |
+| `GET /api/sheets/tag-list/user/{user_id}` | Tags used on a specific user's sheets. | user_id recipe |
+| `GET /api/sheets/ref/{ref}` | Public sheets that cite a given ref. | — |
+| `GET /api/sheets/all-sheets/{limiter}/{offset}` | Paginated list of all public sheets. | — |
+| `GET /api/sheets/{parasha}/get_aliyot` | Aliyot ranges for a parasha (sheet builder helper). | — |
+
+### Collections (3)
+
+| Endpoint | Description | Notes |
+|---|---|---|
+| `GET /api/collections` | List collections. | Unauthenticated shape; logged-in users see more |
+| `GET /api/collections/{slug}` | Fetch a single collection. | Unauthenticated shape; logged-in users see more |
+| `GET /api/collections/user-collections/{user_id}` | List a user's collections. | user_id recipe |
+
+### Text (2)
+
+| Endpoint | Description |
+|---|---|
+| `GET /api/bulktext/{refs}` | Text for many refs at once (pipe-delimited). |
+| `GET /api/passages/{refs}` | Contiguous passages for refs. |
+
+(`GET /api/texts/parashat_hashavua` was originally in scope but moved to "broken / unreliable" — see below — after consistent 504s during capture on 2026-05-05.)
+
+### Index (6, including Authors fold-in)
+
+| Endpoint | Description |
+|---|---|
+| `GET /api/index/titles/` | All index titles. |
+| `GET /api/index/{title}` | Index metadata. |
+| `GET /api/v2/index/{title}` | v2 index metadata. |
+| `GET /api/counts/{title}` | Word/segment counts for a title. |
+| `GET /api/counts/links/{cat1}/{cat2}` | Link counts between two categories. |
+| `GET /api/counts/words/{title}/{version}/{language}` | Word counts for a specific version. |
+| `GET /api/authors/{author_slug}/indexes/` | List of indexes by an author. (author_slug lookup recipe.) |
+
+### Related (1)
+
+| Endpoint | Description |
+|---|---|
+| `GET /api/link-summary/{ref}` | Summary of links by category. |
+
+### Calendars (2)
+
+| Endpoint | Description | Notes |
+|---|---|---|
+| `GET /api/calendars/topics/parasha/` | Topic info for current parasha. | — |
+| `GET /api/calendars/topics/holiday/` | Topic info for current holiday. | Returns 404 when no holiday is active; example uses a fixed canonical holiday date |
+
+### Misc (1, including Profile fold-in)
+
+| Endpoint | Description |
+|---|---|
+| `GET /api/profile/{slug}` | Public profile by slug. |
+
+## Already documented (30 endpoints)
+
+These are present in `openAPI.json` as of 2026-05-04. No re-work in this pass; new entries will reuse their tags and component schemas where possible.
+
+| Endpoint | Tag |
+|---|---|
+| `GET /api/v3/texts/{tref}` | Text |
+| `GET /api/texts/{tref}` | Text |
+| `GET /api/texts/versions/{index}` | Text |
+| `GET /api/texts/translations` | Text |
+| `GET /api/texts/translations/{lang}` | Text |
+| `GET /api/texts/random` | Text |
+| `GET /api/texts/random-by-topic` | Text |
+| `GET /api/index` | Index |
+| `GET /api/v2/raw/index/{index_title}` | Index |
+| `GET /api/shape/{title}` | Index |
+| `GET /api/links/{tref}` | Related |
+| `GET /api/related/{tref}` | Related |
+| `GET /api/related/{tref}/websites` | Related |
+| `GET /api/manuscripts/{tref}` | Related |
+| `GET /api/img-gen/{tref}` | Related |
+| `GET /api/calendars` | Calendars |
+| `GET /api/calendars/next-read/{parasha}` | Calendars |
+| `GET /api/words/{word}` | Lexicon |
+| `GET /api/words/completion/{word}/{lexicon}` | Lexicon |
+| `GET /api/topics` | Topic |
+| `GET /api/topics/{topic_slug}` | Topic |
+| `GET /api/v2/topics/{topic_slug}` | Topic |
+| `GET /api/topics-graph/{topic_slug}` | Topic |
+| `GET /api/ref-topic-links/{tref}` | Topic |
+| `GET /api/recommend/topics/{ref_list}` | Topic |
+| `GET /api/terms/{name}` | Term |
+| `GET /api/category/{category_path}` | Misc |
+| `GET /api/name/{name}` | Misc |
+| `POST /api/find-refs` | Misc |
+| `POST /api/search-wrapper` | Misc |
+
+## Out of scope — login required (per-user data)
+
+Skipped because they require `@login_required` and we do not distribute API keys.
+
+- `POST /api/sheets/`, `POST /api/sheets/{id}`, `POST /api/sheets/{id}/delete`, `POST /api/sheets/{id}/add`, `POST /api/sheets/{id}/add_ref`, `POST /api/sheets/{id}/copy_source`, `POST /api/sheets/{id}/topics`, `POST /api/sheets/{id}/like`, `POST /api/sheets/{id}/unlike`, `POST /api/sheets/{id}/export_to_drive`, `POST /api/sheets/create/{ref}`, `POST /api/sheets/upload-image`
+- `GET/POST/DELETE /api/sheets/{id}.{node_id}` (also internal-shaped)
+- `GET /api/sheets/{id}/visualize` (no auth, but tightly coupled to internal renderer)
+- `POST /api/collections`, `POST/DELETE /api/collections/{slug}`, `POST /api/collections/upload`, `GET /api/collections/for-sheet/{id}`, `POST /api/collections/{slug}/set-role/{uid}/{role}`, `POST /api/collections/{slug}/invite/{uid_or_email}` (and uninvite), `POST /api/collections/{slug}/(add|remove)/{id}`, `POST /api/collections/{slug}/pin-sheet/{id}`
+- `GET /api/profile` (own profile), `POST /api/profile/{slug}`, `GET /api/profile/user_history`, `POST /api/profile/sync`, `POST /api/profile/upload-photo`, `POST /api/profile/experiments/opt-in`
+- `GET /api/notes/all`, `GET/POST/DELETE /api/notes/{id_or_ref}`
+- `GET /api/notifications/`, `POST /api/notifications/read`
+- `POST /api/(follow|unfollow)/{uid}`, `GET /api/(followers|followees)/{uid}`, `POST /api/(block|unblock)/{uid}`
+- `GET /api/user_history/saved`
+- `GET /api/user_stats/{uid}`, `GET /api/site_stats/`
+- `GET /api/profile/{slug}/(followers|following)` (skipped this pass per product call; not auth-required)
+- `DELETE /api/account/delete`
+
+## Out of scope — staff only (admin / moderation)
+
+Skipped because they require `@staff_member_required`.
+
+- `POST /api/texts/modify-bulk/{title}`
+- `POST/PATCH /api/versions/`
+- `POST /api/topics/generate-prompts/{slug}`, `POST /api/topic/new`, `DELETE /api/topic/delete/{topic}`, `POST /api/topic/reorder`, `POST /api/source/reorder`
+- `POST /api/sheets/next-untagged/`, `POST /api/sheets/next-uncategorized/`
+- `GET/POST /api/locks/(set|release|check)/{tref}/{lang}/{version}`, `POST /api/locktext/{title}/{lang}/{version}`, `POST /api/version/flags/{title}/{lang}/{version}`, `POST /api/revert/{tref}/{lang}/{version}/{revision}`
+- `POST /api/text-upload`
+- `POST` mutations on `/api/index/{title}`, `/api/v2/index/{title}`, `/api/category/{path}`, `/api/tag-category/{path}`, `/api/terms/{name}`, `/api/topics/{topic}`, `/api/ref-topic-links/{tref}`, `/api/links/{ref}`
+
+## Out of scope — internal infrastructure
+
+Built for our own services, not external consumers.
+
+- `GET /api/remote-config/`
+- `GET /api/strapi/graphql-cache`, `POST /api/strapi/cache-invalidate`
+- `GET /api/async/{task_id}` (only useful when paired with a task-creating endpoint, none of which are public)
+- `GET /api/opensearch-suggestions/` (browser-integration, not API)
+- `GET /api/dummy-search` (test scaffold)
+- `GET /api/background-data` (client-bootstrap blob)
+- `POST /api/linker-track` (telemetry)
+- `GET /api/preview/{title}` (lightweight variant of `/api/texts/{tref}`)
+
+## Out of scope — auth flow
+
+Worth documenting later as a dedicated sub-project. Documenting these would unlock external use of the login-required endpoints above.
+
+- `POST /api/login` (JWT obtain)
+- `POST /api/login/refresh` (JWT refresh)
+- `POST /api/register/`
+- `DELETE /api/account/delete`
+
+## Out of scope — forms / telemetry
+
+CSRF-form-shaped endpoints, not API-shaped consumer endpoints.
+
+- `POST /api/send_feedback`
+- `POST /api/subscribe/{email}`, `POST /api/subscribe/{org}/{email}`
+- `GET /api/newsletter_mailing_lists/`
+- `POST /api/find-refs/report/`
+
+## Out of scope — duplicates or version-status helpers
+
+Alternate shapes of already-documented endpoints, or admin-dashboard helpers.
+
+- `POST /api/search-wrapper/es6`, `POST /api/search-wrapper/es8` (ES6/ES8 compat shapes — `/api/search-wrapper` is the documented one)
+- `GET /api/texts/{tref}/{lang}/{version}` (legacy redirect to v3)
+- `GET /api/texts/version-status/`, `GET /api/texts/version-status/tree/{lang}` (admin-dashboard helpers)
+- `GET /api/topics/pools/{pool_name}`, `GET /api/topics/trending/`, `GET /_api/topics/featured-topic/` (skipped this pass per product call)
+- `GET /api/links/bare/{book}/{cat}` (currently non-functional per product)
+- `GET /api/tag-category/{path}` (overlaps with topics)
+- `GET /api/search-path-filter/{book_title}` (search-internal helper)
+- `GET /api/regexs/{titles}`, `GET /api/linker-data/{titles}` (linker; skipped this pass)
+- `GET /api/websites/{domain}`, `GET /api/portals/{slug}` (skipped this pass)
+- `GET /api/history/{tref}`, `GET /api/history/{tref}/{lang}/{version}` (skipped this pass)
+- `GET /api/updates/{gid}`, `GET /api/guides/{guide_key}`, `GET /api/stats/library-stats`, `GET /api/stats/core-link-stats` (skipped this pass)
+
+## Out of scope — broken / unreliable
+
+Returned 504 Gateway Timeout under normal load when verified live. Should be reviewed by engineering.
+
+- `GET /api/sheets/tag/{tag}` (verified 2026-05-04)
+- `GET /api/v2/sheets/tag/{tag}` (verified 2026-05-04)
+- `GET /api/texts/parashat_hashavua` (verified 2026-05-05; multiple retries with 60s and 120s timeouts all returned 504)
+
+## ReadMe folder structure
+
+Endpoints group into the following sidebar folders (= OpenAPI `tags`):
+
+| Tag | Endpoint count | Net change |
+|---|---|---|
+| Text | 8 | +3 |
+| Index | 11 | +7 (incl. Authors fold-in) |
+| Related | 5 | +1 |
+| Calendars | 4 | +2 |
+| Lexicon | 3 | unchanged |
+| Topic | 5 | unchanged |
+| Term | 1 | unchanged |
+| Sheets *(new)* | 12 | +12 |
+| Collections *(new)* | 3 | +3 |
+| Misc | 7 | +1 (Profile fold-in) |

--- a/docs/openAPI.json
+++ b/docs/openAPI.json
@@ -49,16 +49,16 @@
       "description": "Operations related to retrieving Term data (a Sefaria Term is a shared title node)"
     },
     {
-      "name": "Misc",
-      "description": "Miscellaneous API endpoints"
-    },
-    {
       "name": "Sheets",
       "description": "Operations related to Sefaria source sheets"
     },
     {
       "name": "Collections",
       "description": "Operations related to Sefaria collections — curated groups of source sheets"
+    },
+    {
+      "name": "Misc",
+      "description": "Miscellaneous API endpoints"
     }
   ],
   "paths": {
@@ -5785,7 +5785,7 @@
         "parameters": [
           {
             "name": "sheet_id",
-            "description": "The numeric ID of the sheet. To find a sheet's ID, open the sheet on `voices.sefaria.org` and copy the number from the URL — for example, `https://voices.sefaria.org/sheets/643492` has a sheet ID of `643492`. The API call itself is made to `www.sefaria.org`.",
+            "description": "Numeric sheet ID. Find it in the sheet URL: `https://www.sefaria.org/sheets/{sheet_id}`.",
             "schema": {
               "type": "integer"
             },
@@ -6242,10 +6242,16 @@
             "name": "author_slug",
             "description": "The author's topic slug. To find a slug: search for the author on `https://www.sefaria.org`, open their topic page, and copy the last segment of the URL — for example, `https://www.sefaria.org/topics/rashi` has an author slug of `rashi`.",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "default": "rashi"
             },
             "in": "path",
-            "required": true
+            "required": true,
+            "examples": {
+              "Rashi": {
+                "value": "rashi"
+              }
+            }
           }
         ],
         "responses": {
@@ -7316,47 +7322,6 @@
         "description": "Returns the list of indexes (works) attributed to a given Sefaria author."
       }
     },
-    "/api/sheets/{sheet_id}/likers": {
-      "summary": "Sheet Likers",
-      "description": "Returns the list of users who have liked a sheet.",
-      "get": {
-        "operationId": "get-sheet-likers",
-        "tags": [
-          "Sheets"
-        ],
-        "parameters": [
-          {
-            "name": "sheet_id",
-            "description": "The numeric ID of the sheet. To find a sheet's ID, open the sheet on `voices.sefaria.org` and copy the number from the URL — for example, `https://voices.sefaria.org/sheets/643492` has a sheet ID of `643492`. The API call itself is made to `www.sefaria.org`.",
-            "schema": {
-              "type": "integer"
-            },
-            "in": "path",
-            "required": true
-          }
-        ],
-        "description": "Returns the list of users who have liked a sheet.",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SheetLikersJSON"
-                },
-                "examples": {
-                  "Sheet 643492": {
-                    "value": {
-                      "likers": []
-                    }
-                  }
-                }
-              }
-            },
-            "description": "Successful Response"
-          }
-        }
-      }
-    },
     "/api/sheets/modified/{sheet_id}/{timestamp}": {
       "summary": "Sheet Modified Check",
       "description": "Returns the full sheet if it has been modified since the given timestamp; otherwise returns an empty/unchanged response. Useful for clients that cache sheets.",
@@ -7368,7 +7333,7 @@
         "parameters": [
           {
             "name": "sheet_id",
-            "description": "The numeric ID of the sheet. To find a sheet's ID, open the sheet on `voices.sefaria.org` and copy the number from the URL — for example, `https://voices.sefaria.org/sheets/643492` has a sheet ID of `643492`. The API call itself is made to `www.sefaria.org`.",
+            "description": "Numeric sheet ID. Find it in the sheet URL: `https://www.sefaria.org/sheets/{sheet_id}`.",
             "schema": {
               "type": "integer"
             },
@@ -7379,10 +7344,16 @@
             "name": "timestamp",
             "description": "An ISO-8601 timestamp. The sheet is returned only if its `dateModified` is more recent than this value.",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "default": "2024-01-01T00:00:00"
             },
             "in": "path",
-            "required": true
+            "required": true,
+            "examples": {
+              "Example timestamp": {
+                "value": "2024-01-01T00:00:00"
+              }
+            }
           }
         ],
         "description": "Returns the full sheet if it has been modified since the given timestamp; otherwise returns an empty/unchanged response. Useful for clients that cache sheets.",
@@ -7658,7 +7629,7 @@
         }
       }
     },
-    "/api/sheets/user/{user_id}/": {
+    "/api/sheets/user/{user_id}": {
       "summary": "User's Sheets",
       "description": "Returns a user's public sheets. For anonymous callers, only public sheets are returned. An authenticated user requesting their own user_id additionally sees their private sheets.",
       "get": {
@@ -7669,7 +7640,7 @@
         "parameters": [
           {
             "name": "user_id",
-            "description": "The numeric Sefaria user ID. To find a user_id, open the user's profile page (e.g. `https://voices.sefaria.org/profile/user-slug`), then call `GET /api/profile/{slug}` with the slug from the URL — the response contains the numeric `id`.",
+            "description": "Numeric user ID. To find it, call `GET /api/profile/{slug}` with the user's profile slug and read the `id` field from the response.",
             "schema": {
               "type": "integer"
             },
@@ -8763,7 +8734,7 @@
         "parameters": [
           {
             "name": "user_id",
-            "description": "The numeric Sefaria user ID. To find a user_id, open the user's profile page (e.g. `https://voices.sefaria.org/profile/user-slug`), then call `GET /api/profile/{slug}` with the slug from the URL — the response contains the numeric `id`.",
+            "description": "Numeric user ID. To find it, call `GET /api/profile/{slug}` with the user's profile slug and read the `id` field from the response.",
             "schema": {
               "type": "integer"
             },
@@ -8778,28 +8749,46 @@
               "enum": [
                 "date",
                 "views"
-              ]
+              ],
+              "default": "date"
             },
             "in": "path",
-            "required": true
+            "required": true,
+            "examples": {
+              "By date": {
+                "value": "date"
+              }
+            }
           },
           {
             "name": "limiter",
             "description": "Maximum number of sheets to return.",
             "schema": {
-              "type": "integer"
+              "type": "integer",
+              "default": 10
             },
             "in": "path",
-            "required": true
+            "required": true,
+            "examples": {
+              "First 10": {
+                "value": 10
+              }
+            }
           },
           {
             "name": "offset",
             "description": "Offset into the result set, used for pagination.",
             "schema": {
-              "type": "integer"
+              "type": "integer",
+              "default": 0
             },
             "in": "path",
-            "required": true
+            "required": true,
+            "examples": {
+              "First page": {
+                "value": 0
+              }
+            }
           }
         ],
         "description": "Returns a user's public sheets, paginated and sorted. Same response shape as the unparameterized variant.",
@@ -8999,7 +8988,7 @@
         "parameters": [
           {
             "name": "sheet_id_list",
-            "description": "Pipe-delimited list of sheet IDs, e.g. `643492|643493`. Each ID is the numeric segment from the sheet's URL on `voices.sefaria.org`.",
+            "description": "Pipe-delimited list of numeric sheet IDs. Find each ID in its sheet URL: `https://www.sefaria.org/sheets/{sheet_id}`.",
             "schema": {
               "type": "string"
             },
@@ -9169,10 +9158,16 @@
               "enum": [
                 "count",
                 "alpha"
-              ]
+              ],
+              "default": "count"
             },
             "in": "path",
-            "required": true
+            "required": true,
+            "examples": {
+              "By count": {
+                "value": "count"
+              }
+            }
           }
         ],
         "description": "Returns all sheet tags with their usage counts, sorted by the given key.",
@@ -9290,7 +9285,7 @@
         "parameters": [
           {
             "name": "user_id",
-            "description": "The numeric Sefaria user ID. To find a user_id, open the user's profile page (e.g. `https://voices.sefaria.org/profile/user-slug`), then call `GET /api/profile/{slug}` with the slug from the URL — the response contains the numeric `id`.",
+            "description": "Numeric user ID. To find it, call `GET /api/profile/{slug}` with the user's profile slug and read the `id` field from the response.",
             "schema": {
               "type": "integer"
             },
@@ -9748,10 +9743,16 @@
             "name": "ref",
             "description": "Sefaria ref, e.g. `Genesis.1.1`. Use dots for section separators in the URL.",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "default": "Genesis.1.1"
             },
             "in": "path",
-            "required": true
+            "required": true,
+            "examples": {
+              "Genesis 1:1": {
+                "value": "Genesis.1.1"
+              }
+            }
           }
         ],
         "description": "Returns public sheets that cite the given Sefaria ref.",
@@ -10115,19 +10116,31 @@
             "name": "limiter",
             "description": "Maximum number of sheets to return.",
             "schema": {
-              "type": "integer"
+              "type": "integer",
+              "default": 10
             },
             "in": "path",
-            "required": true
+            "required": true,
+            "examples": {
+              "First 10": {
+                "value": 10
+              }
+            }
           },
           {
             "name": "offset",
             "description": "Offset into the result set, used for pagination.",
             "schema": {
-              "type": "integer"
+              "type": "integer",
+              "default": 0
             },
             "in": "path",
-            "required": true
+            "required": true,
+            "examples": {
+              "First page": {
+                "value": 0
+              }
+            }
           }
         ],
         "description": "Returns a paginated list of all public sheets.",
@@ -10430,17 +10443,23 @@
       "get": {
         "operationId": "get-aliyot-by-parasha",
         "tags": [
-          "Sheets"
+          "Calendars"
         ],
         "parameters": [
           {
             "name": "parasha",
             "description": "Parasha name in transliteration, e.g. `Bereshit`.",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "default": "Bereshit"
             },
             "in": "path",
-            "required": true
+            "required": true,
+            "examples": {
+              "Bereshit": {
+                "value": "Bereshit"
+              }
+            }
           }
         ],
         "description": "Returns the seven aliyot ranges for a given parasha. Used by the source sheet builder when seeding a sheet from a weekly reading.",
@@ -10552,10 +10571,16 @@
             "name": "slug",
             "description": "URL slug for the collection, e.g. `parshawisdom`. The slug appears in the collection's URL on Sefaria.",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "default": "parshawisdom"
             },
             "in": "path",
-            "required": true
+            "required": true,
+            "examples": {
+              "Example collection": {
+                "value": "parshawisdom"
+              }
+            }
           }
         ],
         "description": "Returns the full content of a single collection, including its member sheets. For unauthenticated callers, only publicly-listed collections are accessible.",
@@ -11029,7 +11054,7 @@
         "parameters": [
           {
             "name": "user_id",
-            "description": "The numeric Sefaria user ID. To find a user_id, open the user's profile page (e.g. `https://voices.sefaria.org/profile/user-slug`), then call `GET /api/profile/{slug}` with the slug from the URL — the response contains the numeric `id`.",
+            "description": "Numeric user ID. To find it, call `GET /api/profile/{slug}` with the user's profile slug and read the `id` field from the response.",
             "schema": {
               "type": "integer"
             },
@@ -11159,7 +11184,7 @@
     },
     "/api/bulktext/{refs}": {
       "summary": "Bulk Text",
-      "description": "Returns the English and Hebrew text plus version metadata for many refs at once. The path parameter is a pipe-delimited list of refs.",
+      "description": "Returns the English and Hebrew text plus metadata such as the language, ref for the url, etc. for many refs at once. The path parameter is a pipe-delimited list of refs.",
       "get": {
         "operationId": "get-bulktext",
         "tags": [
@@ -11168,15 +11193,21 @@
         "parameters": [
           {
             "name": "refs",
-            "description": "Pipe-delimited list of Sefaria refs, e.g. `Genesis.1.1|Exodus.1.1`. Use dots for section separators.",
+            "description": "Pipe-delimited list of Sefaria refs. Use dots for section separators, e.g. `Genesis.1.1|Exodus.1.1`.",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "default": "Genesis.1.1|Exodus.1.1"
             },
             "in": "path",
-            "required": true
+            "required": true,
+            "examples": {
+              "Genesis 1:1 and Exodus 1:1": {
+                "value": "Genesis.1.1|Exodus.1.1"
+              }
+            }
           }
         ],
-        "description": "Returns the English and Hebrew text plus version metadata for many refs at once. The path parameter is a pipe-delimited list of refs.",
+        "description": "Returns the English and Hebrew text plus metadata such as the language, ref for the url, etc. for many refs at once. The path parameter is a pipe-delimited list of refs.",
         "responses": {
           "200": {
             "content": {
@@ -11215,7 +11246,7 @@
     },
     "/api/passages/{refs}": {
       "summary": "Passages",
-      "description": "Maps each requested ref to the canonical passage that contains it (e.g. a single verse mapped to its three-verse parasha-style passage).",
+      "description": "Maps each requested ref to the canonical passage that contains it. Particularly useful for Talmud sugyot — a single amud ref is mapped to the full sugya boundary. Also works for Tanakh, where a verse maps to its parasha-style passage. Pass a pipe-delimited list of refs.",
       "get": {
         "operationId": "get-passages",
         "tags": [
@@ -11224,15 +11255,21 @@
         "parameters": [
           {
             "name": "refs",
-            "description": "Pipe-delimited list of Sefaria refs, e.g. `Genesis.1.1`.",
+            "description": "A Sefaria ref from Tanakh, Mishnah or Talmud.",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "default": "Genesis.1.1"
             },
             "in": "path",
-            "required": true
+            "required": true,
+            "examples": {
+              "Genesis 1:1": {
+                "value": "Genesis.1.1"
+              }
+            }
           }
         ],
-        "description": "Maps each requested ref to the canonical passage that contains it (e.g. a single verse mapped to its three-verse parasha-style passage).",
+        "description": "Maps each requested ref to the canonical passage that contains it. Particularly useful for Talmud sugyot — a single amud ref is mapped to the full sugya boundary. Also works for Tanakh, where a verse maps to its parasha-style passage. Pass a pipe-delimited list of refs.",
         "responses": {
           "200": {
             "content": {
@@ -11308,10 +11345,16 @@
             "name": "title",
             "description": "The index title, e.g. `Genesis`. Use the canonical English title; check `GET /api/index/titles` for valid values.",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "default": "Genesis"
             },
             "in": "path",
-            "required": true
+            "required": true,
+            "examples": {
+              "Genesis": {
+                "value": "Genesis"
+              }
+            }
           }
         ],
         "description": "Returns metadata for a single index (work) by title — categories, schema (text structure), authors, descriptive copy, and ordering hints.",
@@ -12458,10 +12501,16 @@
             "name": "title",
             "description": "The index title, e.g. `Genesis`.",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "default": "Genesis"
             },
             "in": "path",
-            "required": true
+            "required": true,
+            "examples": {
+              "Genesis": {
+                "value": "Genesis"
+              }
+            }
           }
         ],
         "description": "Same as `GET /api/index/{title}`. Returns metadata for a single index (work) by title.",
@@ -13608,10 +13657,16 @@
             "name": "title",
             "description": "The index title, e.g. `Genesis`.",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "default": "Genesis"
             },
             "in": "path",
-            "required": true
+            "required": true,
+            "examples": {
+              "Genesis": {
+                "value": "Genesis"
+              }
+            }
           }
         ],
         "description": "Returns word and segment counts for a text, broken down by language.",
@@ -18629,19 +18684,31 @@
             "name": "cat1",
             "description": "First Sefaria category, e.g. `Tanakh`.",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "default": "Tanakh"
             },
             "in": "path",
-            "required": true
+            "required": true,
+            "examples": {
+              "Tanakh": {
+                "value": "Tanakh"
+              }
+            }
           },
           {
             "name": "cat2",
             "description": "Second Sefaria category, e.g. `Bavli`.",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "default": "Bavli"
             },
             "in": "path",
-            "required": true
+            "required": true,
+            "examples": {
+              "Bavli": {
+                "value": "Bavli"
+              }
+            }
           }
         ],
         "description": "Returns the number of links between every book in `cat1` and every book in `cat2`. Returns an error response if no links exist between the requested category pair.",
@@ -18720,7 +18787,7 @@
     },
     "/api/counts/words/{title}/{version}/{language}": {
       "summary": "Word Count for Version",
-      "description": "Returns the word count for a specific text version.",
+      "description": "Returns the word count for a specific text version. Example: title=`Genesis`, version=`Miqra according to the Masorah`, language=`he`.",
       "get": {
         "operationId": "get-counts-words",
         "tags": [
@@ -18731,31 +18798,49 @@
             "name": "title",
             "description": "The index title, e.g. `Genesis`.",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "default": "Genesis"
             },
             "in": "path",
-            "required": true
+            "required": true,
+            "examples": {
+              "Genesis": {
+                "value": "Genesis"
+              }
+            }
           },
           {
             "name": "version",
-            "description": "The version title. URL-encode any special characters.",
+            "description": "The version title. Use `GET /api/texts/versions/{index}` to list available versions for a given text. URL-encode any special characters.",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "default": "Miqra according to the Masorah"
             },
             "in": "path",
-            "required": true
+            "required": true,
+            "examples": {
+              "Miqra according to the Masorah": {
+                "value": "Miqra according to the Masorah"
+              }
+            }
           },
           {
             "name": "language",
             "description": "The version language code, e.g. `en` or `he`.",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "default": "he"
             },
             "in": "path",
-            "required": true
+            "required": true,
+            "examples": {
+              "Hebrew": {
+                "value": "he"
+              }
+            }
           }
         ],
-        "description": "Returns the word count for a specific text version.",
+        "description": "Returns the word count for a specific text version. Example: title=`Genesis`, version=`Miqra according to the Masorah`, language=`he`.",
         "responses": {
           "200": {
             "content": {
@@ -18764,9 +18849,9 @@
                   "$ref": "#/components/schemas/CountsWordsJSON"
                 },
                 "examples": {
-                  "JPS 1917 Genesis (en)": {
+                  "Miqra according to the Masorah (Genesis, he)": {
                     "value": {
-                      "wordCount": 38340
+                      "wordCount": 20621
                     }
                   }
                 }
@@ -18790,10 +18875,16 @@
             "name": "ref",
             "description": "Sefaria ref, e.g. `Genesis.1.1`.",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "default": "Mishnah_Peah.2.1"
             },
             "in": "path",
-            "required": true
+            "required": true,
+            "examples": {
+              "Mishnah Peah 2:1": {
+                "value": "Mishnah_Peah.2.1"
+              }
+            }
           }
         ],
         "description": "Returns a summary of all links targeting a ref, grouped by category, with per-book breakdowns.",
@@ -18808,476 +18899,25 @@
                   }
                 },
                 "examples": {
-                  "Genesis 1:1 link summary": {
+                  "Mishnah Peah 2:1": {
                     "value": [
                       {
                         "name": "Commentary",
-                        "count": 1431,
+                        "count": 133,
                         "books": {
-                          "Rashbam on Genesis": 1,
-                          "Ramban on Genesis": 4,
-                          "Sforno on Genesis": 6,
-                          "Kli Yakar on Genesis": 10,
-                          "Ibn Ezra on Genesis": 10,
-                          "Shadal on Genesis": 3,
-                          "Kitzur Ba'al HaTurim on Genesis": 1,
-                          "Or HaChaim on Genesis": 64,
-                          "Radak on Genesis": 6,
-                          "Haamek Davar on Genesis": 2,
-                          "Meshekh Chokhmah, Bereshit": 1,
-                          "Penei David, Genesis, Bereshit": 5,
-                          "Tur HaArokh, Genesis": 1,
-                          "Minchat Shai on Torah, Genesis": 3,
-                          "Mizrachi, Genesis": 25,
-                          "Rabbeinu Bahya, Bereshit": 7,
-                          "Malbim on Genesis": 2,
-                          "HaKtav VeHaKabalah, Genesis": 5,
-                          "Torah Temimah on Torah, Genesis": 9,
-                          "Riva on Torah, Genesis": 2,
-                          "Siftei Chakhamim, Genesis": 20,
-                          "Ralbag Beur HaMilot on Torah, Genesis": 1,
-                          "Tzror HaMor on Torah, Genesis": 4,
-                          "Ralbag on Torah, Genesis": 8,
-                          "Recanati on the Torah, Bereshit": 1,
-                          "Rosh on Torah, Genesis": 3,
-                          "Nachal Kedumim on Torah, Genesis": 6,
-                          "Yeriot Shlomo on Torah, Genesis": 6,
-                          "Toledot Yitzchak on Torah, Genesis": 3,
-                          "Minei Targuma on Torah, Genesis": 1,
-                          "Paaneach Raza, Bereshit": 31,
-                          "Gur Aryeh on Bereishit": 19,
-                          "Rav Hirsch on Torah, Genesis": 6,
-                          "Maskil LeDavid, Genesis": 5,
-                          "Tzror HaMor on Torah, Exodus": 1,
-                          "The Five Books of Moses, by Everett Fox, Genesis, Part I; The Primeval History": 3,
-                          "The Five Books of Moses, by Everett Fox, Genesis, Part I; The Primeval History, God as Creator": 2,
-                          "The Five Books of Moses, by Everett Fox, Genesis, On the Book of Genesis and Its Structure": 2,
-                          "Magen Avraham": 1,
-                          "Saadia Gaon on Genesis": 3,
-                          "Hadar Zekenim on Torah, Genesis": 7,
-                          "Reggio on Torah, Genesis": 3,
-                          "Netinah LaGer, Genesis": 2,
-                          "Levush HaOrah, Genesis": 6,
-                          "Rashi on Genesis": 3,
-                          "Steinsaltz on Genesis": 1,
-                          "Tze'enah Ure'enah, Bereshit": 1,
-                          "Pardes Yosef, Genesis": 12,
-                          "Nachalat Ya'akov, Genesis": 4,
-                          "Mechokekei Yehudah; Karnei Ohr, Genesis": 40,
-                          "Mechokekei Yehudah; Yahel Ohr, Genesis": 115,
-                          "The Torah; A Women's Commentary, Genesis": 9,
-                          "The Kehot Chumash; A Chasidic Commentary, Genesis": 13,
-                          "Siftei Kohen on Torah, Genesis": 14,
-                          "Ramban on Leviticus": 3,
-                          "Metzudat Zion on Isaiah": 5,
-                          "Malbim Beur Hamilot on Isaiah": 1,
-                          "Metzudat Zion on Jeremiah": 2,
-                          "Metzudat David on Psalms": 1,
-                          "Rabbeinu Bahya, Devarim": 6,
-                          "Rashi on Bava Kamma": 1,
-                          "Rashi on Berakhot": 1,
-                          "Rash MiShantz on Mishnah Kelim": 1,
-                          "Steinsaltz on Megillah": 3,
-                          "Steinsaltz on Taanit": 1,
-                          "Minchat Ani on Pesach Haggadah, Nirtzah, Chad Gadya": 1,
-                          "Or HaChaim on Numbers": 3,
-                          "Rashba on Megillah": 4,
-                          "Rereading the Rabbis; A Woman's Voice, 6 Procreation": 2,
-                          "Ran on Kiddushin": 1,
-                          "Rif Chullin": 1,
-                          "The Five Books of Moses, by Everett Fox, Exodus, Part I; The Deliverance Narrative": 1,
-                          "The Five Books of Moses, by Everett Fox, Exodus, Part III; The Meeting and Covenant At Sinai, The Meeting and the Covenant": 1,
-                          "The Five Books of Moses, by Everett Fox, Leviticus, On the Book of Leviticus and Its Structure": 2,
-                          "The Five Books of Moses, by Everett Fox, Leviticus, Part II; Ritual Pollution and Purification": 1,
-                          "Ohr LaYesharim on Jerusalem Talmud Chagigah": 3,
-                          "Ohr LaYesharim on Jerusalem Talmud Megillah": 3,
-                          "Ohr LaYesharim on Jerusalem Talmud Rosh Hashanah": 1,
-                          "Karati Bekhol Lev, Shmini": 1,
-                          "Reggio on Torah, Leviticus": 2,
-                          "Judaism's Life Changing Ideas; A Weekly Reading of the Jewish Bible, Noah; The Trace of God": 4,
-                          "I Believe; A Weekly Reading of the Jewish Bible, Bereshit; The Genesis of Love": 5,
-                          "I Believe; A Weekly Reading of the Jewish Bible, Kedoshim; Made with Love": 2,
-                          "I Believe; A Weekly Reading of the Jewish Bible, Naso; The Ethic of Love": 1,
-                          "Megalleh Amukkot on Torah, Vayechi": 1,
-                          "Megalleh Amukkot on Torah, Vayigash": 1,
-                          "Lessons in Leadership; A Weekly Reading of the Jewish Bible, Metzora; How to Praise": 1,
-                          "Sulam on Zohar, Introduction": 19,
-                          "Megalleh Amukkot on Torah, Lech Lecha": 1,
-                          "Megalleh Amukkot on Torah, Vayishlach": 2,
-                          "Megalleh Amukkot on Torah, Vayetzei": 2,
-                          "Megalleh Amukkot on Torah, Vayeshev": 3,
-                          "The Torah; A Women's Commentary, Leviticus": 2,
-                          "The Torah; A Women's Commentary, Contemporary Reflection, Bereshit": 5,
-                          "The Torah; A Women's Commentary, Contemporary Reflection, Noach": 3,
-                          "The Torah; A Women's Commentary, Contemporary Reflection, Tazria": 1,
-                          "The Torah; A Women's Commentary, Numbers": 2,
-                          "The Torah; A Women's Commentary, Deuteronomy": 1,
-                          "The Torah; A Women's Commentary, Parashah Introductions, Bamidbar": 1,
-                          "The Torah; A Women's Commentary, Parashah Introductions, Bereshit": 7,
-                          "The Torah; A Women's Commentary, Exodus": 4,
-                          "The Torah; A Women's Commentary, Parashah Introductions, Kedoshim": 1,
-                          "The Torah; A Women's Commentary, Parashah Introductions, Noach": 1,
-                          "The Torah; A Women's Commentary, Parashah Introductions, Pekudei": 1,
-                          "The Torah; A Women's Commentary, Parashah Introductions, Vayikra": 2,
-                          "The Torah; A Women's Commentary, Postbiblical Interpretations, Bereshit": 1,
-                          "The Torah; A Women's Commentary, Postbiblical Interpretations, Tetzaveh": 1,
-                          "The Torah; A Women's Commentary, Women and Interpretation of the Torah": 1,
-                          "Rashi on Taanit": 2,
-                          "Ikar Tosafot Yom Tov on Mishnah Pesachim": 1,
-                          "Ikar Tosafot Yom Tov on Mishnah Taanit": 1,
-                          "Sforno on Exodus": 1,
-                          "Kitzur Ba'al HaTurim on Exodus": 1,
-                          "Ibn Ezra on Exodus": 8,
-                          "Kli Yakar on Leviticus": 1,
-                          "Metzudat Zion on Psalms": 1,
-                          "Ralbag on Proverbs": 2,
-                          "Ibn Ezra on Psalms": 3,
-                          "Mishnah Berurah": 1,
-                          "Tosafot on Taanit": 2,
-                          "Haamek Davar on Genesis, Kidmat Ha'Emek": 1,
-                          "Haamek Davar on Exodus": 2,
-                          "Haamek Davar on Leviticus": 1,
-                          "Rashi on Shabbat": 1,
-                          "Kli Yakar on Deuteronomy": 1,
-                          "Haamek Davar on Deuteronomy": 2,
-                          "Rashba on Berakhot": 1,
-                          "Kinaat Sofrim on Sefer HaMitzvot, Shorashim": 1,
-                          "Rabbeinu Yonah on Pirkei Avot": 1,
-                          "Tosafot Yom Tov on Mishnah Pesachim": 1,
-                          "Tosafot Yom Tov on Mishnah Shabbat": 1,
-                          "Rabbeinu Bahya, Shemot": 12,
-                          "Rabbeinu Bahya, Vayikra": 3,
-                          "Rabbeinu Bahya, Bamidbar": 5,
-                          "Ralbag Esther, Benefits": 1,
-                          "Yachin on Pirkei Avot": 1,
-                          "Ra'avad on Sefer Yetzirah, Introduction, The Fifty Gates of Understanding": 2,
-                          "Ra'avad on Sefer Yetzirah": 1,
-                          "Ritva on Taanit": 2,
-                          "Minchat Shai on Judges": 1,
-                          "Minchat Shai on Jeremiah": 1,
-                          "Minchat Shai on Ezekiel": 2,
-                          "Minchat Shai on Hosea": 1,
-                          "Minchat Shai on Psalms": 1,
-                          "Minchat Shai on Job": 1,
-                          "Minchat Shai on Daniel": 1,
-                          "Minchat Shai on I Chronicles": 1,
-                          "Minchat Shai on Torah, Exodus": 2,
-                          "Minchat Shai on Torah, Leviticus": 1,
-                          "Minchat Shai on Torah, Numbers": 3,
-                          "Minchat Shai on Torah, Deuteronomy": 2,
-                          "Ibn Ezra on Deuteronomy": 3,
-                          "Tosafot Rid on Megillah Second Recension": 1,
-                          "Melekhet Shelomoh on Mishnah Taanit": 1,
-                          "Mizrachi, Numbers": 2,
-                          "Mizrachi, Deuteronomy": 3,
-                          "Ibn Ezra on Isaiah": 5,
-                          "Mizrachi, Exodus": 6,
-                          "Mizrachi, Leviticus": 1,
-                          "HaKtav VeHaKabalah, Leviticus": 1,
-                          "Steinsaltz on Sukkah": 1,
-                          "Steinsaltz on Rosh Hashanah": 1,
-                          "Steinsaltz on Chagigah": 3,
-                          "Steinsaltz on Bava Kamma": 1,
-                          "Redeeming Relevance; Genesis": 1,
-                          "Masat Moshe on Esther": 1,
-                          "Riva on Torah, Numbers": 1,
-                          "Siftei Chakhamim, Exodus": 2,
-                          "Siftei Chakhamim, Leviticus": 1,
-                          "Tevat Gome, Sh'lach": 1,
-                          "Malbim on Job": 1,
-                          "Ralbag Beur HaMilot on Torah, Exodus": 1,
-                          "Ralbag Beur HaMilot on Torah, Leviticus": 5,
-                          "Ralbag Beur HaMilot on Torah, Deuteronomy": 1,
-                          "Kaf HaChayim on Shulchan Arukh, Orach Chayim": 1,
-                          "Radak on Psalms": 1,
-                          "Or HaChaim on Deuteronomy": 1,
-                          "Mekhir Yayin on Esther": 1,
-                          "Petach Einayim on Shabbat": 1,
-                          "Ralbag on Torah, Exodus": 3,
-                          "Ralbag on Torah, Leviticus": 3,
-                          "Machatzit HaShekel on Orach Chayim": 1,
-                          "Haflaah on Ketubot": 1,
-                          "Naftali Seva Ratzon on Pesach Haggadah, Karpas": 1,
-                          "Recanati on the Torah, Vayera": 2,
-                          "Recanati on the Torah, Toldot": 2,
-                          "Recanati on the Torah, Vayigash": 1,
-                          "Recanati on the Torah, Shemot": 2,
-                          "Recanati on the Torah, Beshalach": 2,
-                          "Recanati on the Torah, Ki Tisa": 1,
-                          "Recanati on the Torah, Achrei Mot": 1,
-                          "Recanati on the Torah, Emor": 1,
-                          "Recanati on the Torah, Eikev": 2,
-                          "Recanati on the Torah, Ki Teitzei": 2,
-                          "Recanati on the Torah, Index, Bereshit": 1,
-                          "Steinsaltz on Arakhin": 1,
-                          "Steinsaltz on Tamid": 1,
-                          "Notes and Corrections on Midrash Lekach Tov, Exodus": 1,
-                          "Rosh David, Bereshit": 1,
-                          "Haamek Sheilah on Sheiltot d'Rav Achai Gaon, Kidmat HaEmek, Part II": 1,
-                          "Haamek Sheilah on Sheiltot d'Rav Achai Gaon, Kidmat HaEmek, Part III": 1,
-                          "Kisse Rahamim on Tractate Soferim": 1,
-                          "Rosh David, Emor": 1,
-                          "Tzror HaMor on Torah, Leviticus": 2,
-                          "Tzror HaMor on Torah, Numbers": 3,
-                          "Tzror HaMor on Torah, Deuteronomy": 1,
-                          "Romemot El on Psalms": 1,
-                          "Yein Levanon on Avot": 2,
-                          "Haamek Davar on Exodus, Introduction to Exodus": 1,
-                          "Nachalat Avot on Avot": 5,
-                          "Machzor Vitry, Laws of Sefer Torah": 1,
-                          "Reshimot Shiurim on Berakhot": 1,
-                          "Peirush Hafla'ah on Pesach Haggadah, Magid, Rabban Gamliel's Three Things": 1,
-                          "Ramban on Exodus": 2,
-                          "Malbim on Psalms": 1,
-                          "Malbim on Jeremiah": 1,
-                          "Notes by Rabbi Yehoshua Hartman on Derekh Chayim, Kol Yisrael; The Opening Mishna": 2,
-                          "Notes by Rabbi Yehoshua Hartman on Derekh Chayim": 44,
-                          "Rashi on Bereshit Rabbah": 1,
-                          "Matnot Kehunah on Bereshit Rabbah": 1,
-                          "Perush Maharzu on Bamidbar Rabbah": 1,
-                          "Matnot Kehunah on Vayikra Rabbah": 1,
-                          "Matnot Kehunah on Devarim Rabbah": 1,
-                          "Matnot Kehunah on Bamidbar Rabbah": 1,
-                          "Notes by Rabbi Yehoshua Hartman on Be'er HaGolah, Well 4": 12,
-                          "Notes by Rabbi Yehoshua Hartman on Be'er HaGolah, Well 5": 3,
-                          "Notes by Rabbi Yehoshua Hartman on Be'er HaGolah, Well 6": 4,
-                          "Notes by Rabbi Yehoshua Hartman on Be'er HaGolah, Well 7": 1,
-                          "Ohr Chadash": 3,
-                          "Notes by Rabbi Yehoshua Hartman on Ohr Chadash, Introduction": 1,
-                          "Notes by Rabbi Yehoshua Hartman on Ohr Chadash": 14,
-                          "Notes by Rabbi Yehoshua Hartman on Ner Mitzvah, Volume I": 1,
-                          "Reshimot Shiurim on Sukkah": 1,
-                          "Notes by Rabbi Yehoshua Hartman on Gevurot Hashem, Introduction to Gevurot Hashem": 2,
-                          "Notes by Rabbi Yehoshua Hartman on Gevurot Hashem, Second Introduction to Gevurot Hashem": 1,
-                          "Notes by Rabbi Yehoshua Hartman on Gevurot Hashem, Third Introduction to Gevurot Hashem": 3,
-                          "Notes by Rabbi Yehoshua Hartman on Gevurot Hashem": 90,
-                          "Notes by Rabbi Yehoshua Hartman on Netivot Olam, Netiv Hatorah": 11,
-                          "Ohev Ger, Part II, Introduction": 1,
-                          "Ohev Ger, Additions, Variants According to Bologna 1482 Edition": 1,
-                          "Rereading the Rabbis; A Woman's Voice, Introduction": 1,
-                          "Meiri on Taanit": 1,
-                          "Rav Hirsch on Torah, Exodus": 1,
-                          "Ibn Ezra on Genesis, Introduction": 1,
-                          "Shiltei HaGiborim on Megillah": 1,
-                          "Mishnat Eretz Yisrael on Mishnah Chagigah": 1,
-                          "Mishnat Eretz Yisrael on Mishnah Megillah": 1,
-                          "Mishnat Eretz Yisrael on Mishnah Taanit": 1,
-                          "Notes by Rabbi Yehoshua Hartman on Tiferet Yisrael": 12,
-                          "Korban HaEdah on Jerusalem Talmud Taanit": 2,
-                          "Korban HaEdah on Jerusalem Talmud Megillah": 1,
-                          "Penei Moshe on Jerusalem Talmud Taanit": 3,
-                          "Gur Aryeh on Shemot": 2,
-                          "Gur Aryeh on Bamidbar": 1,
-                          "Gur Aryeh on Devarim": 1,
-                          "Ohr LaYesharim on Jerusalem Talmud Berakhot": 3,
-                          "Ohr LaYesharim on Jerusalem Talmud Taanit": 1,
-                          "Notes by Rabbi Yehoshua Hartman on Netzach Yisrael": 8,
-                          "Karati Bekhol Lev, Bereshit": 2,
-                          "Karati Bekhol Lev, Bo": 1,
-                          "Hadar Zekenim on Torah, Numbers": 1,
-                          "Sources and References on Torah Ohr, Bereshit": 1,
-                          "Sources and References on Torah Ohr, Miketz": 1,
-                          "Sources and References on Torah Ohr, Mishpatim": 1,
-                          "Sources and References on Torah Ohr, Vayigash": 1,
-                          "Sulam on Zohar, Noach": 1,
-                          "Mikdash Melekh on Zohar": 9,
-                          "Mikdash Melekh, RaMaZ Commentary on Zohar": 8,
-                          "Reggio on Torah, Deuteronomy": 1,
-                          "Mishnat Eretz Yisrael on Mishnah Keritot": 1,
-                          "Mishnat Eretz Yisrael on Mishnah Sanhedrin": 1,
-                          "Ketem Paz on Zohar": 6,
-                          "Ohr HaChammah on Zohar, Preface": 1,
-                          "Ohr HaChammah on Zohar": 30,
-                          "Mishnat Eretz Yisrael on Pirkei Avot": 1,
-                          "Levush HaOrah, Introduction": 1,
-                          "Ohel Ya'akov on Torah, Yitro": 1,
-                          "Ohel Ya'akov on Torah, Tazria": 1,
-                          "Ohel Ya'akov on Torah, Kedoshim": 1,
-                          "Ohel Ya'akov on Torah, Chukat": 1,
-                          "Ohel Ya'akov on Torah, Emor": 1,
-                          "Ohel Ya'akov on Torah, Shoftim": 1,
-                          "Ohel Ya'akov on Torah, Vaetchanan": 1,
-                          "Notes by Rabbi Yehoshua Hartman on Derush al HaTorah, Introduction": 2,
-                          "Notes by Rabbi Yehoshua Hartman on Derush al HaTorah": 8,
-                          "Notes by Rabbi Yehoshua Hartman on Derashat Shabbat HaGadol": 12,
-                          "Pirkei Moshe on Avot": 1,
-                          "Yahel Ohr on Zohar": 72,
-                          "Yahel Ohr on Zohar, Addenda": 3,
-                          "Steinsaltz on Isaiah": 1,
-                          "Steinsaltz on Mishneh Torah, Prayer and the Priestly Blessing": 1,
-                          "Judaism's Life Changing Ideas; A Weekly Reading of the Jewish Bible, Shemini; When Weakness Becomes Strength": 1,
-                          "Studies in Spirituality; A Weekly Reading of the Jewish Bible, Tazria Metzora; The Power of Shame": 1,
-                          "Studies in Spirituality; A Weekly Reading of the Jewish Bible, Bemidbar; The Sound of Silence": 1,
-                          "Studies in Spirituality; A Weekly Reading of the Jewish Bible, Ekev; The Spirituality of Listening": 1,
-                          "Tze'enah Ure'enah, Ki Tavo": 1,
-                          "Megalleh Amukkot on Torah, Shemot": 1,
-                          "Megalleh Amukkot on Torah, Vaera": 2,
-                          "Megalleh Amukkot on Torah, Bo": 2,
-                          "Megalleh Amukkot on Torah, Shmini": 3,
-                          "Megalleh Amukkot on Torah, Kedoshim": 1,
-                          "Megalleh Amukkot on Torah, Korach": 2,
-                          "Megalleh Amukkot on Torah, Bechukotai": 1,
-                          "Megalleh Amukkot on Torah, Sh'lach": 2,
-                          "Megalleh Amukkot on Torah, Balak": 1,
-                          "Megalleh Amukkot on Torah, Shoftim": 1,
-                          "Megalleh Amukkot on Torah, Nitzavim": 1,
-                          "Sirilio on Jerusalem Talmud Kilayim": 1,
-                          "Mechokekei Yehudah; Karnei Ohr, Exodus": 1,
-                          "Mechokekei Yehudah; Yahel Ohr, Introduction": 3,
-                          "Mechokekei Yehudah; Yahel Ohr, Exodus": 10,
-                          "The Torah; A Women's Commentary, Parashah Introductions, Shemot": 1,
-                          "Judaism's Life Changing Ideas; A Weekly Reading of the Jewish Bible, Pekudei; Making Space": 1,
-                          "I Believe; A Weekly Reading of the Jewish Bible, Haazinu; The Arc of the Moral Universe": 1,
-                          "Or HaChaim on Exodus": 1,
-                          "Peri Megadim on Orach Chayim, Eshel Avraham": 1,
-                          "Rashi on Proverbs": 2,
-                          "Od Yosef Chai; Derashot, Bereshit": 1,
-                          "Od Yosef Chai; Derashot, Tetzaveh": 1,
-                          "Od Yosef Chai; Derashot, Ki Tisa": 1,
-                          "The Kehot Chumash; A Chasidic Commentary, Parashah Overviews, Bereshit": 1,
-                          "The Kehot Chumash; A Chasidic Commentary, Parashah Overviews, Bamidbar": 1,
-                          "The Kehot Chumash; A Chasidic Commentary, Exodus": 1,
-                          "Keli Chemdah on Torah, Author's Introduction to Genesis and Exodus": 1,
-                          "Marot HaTzoveot on Joshua": 1,
-                          "Siftei Kohen on Torah, Exodus": 6,
-                          "Siftei Kohen on Torah, Numbers": 1,
-                          "Siftei Kohen on Torah, Deuteronomy": 4,
-                          "Kli Yakar on Exodus": 1,
-                          "Minchat Ani on Torah, Bereshit": 1,
-                          "Sulam on Zohar, Bereshit II": 1,
-                          "Ba'al HaTurim on Genesis": 3,
-                          "Da'at Zekenim on Genesis": 2,
-                          "Abarbanel on Torah, Genesis": 2,
-                          "Bekhor Shor, Genesis": 1,
-                          "Chizkuni, Genesis": 6,
-                          "Avi Ezer, Genesis": 3,
-                          "Chomat Anakh on Torah, Genesis": 1,
-                          "Bartenura on Torah, Genesis": 4,
-                          "Aderet Eliyahu, Genesis": 15,
-                          "Birkat Asher on Torah, Genesis": 6,
-                          "Aderet Eliyahu (Rabbi Yosef Chaim), Bereshit": 1,
-                          "Chanukat HaTorah": 1,
-                          "Chatam Sofer on Torah, Bereshit": 2,
-                          "Em LaMikra, Genesis": 10,
-                          "Alshekh on Torah, Genesis": 1,
-                          "Cassuto on Genesis, From Adam to Noah": 3,
-                          "Divrei David on Rashi, Genesis": 7,
-                          "Buber footnotes on Midrash Mishlei": 1,
-                          "Daf Shevui to Megillah": 1,
-                          "Chizkuni, Exodus": 1,
-                          "Bartenura on Torah, Deuteronomy": 1,
-                          "Birkat Asher on Torah, Exodus": 1,
-                          "Ben Yehoyada on Shabbat": 2,
-                          "Ben Yehoyada on Eruvin": 1,
-                          "Ben Yehoyada on Yoma": 1,
-                          "Ben Yehoyada on Sukkah": 3,
-                          "Ben Yehoyada on Megillah": 1,
-                          "Ben Yehoyada on Taanit": 1,
-                          "Benayahu on Eruvin": 1,
-                          "Benayahu on Yoma": 1,
-                          "Benayahu on Megillah": 1,
-                          "Ben Yehoyada on Kiddushin": 1,
-                          "Ben Yehoyada on Sanhedrin": 2,
-                          "Ben Yehoyada on Chullin": 1,
-                          "Ben Yehoyada on Avodah Zarah": 1,
-                          "Ben Yehoyada on Menachot": 1,
-                          "Derekh Chayyim": 12,
-                          "Commentary on Selected Paragraphs of Arpilei Tohar": 1,
-                          "Birkat Asher on Torah, Deuteronomy": 1,
-                          "Ezra ben Solomon on Song of Songs": 1,
-                          "Eretz Chemdah, Bereshit": 1,
-                          "Cassuto on Genesis, From Noah to Abraham": 1,
-                          "Covenant and Conversation; Genesis; The Book of the Beginnings, Bereshit, The Book of Teaching": 1,
-                          "Covenant and Conversation; Genesis; The Book of the Beginnings, Noach, Drama in Four Acts": 1
+                          "Tosefot Yom Tov on Mishnah Peah": 7,
+                          "Rambam on Mishnah Peah": 8,
+                          "Rash MiShantz on Mishnah Peah": 9,
+                          "Bartenura on Mishnah Peah": 11,
+                          "Yachin on Mishnah Peah": 13,
+                          "Melekhet Shelomoh on Mishnah Peah": 6
                         }
                       },
                       {
                         "name": "Midrash",
-                        "count": 172,
+                        "count": 1,
                         "books": {
-                          "Legends of the Jews": 2,
-                          "Midrash Aggadah, Genesis": 13,
-                          "Midrash Lekach Tov, Genesis": 36,
-                          "Midrash Lekach Tov, Numbers": 1,
-                          "Midrash Lekach Tov, Deuteronomy": 2,
-                          "Yalkut Shimoni on Torah": 8,
-                          "Otzar Midrashim, Midrash Lekach Tov": 1,
-                          "Ruth Rabbah": 1,
-                          "Sifrei Devarim": 1,
-                          "Shemot Rabbah": 10,
-                          "Vayikra Rabbah": 11,
-                          "Tanna DeBei Eliyahu Rabbah": 2,
-                          "Mekhilta DeRabbi Shimon Ben Yochai": 1,
-                          "Pirkei DeRabbi Eliezer": 3,
-                          "Tanna DeBei Eliyahu Zuta, Additions to Seder Eliyahu Zuta, Pirkei DeRabbi Eliezer": 1,
-                          "Yalkut Shimoni on Nach": 1,
-                          "Midrash Tehillim": 4,
-                          "Otzar Midrashim, Midrash Hagadol": 1,
-                          "Otzar Midrashim, R' Nechunya Ben HaKanah": 1,
-                          "Otzar Midrashim, Sefer Tagin ('Crowns')": 3,
-                          "Otzar Midrashim, Seventy Names of Metatron": 1,
-                          "Otzar Midrashim, Midrash on the Ten Commandments": 1,
-                          "Midrash Tanchuma, Chayei Sara": 1,
-                          "Midrash Tanchuma, Shemot": 1,
-                          "Midrash Tanchuma, Vaera": 1,
-                          "Midrash Tanchuma, Bereshit": 3,
-                          "Midrash Tanchuma, Tetzaveh": 1,
-                          "Midrash Tanchuma, Pekudei": 1,
-                          "Midrash Tanchuma, Nasso": 1,
-                          "Shir HaShirim Rabbah": 1,
-                          "Kohelet Rabbah": 1,
-                          "Ruth Rabbah, Petichta": 1,
-                          "Midrash Tanchuma Buber, Bereshit": 12,
-                          "Midrash Tanchuma Buber, Shemot": 1,
-                          "Midrash Tanchuma Buber, Vaera": 1,
-                          "Midrash Tanchuma Buber, Yitro": 1,
-                          "Midrash Lekach Tov, Exodus": 1,
-                          "Pesikta DeRav Kahana": 2,
-                          "Midrash Yelamdenu, Selections from Yalkut Talmud Torah": 1,
-                          "Mekhilta DeRabbi Yishmael, Tractate Pischa": 2,
-                          "Mekhilta DeRabbi Yishmael, Tractate Shirah": 1,
-                          "Bereshit Rabbah": 21,
-                          "Eikhah Rabbah, Petichta": 1,
-                          "Ein Yaakov, Khagigah": 2,
-                          "Ein Yaakov (Glick Edition), Sukkah": 1,
-                          "Ein Yaakov (Glick Edition), Khagigah": 2,
-                          "Ein Yaakov (Glick Edition), Megillah": 1,
-                          "Bamidbar Rabbah": 2,
-                          "Devarim Rabbah": 1,
-                          "Bereshit Rabbati, Parashat Bereshit": 2
-                        }
-                      },
-                      {
-                        "name": "Tanakh",
-                        "count": 256,
-                        "books": {
-                          "Psalms": 2,
-                          "Genesis": 248,
-                          "Proverbs": 1,
-                          "Jeremiah": 1,
-                          "Lessons in Leadership; Hebrew Edition, Kedoshim; From Priest to People": 2,
-                          "Lessons in Leadership; Hebrew Edition, Naso; Pursuing Peace": 1,
-                          "Deuteronomy": 1
-                        }
-                      },
-                      {
-                        "name": "Mishnah",
-                        "count": 6,
-                        "books": {
-                          "Mishnah Chagigah": 1,
-                          "Mishnah Ta'anit": 2,
-                          "Mishnah Megillah": 3
-                        }
-                      },
-                      {
-                        "name": "Targum",
-                        "count": 5,
-                        "books": {
-                          "Targum Jonathan on Genesis": 1,
-                          "Targum Neofiti": 1,
-                          "Onkelos Genesis": 1,
-                          "Targum Jerusalem, Genesis": 1,
-                          "Tafsir Rasag, Genesis": 1
+                          "Sifra, Kedoshim, Chapter 2": 1
                         }
                       }
                     ]
@@ -19387,13 +19027,14 @@
           },
           {
             "name": "lang",
-            "description": "Interface language. Defaults to `en`.",
+            "description": "Interface language for returned text fields. Defaults to `en`. Must be passed explicitly — the endpoint does not infer a default from the request.",
             "schema": {
               "type": "string",
               "enum": [
                 "en",
                 "he"
-              ]
+              ],
+              "default": "en"
             },
             "in": "query",
             "required": false
@@ -19589,7 +19230,7 @@
         "parameters": [
           {
             "name": "slug",
-            "description": "Profile URL slug, e.g. `sefaria`. Found in the user's profile URL on Sefaria.",
+            "description": "Profile URL slug. Found in the profile URL: `https://www.sefaria.org/profile/{slug}`. For example, the profile at `https://www.sefaria.org/profile/brett-lockspeiser` has slug `brett-lockspeiser`.",
             "schema": {
               "type": "string"
             },
@@ -25736,11 +25377,6 @@
             "description": "the Sefaria User ID of the sheet's owner.",
             "type": "integer"
           },
-          "_id": {
-            "description": "The unique `id` for the source sheet.",
-            "type": "string",
-            "nullable": true
-          },
           "id": {
             "description": "The `id` of the sheet. This is used in the URL to retrieve sheets, for example, a sheet with an `id` of 1, would be accessible on [Sefaria](sefaria.org) at [sefaria.org/sheets/1](sefaria.org/sheets/1).",
             "type": "string"
@@ -28092,10 +27728,6 @@
             "description": "Numeric `id` of the sheet — the same value that appears in the sheet's URL on `voices.sefaria.org`.",
             "type": "integer"
           },
-          "_id": {
-            "description": "Internal MongoDB identifier for the sheet.",
-            "type": "string"
-          },
           "title": {
             "description": "Title of the source sheet.",
             "type": "string"
@@ -28577,31 +28209,6 @@
           }
         }
       },
-      "SheetLikersJSON": {
-        "title": "Root Type for SheetLikersJSON",
-        "description": "List of users who have liked a sheet.",
-        "type": "object",
-        "properties": {
-          "likers": {
-            "description": "List of users who liked the sheet.",
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "type": "integer"
-                },
-                "name": {
-                  "type": "string"
-                },
-                "url": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      },
       "BulkSheetEntryJSON": {
         "title": "Root Type for BulkSheetEntryJSON",
         "description": "Lightweight summary of a single sheet returned by the bulk endpoint.",
@@ -28693,7 +28300,7 @@
       },
       "BulktextJSON": {
         "title": "Root Type for BulktextJSON",
-        "description": "A map keyed by Sefaria ref. Each entry contains the ref's English and Hebrew text plus version metadata. The exact key set matches the requested refs.",
+        "description": "A map keyed by Sefaria ref. Each entry contains the ref's English and Hebrew text plus metadata such as the language, ref for the url, etc. The exact key set matches the requested refs.",
         "type": "object",
         "additionalProperties": {
           "type": "object"
@@ -28701,7 +28308,7 @@
       },
       "PassagesJSON": {
         "title": "Root Type for PassagesJSON",
-        "description": "A map keyed by the requested Sefaria ref. Each value is the canonical passage ref containing it (e.g. a verse mapped to its three-verse passage).",
+        "description": "A map keyed by the requested Sefaria ref. Each value is the canonical passage ref that contains it — for Tanakh a parasha-style passage, for Mishnah a chapter passage, for Talmud a full sugya boundary.",
         "type": "object",
         "additionalProperties": {
           "$ref": "#/components/schemas/ref"
@@ -28788,17 +28395,47 @@
       },
       "CountsJSON": {
         "title": "Root Type for CountsJSON",
-        "description": "Word and segment counts for a text, broken down by language.",
+        "description": "Availability and coverage data for a text, broken down by language. `_all` covers all languages combined; `_he` and `_en` are language-specific. Each language bucket contains availability bitmaps (`availableTexts`), word/segment counts (`availableCounts`), and coverage statistics (`percentAvailable`, `completenessPercent`, `textComplete`, `sparseness`).",
         "type": "object",
         "properties": {
           "_all": {
-            "type": "object"
+            "description": "Coverage across all languages: `availableTexts` (per-chapter availability arrays) and `shape` (structural shape of the text).",
+            "type": "object",
+            "properties": {
+              "availableTexts": {
+                "description": "Nested arrays indicating which segments have text, one array per chapter.",
+                "type": "array",
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  }
+                }
+              },
+              "shape": {
+                "description": "Structural shape of the text (chapter/verse counts).",
+                "type": "array",
+                "items": {
+                  "type": "integer"
+                }
+              }
+            }
           },
           "_he": {
-            "type": "object"
+            "description": "Hebrew-language coverage statistics.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CountsLangJSON"
+              }
+            ]
           },
           "_en": {
-            "type": "object"
+            "description": "English-language coverage statistics.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CountsLangJSON"
+              }
+            ]
           }
         }
       },
@@ -28954,6 +28591,50 @@
             "items": {
               "type": "string"
             }
+          }
+        }
+      },
+      "CountsLangJSON": {
+        "title": "CountsLangJSON",
+        "description": "Per-language coverage statistics for a text.",
+        "type": "object",
+        "properties": {
+          "availableTexts": {
+            "description": "Nested arrays indicating which segments have text in this language.",
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
+            }
+          },
+          "availableCounts": {
+            "description": "Word and segment counts by unit (e.g. chapters, verses).",
+            "type": "array",
+            "items": {
+              "type": "integer"
+            }
+          },
+          "percentAvailable": {
+            "description": "Percentage of segments that have text in this language.",
+            "type": "number"
+          },
+          "completenessPercent": {
+            "description": "Completeness score as a percentage.",
+            "type": "number"
+          },
+          "textComplete": {
+            "description": "Whether the text is considered complete in this language.",
+            "type": "boolean"
+          },
+          "sparseness": {
+            "description": "Sparseness level (0 = dense, higher = more gaps).",
+            "type": "integer"
+          },
+          "percentAvailableInvalid": {
+            "description": "True when the percentAvailable figure could not be calculated.",
+            "type": "boolean"
           }
         }
       }

--- a/docs/openAPI.json
+++ b/docs/openAPI.json
@@ -1339,7 +1339,7 @@
             }
           },
           "name": "tref",
-          "description": "A valid textual `Ref` to a Sefaria text.",
+          "description": "A valid Sefaria ref. A Sefaria ref is a human-readable text citation, e.g. `Genesis 1:1`, `Berakhot 2a`, or `Rashi on Genesis 1:1`.",
           "schema": {
             "allOf": [
               {
@@ -1654,7 +1654,7 @@
               }
             },
             "name": "tref",
-            "description": "The `tref` parameter must a valid Sefaria ref to a text.",
+            "description": "A valid Sefaria ref. A Sefaria ref is a human-readable text citation, e.g. `Genesis 1:1`, `Berakhot 2a`, or `Rashi on Genesis 1:1`.",
             "schema": {
               "type": "string",
               "default": "Numbers 12.1"
@@ -1734,7 +1734,7 @@
             }
           },
           "name": "tref",
-          "description": "A valid Sefaria ref",
+          "description": "A valid Sefaria ref. A Sefaria ref is a human-readable text citation, e.g. `Genesis 1:1`, `Berakhot 2a`, or `Rashi on Genesis 1:1`.",
           "schema": {
             "type": "string",
             "default": "Numbers.17.2"
@@ -3536,7 +3536,7 @@
             }
           },
           "name": "tref",
-          "description": "A valid Sefaria textual `Ref`. ",
+          "description": "A valid Sefaria ref. A Sefaria ref is a human-readable text citation, e.g. `Genesis 1:1`, `Berakhot 2a`, or `Rashi on Genesis 1:1`.",
           "schema": {
             "allOf": [
               {
@@ -3713,7 +3713,7 @@
             }
           },
           "name": "tref",
-          "description": "A valid Sefaria textual `Ref`.",
+          "description": "A valid Sefaria ref. A Sefaria ref is a human-readable text citation, e.g. `Genesis 1:1`, `Berakhot 2a`, or `Rashi on Genesis 1:1`.",
           "schema": {
             "allOf": [
               {
@@ -3805,7 +3805,7 @@
             }
           },
           "name": "tref",
-          "description": "A valid Sefaria textual `Ref`",
+          "description": "A valid Sefaria ref. A Sefaria ref is a human-readable text citation, e.g. `Genesis 1:1`, `Berakhot 2a`, or `Rashi on Genesis 1:1`.",
           "schema": {
             "allOf": [
               {
@@ -5693,7 +5693,7 @@
             }
           },
           "name": "tref",
-          "description": "A valid Sefaria textual `Ref`.",
+          "description": "A valid Sefaria ref. A Sefaria ref is a human-readable text citation, e.g. `Genesis 1:1`, `Berakhot 2a`, or `Rashi on Genesis 1:1`.",
           "schema": {
             "allOf": [
               {
@@ -9741,7 +9741,7 @@
         "parameters": [
           {
             "name": "ref",
-            "description": "Sefaria ref, e.g. `Genesis.1.1`. Use dots for section separators in the URL.",
+            "description": "Sefaria ref. A Sefaria ref is a human-readable text citation, e.g. `Genesis 1:1`, `Berakhot 2a`, or `Rashi on Genesis 1:1`. Use dots for section separators in the URL.",
             "schema": {
               "type": "string",
               "default": "Genesis.1.1"
@@ -11193,7 +11193,7 @@
         "parameters": [
           {
             "name": "refs",
-            "description": "Pipe-delimited list of Sefaria refs. Use dots for section separators, e.g. `Genesis.1.1|Exodus.1.1`.",
+            "description": "Pipe-delimited list of Sefaria refs. A Sefaria ref is a human-readable text citation, e.g. `Genesis 1:1`, `Berakhot 2a`, or `Rashi on Genesis 1:1`. Use dots for section separators, e.g. `Genesis.1.1|Exodus.1.1`.",
             "schema": {
               "type": "string",
               "default": "Genesis.1.1|Exodus.1.1"
@@ -11255,7 +11255,7 @@
         "parameters": [
           {
             "name": "refs",
-            "description": "A Sefaria ref from Tanakh, Mishnah or Talmud.",
+            "description": "A pipe-delimited list of Sefaria refs. A Sefaria ref is a human-readable text citation, e.g. `Genesis 1:1`, `Berakhot 2a`, or `Rashi on Genesis 1:1`. Use dots for section separators in the URL, e.g. `Berakhot.2a|Genesis.1.1`.",
             "schema": {
               "type": "string",
               "default": "Genesis.1.1"
@@ -18873,7 +18873,7 @@
         "parameters": [
           {
             "name": "ref",
-            "description": "Sefaria ref, e.g. `Genesis.1.1`.",
+            "description": "Sefaria ref, e.g. `Mishnah Peah 2:1`. A Sefaria ref is a human-readable text citation, e.g. `Genesis 1:1`, `Berakhot 2a`, or `Rashi on Genesis 1:1`.",
             "schema": {
               "type": "string",
               "default": "Mishnah_Peah.2.1"
@@ -19002,7 +19002,8 @@
             "name": "year",
             "description": "Year. Must be combined with `month` and `day`.",
             "schema": {
-              "type": "integer"
+              "type": "integer",
+              "default": 2026
             },
             "in": "query",
             "required": false
@@ -19011,7 +19012,8 @@
             "name": "month",
             "description": "Month (1–12). Must be combined with `year` and `day`.",
             "schema": {
-              "type": "integer"
+              "type": "integer",
+              "default": 4
             },
             "in": "query",
             "required": false
@@ -19020,7 +19022,8 @@
             "name": "day",
             "description": "Day of month. Must be combined with `year` and `month`.",
             "schema": {
-              "type": "integer"
+              "type": "integer",
+              "default": 3
             },
             "in": "query",
             "required": false
@@ -19230,7 +19233,7 @@
         "parameters": [
           {
             "name": "slug",
-            "description": "Profile URL slug. Found in the profile URL: `https://www.sefaria.org/profile/{slug}`. For example, the profile at `https://www.sefaria.org/profile/brett-lockspeiser` has slug `brett-lockspeiser`.",
+            "description": "Profile URL slug. Found in the profile URL: `https://www.sefaria.org/profile/{slug}`. For example, the profile at `https://www.sefaria.org/profile/i-love-sefaria` has slug `i-love-sefaria`.",
             "schema": {
               "type": "string"
             },
@@ -28190,7 +28193,7 @@
             "description": "Sheets owned by the user. For anonymous requests this contains only public sheets; an authenticated user requesting their own user_id additionally sees their private sheets.",
             "type": "array",
             "items": {
-              "type": "object"
+              "$ref": "#/components/schemas/SheetsJSON"
             }
           }
         }
@@ -28302,16 +28305,44 @@
         "title": "Root Type for BulktextJSON",
         "description": "A map keyed by Sefaria ref. Each entry contains the ref's English and Hebrew text plus metadata such as the language, ref for the url, etc. The exact key set matches the requested refs.",
         "type": "object",
-        "additionalProperties": {
-          "type": "object"
-        }
+          "properties": {
+            "he": {
+              "type": "string",
+              "description": "Hebrew text for the ref. May be an empty string if no Hebrew text is available."
+            },
+            "en": {
+              "type": "string",
+              "description": "English text for the ref. May be an empty string if no English text is available."
+            },
+            "lang": {
+              "type": "string",
+              "description": "Language of the ref string itself — `he` if the input ref was Hebrew, `en` otherwise."
+            },
+            "ref": {
+              "type": "string",
+              "description": "Normalized canonical ref."
+            },
+            "heRef": {
+              "type": "string",
+              "description": "Hebrew form of the ref."
+            },
+            "url": {
+              "type": "string",
+              "description": "URL-safe form of the ref, suitable for constructing a Sefaria link."
+            },
+            "primary_category": {
+              "type": "string",
+              "description": "Top-level category of the text. Only present when `useTextFamily=1` is passed."
+            }
+          }
       },
       "PassagesJSON": {
         "title": "Root Type for PassagesJSON",
         "description": "A map keyed by the requested Sefaria ref. Each value is the canonical passage ref that contains it — for Tanakh a parasha-style passage, for Mishnah a chapter passage, for Talmud a full sugya boundary.",
         "type": "object",
         "additionalProperties": {
-          "$ref": "#/components/schemas/ref"
+          "type": "string",
+          "description": "The canonical passage ref that contains the input ref."
         }
       },
       "IndexTitlesJSON": {
@@ -28358,7 +28389,22 @@
           "authors": {
             "type": "array",
             "items": {
-              "type": "object"
+              "type": "object",
+              "properties": {
+                "en": {
+                  "type": "string",
+                  "description": "Author's English name."
+                },
+                "he": {
+                  "type": "string",
+                  "description": "Author's Hebrew name."
+                },
+                "slug": {
+                  "type": "string",
+                  "description": "Author's Sefaria topic slug."
+                }
+              },
+              "additionalProperties": false
             }
           },
           "enDesc": {
@@ -28413,7 +28459,7 @@
                 }
               },
               "shape": {
-                "description": "Structural shape of the text (chapter/verse counts).",
+                "description": "Structural shape of the text (chapter/verse counts). Each position represents a chapter (i.e. the first value in the array is the number of verses in chapter 1, the following value in the array is the number of verses in chapter 2)",
                 "type": "array",
                 "items": {
                   "type": "integer"
@@ -28480,10 +28526,7 @@
           },
           "books": {
             "description": "Per-book breakdown within the category, keyed by book title. Each value is the number of links from that book.",
-            "type": "object",
-            "additionalProperties": {
-              "type": "integer"
-            }
+            "type": "object"
           }
         }
       },

--- a/docs/openAPI.json
+++ b/docs/openAPI.json
@@ -25,25 +25,25 @@
       "description": "Operations related to retrieving texts"
     },
     {
-      "name": "Index", 
+      "name": "Index",
       "description": "Operations related to Sefaria indices"
     },
     {
       "name": "Related",
       "description": "Operations related to retrieving links and relationships between texts"
-    }, 
+    },
     {
-      "name": "Calendars", 
+      "name": "Calendars",
       "description": "Operations related to retrieving calendar data"
-    }, 
+    },
     {
       "name": "Lexicon",
       "description": "Operations related to retrieving lexicon (dictionary) data"
-    }, 
+    },
     {
-      "name": "Topic", 
+      "name": "Topic",
       "description": "Operations related to retrieving topic data"
-    }, 
+    },
     {
       "name": "Term",
       "description": "Operations related to retrieving Term data (a Sefaria Term is a shared title node)"
@@ -51,6 +51,14 @@
     {
       "name": "Misc",
       "description": "Miscellaneous API endpoints"
+    },
+    {
+      "name": "Sheets",
+      "description": "Operations related to Sefaria source sheets"
+    },
+    {
+      "name": "Collections",
+      "description": "Operations related to Sefaria collections — curated groups of source sheets"
     }
   ],
   "paths": {
@@ -1216,7 +1224,9 @@
             "description": "A valid textual `Ref` to a Sefaria text.",
             "schema": {
               "allOf": [
-                { "$ref": "#/components/schemas/ref" }
+                {
+                  "$ref": "#/components/schemas/ref"
+                }
               ],
               "default": "Kohelet 5:10"
             },
@@ -1332,7 +1342,9 @@
           "description": "A valid textual `Ref` to a Sefaria text.",
           "schema": {
             "allOf": [
-              { "$ref": "#/components/schemas/ref" }
+              {
+                "$ref": "#/components/schemas/ref"
+              }
             ],
             "default": "Kohelet 5:10"
           },
@@ -2510,479 +2522,475 @@
       "description": "The shape API allows one to retrieve information about the shape of an Index on Sefaria. The shape refers some basic statistics about the Index, mostly the number of chapters, and the number of segments per chapter.",
       "get": {
         "operationId": "get-shape",
-          "tags": [
-              "Index"
-          ],
-          "responses": {
-              "200": {
-                  "content": {
-                      "application/json": {
-                          "schema": {
-                              "$ref": "#/components/schemas/ShapeJSON"
-                          },
-                          "examples": {
-                              "Complex Text": {
-                                  "value": 
-                                      {
-                                          "isComplex": true,
-                                          "section": "Haggadah",
-                                          "length": 38,
-                                          "chapters": [
-                                              {
-                                                  "section": "Haggadah",
-                                                  "heTitle": "הגדה של פסח, קדש",
-                                                  "title": "Pesach Haggadah, Kadesh",
-                                                  "length": 1,
-                                                  "chapters": 13,
-                                                  "book": "Pesach Haggadah",
-                                                  "heBook": "הגדה של פסח"
-                                              },
-                                              {
-                                                  "section": "Haggadah",
-                                                  "heTitle": "הגדה של פסח, ורחץ",
-                                                  "title": "Pesach Haggadah, Urchatz",
-                                                  "length": 1,
-                                                  "chapters": 2,
-                                                  "book": "Pesach Haggadah",
-                                                  "heBook": "הגדה של פסח"
-                                              },
-                                              {
-                                                  "section": "Haggadah",
-                                                  "heTitle": "הגדה של פסח, כרפס",
-                                                  "title": "Pesach Haggadah, Karpas",
-                                                  "length": 1,
-                                                  "chapters": 3,
-                                                  "book": "Pesach Haggadah",
-                                                  "heBook": "הגדה של פסח"
-                                              },
-                                              {
-                                                  "section": "Haggadah",
-                                                  "heTitle": "הגדה של פסח, יחץ",
-                                                  "title": "Pesach Haggadah, Yachatz",
-                                                  "length": 1,
-                                                  "chapters": 2,
-                                                  "book": "Pesach Haggadah",
-                                                  "heBook": "הגדה של פסח"
-                                              },
-                                              {
-                                                  "section": "Haggadah",
-                                                  "heTitle": "הגדה של פסח, מגיד, הא לחמא עניא",
-                                                  "title": "Pesach Haggadah, Magid, Ha Lachma Anya",
-                                                  "length": 1,
-                                                  "chapters": 3,
-                                                  "book": "Pesach Haggadah",
-                                                  "heBook": "הגדה של פסח"
-                                              },
-                                              {
-                                                  "section": "Haggadah",
-                                                  "heTitle": "הגדה של פסח, מגיד, מה נשתנה",
-                                                  "title": "Pesach Haggadah, Magid, Four Questions",
-                                                  "length": 1,
-                                                  "chapters": 2,
-                                                  "book": "Pesach Haggadah",
-                                                  "heBook": "הגדה של פסח"
-                                              },
-                                              {
-                                                  "section": "Haggadah",
-                                                  "heTitle": "הגדה של פסח, מגיד, עבדים היינו",
-                                                  "title": "Pesach Haggadah, Magid, We Were Slaves in Egypt",
-                                                  "length": 1,
-                                                  "chapters": 2,
-                                                  "book": "Pesach Haggadah",
-                                                  "heBook": "הגדה של פסח"
-                                              },
-                                              {
-                                                  "section": "Haggadah",
-                                                  "heTitle": "הגדה של פסח, מגיד, מעשה שהיה בבני ברק",
-                                                  "title": "Pesach Haggadah, Magid, Story of the Five Rabbis",
-                                                  "length": 1,
-                                                  "chapters": 2,
-                                                  "book": "Pesach Haggadah",
-                                                  "heBook": "הגדה של פסח"
-                                              },
-                                              {
-                                                  "section": "Haggadah",
-                                                  "heTitle": "הגדה של פסח, מגיד, כנגד ארבעה בנים",
-                                                  "title": "Pesach Haggadah, Magid, The Four Sons",
-                                                  "length": 1,
-                                                  "chapters": 5,
-                                                  "book": "Pesach Haggadah",
-                                                  "heBook": "הגדה של פסח"
-                                              },
-                                              {
-                                                  "section": "Haggadah",
-                                                  "heTitle": "הגדה של פסח, מגיד, יכול מראש חודש",
-                                                  "title": "Pesach Haggadah, Magid, Yechol Me'rosh Chodesh",
-                                                  "length": 1,
-                                                  "chapters": 1,
-                                                  "book": "Pesach Haggadah",
-                                                  "heBook": "הגדה של פסח"
-                                              },
-                                              {
-                                                  "section": "Haggadah",
-                                                  "heTitle": "הגדה של פסח, מגיד, מתחילה עובדי עבודה זרה היו אבותינו",
-                                                  "title": "Pesach Haggadah, Magid, In the Beginning Our Fathers Were Idol Worshipers",
-                                                  "length": 1,
-                                                  "chapters": 5,
-                                                  "book": "Pesach Haggadah",
-                                                  "heBook": "הגדה של פסח"
-                                              },
-                                              {
-                                                  "section": "Haggadah",
-                                                  "heTitle": "הגדה של פסח, מגיד, ארמי אבד אבי",
-                                                  "title": "Pesach Haggadah, Magid, First Fruits Declaration",
-                                                  "length": 1,
-                                                  "chapters": 24,
-                                                  "book": "Pesach Haggadah",
-                                                  "heBook": "הגדה של פסח"
-                                              },
-                                              {
-                                                  "section": "Haggadah",
-                                                  "heTitle": "הגדה של פסח, מגיד, עשר המכות",
-                                                  "title": "Pesach Haggadah, Magid, The Ten Plagues",
-                                                  "length": 1,
-                                                  "chapters": 20,
-                                                  "book": "Pesach Haggadah",
-                                                  "heBook": "הגדה של פסח"
-                                              },
-                                              {
-                                                  "section": "Haggadah",
-                                                  "heTitle": "הגדה של פסח, מגיד, דיינו",
-                                                  "title": "Pesach Haggadah, Magid, Dayenu",
-                                                  "length": 1,
-                                                  "chapters": 16,
-                                                  "book": "Pesach Haggadah",
-                                                  "heBook": "הגדה של פסח"
-                                              },
-                                              {
-                                                  "section": "Haggadah",
-                                                  "heTitle": "הגדה של פסח, מגיד, פסח מצה ומרור",
-                                                  "title": "Pesach Haggadah, Magid, Rabban Gamliel's Three Things",
-                                                  "length": 1,
-                                                  "chapters": 7,
-                                                  "book": "Pesach Haggadah",
-                                                  "heBook": "הגדה של פסח"
-                                              },
-                                              {
-                                                  "section": "Haggadah",
-                                                  "heTitle": "הגדה של פסח, מגיד, חצי הלל",
-                                                  "title": "Pesach Haggadah, Magid, First Half of Hallel",
-                                                  "length": 1,
-                                                  "chapters": 4,
-                                                  "book": "Pesach Haggadah",
-                                                  "heBook": "הגדה של פסח"
-                                              },
-                                              {
-                                                  "section": "Haggadah",
-                                                  "heTitle": "הגדה של פסח, מגיד, כוס שניה",
-                                                  "title": "Pesach Haggadah, Magid, Second Cup of Wine",
-                                                  "length": 1,
-                                                  "chapters": 4,
-                                                  "book": "Pesach Haggadah",
-                                                  "heBook": "הגדה של פסח"
-                                              },
-                                              {
-                                                  "section": "Haggadah",
-                                                  "heTitle": "הגדה של פסח, רחצה",
-                                                  "title": "Pesach Haggadah, Rachtzah",
-                                                  "length": 1,
-                                                  "chapters": 3,
-                                                  "book": "Pesach Haggadah",
-                                                  "heBook": "הגדה של פסח"
-                                              },
-                                              {
-                                                  "section": "Haggadah",
-                                                  "heTitle": "הגדה של פסח, מוציא מצה",
-                                                  "title": "Pesach Haggadah, Motzi Matzah",
-                                                  "length": 1,
-                                                  "chapters": 4,
-                                                  "book": "Pesach Haggadah",
-                                                  "heBook": "הגדה של פסח"
-                                              },
-                                              {
-                                                  "section": "Haggadah",
-                                                  "heTitle": "הגדה של פסח, מרור",
-                                                  "title": "Pesach Haggadah, Maror",
-                                                  "length": 1,
-                                                  "chapters": 3,
-                                                  "book": "Pesach Haggadah",
-                                                  "heBook": "הגדה של פסח"
-                                              },
-                                              {
-                                                  "section": "Haggadah",
-                                                  "heTitle": "הגדה של פסח, כורך",
-                                                  "title": "Pesach Haggadah, Korech",
-                                                  "length": 1,
-                                                  "chapters": 4,
-                                                  "book": "Pesach Haggadah",
-                                                  "heBook": "הגדה של פסח"
-                                              },
-                                              {
-                                                  "section": "Haggadah",
-                                                  "heTitle": "הגדה של פסח, שולחן עורך",
-                                                  "title": "Pesach Haggadah, Shulchan Orech",
-                                                  "length": 1,
-                                                  "chapters": 2,
-                                                  "book": "Pesach Haggadah",
-                                                  "heBook": "הגדה של פסח"
-                                              },
-                                              {
-                                                  "section": "Haggadah",
-                                                  "heTitle": "הגדה של פסח, צפון",
-                                                  "title": "Pesach Haggadah, Tzafun",
-                                                  "length": 1,
-                                                  "chapters": 3,
-                                                  "book": "Pesach Haggadah",
-                                                  "heBook": "הגדה של פסח"
-                                              },
-                                              {
-                                                  "section": "Haggadah",
-                                                  "heTitle": "הגדה של פסח, ברך, ברכת המזון",
-                                                  "title": "Pesach Haggadah, Barech, Birkat Hamazon",
-                                                  "length": 1,
-                                                  "chapters": 23,
-                                                  "book": "Pesach Haggadah",
-                                                  "heBook": "הגדה של פסח"
-                                              },
-                                              {
-                                                  "section": "Haggadah",
-                                                  "heTitle": "הגדה של פסח, ברך, כוס שלישית",
-                                                  "title": "Pesach Haggadah, Barech, Third Cup of Wine",
-                                                  "length": 1,
-                                                  "chapters": 2,
-                                                  "book": "Pesach Haggadah",
-                                                  "heBook": "הגדה של פסח"
-                                              },
-                                              {
-                                                  "section": "Haggadah",
-                                                  "heTitle": "הגדה של פסח, ברך, שפוך חמתך",
-                                                  "title": "Pesach Haggadah, Barech, Pour Out Thy Wrath",
-                                                  "length": 1,
-                                                  "chapters": 2,
-                                                  "book": "Pesach Haggadah",
-                                                  "heBook": "הגדה של פסח"
-                                              },
-                                              {
-                                                  "section": "Haggadah",
-                                                  "heTitle": "הגדה של פסח, הלל, מסיימים את ההלל",
-                                                  "title": "Pesach Haggadah, Hallel, Second Half of Hallel",
-                                                  "length": 1,
-                                                  "chapters": 10,
-                                                  "book": "Pesach Haggadah",
-                                                  "heBook": "הגדה של פסח"
-                                              },
-                                              {
-                                                  "section": "Haggadah",
-                                                  "heTitle": "הגדה של פסח, הלל, מזמורי הודיה",
-                                                  "title": "Pesach Haggadah, Hallel, Songs of Praise and Thanks",
-                                                  "length": 1,
-                                                  "chapters": 6,
-                                                  "book": "Pesach Haggadah",
-                                                  "heBook": "הגדה של פסח"
-                                              },
-                                              {
-                                                  "section": "Haggadah",
-                                                  "heTitle": "הגדה של פסח, הלל, כוס רביעית",
-                                                  "title": "Pesach Haggadah, Hallel, Fourth Cup of Wine",
-                                                  "length": 1,
-                                                  "chapters": 4,
-                                                  "book": "Pesach Haggadah",
-                                                  "heBook": "הגדה של פסח"
-                                              },
-                                              {
-                                                  "section": "Haggadah",
-                                                  "heTitle": "הגדה של פסח, נרצה, חסל סידור פסח",
-                                                  "title": "Pesach Haggadah, Nirtzah, Chasal Siddur Pesach",
-                                                  "length": 1,
-                                                  "chapters": 2,
-                                                  "book": "Pesach Haggadah",
-                                                  "heBook": "הגדה של פסח"
-                                              },
-                                              {
-                                                  "section": "Haggadah",
-                                                  "heTitle": "הגדה של פסח, נרצה, לשנה הבאה",
-                                                  "title": "Pesach Haggadah, Nirtzah, L'Shana HaBaa",
-                                                  "length": 1,
-                                                  "chapters": 1,
-                                                  "book": "Pesach Haggadah",
-                                                  "heBook": "הגדה של פסח"
-                                              },
-                                              {
-                                                  "section": "Haggadah",
-                                                  "heTitle": "הגדה של פסח, נרצה, ויהי בחצי הלילה",
-                                                  "title": "Pesach Haggadah, Nirtzah, And It Happened at Midnight",
-                                                  "length": 1,
-                                                  "chapters": 11,
-                                                  "book": "Pesach Haggadah",
-                                                  "heBook": "הגדה של פסח"
-                                              },
-                                              {
-                                                  "section": "Haggadah",
-                                                  "heTitle": "הגדה של פסח, נרצה, זבח פסח",
-                                                  "title": "Pesach Haggadah, Nirtzah, Zevach Pesach",
-                                                  "length": 1,
-                                                  "chapters": 8,
-                                                  "book": "Pesach Haggadah",
-                                                  "heBook": "הגדה של פסח"
-                                              },
-                                              {
-                                                  "section": "Haggadah",
-                                                  "heTitle": "הגדה של פסח, נרצה, אדיר במלוכה",
-                                                  "title": "Pesach Haggadah, Nirtzah, Ki Lo Na'e",
-                                                  "length": 1,
-                                                  "chapters": 9,
-                                                  "book": "Pesach Haggadah",
-                                                  "heBook": "הגדה של פסח"
-                                              },
-                                              {
-                                                  "section": "Haggadah",
-                                                  "heTitle": "הגדה של פסח, נרצה, אדיר הוא",
-                                                  "title": "Pesach Haggadah, Nirtzah, Adir Hu",
-                                                  "length": 1,
-                                                  "chapters": 8,
-                                                  "book": "Pesach Haggadah",
-                                                  "heBook": "הגדה של פסח"
-                                              },
-                                              {
-                                                  "section": "Haggadah",
-                                                  "heTitle": "הגדה של פסח, נרצה, ספירת העומר",
-                                                  "title": "Pesach Haggadah, Nirtzah, Sefirat HaOmer",
-                                                  "length": 1,
-                                                  "chapters": 2,
-                                                  "book": "Pesach Haggadah",
-                                                  "heBook": "הגדה של פסח"
-                                              },
-                                              {
-                                                  "section": "Haggadah",
-                                                  "heTitle": "הגדה של פסח, נרצה, אחד מי יודע",
-                                                  "title": "Pesach Haggadah, Nirtzah, Echad Mi Yodea",
-                                                  "length": 1,
-                                                  "chapters": 1,
-                                                  "book": "Pesach Haggadah",
-                                                  "heBook": "הגדה של פסח"
-                                              },
-                                              {
-                                                  "section": "Haggadah",
-                                                  "heTitle": "הגדה של פסח, נרצה, חד גדיא",
-                                                  "title": "Pesach Haggadah, Nirtzah, Chad Gadya",
-                                                  "length": 1,
-                                                  "chapters": 10,
-                                                  "book": "Pesach Haggadah",
-                                                  "heBook": "הגדה של פסח"
-                                              }
-                                          ],
-                                          "book": "Pesach Haggadah",
-                                          "heBook": "הגדה של פסח"
-                                      }
-                                  
-                              },
-                              "Simple Text": {
-                                  "value": 
-                                      {
-                                          "section": "Torah",
-                                          "heTitle": "שמות",
-                                          "title": "Exodus",
-                                          "length": 40,
-                                          "chapters": [
-                                              22,
-                                              25,
-                                              22,
-                                              31,
-                                              23,
-                                              30,
-                                              29,
-                                              28,
-                                              35,
-                                              29,
-                                              10,
-                                              51,
-                                              22,
-                                              31,
-                                              27,
-                                              36,
-                                              16,
-                                              27,
-                                              25,
-                                              23,
-                                              37,
-                                              30,
-                                              33,
-                                              18,
-                                              40,
-                                              37,
-                                              21,
-                                              43,
-                                              46,
-                                              38,
-                                              18,
-                                              35,
-                                              23,
-                                              35,
-                                              35,
-                                              38,
-                                              29,
-                                              31,
-                                              43,
-                                              38
-                                          ],
-                                          "book": "Exodus",
-                                          "heBook": "שמות"
-                                      }
-                                  
-                              }
-                          }
-                      }
+        "tags": [
+          "Index"
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ShapeJSON"
+                },
+                "examples": {
+                  "Complex Text": {
+                    "value": {
+                      "isComplex": true,
+                      "section": "Haggadah",
+                      "length": 38,
+                      "chapters": [
+                        {
+                          "section": "Haggadah",
+                          "heTitle": "הגדה של פסח, קדש",
+                          "title": "Pesach Haggadah, Kadesh",
+                          "length": 1,
+                          "chapters": 13,
+                          "book": "Pesach Haggadah",
+                          "heBook": "הגדה של פסח"
+                        },
+                        {
+                          "section": "Haggadah",
+                          "heTitle": "הגדה של פסח, ורחץ",
+                          "title": "Pesach Haggadah, Urchatz",
+                          "length": 1,
+                          "chapters": 2,
+                          "book": "Pesach Haggadah",
+                          "heBook": "הגדה של פסח"
+                        },
+                        {
+                          "section": "Haggadah",
+                          "heTitle": "הגדה של פסח, כרפס",
+                          "title": "Pesach Haggadah, Karpas",
+                          "length": 1,
+                          "chapters": 3,
+                          "book": "Pesach Haggadah",
+                          "heBook": "הגדה של פסח"
+                        },
+                        {
+                          "section": "Haggadah",
+                          "heTitle": "הגדה של פסח, יחץ",
+                          "title": "Pesach Haggadah, Yachatz",
+                          "length": 1,
+                          "chapters": 2,
+                          "book": "Pesach Haggadah",
+                          "heBook": "הגדה של פסח"
+                        },
+                        {
+                          "section": "Haggadah",
+                          "heTitle": "הגדה של פסח, מגיד, הא לחמא עניא",
+                          "title": "Pesach Haggadah, Magid, Ha Lachma Anya",
+                          "length": 1,
+                          "chapters": 3,
+                          "book": "Pesach Haggadah",
+                          "heBook": "הגדה של פסח"
+                        },
+                        {
+                          "section": "Haggadah",
+                          "heTitle": "הגדה של פסח, מגיד, מה נשתנה",
+                          "title": "Pesach Haggadah, Magid, Four Questions",
+                          "length": 1,
+                          "chapters": 2,
+                          "book": "Pesach Haggadah",
+                          "heBook": "הגדה של פסח"
+                        },
+                        {
+                          "section": "Haggadah",
+                          "heTitle": "הגדה של פסח, מגיד, עבדים היינו",
+                          "title": "Pesach Haggadah, Magid, We Were Slaves in Egypt",
+                          "length": 1,
+                          "chapters": 2,
+                          "book": "Pesach Haggadah",
+                          "heBook": "הגדה של פסח"
+                        },
+                        {
+                          "section": "Haggadah",
+                          "heTitle": "הגדה של פסח, מגיד, מעשה שהיה בבני ברק",
+                          "title": "Pesach Haggadah, Magid, Story of the Five Rabbis",
+                          "length": 1,
+                          "chapters": 2,
+                          "book": "Pesach Haggadah",
+                          "heBook": "הגדה של פסח"
+                        },
+                        {
+                          "section": "Haggadah",
+                          "heTitle": "הגדה של פסח, מגיד, כנגד ארבעה בנים",
+                          "title": "Pesach Haggadah, Magid, The Four Sons",
+                          "length": 1,
+                          "chapters": 5,
+                          "book": "Pesach Haggadah",
+                          "heBook": "הגדה של פסח"
+                        },
+                        {
+                          "section": "Haggadah",
+                          "heTitle": "הגדה של פסח, מגיד, יכול מראש חודש",
+                          "title": "Pesach Haggadah, Magid, Yechol Me'rosh Chodesh",
+                          "length": 1,
+                          "chapters": 1,
+                          "book": "Pesach Haggadah",
+                          "heBook": "הגדה של פסח"
+                        },
+                        {
+                          "section": "Haggadah",
+                          "heTitle": "הגדה של פסח, מגיד, מתחילה עובדי עבודה זרה היו אבותינו",
+                          "title": "Pesach Haggadah, Magid, In the Beginning Our Fathers Were Idol Worshipers",
+                          "length": 1,
+                          "chapters": 5,
+                          "book": "Pesach Haggadah",
+                          "heBook": "הגדה של פסח"
+                        },
+                        {
+                          "section": "Haggadah",
+                          "heTitle": "הגדה של פסח, מגיד, ארמי אבד אבי",
+                          "title": "Pesach Haggadah, Magid, First Fruits Declaration",
+                          "length": 1,
+                          "chapters": 24,
+                          "book": "Pesach Haggadah",
+                          "heBook": "הגדה של פסח"
+                        },
+                        {
+                          "section": "Haggadah",
+                          "heTitle": "הגדה של פסח, מגיד, עשר המכות",
+                          "title": "Pesach Haggadah, Magid, The Ten Plagues",
+                          "length": 1,
+                          "chapters": 20,
+                          "book": "Pesach Haggadah",
+                          "heBook": "הגדה של פסח"
+                        },
+                        {
+                          "section": "Haggadah",
+                          "heTitle": "הגדה של פסח, מגיד, דיינו",
+                          "title": "Pesach Haggadah, Magid, Dayenu",
+                          "length": 1,
+                          "chapters": 16,
+                          "book": "Pesach Haggadah",
+                          "heBook": "הגדה של פסח"
+                        },
+                        {
+                          "section": "Haggadah",
+                          "heTitle": "הגדה של פסח, מגיד, פסח מצה ומרור",
+                          "title": "Pesach Haggadah, Magid, Rabban Gamliel's Three Things",
+                          "length": 1,
+                          "chapters": 7,
+                          "book": "Pesach Haggadah",
+                          "heBook": "הגדה של פסח"
+                        },
+                        {
+                          "section": "Haggadah",
+                          "heTitle": "הגדה של פסח, מגיד, חצי הלל",
+                          "title": "Pesach Haggadah, Magid, First Half of Hallel",
+                          "length": 1,
+                          "chapters": 4,
+                          "book": "Pesach Haggadah",
+                          "heBook": "הגדה של פסח"
+                        },
+                        {
+                          "section": "Haggadah",
+                          "heTitle": "הגדה של פסח, מגיד, כוס שניה",
+                          "title": "Pesach Haggadah, Magid, Second Cup of Wine",
+                          "length": 1,
+                          "chapters": 4,
+                          "book": "Pesach Haggadah",
+                          "heBook": "הגדה של פסח"
+                        },
+                        {
+                          "section": "Haggadah",
+                          "heTitle": "הגדה של פסח, רחצה",
+                          "title": "Pesach Haggadah, Rachtzah",
+                          "length": 1,
+                          "chapters": 3,
+                          "book": "Pesach Haggadah",
+                          "heBook": "הגדה של פסח"
+                        },
+                        {
+                          "section": "Haggadah",
+                          "heTitle": "הגדה של פסח, מוציא מצה",
+                          "title": "Pesach Haggadah, Motzi Matzah",
+                          "length": 1,
+                          "chapters": 4,
+                          "book": "Pesach Haggadah",
+                          "heBook": "הגדה של פסח"
+                        },
+                        {
+                          "section": "Haggadah",
+                          "heTitle": "הגדה של פסח, מרור",
+                          "title": "Pesach Haggadah, Maror",
+                          "length": 1,
+                          "chapters": 3,
+                          "book": "Pesach Haggadah",
+                          "heBook": "הגדה של פסח"
+                        },
+                        {
+                          "section": "Haggadah",
+                          "heTitle": "הגדה של פסח, כורך",
+                          "title": "Pesach Haggadah, Korech",
+                          "length": 1,
+                          "chapters": 4,
+                          "book": "Pesach Haggadah",
+                          "heBook": "הגדה של פסח"
+                        },
+                        {
+                          "section": "Haggadah",
+                          "heTitle": "הגדה של פסח, שולחן עורך",
+                          "title": "Pesach Haggadah, Shulchan Orech",
+                          "length": 1,
+                          "chapters": 2,
+                          "book": "Pesach Haggadah",
+                          "heBook": "הגדה של פסח"
+                        },
+                        {
+                          "section": "Haggadah",
+                          "heTitle": "הגדה של פסח, צפון",
+                          "title": "Pesach Haggadah, Tzafun",
+                          "length": 1,
+                          "chapters": 3,
+                          "book": "Pesach Haggadah",
+                          "heBook": "הגדה של פסח"
+                        },
+                        {
+                          "section": "Haggadah",
+                          "heTitle": "הגדה של פסח, ברך, ברכת המזון",
+                          "title": "Pesach Haggadah, Barech, Birkat Hamazon",
+                          "length": 1,
+                          "chapters": 23,
+                          "book": "Pesach Haggadah",
+                          "heBook": "הגדה של פסח"
+                        },
+                        {
+                          "section": "Haggadah",
+                          "heTitle": "הגדה של פסח, ברך, כוס שלישית",
+                          "title": "Pesach Haggadah, Barech, Third Cup of Wine",
+                          "length": 1,
+                          "chapters": 2,
+                          "book": "Pesach Haggadah",
+                          "heBook": "הגדה של פסח"
+                        },
+                        {
+                          "section": "Haggadah",
+                          "heTitle": "הגדה של פסח, ברך, שפוך חמתך",
+                          "title": "Pesach Haggadah, Barech, Pour Out Thy Wrath",
+                          "length": 1,
+                          "chapters": 2,
+                          "book": "Pesach Haggadah",
+                          "heBook": "הגדה של פסח"
+                        },
+                        {
+                          "section": "Haggadah",
+                          "heTitle": "הגדה של פסח, הלל, מסיימים את ההלל",
+                          "title": "Pesach Haggadah, Hallel, Second Half of Hallel",
+                          "length": 1,
+                          "chapters": 10,
+                          "book": "Pesach Haggadah",
+                          "heBook": "הגדה של פסח"
+                        },
+                        {
+                          "section": "Haggadah",
+                          "heTitle": "הגדה של פסח, הלל, מזמורי הודיה",
+                          "title": "Pesach Haggadah, Hallel, Songs of Praise and Thanks",
+                          "length": 1,
+                          "chapters": 6,
+                          "book": "Pesach Haggadah",
+                          "heBook": "הגדה של פסח"
+                        },
+                        {
+                          "section": "Haggadah",
+                          "heTitle": "הגדה של פסח, הלל, כוס רביעית",
+                          "title": "Pesach Haggadah, Hallel, Fourth Cup of Wine",
+                          "length": 1,
+                          "chapters": 4,
+                          "book": "Pesach Haggadah",
+                          "heBook": "הגדה של פסח"
+                        },
+                        {
+                          "section": "Haggadah",
+                          "heTitle": "הגדה של פסח, נרצה, חסל סידור פסח",
+                          "title": "Pesach Haggadah, Nirtzah, Chasal Siddur Pesach",
+                          "length": 1,
+                          "chapters": 2,
+                          "book": "Pesach Haggadah",
+                          "heBook": "הגדה של פסח"
+                        },
+                        {
+                          "section": "Haggadah",
+                          "heTitle": "הגדה של פסח, נרצה, לשנה הבאה",
+                          "title": "Pesach Haggadah, Nirtzah, L'Shana HaBaa",
+                          "length": 1,
+                          "chapters": 1,
+                          "book": "Pesach Haggadah",
+                          "heBook": "הגדה של פסח"
+                        },
+                        {
+                          "section": "Haggadah",
+                          "heTitle": "הגדה של פסח, נרצה, ויהי בחצי הלילה",
+                          "title": "Pesach Haggadah, Nirtzah, And It Happened at Midnight",
+                          "length": 1,
+                          "chapters": 11,
+                          "book": "Pesach Haggadah",
+                          "heBook": "הגדה של פסח"
+                        },
+                        {
+                          "section": "Haggadah",
+                          "heTitle": "הגדה של פסח, נרצה, זבח פסח",
+                          "title": "Pesach Haggadah, Nirtzah, Zevach Pesach",
+                          "length": 1,
+                          "chapters": 8,
+                          "book": "Pesach Haggadah",
+                          "heBook": "הגדה של פסח"
+                        },
+                        {
+                          "section": "Haggadah",
+                          "heTitle": "הגדה של פסח, נרצה, אדיר במלוכה",
+                          "title": "Pesach Haggadah, Nirtzah, Ki Lo Na'e",
+                          "length": 1,
+                          "chapters": 9,
+                          "book": "Pesach Haggadah",
+                          "heBook": "הגדה של פסח"
+                        },
+                        {
+                          "section": "Haggadah",
+                          "heTitle": "הגדה של פסח, נרצה, אדיר הוא",
+                          "title": "Pesach Haggadah, Nirtzah, Adir Hu",
+                          "length": 1,
+                          "chapters": 8,
+                          "book": "Pesach Haggadah",
+                          "heBook": "הגדה של פסח"
+                        },
+                        {
+                          "section": "Haggadah",
+                          "heTitle": "הגדה של פסח, נרצה, ספירת העומר",
+                          "title": "Pesach Haggadah, Nirtzah, Sefirat HaOmer",
+                          "length": 1,
+                          "chapters": 2,
+                          "book": "Pesach Haggadah",
+                          "heBook": "הגדה של פסח"
+                        },
+                        {
+                          "section": "Haggadah",
+                          "heTitle": "הגדה של פסח, נרצה, אחד מי יודע",
+                          "title": "Pesach Haggadah, Nirtzah, Echad Mi Yodea",
+                          "length": 1,
+                          "chapters": 1,
+                          "book": "Pesach Haggadah",
+                          "heBook": "הגדה של פסח"
+                        },
+                        {
+                          "section": "Haggadah",
+                          "heTitle": "הגדה של פסח, נרצה, חד גדיא",
+                          "title": "Pesach Haggadah, Nirtzah, Chad Gadya",
+                          "length": 1,
+                          "chapters": 10,
+                          "book": "Pesach Haggadah",
+                          "heBook": "הגדה של פסח"
+                        }
+                      ],
+                      "book": "Pesach Haggadah",
+                      "heBook": "הגדה של פסח"
+                    }
                   },
-                  "description": "Retrieve basic statistics and information about the \"shape\" of an `Index` on Sefaria. "
+                  "Simple Text": {
+                    "value": {
+                      "section": "Torah",
+                      "heTitle": "שמות",
+                      "title": "Exodus",
+                      "length": 40,
+                      "chapters": [
+                        22,
+                        25,
+                        22,
+                        31,
+                        23,
+                        30,
+                        29,
+                        28,
+                        35,
+                        29,
+                        10,
+                        51,
+                        22,
+                        31,
+                        27,
+                        36,
+                        16,
+                        27,
+                        25,
+                        23,
+                        37,
+                        30,
+                        33,
+                        18,
+                        40,
+                        37,
+                        21,
+                        43,
+                        46,
+                        38,
+                        18,
+                        35,
+                        23,
+                        35,
+                        35,
+                        38,
+                        29,
+                        31,
+                        43,
+                        38
+                      ],
+                      "book": "Exodus",
+                      "heBook": "שמות"
+                    }
+                  }
+                }
               }
-          },
-          "summary": "Shape",
-          "description": "Retrieve basic statistics and information about the \"shape\" of an `Index` on Sefaria. "
+            },
+            "description": "Retrieve basic statistics and information about the \"shape\" of an `Index` on Sefaria. "
+          }
+        },
+        "summary": "Shape",
+        "description": "Retrieve basic statistics and information about the \"shape\" of an `Index` on Sefaria. "
       },
       "parameters": [
-          {
-              "examples": {
-                  "Tanakh": {
-                      "value": "Jonah"
-                  },
-                  "Talmud": {
-                      "value": "Pesachim"
-                  },
-                  "Commentary": {
-                      "value": "Rashi on Exodus"
-                  },
-                  "Category": {
-                      "value": "Tanakh/Modern Commentary on Tanakh/Steinsaltz"
-                  }
-              },
-              "name": "title",
-              "description": "The title of a valid Sefaria `Index`, or the path of a valid Sefaria category. ",
-              "schema": {
-                  "type": "string",
-                  "default": "Jonah"
-              },
-              "in": "path",
-              "required": true
+        {
+          "examples": {
+            "Tanakh": {
+              "value": "Jonah"
+            },
+            "Talmud": {
+              "value": "Pesachim"
+            },
+            "Commentary": {
+              "value": "Rashi on Exodus"
+            },
+            "Category": {
+              "value": "Tanakh/Modern Commentary on Tanakh/Steinsaltz"
+            }
           },
-          {
-              "name": "depth",
-              "description": "The `depth` parameter in the query string indicates how many levels in the category tree to descend.\nIf `depth=0` is passed, then the returned JSON descends to end of tree.\nThe default is `depth=2`.",
-              "schema": {
-                  "type": "integer"
-              },
-              "in": "query"
+          "name": "title",
+          "description": "The title of a valid Sefaria `Index`, or the path of a valid Sefaria category. ",
+          "schema": {
+            "type": "string",
+            "default": "Jonah"
           },
-          {
-              "name": "dependents",
-              "description": "The dependents parameter, if `true`, includes dependent texts. By default, they are filtered out.",
-              "schema": {
-                  "type": "boolean"
-              },
-              "in": "query",
-              "required": false
-          }
+          "in": "path",
+          "required": true
+        },
+        {
+          "name": "depth",
+          "description": "The `depth` parameter in the query string indicates how many levels in the category tree to descend.\nIf `depth=0` is passed, then the returned JSON descends to end of tree.\nThe default is `depth=2`.",
+          "schema": {
+            "type": "integer"
+          },
+          "in": "query"
+        },
+        {
+          "name": "dependents",
+          "description": "The dependents parameter, if `true`, includes dependent texts. By default, they are filtered out.",
+          "schema": {
+            "type": "boolean"
+          },
+          "in": "query",
+          "required": false
+        }
       ]
-  },
+    },
     "/api/related/{tref}": {
       "summary": "The Related API",
       "description": "The Related API returns all related links, sheets, notes, topics, manuscripts, and other connected media for a given `Ref`. ",
@@ -3531,7 +3539,9 @@
           "description": "A valid Sefaria textual `Ref`. ",
           "schema": {
             "allOf": [
-              { "$ref": "#/components/schemas/ref" }
+              {
+                "$ref": "#/components/schemas/ref"
+              }
             ],
             "default": "Deuteronomy 1.1"
           },
@@ -3564,7 +3574,31 @@
                       {
                         "url": "https://etzion.org.il/en/mission-spies",
                         "title": "The Mission of the Spies | vbm haretzion",
-                        "refs": ["Joshua 2:2-3", "I Samuel 26:9", "Deuteronomy 32:51", "Numbers 34:16-29", "Numbers 26:52-56", "Joshua 14", "Numbers 13", "Numbers 20:12", "Numbers 32:9", "Deuteronomy 9:1-2", "Numbers 13:20", "Genesis 13:17", "Numbers 13:21", "Numbers 13:22", "Deuteronomy 1:37", "Joshua 2:1", "Deuteronomy 1:22", "Deuteronomy 1", "Numbers 34", "Deuteronomy 1:21", "Numbers 32", "Deuteronomy 1:24", "Joshua 18:3-9"],
+                        "refs": [
+                          "Joshua 2:2-3",
+                          "I Samuel 26:9",
+                          "Deuteronomy 32:51",
+                          "Numbers 34:16-29",
+                          "Numbers 26:52-56",
+                          "Joshua 14",
+                          "Numbers 13",
+                          "Numbers 20:12",
+                          "Numbers 32:9",
+                          "Deuteronomy 9:1-2",
+                          "Numbers 13:20",
+                          "Genesis 13:17",
+                          "Numbers 13:21",
+                          "Numbers 13:22",
+                          "Deuteronomy 1:37",
+                          "Joshua 2:1",
+                          "Deuteronomy 1:22",
+                          "Deuteronomy 1",
+                          "Numbers 34",
+                          "Deuteronomy 1:21",
+                          "Numbers 32",
+                          "Deuteronomy 1:24",
+                          "Joshua 18:3-9"
+                        ],
                         "description": "Parshat HaShavua Yeshivat Har Etzion PARASHAT SHELACH The Mission of the Spies by Rav Yaakov Medan A  The Problem",
                         "linkerHits": 283,
                         "domain": "etzion.org.il",
@@ -3573,7 +3607,9 @@
                         "authors": "",
                         "articleSource": "",
                         "anchorRef": "Deuteronomy 1:2",
-                        "anchorRefExpanded": ["Deuteronomy 1:2"]
+                        "anchorRefExpanded": [
+                          "Deuteronomy 1:2"
+                        ]
                       }
                     ]
                   }
@@ -3680,7 +3716,9 @@
           "description": "A valid Sefaria textual `Ref`.",
           "schema": {
             "allOf": [
-              { "$ref": "#/components/schemas/ref" }
+              {
+                "$ref": "#/components/schemas/ref"
+              }
             ],
             "default": "Obadiah 1.2"
           },
@@ -3770,7 +3808,9 @@
           "description": "A valid Sefaria textual `Ref`",
           "schema": {
             "allOf": [
-              { "$ref": "#/components/schemas/ref" }
+              {
+                "$ref": "#/components/schemas/ref"
+              }
             ],
             "default": "Judges 12"
           },
@@ -4628,41 +4668,44 @@
         ],
         "parameters": [
           {
-              "examples": {
-                  "Return all topics": {
-                      "value": 0
-                  },
-                  "Return 20 topics": {
-                      "value": 20
-                  }
+            "examples": {
+              "Return all topics": {
+                "value": 0
               },
-              "name": "limit",
-              "description": "This parameter limits the number of topics returned. The default is `1000`. If `limit=0` then all topics will be returned.",
-              "schema": {
-                  "type": "integer",
-                  "default": 1000
-              },
-              "in": "query"
+              "Return 20 topics": {
+                "value": 20
+              }
+            },
+            "name": "limit",
+            "description": "This parameter limits the number of topics returned. The default is `1000`. If `limit=0` then all topics will be returned.",
+            "schema": {
+              "type": "integer",
+              "default": 1000
+            },
+            "in": "query"
           },
           {
-              "examples": {
-                  "Minified response (default)": {
-                      "value": 1
-                  },
-                  "Full response with images": {
-                      "value": 0
-                  }
+            "examples": {
+              "Minified response (default)": {
+                "value": 1
               },
-              "name": "minify",
-              "description": "When set to `1` (default), returns a minified response with only essential fields (slug, titles, primaryTitle, description, categoryDescription, displayOrder, pools, shouldDisplay). When set to `0`, returns the full topic data including images and all other fields.",
-              "schema": {
-                  "type": "integer",
-                  "enum": [0, 1],
-                  "default": 1
-              },
-              "in": "query"
+              "Full response with images": {
+                "value": 0
+              }
+            },
+            "name": "minify",
+            "description": "When set to `1` (default), returns a minified response with only essential fields (slug, titles, primaryTitle, description, categoryDescription, displayOrder, pools, shouldDisplay). When set to `0`, returns the full topic data including images and all other fields.",
+            "schema": {
+              "type": "integer",
+              "enum": [
+                0,
+                1
+              ],
+              "default": 1
+            },
+            "in": "query"
           }
-      ],
+        ],
         "responses": {
           "200": {
             "content": {
@@ -5241,7 +5284,7 @@
         },
         "summary": "Recommended Topics",
         "description": "Given a list of `Ref`s this API returns the most used topics associated with them. This is a fast way of identifying potential shared topics amongst disparate `Ref`s."
-      }   
+      }
     },
     "/api/texts/random-by-topic": {
       "summary": "Random By Topic API",
@@ -5439,11 +5482,11 @@
             "description": "By default the Name API returns `Ref`s, book titles, authors, topics, and collections. If the `type` is set, the response will only contain items of that type. Note: `Topic` includes authors, topics and people without differentiation.",
             "schema": {
               "enum": [
-                "ref", 
-                "Collection", 
-                "Topic", 
+                "ref",
+                "Collection",
+                "Topic",
                 "TocCategory",
-                "Term", 
+                "Term",
                 "User"
               ],
               "type": "string"
@@ -5541,7 +5584,9 @@
                     "size": 10,
                     "slop": 10,
                     "sort_method": "score",
-                    "sort_fields": ["pagesheetrank"]
+                    "sort_fields": [
+                      "pagesheetrank"
+                    ]
                   }
                 }
               }
@@ -5651,7 +5696,9 @@
           "description": "A valid Sefaria textual `Ref`.",
           "schema": {
             "allOf": [
-              { "$ref": "#/components/schemas/ref" }
+              {
+                "$ref": "#/components/schemas/ref"
+              }
             ],
             "default": "Esther 1.1"
           },
@@ -5726,6 +5773,13867 @@
           "required": true
         }
       ]
+    },
+    "/api/sheets/{sheet_id}": {
+      "summary": "Sheet",
+      "description": "Retrieves the full content and metadata of a single Sefaria source sheet, including all of its sources, topics, and likes.",
+      "get": {
+        "operationId": "get-sheet",
+        "tags": [
+          "Sheets"
+        ],
+        "parameters": [
+          {
+            "name": "sheet_id",
+            "description": "The numeric ID of the sheet. To find a sheet's ID, open the sheet on `voices.sefaria.org` and copy the number from the URL — for example, `https://voices.sefaria.org/sheets/643492` has a sheet ID of `643492`. The API call itself is made to `www.sefaria.org`.",
+            "schema": {
+              "type": "integer"
+            },
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "more_data",
+            "description": "When set to `more_data=1`, returns an enriched panel view of the sheet (additional rendering metadata used by Sefaria's reader). Defaults to `0`.",
+            "schema": {
+              "enum": [
+                "0",
+                "1"
+              ],
+              "type": "string"
+            },
+            "in": "query",
+            "required": false
+          },
+          {
+            "name": "callback",
+            "description": "JSONP callback name. Optional.",
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SheetDetailJSON"
+                },
+                "examples": {
+                  "Sheet 643492": {
+                    "value": {
+                      "_id": "680fedff3dd208fdad8aefb1",
+                      "title": "Lag Baomer",
+                      "options": {
+                        "numbered": 0
+                      },
+                      "sources": [
+                        {
+                          "outsideText": "<h1>Biblical concept of Sefirah</h1>",
+                          "node": 258
+                        },
+                        {
+                          "ref": "Leviticus 23:15-16",
+                          "heRef": "ויקרא כ״ג:ט״ו-ט״ז",
+                          "text": {
+                            "en": "<div>(15) And from the day on which you bring the sheaf of elevation offering—the day after the sabbath—you shall count off seven weeks. They must be complete: (16) you must count until the day after the seventh week—fifty days; then you shall bring an offering of new grain to the Lord.</div>",
+                            "he": "<div><small>(טו)</small> וּסְפַרְתֶּ֤ם לָכֶם֙ מִמָּחֳרַ֣ת הַשַּׁבָּ֔ת מִיּוֹם֙ הֲבִ֣יאֲכֶ֔ם אֶת־עֹ֖מֶר הַתְּנוּפָ֑ה שֶׁ֥בַע שַׁבָּת֖וֹת תְּמִימֹ֥ת תִּהְיֶֽינָה׃ <small>(טז)</small> עַ֣ד מִֽמָּחֳרַ֤ת הַשַּׁבָּת֙ הַשְּׁבִיעִ֔ת תִּסְפְּר֖וּ חֲמִשִּׁ֣ים י֑וֹם וְהִקְרַבְתֶּ֛ם מִנְחָ֥ה חֲדָשָׁ֖ה לַיהוה </div>"
+                          },
+                          "options": {
+                            "sourceLanguage": "",
+                            "sourceLangLayout": "",
+                            "indented": "",
+                            "sourceLayout": ""
+                          },
+                          "node": 3
+                        },
+                        {
+                          "ref": "Ramban on Leviticus 23:36:1",
+                          "heRef": "רמב\"ן על ויקרא כ״ג:ל״ו:א׳",
+                          "text": {
+                            "en": "<div>From then on [i.e., beginning with the second day of Passover] we are to count forty-nine days[of the <i>omer</i>], which are seven weeks comparable to the [seven] “days” of the world, and then to sanctify the “eighth day” [i.e., the Festival of Weeks] just as the eighth day of Tabernacles [is holy]; and [the forty-nine days] counted between them are in the “intermediate days” of the festival, in the interval separating the first day and “eighth day” of the festival, this being the day of the Giving of the Torah.</div>",
+                            "he": "<div>וְצִוָּה בְּחַג הַמַּצּוֹת שִׁבְעָה יָמִים בִּקְדֻשָּׁה לִפְנֵיהֶם וּלְאַחֲרֵיהֶם, כִּי כֻּלָּם קְדֹשִׁים וּבְתוֹכָם יהוה, וּמָנָה מִמֶּנּוּ תִּשְׁעָה וְאַרְבָּעִים יוֹם, שִׁבְעָה שָׁבוּעוֹת כִּימֵי עוֹלָם, וְקִדֵּשׁ יוֹם שְׁמִינִי כִּשְׁמִינִי שֶׁל חָג, וְהַיָּמִים הַסְּפוּרִים בֵּינְתַיִם כְּחֻלּוֹ שֶׁל מוֹעֵד בֵּין הָרִאשׁוֹן וְהַשְּׁמִינִי בֶּחָג, וְהוּא יוֹם מַתַּן תּוֹרָה.</div>"
+                          },
+                          "node": 12
+                        },
+                        {
+                          "outsideText": "<h1>Students of Rabbi Akiva Dying</h1>",
+                          "node": 256
+                        },
+                        {
+                          "ref": "Yevamot 62b:9-11",
+                          "heRef": "יבמות ס״ב ב:ט׳-י״א",
+                          "text": {
+                            "en": "<div>It was said, That Rabbi Akiva had twelve thousand pairs of disciples, from Gabbat to Antifaras; and they all died at the same time because they did not treat each other with respect.  The world remained desolate until Rabbi Akiva came to our Masters in the South and taught the Torah to them. and it was they who revived the Torah at that time.  These were Rabbi Meir, Rabbi Judah, Rabbi Yossi, Rabbi Shimon and Rabbi Eleazar ben Shammua; And it was they who revived the Torah at that time. A Tanna taught:  <u><b>All of them died between Passover and Pentecost.</b></u>  Rabbi Hama bar Abba or, it might be said, Rabbi Chiyya bar Abin said: All of them died a cruel death. What was it? — Rabbi Nahman replied: Croup.</div>",
+                            "he": "<div>אמרו שנים עשר אלף זוגים תלמידים היו לו לרבי עקיבא מגבת עד אנטיפרס וכולן מתו בפרק אחד מפני שלא נהגו כבוד זה לזה והיה העולם שמם עד שבא ר\"ע אצל רבותינו שבדרום ושנאה להם ר\"מ ור' יהודה ור' יוסי ורבי שמעון ורבי אלעזר בן שמוע והם הם העמידו תורה אותה שעה תנא כולם <u><b>מתו מפסח ועד עצרת</b></u> אמר רב חמא בר אבא ואיתימא ר' חייא בר אבין כולם מתו מיתה רעה מאי היא א\"ר נחמן אסכרה.</div>"
+                          },
+                          "options": {
+                            "sourceLanguage": "",
+                            "sourceLangLayout": "",
+                            "indented": "",
+                            "sourceLayout": ""
+                          },
+                          "node": 2
+                        },
+                        {
+                          "ref": "Tur, Orach Chayim 493:1",
+                          "heRef": "טור, אורח חיים תצ״ג:א׳",
+                          "text": {
+                            "en": "<div>...</div>",
+                            "he": "<div>  נוהגין בכל המקומות שלא לישא אשה בין פסח לעצרת והטעם שלא להרבות בשמחה שבאותו זמן מתו תלמידי ר\"ע וכתב הר\"י גיאת דוקא נישואין שהוא עיקר שמחה ... ויש מקומות שנהגו שלא להסתפר <u>ויש מסתפרי' מל\"ג בעומר ואילך שאומרים שאז פסקו מלמות </u></div>"
+                          },
+                          "node": 27
+                        },
+                        {
+                          "ref": "Shulchan Arukh, Orach Chayyim 493:1-2",
+                          "heRef": "אורח חיים תצ״ג:א׳-ב׳",
+                          "text": {
+                            "en": "<div><small>(1)</small> It is customary not to get married between Pesach and Shavuot, until Lag BaOmer (the 33rd day), because during that time, the students of Rabbi Akiva died. However, to do \"erusin\" and \"kiddushin\" (engagement and betrothal) is OK. And even for \"nisuin\" (marriage), if someone did so, we do not punish him. Rema: however, from Lag Ba'Omer onwards, all this is permitted (Abudraham, Beit Yosef &amp; Minhagim).</div>  <div><small>(2)</small> It is customary not to cut one's hair until Lag BaOmer, since it is said that that is when they stopped dying.</div> ",
+                            "he": "<div><small>(א)</small> נוֹהֲגִים שֶׁלֹּא לִשָּׂא אִשָּׁה בֵּין פֶּסַח לַעֲצֶרֶת עַד ל''ג לָעֹמֶר, מִפְּנֵי שֶׁבְּאוֹתוֹ זְמַן מֵתוּ תַּלְמִידֵי רַבִּי עֲקִיבָא; אֲבָל לְאָרֵס וּלְקַדֵּשׁ, שַׁפִּיר דָּמִי, וְנִשּׂוּאִין נָמֵי, מִי שֶׁקָּפַץ וְכָנַס אֵין עוֹנְשִׁין אוֹתוֹ. <small> הַגָּה: מִיהוּ מִלַּ''ג בָּעֹמֶר וָאֵילָךְ הַכֹּל </small> <small> שָׁרֵי </small> <small>(אַבּוּדַרְהַם וּבֵית יוֹסֵף וּמִנְהָגִים)</small><small>. </small> </div>  <div><small>(ב)</small> נוֹהֲגִים שֶׁלֹּא לְהִסְתַּפֵּר עַד ל''ג לָעֹמֶר, שֶׁאוֹמְרִים שֶׁאָז פָּסְקוּ מִלָּמוּת.</div> "
+                          },
+                          "options": {
+                            "sourceLanguage": "",
+                            "sourceLangLayout": "",
+                            "indented": "",
+                            "sourceLayout": ""
+                          },
+                          "node": 5
+                        },
+                        {
+                          "outsideText": "<h1>Why we would celebrate</h1>",
+                          "node": 254
+                        },
+                        {
+                          "ref": "Meiri on Yevamot 62b:4",
+                          "heRef": "מאירי על יבמות ס״ב ב:ד׳",
+                          "text": {
+                            "en": "<div>\"They said about Rabbi Akiva that he had twelve thousand pairs of students and they all died in one period of time, because they did not treat each other with respect. And the world was desolate of Torah until Rabbi Akiva came to our Rabbis in the South and taught them - Rabbi Meir, Rabbi Yehudah, Rabbi Yosei, Rabbi Shimon, and Rabbi Elazar ben Shamua. And these are the very ones who upheld the time.\" And it is mentioned here that these [earlier] students all died from Pesach until Shavuot,<u> but it is a tradition in the hands of the Geonim that the dying stopped on the day of Lag BaOmer - so as a result of that, we are accustomed not to fast on it. And we are also accustomed, as a result of that, not to marry a woman from Pesach [only] until that time.</u> </div>",
+                            "he": "<div>אמרו על ר' עקיבא ששנים עשר אלף זוגות תלמידים היו לו וכלן מתו בפרק אחד על שלא נהגו כבוד זה לזה והיה העולם שמם בלא תורה עד שבא לו אצל רבותינו שבדרום ושנה להם לר' מאיר ור' שמעון ור' יהודה ור' יוסי ור' אלעזר בן שמוע והם הם העמידו את השעה ותלמידים אלו הוזכר כאן שכלם מתו מפסח ועד עצרת <u><b>וקבלה ביד הגאונים שביום ל\"ג בעומר פסקה המיתה ונוהגים מתוך כך שלא להתענות בו וכן נוהגים מתוך כך שלא לישא אשה מפסח עד אותו זמן:</b></u></div>"
+                          },
+                          "node": 1
+                        },
+                        {
+                          "outsideText": "<div><a href=\"\">Se</a><a href=\"https://hakirah.org/vol20first.pdf\">fer Ha-Manhig, vol. 2, p. 538 (Hilkhot Erusin ve-Nissuin). </a></div><div><a href=\"https://www.hebrewbooks.org/pdfpager.aspx?req=14615&amp;st=%d7%a4%d7%a8%d7%95%d7%a1&amp;pgnum=144&amp;hilite=8d7cbfe0-5e2c-4090-b04d-1900615c6ddd\\\">R. Abraham b. Nathan ha-Yarḥi, composed in Toledo in 1204.</a></div>",
+                          "node": 164
+                        },
+                        {
+                          "media": "https://storage.googleapis.com/sheet-user-uploaded-media/41841-974b5cee-249d-11f0-a83f-a6fe11f72b4e.png",
+                          "node": 22
+                        },
+                        {
+                          "outsideText": "<div><b>___________________________________________________</b></div><div><b>Hakira</b>:</div><div><a href=\"https://hakirah.org/vol20first.pdf\">There are many sources from the Geonic period in Palestine documenting that the 18th of Iyyar (Lag Ba-Omer) was observed there as a fast day commemorating the death of Joshua. These sources are collected by Shulamit Elitzur. For example, this fast day is mentioned by the paytannim R. Eleazar Kallir (c. 600) and R. Phinehas (8th century). It is mentioned in other sources from Palestine and Egypt in the subsequent centuries as well. The existence of this fast day is strong evidence that the concept of Lag Ba-Omer as a festive day was not yet in existence in the Tannaitic, Amoraic or Geonic periods.</a></div><div>___________________________________________________</div><div>Rabbi Chaim Vital born in 1543</div><div>Source here</div><div>--------</div><div><a href=\"https://www.chabad.org/therebbe/letters/default_cdo/aid/2279233/jewish/An-explanation-of-the-death-of-Rabbi-Shimon-bar-Yochai-on-Lag-BaOmer.htm/utm_source/chatgpt.com\">This letter was addressed to Rabbi Shlomo Yosef Zevin, one of the foremost Rabbinic scholars of the previous generation.</a></div>",
+                          "node": 206
+                        },
+                        {
+                          "outsideText": "<div>The Rebbe:</div><div>By chance I saw your book HaMoadim BeHalachah, 2nd edi­tion, in the library of my revered father-in-law, the Rebbe Shlita. In the section on Lag BaOmer, I found a quotation from the Pri Etz Chayim (as found in the Dubrovna and Lashtchov printing), Shaar Sefiras HaOmer, ch. 7, in the note: “The reason [for the celebration] is that Rabbi Shimon bar Yochai died on Lag BaOmer. He was one of the students of Rabbi Akiva who died during the Counting of the Omer.”</div><div>...</div><div>This [apparent contradiction] was already discussed in the responsa Divrei Nechemiah, Orach Chayim, Responsum 34, sec. 7, [which] concludes: “Perhaps there is a textual error in the Pri Etz Chayim, in the statement: ‘He was one [of the students]....’ Analysis is required. I heard that in the Karatz printing [of the Pri Etz Chayim], this passage was left out.”</div><div> </div>",
+                          "node": 225
+                        },
+                        {
+                          "outsideText": "<div><b>This is in fact true.</b></div><div>----</div><div>Chidah born in 1724</div>",
+                          "node": 212
+                        },
+                        {
+                          "ref": "Moreh BeEtzba 223:1",
+                          "heRef": "מורה באצבע רכ״ג:א׳",
+                          "text": {
+                            "en": "<div>One should add to the joy of the day of the thirty third of the Omer in honor of Rabbi Shimon bar Yochai, may his merit protect us - as it is the day of his memory (the day he died). And it is known that it was his will that [people] rejoice on this day - as is known from the story of our teacher, the Rabbi Avraham HaLevi (Amigo), may his memory be blessed for life in the world to come, and from other stories that we have heard. And we know them from the mouths of holy rabbis. And there is one who is accustomed to engaging in study on the night of the thirty third of the Omer with ten [men] to teach the praises of Rabbi Shimon bar Yochat that are scattered in the Zohar and the Idra Zuta; and that is a nice custom. </div>",
+                            "he": "<div><b>יום ל״ג לעומר ירבה שמחה לכבוד רשב״י זי״ע כי הוא יומא דהלולא דיליה.</b> ונודע שרצונו הוא שישמחו ביום זה כידוע ממעשה מהר״א הלוי זלה״ה ומעשים אחרים אשר שמענו ונדעם מפום רבנן קדישי. ויש מי שנהג לעשות לימוד בליל ל״ג לעומר בי עשרה ללמוד שבחי רשב״י המפוזרים בזהר ואדרא זוטא והוא מנהג יפה:</div>"
+                          },
+                          "node": 77
+                        },
+                        {
+                          "outsideText": "<div>___________________________________________________</div>",
+                          "node": 226
+                        },
+                        {
+                          "outsideText": "<div>Kaf Hachaim born in 1870  </div>",
+                          "node": 157
+                        },
+                        {
+                          "ref": "Kaf HaChayim on Shulchan Arukh, Orach Chayim 493:26:1",
+                          "heRef": "כף החיים על שולחן ערוך אורח חיים תצ״ג:כ״ו:א׳",
+                          "text": {
+                            "en": "<div>...</div>",
+                            "he": "<div><b>כו) שם. בהגה ומרבים בו קצת שמחה.  </b>לזכר שפסקו מלמות. דרשוא מהרי\"ל ר\"ז או' יהוה. מיהו הפר\"ח הקשה ע\"ז וכתב הטעם<b> שהשמחה היא על אותם תלמידים שהוסיף אח\"כ ר\"ע שלא מתו כאלו יעו\"ש.</b> ועיין בשער הכוו' דף פ\"ז ע\"א שכתב ובבוא יום ל\"ג לעומר אז נתגלה קטנות ב' של אי' שהוא שם אכדט\"ם אשר באי' והנה הוא חילוף שם אלהים (עיין לעיל או' ה') אשר הוא בחי' רחמים בסוד אלהים חיים וכו' ולכן סמך אח\"כ ר\"ע את יהוה תלמידיו הגדולים מבחי' יהוה גבורות דגדלות שהם כנגד יהוה אותיות אכדט\"ם שהם רחמים ואלו נתקיימו בעולם והרביצו תורה ברבים והם ר\"מ ור' יהודה ור' אלעזר בן שמוע ור\"ש ור' נחמיה יעו\"ש.</div>"
+                          },
+                          "node": 78
+                        },
+                        {
+                          "outsideText": "<div>Chtam Sofer born 1762</div>",
+                          "node": 246
+                        },
+                        {
+                          "ref": "Responsa Chatam Sofer, Yoreh De'ah 233:11",
+                          "heRef": "שו\"ת חתם סופר, יורה דעה רל״ג:י״א",
+                          "text": {
+                            "en": "<div>...</div>",
+                            "he": "<div><u>אמנם  ידעתי כי שמעתי שעכשיו אכשיר דרי וממרחק יבואו ידרושו את יהוה בע\"הק צפת ביום ל\"ג בעומר בהלולא דרשב\"י ז\"ל ואם כי כל כוונתם לש\"ש שכרם רב בלי ספק ע\"ד ודיגול\"ו ודליק\"ו נרות עלי אהב' כמ\"ש תוס' ר\"פ אין מעמידין אבל מטעם זה בעצמו הייתי אני מן הפרושים</u> ... בפר\"ח א\"ח סי' תצ\"ו בקונטרס מנהגי איסור שלו אות י\"ד על המקומות <u><b>שעושים י\"ט ביום שנעשה להם נס</b></u> מהא דאמרי' פ\"ק דר\"ה קמיית' בטיל אחריניית' מוסיפי' בתמי' [ובמקומו טרחתי הרב' לקיי' מנהג עיר מולדתי ק\"ק פפ\"דמ העושי' פורי' ביו' כ' אדר א'] ומנהג מצרי' ביו' כ\"ג  </div>"
+                          },
+                          "node": 103
+                        },
+                        {
+                          "outsideText": "<div>Can't make holidays after Charban, gemarah taanit, exception is local holidays for specific people who experienced holidays, what about purim (deoraita because kal vachomer slavery vs death), answer is purim is different because people thought it might lead to geulah</div>",
+                          "node": 104
+                        },
+                        {
+                          "ref": "Rosh Hashanah 19b:3",
+                          "heRef": "ראש השנה י״ט ב:ג׳",
+                          "text": {
+                            "en": "<div>The Gemara concludes: <b>And the </b><i><b>halakha</b></i><b> is</b> that these days <b>were nullified, and the </b><i><b>halakha</b></i><b> is</b> that <b>they were not nullified.</b> The Gemara asks: This <b>is difficult,</b> as one <i><b>halakha</b></i> contradicts <b>the</b> other <i><b>halakha</b></i><b>.</b> The Gemara answers: <b>It</b> is <b>not difficult. Here,</b> it is referring to <b>Hanukkah and Purim.</b> These Festival days were never nullified, and Hanukkah is listed among the Festivals of <i>Megillat Ta’anit</i>. <b>There,</b> the <i>halakha</i> is referring to <b>the rest of the days</b> listed in <i>Megillat Ta’anit</i>, all of which were nullified.</div>",
+                            "he": "<div>וְהִלְכְתָא בָּטְלוּ, וְהִלְכְתָא לֹא בָּטְלוּ. קַשְׁיָא הִלְכְתָא אַהִלְכְתָא! לָא קַשְׁיָא: כָּאן בַּחֲנוּכָּה וּפוּרִים, כָּאן בִּשְׁאָר יוֹמֵי.</div>"
+                          },
+                          "node": 227
+                        }
+                      ],
+                      "dateModified": "2025-05-04T00:12:38.737202",
+                      "dateCreated": "2025-04-28T18:07:11.866973",
+                      "status": "public",
+                      "owner": 41841,
+                      "views": 605,
+                      "nextNode": 259,
+                      "includedRefs": [
+                        "Leviticus 23:15-16",
+                        "Ramban on Leviticus 23:36:1",
+                        "Yevamot 62b:9-11",
+                        "Tur, Orach Chayim 493:1",
+                        "Shulchan Arukh, Orach Chayyim 493:1-2",
+                        "Meiri on Yevamot 62b:4",
+                        "Moreh BeEtzba 223:1",
+                        "Kaf HaChayim on Shulchan Arukh, Orach Chayim 493:26:1",
+                        "Responsa Chatam Sofer, Yoreh De'ah 233:11",
+                        "Rosh Hashanah 19b:3"
+                      ],
+                      "expandedRefs": [
+                        "Ramban on Leviticus 23:36:1",
+                        "Shulchan Arukh, Orach Chayim 493:1",
+                        "Rosh Hashanah 19b:3",
+                        "Yevamot 62b:11",
+                        "Kaf HaChayim on Shulchan Arukh, Orach Chayim 493:26:1",
+                        "Moreh BeEtzba 223:1",
+                        "Meiri on Yevamot 62b:4",
+                        "Responsa Chatam Sofer, Yoreh De'ah 233:11",
+                        "Leviticus 23:16",
+                        "Yevamot 62b:9",
+                        "Leviticus 23:15",
+                        "Yevamot 62b:10",
+                        "Shulchan Arukh, Orach Chayim 493:2",
+                        "Tur, Orach Chayim 493:1"
+                      ],
+                      "sheetLanguage": "english",
+                      "id": 643492,
+                      "summary": "Lag Baomer not having so much history",
+                      "tags": [],
+                      "displayedCollection": "",
+                      "likes": [],
+                      "topics": [
+                        {
+                          "asTyped": "Sefirat HaOmer",
+                          "slug": "sefirat-haomer",
+                          "en": "Sefirat HaOmer",
+                          "he": "ספירת העומר"
+                        },
+                        {
+                          "asTyped": "Lag BaOmer",
+                          "slug": "lag-baomer",
+                          "en": "Lag BaOmer",
+                          "he": "ל\"ג בעומר"
+                        }
+                      ],
+                      "collections": [],
+                      "ownerName": "Matthew Rosenberg",
+                      "ownerProfileUrl": "/profile/matthew-rosenberg1",
+                      "ownerImageUrl": "",
+                      "sheetNotice": null,
+                      "collectionImage": "https://storage.googleapis.com/sefaria-collection-images/117715-5c80031c-0a95-11ef-987a-ce6fa0b21c30.jpg",
+                      "collectionName": "한글타낙",
+                      "rebuild": true,
+                      "datePublished": "2025-05-02T20:06:45.841461",
+                      "llm_scoring": {
+                        "processed_datetime": "2026-01-26 09:32:54.042317",
+                        "sheet": {
+                          "ref_scores": {
+                            "Ramban on Leviticus 23:36:1": 6.9,
+                            "Shulchan Arukh, Orach Chayim 493:1": 10.34,
+                            "Rosh Hashanah 19b:3": 6.9,
+                            "Yevamot 62b:11": 3.44,
+                            "Kaf HaChayim on Shulchan Arukh, Orach Chayim 493:26:1": 6.9,
+                            "Moreh BeEtzba 223:1": 6.9,
+                            "Meiri on Yevamot 62b:4": 10.34,
+                            "Responsa Chatam Sofer, Yoreh De'ah 233:11": 10.34,
+                            "Leviticus 23:16": 3.44,
+                            "Yevamot 62b:9": 10.34,
+                            "Leviticus 23:15": 3.44,
+                            "Yevamot 62b:10": 3.44,
+                            "Shulchan Arukh, Orach Chayim 493:2": 6.9,
+                            "Tur, Orach Chayim 493:1": 10.34
+                          },
+                          "title_interest_level": 3,
+                          "title_interest_reason": "Lag Baomer is a significant Jewish holiday, attracting interest for its historical and cultural relevance.",
+                          "language": "en",
+                          "creativity_score": 0.38341968911917096
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "description": "Retrieves the full content and metadata of a single Sefaria source sheet."
+      }
+    },
+    "/api/sheets/trending-tags": {
+      "summary": "Trending Sheet Tags",
+      "description": "Returns the most-used sheet tags from recent activity. Tags are ordered by `count` (descending).",
+      "get": {
+        "operationId": "get-sheets-trending-tags",
+        "tags": [
+          "Sheets"
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TrendingSheetTagJSON"
+                  }
+                },
+                "examples": {
+                  "Trending tags": {
+                    "value": [
+                      {
+                        "slug": "parashat-shemini",
+                        "count": 42,
+                        "author_count": 31,
+                        "tag": "Parashat Shemini",
+                        "he_tag": "פרשת שמיני",
+                        "primaryTitle": {
+                          "en": "Parashat Shemini",
+                          "he": "פרשת שמיני"
+                        }
+                      },
+                      {
+                        "slug": "parashat-emor",
+                        "count": 35,
+                        "author_count": 31,
+                        "tag": "Parashat Emor",
+                        "he_tag": "פרשת אמור",
+                        "primaryTitle": {
+                          "en": "Parashat Emor",
+                          "he": "פרשת אמור"
+                        }
+                      },
+                      {
+                        "slug": "prayer",
+                        "count": 43,
+                        "author_count": 26,
+                        "tag": "Prayer",
+                        "he_tag": "תפילה",
+                        "primaryTitle": {
+                          "en": "Prayer",
+                          "he": "תפילה"
+                        }
+                      },
+                      {
+                        "slug": "torah",
+                        "count": 35,
+                        "author_count": 24,
+                        "tag": "Torah",
+                        "he_tag": "תורה",
+                        "primaryTitle": {
+                          "en": "Torah",
+                          "he": "תורה"
+                        }
+                      },
+                      {
+                        "slug": "passover",
+                        "count": 31,
+                        "author_count": 21,
+                        "tag": "Passover",
+                        "he_tag": "פסח",
+                        "primaryTitle": {
+                          "en": "Passover",
+                          "he": "פסח"
+                        }
+                      },
+                      {
+                        "slug": "parashat-kedoshim",
+                        "count": 24,
+                        "author_count": 21,
+                        "tag": "Parashat Kedoshim",
+                        "he_tag": "פרשת קדושים",
+                        "primaryTitle": {
+                          "en": "Parashat Kedoshim",
+                          "he": "פרשת קדושים"
+                        }
+                      },
+                      {
+                        "slug": "shabbat",
+                        "count": 22,
+                        "author_count": 20,
+                        "tag": "Shabbat",
+                        "he_tag": "שבת",
+                        "primaryTitle": {
+                          "en": "Shabbat",
+                          "he": "שבת"
+                        }
+                      },
+                      {
+                        "slug": "shavuot",
+                        "count": 21,
+                        "author_count": 19,
+                        "tag": "Shavuot",
+                        "he_tag": "שבועות",
+                        "primaryTitle": {
+                          "en": "Shavuot",
+                          "he": "שבועות"
+                        }
+                      },
+                      {
+                        "slug": "sacrifices",
+                        "count": 29,
+                        "author_count": 19,
+                        "tag": "Sacrifices",
+                        "he_tag": "קרבן",
+                        "primaryTitle": {
+                          "en": "Sacrifices",
+                          "he": "קרבן"
+                        }
+                      },
+                      {
+                        "slug": "women",
+                        "count": 20,
+                        "author_count": 19,
+                        "tag": "Women",
+                        "he_tag": "נשים",
+                        "primaryTitle": {
+                          "en": "Women",
+                          "he": "נשים"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "description": "Returns the most-used sheet tags from recent activity."
+      }
+    },
+    "/api/authors/{author_slug}/indexes": {
+      "summary": "Author Indexes",
+      "description": "Returns the list of indexes (works) attributed to a given Sefaria author.",
+      "get": {
+        "operationId": "get-author-indexes",
+        "tags": [
+          "Index"
+        ],
+        "parameters": [
+          {
+            "name": "author_slug",
+            "description": "The author's topic slug. To find a slug: search for the author on `https://www.sefaria.org`, open their topic page, and copy the last segment of the URL — for example, `https://www.sefaria.org/topics/rashi` has an author slug of `rashi`.",
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthorIndexesJSON"
+                },
+                "examples": {
+                  "Rashi": {
+                    "value": {
+                      "indexes": [
+                        {
+                          "title": "Rashi on Genesis",
+                          "heTitle": "רש\"י על בראשית",
+                          "categories": [
+                            "Tanakh",
+                            "Rishonim on Tanakh",
+                            "Rashi",
+                            "Torah"
+                          ],
+                          "url": "/Rashi_on_Genesis",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Exodus",
+                          "heTitle": "רש\"י על שמות",
+                          "categories": [
+                            "Tanakh",
+                            "Rishonim on Tanakh",
+                            "Rashi",
+                            "Torah"
+                          ],
+                          "url": "/Rashi_on_Exodus",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Leviticus",
+                          "heTitle": "רש\"י על ויקרא",
+                          "categories": [
+                            "Tanakh",
+                            "Rishonim on Tanakh",
+                            "Rashi",
+                            "Torah"
+                          ],
+                          "url": "/Rashi_on_Leviticus",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Numbers",
+                          "heTitle": "רש\"י על במדבר",
+                          "categories": [
+                            "Tanakh",
+                            "Rishonim on Tanakh",
+                            "Rashi",
+                            "Torah"
+                          ],
+                          "url": "/Rashi_on_Numbers",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Deuteronomy",
+                          "heTitle": "רש\"י על דברים",
+                          "categories": [
+                            "Tanakh",
+                            "Rishonim on Tanakh",
+                            "Rashi",
+                            "Torah"
+                          ],
+                          "url": "/Rashi_on_Deuteronomy",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Joshua",
+                          "heTitle": "רש\"י על יהושע",
+                          "categories": [
+                            "Tanakh",
+                            "Rishonim on Tanakh",
+                            "Rashi",
+                            "Prophets"
+                          ],
+                          "url": "/Rashi_on_Joshua",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Judges",
+                          "heTitle": "רש\"י על שופטים",
+                          "categories": [
+                            "Tanakh",
+                            "Rishonim on Tanakh",
+                            "Rashi",
+                            "Prophets"
+                          ],
+                          "url": "/Rashi_on_Judges",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on I Samuel",
+                          "heTitle": "רש\"י על שמואל א",
+                          "categories": [
+                            "Tanakh",
+                            "Rishonim on Tanakh",
+                            "Rashi",
+                            "Prophets"
+                          ],
+                          "url": "/Rashi_on_I_Samuel",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on II Samuel",
+                          "heTitle": "רש\"י על שמואל ב",
+                          "categories": [
+                            "Tanakh",
+                            "Rishonim on Tanakh",
+                            "Rashi",
+                            "Prophets"
+                          ],
+                          "url": "/Rashi_on_II_Samuel",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on I Kings",
+                          "heTitle": "רש\"י על מלכים א",
+                          "categories": [
+                            "Tanakh",
+                            "Rishonim on Tanakh",
+                            "Rashi",
+                            "Prophets"
+                          ],
+                          "url": "/Rashi_on_I_Kings",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on II Kings",
+                          "heTitle": "רש\"י על מלכים ב",
+                          "categories": [
+                            "Tanakh",
+                            "Rishonim on Tanakh",
+                            "Rashi",
+                            "Prophets"
+                          ],
+                          "url": "/Rashi_on_II_Kings",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Isaiah",
+                          "heTitle": "רש\"י על ישעיהו",
+                          "categories": [
+                            "Tanakh",
+                            "Rishonim on Tanakh",
+                            "Rashi",
+                            "Prophets"
+                          ],
+                          "url": "/Rashi_on_Isaiah",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Jeremiah",
+                          "heTitle": "רש\"י על ירמיהו",
+                          "categories": [
+                            "Tanakh",
+                            "Rishonim on Tanakh",
+                            "Rashi",
+                            "Prophets"
+                          ],
+                          "url": "/Rashi_on_Jeremiah",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Ezekiel",
+                          "heTitle": "רש\"י על יחזקאל",
+                          "categories": [
+                            "Tanakh",
+                            "Rishonim on Tanakh",
+                            "Rashi",
+                            "Prophets"
+                          ],
+                          "url": "/Rashi_on_Ezekiel",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Hosea",
+                          "heTitle": "רש\"י על הושע",
+                          "categories": [
+                            "Tanakh",
+                            "Rishonim on Tanakh",
+                            "Rashi",
+                            "Prophets"
+                          ],
+                          "url": "/Rashi_on_Hosea",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Joel",
+                          "heTitle": "רש\"י על יואל",
+                          "categories": [
+                            "Tanakh",
+                            "Rishonim on Tanakh",
+                            "Rashi",
+                            "Prophets"
+                          ],
+                          "url": "/Rashi_on_Joel",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Amos",
+                          "heTitle": "רש\"י על עמוס",
+                          "categories": [
+                            "Tanakh",
+                            "Rishonim on Tanakh",
+                            "Rashi",
+                            "Prophets"
+                          ],
+                          "url": "/Rashi_on_Amos",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Obadiah",
+                          "heTitle": "רש\"י על עובדיה",
+                          "categories": [
+                            "Tanakh",
+                            "Rishonim on Tanakh",
+                            "Rashi",
+                            "Prophets"
+                          ],
+                          "url": "/Rashi_on_Obadiah",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Jonah",
+                          "heTitle": "רש\"י על יונה",
+                          "categories": [
+                            "Tanakh",
+                            "Rishonim on Tanakh",
+                            "Rashi",
+                            "Prophets"
+                          ],
+                          "url": "/Rashi_on_Jonah",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Micah",
+                          "heTitle": "רש\"י על מיכה",
+                          "categories": [
+                            "Tanakh",
+                            "Rishonim on Tanakh",
+                            "Rashi",
+                            "Prophets"
+                          ],
+                          "url": "/Rashi_on_Micah",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Nahum",
+                          "heTitle": "רש\"י על נחום",
+                          "categories": [
+                            "Tanakh",
+                            "Rishonim on Tanakh",
+                            "Rashi",
+                            "Prophets"
+                          ],
+                          "url": "/Rashi_on_Nahum",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Habakkuk",
+                          "heTitle": "רש\"י על חבקוק",
+                          "categories": [
+                            "Tanakh",
+                            "Rishonim on Tanakh",
+                            "Rashi",
+                            "Prophets"
+                          ],
+                          "url": "/Rashi_on_Habakkuk",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Zephaniah",
+                          "heTitle": "רש\"י על צפניה",
+                          "categories": [
+                            "Tanakh",
+                            "Rishonim on Tanakh",
+                            "Rashi",
+                            "Prophets"
+                          ],
+                          "url": "/Rashi_on_Zephaniah",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Haggai",
+                          "heTitle": "רש\"י על חגי",
+                          "categories": [
+                            "Tanakh",
+                            "Rishonim on Tanakh",
+                            "Rashi",
+                            "Prophets"
+                          ],
+                          "url": "/Rashi_on_Haggai",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Zechariah",
+                          "heTitle": "רש\"י על זכריה",
+                          "categories": [
+                            "Tanakh",
+                            "Rishonim on Tanakh",
+                            "Rashi",
+                            "Prophets"
+                          ],
+                          "url": "/Rashi_on_Zechariah",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Malachi",
+                          "heTitle": "רש\"י על מלאכי",
+                          "categories": [
+                            "Tanakh",
+                            "Rishonim on Tanakh",
+                            "Rashi",
+                            "Prophets"
+                          ],
+                          "url": "/Rashi_on_Malachi",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Psalms",
+                          "heTitle": "רש\"י על תהילים",
+                          "categories": [
+                            "Tanakh",
+                            "Rishonim on Tanakh",
+                            "Rashi",
+                            "Writings"
+                          ],
+                          "url": "/Rashi_on_Psalms",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Proverbs",
+                          "heTitle": "רש\"י על משלי",
+                          "categories": [
+                            "Tanakh",
+                            "Rishonim on Tanakh",
+                            "Rashi",
+                            "Writings"
+                          ],
+                          "url": "/Rashi_on_Proverbs",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Job",
+                          "heTitle": "רש\"י על איוב",
+                          "categories": [
+                            "Tanakh",
+                            "Rishonim on Tanakh",
+                            "Rashi",
+                            "Writings"
+                          ],
+                          "url": "/Rashi_on_Job",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Song of Songs",
+                          "heTitle": "רש\"י על שיר השירים",
+                          "categories": [
+                            "Tanakh",
+                            "Rishonim on Tanakh",
+                            "Rashi",
+                            "Writings"
+                          ],
+                          "url": "/Rashi_on_Song_of_Songs",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Ruth",
+                          "heTitle": "רש\"י על רות",
+                          "categories": [
+                            "Tanakh",
+                            "Rishonim on Tanakh",
+                            "Rashi",
+                            "Writings"
+                          ],
+                          "url": "/Rashi_on_Ruth",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Lamentations",
+                          "heTitle": "רש\"י על איכה",
+                          "categories": [
+                            "Tanakh",
+                            "Rishonim on Tanakh",
+                            "Rashi",
+                            "Writings"
+                          ],
+                          "url": "/Rashi_on_Lamentations",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Ecclesiastes",
+                          "heTitle": "רש\"י על קהלת",
+                          "categories": [
+                            "Tanakh",
+                            "Rishonim on Tanakh",
+                            "Rashi",
+                            "Writings"
+                          ],
+                          "url": "/Rashi_on_Ecclesiastes",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Esther",
+                          "heTitle": "רש\"י על אסתר",
+                          "categories": [
+                            "Tanakh",
+                            "Rishonim on Tanakh",
+                            "Rashi",
+                            "Writings"
+                          ],
+                          "url": "/Rashi_on_Esther",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Daniel",
+                          "heTitle": "רש\"י על דניאל",
+                          "categories": [
+                            "Tanakh",
+                            "Rishonim on Tanakh",
+                            "Rashi",
+                            "Writings"
+                          ],
+                          "url": "/Rashi_on_Daniel",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Ezra",
+                          "heTitle": "רש\"י על עזרא",
+                          "categories": [
+                            "Tanakh",
+                            "Rishonim on Tanakh",
+                            "Rashi",
+                            "Writings"
+                          ],
+                          "url": "/Rashi_on_Ezra",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Nehemiah",
+                          "heTitle": "רש\"י על נחמיה",
+                          "categories": [
+                            "Tanakh",
+                            "Rishonim on Tanakh",
+                            "Rashi",
+                            "Writings"
+                          ],
+                          "url": "/Rashi_on_Nehemiah",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on I Chronicles",
+                          "heTitle": "רש\"י על דברי הימים א",
+                          "categories": [
+                            "Tanakh",
+                            "Rishonim on Tanakh",
+                            "Rashi",
+                            "Writings"
+                          ],
+                          "url": "/Rashi_on_I_Chronicles",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on II Chronicles",
+                          "heTitle": "רש\"י על דברי הימים ב",
+                          "categories": [
+                            "Tanakh",
+                            "Rishonim on Tanakh",
+                            "Rashi",
+                            "Writings"
+                          ],
+                          "url": "/Rashi_on_II_Chronicles",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Avot",
+                          "heTitle": "רש\"י על משנה אבות",
+                          "categories": [
+                            "Mishnah",
+                            "Rishonim on Mishnah",
+                            "Rashi",
+                            "Seder Nezikin"
+                          ],
+                          "url": "/Rashi_on_Avot",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Berakhot",
+                          "heTitle": "רש\"י על ברכות",
+                          "categories": [
+                            "Talmud",
+                            "Bavli",
+                            "Rishonim on Talmud",
+                            "Rashi",
+                            "Seder Zeraim"
+                          ],
+                          "url": "/Rashi_on_Berakhot",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Shabbat",
+                          "heTitle": "רש\"י על שבת",
+                          "categories": [
+                            "Talmud",
+                            "Bavli",
+                            "Rishonim on Talmud",
+                            "Rashi",
+                            "Seder Moed"
+                          ],
+                          "url": "/Rashi_on_Shabbat",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Eruvin",
+                          "heTitle": "רש\"י על עירובין",
+                          "categories": [
+                            "Talmud",
+                            "Bavli",
+                            "Rishonim on Talmud",
+                            "Rashi",
+                            "Seder Moed"
+                          ],
+                          "url": "/Rashi_on_Eruvin",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Pesachim",
+                          "heTitle": "רש\"י על פסחים",
+                          "categories": [
+                            "Talmud",
+                            "Bavli",
+                            "Rishonim on Talmud",
+                            "Rashi",
+                            "Seder Moed"
+                          ],
+                          "url": "/Rashi_on_Pesachim",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Rosh Hashanah",
+                          "heTitle": "רש\"י על ראש השנה",
+                          "categories": [
+                            "Talmud",
+                            "Bavli",
+                            "Rishonim on Talmud",
+                            "Rashi",
+                            "Seder Moed"
+                          ],
+                          "url": "/Rashi_on_Rosh_Hashanah",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Yoma",
+                          "heTitle": "רש\"י על יומא",
+                          "categories": [
+                            "Talmud",
+                            "Bavli",
+                            "Rishonim on Talmud",
+                            "Rashi",
+                            "Seder Moed"
+                          ],
+                          "url": "/Rashi_on_Yoma",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Sukkah",
+                          "heTitle": "רש\"י על סוכה",
+                          "categories": [
+                            "Talmud",
+                            "Bavli",
+                            "Rishonim on Talmud",
+                            "Rashi",
+                            "Seder Moed"
+                          ],
+                          "url": "/Rashi_on_Sukkah",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Beitzah",
+                          "heTitle": "רש\"י על ביצה",
+                          "categories": [
+                            "Talmud",
+                            "Bavli",
+                            "Rishonim on Talmud",
+                            "Rashi",
+                            "Seder Moed"
+                          ],
+                          "url": "/Rashi_on_Beitzah",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Taanit",
+                          "heTitle": "רש\"י על תענית",
+                          "categories": [
+                            "Talmud",
+                            "Bavli",
+                            "Rishonim on Talmud",
+                            "Rashi",
+                            "Seder Moed"
+                          ],
+                          "url": "/Rashi_on_Taanit",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Megillah",
+                          "heTitle": "רש\"י על מגילה",
+                          "categories": [
+                            "Talmud",
+                            "Bavli",
+                            "Rishonim on Talmud",
+                            "Rashi",
+                            "Seder Moed"
+                          ],
+                          "url": "/Rashi_on_Megillah",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Moed Katan",
+                          "heTitle": "רש\"י על מועד קטן",
+                          "categories": [
+                            "Talmud",
+                            "Bavli",
+                            "Rishonim on Talmud",
+                            "Rashi",
+                            "Seder Moed"
+                          ],
+                          "url": "/Rashi_on_Moed_Katan",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Chagigah",
+                          "heTitle": "רש\"י על חגיגה",
+                          "categories": [
+                            "Talmud",
+                            "Bavli",
+                            "Rishonim on Talmud",
+                            "Rashi",
+                            "Seder Moed"
+                          ],
+                          "url": "/Rashi_on_Chagigah",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Yevamot",
+                          "heTitle": "רש\"י על יבמות",
+                          "categories": [
+                            "Talmud",
+                            "Bavli",
+                            "Rishonim on Talmud",
+                            "Rashi",
+                            "Seder Nashim"
+                          ],
+                          "url": "/Rashi_on_Yevamot",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Ketubot",
+                          "heTitle": "רש\"י על כתובות",
+                          "categories": [
+                            "Talmud",
+                            "Bavli",
+                            "Rishonim on Talmud",
+                            "Rashi",
+                            "Seder Nashim"
+                          ],
+                          "url": "/Rashi_on_Ketubot",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Nedarim",
+                          "heTitle": "רש\"י על נדרים",
+                          "categories": [
+                            "Talmud",
+                            "Bavli",
+                            "Rishonim on Talmud",
+                            "Rashi",
+                            "Seder Nashim"
+                          ],
+                          "url": "/Rashi_on_Nedarim",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Nazir",
+                          "heTitle": "רש\"י על נזיר",
+                          "categories": [
+                            "Talmud",
+                            "Bavli",
+                            "Rishonim on Talmud",
+                            "Rashi",
+                            "Seder Nashim"
+                          ],
+                          "url": "/Rashi_on_Nazir",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Sotah",
+                          "heTitle": "רש\"י על סוטה",
+                          "categories": [
+                            "Talmud",
+                            "Bavli",
+                            "Rishonim on Talmud",
+                            "Rashi",
+                            "Seder Nashim"
+                          ],
+                          "url": "/Rashi_on_Sotah",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Gittin",
+                          "heTitle": "רש\"י על גיטין",
+                          "categories": [
+                            "Talmud",
+                            "Bavli",
+                            "Rishonim on Talmud",
+                            "Rashi",
+                            "Seder Nashim"
+                          ],
+                          "url": "/Rashi_on_Gittin",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Kiddushin",
+                          "heTitle": "רש\"י על קידושין",
+                          "categories": [
+                            "Talmud",
+                            "Bavli",
+                            "Rishonim on Talmud",
+                            "Rashi",
+                            "Seder Nashim"
+                          ],
+                          "url": "/Rashi_on_Kiddushin",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Bava Kamma",
+                          "heTitle": "רש\"י על בבא קמא",
+                          "categories": [
+                            "Talmud",
+                            "Bavli",
+                            "Rishonim on Talmud",
+                            "Rashi",
+                            "Seder Nezikin"
+                          ],
+                          "url": "/Rashi_on_Bava_Kamma",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Bava Metzia",
+                          "heTitle": "רש\"י על בבא מציעא",
+                          "categories": [
+                            "Talmud",
+                            "Bavli",
+                            "Rishonim on Talmud",
+                            "Rashi",
+                            "Seder Nezikin"
+                          ],
+                          "url": "/Rashi_on_Bava_Metzia",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Bava Batra",
+                          "heTitle": "רש\"י על בבא בתרא",
+                          "categories": [
+                            "Talmud",
+                            "Bavli",
+                            "Rishonim on Talmud",
+                            "Rashi",
+                            "Seder Nezikin"
+                          ],
+                          "url": "/Rashi_on_Bava_Batra",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Sanhedrin",
+                          "heTitle": "רש\"י על סנהדרין",
+                          "categories": [
+                            "Talmud",
+                            "Bavli",
+                            "Rishonim on Talmud",
+                            "Rashi",
+                            "Seder Nezikin"
+                          ],
+                          "url": "/Rashi_on_Sanhedrin",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Makkot",
+                          "heTitle": "רש\"י על מכות",
+                          "categories": [
+                            "Talmud",
+                            "Bavli",
+                            "Rishonim on Talmud",
+                            "Rashi",
+                            "Seder Nezikin"
+                          ],
+                          "url": "/Rashi_on_Makkot",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Shevuot",
+                          "heTitle": "רש\"י על שבועות",
+                          "categories": [
+                            "Talmud",
+                            "Bavli",
+                            "Rishonim on Talmud",
+                            "Rashi",
+                            "Seder Nezikin"
+                          ],
+                          "url": "/Rashi_on_Shevuot",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Avodah Zarah",
+                          "heTitle": "רש\"י על עבודה זרה",
+                          "categories": [
+                            "Talmud",
+                            "Bavli",
+                            "Rishonim on Talmud",
+                            "Rashi",
+                            "Seder Nezikin"
+                          ],
+                          "url": "/Rashi_on_Avodah_Zarah",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Horayot",
+                          "heTitle": "רש\"י על הוריות",
+                          "categories": [
+                            "Talmud",
+                            "Bavli",
+                            "Rishonim on Talmud",
+                            "Rashi",
+                            "Seder Nezikin"
+                          ],
+                          "url": "/Rashi_on_Horayot",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Zevachim",
+                          "heTitle": "רש\"י על זבחים",
+                          "categories": [
+                            "Talmud",
+                            "Bavli",
+                            "Rishonim on Talmud",
+                            "Rashi",
+                            "Seder Kodashim"
+                          ],
+                          "url": "/Rashi_on_Zevachim",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Menachot",
+                          "heTitle": "רש\"י על מנחות",
+                          "categories": [
+                            "Talmud",
+                            "Bavli",
+                            "Rishonim on Talmud",
+                            "Rashi",
+                            "Seder Kodashim"
+                          ],
+                          "url": "/Rashi_on_Menachot",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Chullin",
+                          "heTitle": "רש\"י על חולין",
+                          "categories": [
+                            "Talmud",
+                            "Bavli",
+                            "Rishonim on Talmud",
+                            "Rashi",
+                            "Seder Kodashim"
+                          ],
+                          "url": "/Rashi_on_Chullin",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Bekhorot",
+                          "heTitle": "רש\"י על בכורות",
+                          "categories": [
+                            "Talmud",
+                            "Bavli",
+                            "Rishonim on Talmud",
+                            "Rashi",
+                            "Seder Kodashim"
+                          ],
+                          "url": "/Rashi_on_Bekhorot",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Arakhin",
+                          "heTitle": "רש\"י על ערכין",
+                          "categories": [
+                            "Talmud",
+                            "Bavli",
+                            "Rishonim on Talmud",
+                            "Rashi",
+                            "Seder Kodashim"
+                          ],
+                          "url": "/Rashi_on_Arakhin",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Temurah",
+                          "heTitle": "רש\"י על תמורה",
+                          "categories": [
+                            "Talmud",
+                            "Bavli",
+                            "Rishonim on Talmud",
+                            "Rashi",
+                            "Seder Kodashim"
+                          ],
+                          "url": "/Rashi_on_Temurah",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Keritot",
+                          "heTitle": "רש\"י על כריתות",
+                          "categories": [
+                            "Talmud",
+                            "Bavli",
+                            "Rishonim on Talmud",
+                            "Rashi",
+                            "Seder Kodashim"
+                          ],
+                          "url": "/Rashi_on_Keritot",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Meilah",
+                          "heTitle": "רש\"י על מעילה",
+                          "categories": [
+                            "Talmud",
+                            "Bavli",
+                            "Rishonim on Talmud",
+                            "Rashi",
+                            "Seder Kodashim"
+                          ],
+                          "url": "/Rashi_on_Meilah",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Niddah",
+                          "heTitle": "רש\"י על נדה",
+                          "categories": [
+                            "Talmud",
+                            "Bavli",
+                            "Rishonim on Talmud",
+                            "Rashi",
+                            "Seder Tahorot"
+                          ],
+                          "url": "/Rashi_on_Niddah",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Ktav Yad Rashi on Menachot",
+                          "heTitle": "כתב יד רש\"י על מנחות",
+                          "categories": [
+                            "Talmud",
+                            "Bavli",
+                            "Rishonim on Talmud",
+                            "Ktav Yad Rashi",
+                            "Seder Kodashim"
+                          ],
+                          "url": "/Ktav_Yad_Rashi_on_Menachot",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Ktav Yad Rashi on Bekhorot",
+                          "heTitle": "כתב יד רש\"י על בכורות",
+                          "categories": [
+                            "Talmud",
+                            "Bavli",
+                            "Rishonim on Talmud",
+                            "Ktav Yad Rashi",
+                            "Seder Kodashim"
+                          ],
+                          "url": "/Ktav_Yad_Rashi_on_Bekhorot",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Rashi on Bereshit Rabbah",
+                          "heTitle": "רש\"י על בראשית רבה",
+                          "categories": [
+                            "Midrash",
+                            "Aggadah",
+                            "Midrash Rabbah",
+                            "Commentary",
+                            "Rashi"
+                          ],
+                          "url": "/Rashi_on_Bereshit_Rabbah",
+                          "dependence": "Commentary"
+                        },
+                        {
+                          "title": "Issur VeHeter LeRashi",
+                          "heTitle": "איסור והיתר לרש\"י",
+                          "categories": [
+                            "Halakhah",
+                            "Rishonim"
+                          ],
+                          "url": "/Issur_VeHeter_LeRashi",
+                          "dependence": null
+                        },
+                        {
+                          "title": "Likkutei HaPardes",
+                          "heTitle": "לקוטי הפרדס",
+                          "categories": [
+                            "Halakhah",
+                            "Rishonim"
+                          ],
+                          "url": "/Likkutei_HaPardes",
+                          "dependence": null
+                        },
+                        {
+                          "title": "Sefer HaOrah",
+                          "heTitle": "ספר האורה",
+                          "categories": [
+                            "Halakhah",
+                            "Rishonim"
+                          ],
+                          "url": "/Sefer_HaOrah",
+                          "dependence": null
+                        },
+                        {
+                          "title": "Siddur Rashi",
+                          "heTitle": "סידור רש\"י",
+                          "categories": [
+                            "Halakhah",
+                            "Rishonim"
+                          ],
+                          "url": "/Siddur_Rashi",
+                          "dependence": null
+                        },
+                        {
+                          "title": "Teshuvot Rashi",
+                          "heTitle": "תשובות רש\"י",
+                          "categories": [
+                            "Responsa",
+                            "Rishonim"
+                          ],
+                          "url": "/Teshuvot_Rashi",
+                          "dependence": null
+                        }
+                      ],
+                      "total": 84,
+                      "author": {
+                        "slug": "rashi",
+                        "title": {
+                          "en": "Rashi",
+                          "he": "רש״י"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "description": "Returns the list of indexes (works) attributed to a given Sefaria author."
+      }
+    },
+    "/api/sheets/{sheet_id}/likers": {
+      "summary": "Sheet Likers",
+      "description": "Returns the list of users who have liked a sheet.",
+      "get": {
+        "operationId": "get-sheet-likers",
+        "tags": [
+          "Sheets"
+        ],
+        "parameters": [
+          {
+            "name": "sheet_id",
+            "description": "The numeric ID of the sheet. To find a sheet's ID, open the sheet on `voices.sefaria.org` and copy the number from the URL — for example, `https://voices.sefaria.org/sheets/643492` has a sheet ID of `643492`. The API call itself is made to `www.sefaria.org`.",
+            "schema": {
+              "type": "integer"
+            },
+            "in": "path",
+            "required": true
+          }
+        ],
+        "description": "Returns the list of users who have liked a sheet.",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SheetLikersJSON"
+                },
+                "examples": {
+                  "Sheet 643492": {
+                    "value": {
+                      "likers": []
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        }
+      }
+    },
+    "/api/sheets/modified/{sheet_id}/{timestamp}": {
+      "summary": "Sheet Modified Check",
+      "description": "Returns the full sheet if it has been modified since the given timestamp; otherwise returns an empty/unchanged response. Useful for clients that cache sheets.",
+      "get": {
+        "operationId": "get-sheet-modified",
+        "tags": [
+          "Sheets"
+        ],
+        "parameters": [
+          {
+            "name": "sheet_id",
+            "description": "The numeric ID of the sheet. To find a sheet's ID, open the sheet on `voices.sefaria.org` and copy the number from the URL — for example, `https://voices.sefaria.org/sheets/643492` has a sheet ID of `643492`. The API call itself is made to `www.sefaria.org`.",
+            "schema": {
+              "type": "integer"
+            },
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "timestamp",
+            "description": "An ISO-8601 timestamp. The sheet is returned only if its `dateModified` is more recent than this value.",
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "required": true
+          }
+        ],
+        "description": "Returns the full sheet if it has been modified since the given timestamp; otherwise returns an empty/unchanged response. Useful for clients that cache sheets.",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SheetDetailJSON"
+                },
+                "examples": {
+                  "Sheet 643492 since 2020-01-01": {
+                    "value": {
+                      "_id": "680fedff3dd208fdad8aefb1",
+                      "title": "Lag Baomer",
+                      "options": {
+                        "numbered": 0
+                      },
+                      "sources": [
+                        {
+                          "outsideText": "<h1>Biblical concept of Sefirah</h1>",
+                          "node": 258
+                        },
+                        {
+                          "ref": "Leviticus 23:15-16",
+                          "heRef": "ויקרא כ״ג:ט״ו-ט״ז",
+                          "text": {
+                            "en": "<div>(15) And from the day on which you bring the sheaf of elevation offering—the day after the sabbath—you shall count off seven weeks. They must be complete: (16) you must count until the day after the seventh week—fifty days; then you shall bring an offering of new grain to the Lord.</div>",
+                            "he": "<div><small>(טו)</small> וּסְפַרְתֶּ֤ם לָכֶם֙ מִמָּחֳרַ֣ת הַשַּׁבָּ֔ת מִיּוֹם֙ הֲבִ֣יאֲכֶ֔ם אֶת־עֹ֖מֶר הַתְּנוּפָ֑ה שֶׁ֥בַע שַׁבָּת֖וֹת תְּמִימֹ֥ת תִּהְיֶֽינָה׃ <small>(טז)</small> עַ֣ד מִֽמָּחֳרַ֤ת הַשַּׁבָּת֙ הַשְּׁבִיעִ֔ת תִּסְפְּר֖וּ חֲמִשִּׁ֣ים י֑וֹם וְהִקְרַבְתֶּ֛ם מִנְחָ֥ה חֲדָשָׁ֖ה לַיהוה </div>"
+                          },
+                          "options": {
+                            "sourceLanguage": "",
+                            "sourceLangLayout": "",
+                            "indented": "",
+                            "sourceLayout": ""
+                          },
+                          "node": 3
+                        },
+                        {
+                          "ref": "Ramban on Leviticus 23:36:1",
+                          "heRef": "רמב\"ן על ויקרא כ״ג:ל״ו:א׳",
+                          "text": {
+                            "en": "<div>From then on [i.e., beginning with the second day of Passover] we are to count forty-nine days[of the <i>omer</i>], which are seven weeks comparable to the [seven] “days” of the world, and then to sanctify the “eighth day” [i.e., the Festival of Weeks] just as the eighth day of Tabernacles [is holy]; and [the forty-nine days] counted between them are in the “intermediate days” of the festival, in the interval separating the first day and “eighth day” of the festival, this being the day of the Giving of the Torah.</div>",
+                            "he": "<div>וְצִוָּה בְּחַג הַמַּצּוֹת שִׁבְעָה יָמִים בִּקְדֻשָּׁה לִפְנֵיהֶם וּלְאַחֲרֵיהֶם, כִּי כֻּלָּם קְדֹשִׁים וּבְתוֹכָם יהוה, וּמָנָה מִמֶּנּוּ תִּשְׁעָה וְאַרְבָּעִים יוֹם, שִׁבְעָה שָׁבוּעוֹת כִּימֵי עוֹלָם, וְקִדֵּשׁ יוֹם שְׁמִינִי כִּשְׁמִינִי שֶׁל חָג, וְהַיָּמִים הַסְּפוּרִים בֵּינְתַיִם כְּחֻלּוֹ שֶׁל מוֹעֵד בֵּין הָרִאשׁוֹן וְהַשְּׁמִינִי בֶּחָג, וְהוּא יוֹם מַתַּן תּוֹרָה.</div>"
+                          },
+                          "node": 12
+                        },
+                        {
+                          "outsideText": "<h1>Students of Rabbi Akiva Dying</h1>",
+                          "node": 256
+                        },
+                        {
+                          "ref": "Yevamot 62b:9-11",
+                          "heRef": "יבמות ס״ב ב:ט׳-י״א",
+                          "text": {
+                            "en": "<div>It was said, That Rabbi Akiva had twelve thousand pairs of disciples, from Gabbat to Antifaras; and they all died at the same time because they did not treat each other with respect.  The world remained desolate until Rabbi Akiva came to our Masters in the South and taught the Torah to them. and it was they who revived the Torah at that time.  These were Rabbi Meir, Rabbi Judah, Rabbi Yossi, Rabbi Shimon and Rabbi Eleazar ben Shammua; And it was they who revived the Torah at that time. A Tanna taught:  <u><b>All of them died between Passover and Pentecost.</b></u>  Rabbi Hama bar Abba or, it might be said, Rabbi Chiyya bar Abin said: All of them died a cruel death. What was it? — Rabbi Nahman replied: Croup.</div>",
+                            "he": "<div>אמרו שנים עשר אלף זוגים תלמידים היו לו לרבי עקיבא מגבת עד אנטיפרס וכולן מתו בפרק אחד מפני שלא נהגו כבוד זה לזה והיה העולם שמם עד שבא ר\"ע אצל רבותינו שבדרום ושנאה להם ר\"מ ור' יהודה ור' יוסי ורבי שמעון ורבי אלעזר בן שמוע והם הם העמידו תורה אותה שעה תנא כולם <u><b>מתו מפסח ועד עצרת</b></u> אמר רב חמא בר אבא ואיתימא ר' חייא בר אבין כולם מתו מיתה רעה מאי היא א\"ר נחמן אסכרה.</div>"
+                          },
+                          "options": {
+                            "sourceLanguage": "",
+                            "sourceLangLayout": "",
+                            "indented": "",
+                            "sourceLayout": ""
+                          },
+                          "node": 2
+                        },
+                        {
+                          "ref": "Tur, Orach Chayim 493:1",
+                          "heRef": "טור, אורח חיים תצ״ג:א׳",
+                          "text": {
+                            "en": "<div>...</div>",
+                            "he": "<div>  נוהגין בכל המקומות שלא לישא אשה בין פסח לעצרת והטעם שלא להרבות בשמחה שבאותו זמן מתו תלמידי ר\"ע וכתב הר\"י גיאת דוקא נישואין שהוא עיקר שמחה ... ויש מקומות שנהגו שלא להסתפר <u>ויש מסתפרי' מל\"ג בעומר ואילך שאומרים שאז פסקו מלמות </u></div>"
+                          },
+                          "node": 27
+                        },
+                        {
+                          "ref": "Shulchan Arukh, Orach Chayyim 493:1-2",
+                          "heRef": "אורח חיים תצ״ג:א׳-ב׳",
+                          "text": {
+                            "en": "<div><small>(1)</small> It is customary not to get married between Pesach and Shavuot, until Lag BaOmer (the 33rd day), because during that time, the students of Rabbi Akiva died. However, to do \"erusin\" and \"kiddushin\" (engagement and betrothal) is OK. And even for \"nisuin\" (marriage), if someone did so, we do not punish him. Rema: however, from Lag Ba'Omer onwards, all this is permitted (Abudraham, Beit Yosef &amp; Minhagim).</div>  <div><small>(2)</small> It is customary not to cut one's hair until Lag BaOmer, since it is said that that is when they stopped dying.</div> ",
+                            "he": "<div><small>(א)</small> נוֹהֲגִים שֶׁלֹּא לִשָּׂא אִשָּׁה בֵּין פֶּסַח לַעֲצֶרֶת עַד ל''ג לָעֹמֶר, מִפְּנֵי שֶׁבְּאוֹתוֹ זְמַן מֵתוּ תַּלְמִידֵי רַבִּי עֲקִיבָא; אֲבָל לְאָרֵס וּלְקַדֵּשׁ, שַׁפִּיר דָּמִי, וְנִשּׂוּאִין נָמֵי, מִי שֶׁקָּפַץ וְכָנַס אֵין עוֹנְשִׁין אוֹתוֹ. <small> הַגָּה: מִיהוּ מִלַּ''ג בָּעֹמֶר וָאֵילָךְ הַכֹּל </small> <small> שָׁרֵי </small> <small>(אַבּוּדַרְהַם וּבֵית יוֹסֵף וּמִנְהָגִים)</small><small>. </small> </div>  <div><small>(ב)</small> נוֹהֲגִים שֶׁלֹּא לְהִסְתַּפֵּר עַד ל''ג לָעֹמֶר, שֶׁאוֹמְרִים שֶׁאָז פָּסְקוּ מִלָּמוּת.</div> "
+                          },
+                          "options": {
+                            "sourceLanguage": "",
+                            "sourceLangLayout": "",
+                            "indented": "",
+                            "sourceLayout": ""
+                          },
+                          "node": 5
+                        },
+                        {
+                          "outsideText": "<h1>Why we would celebrate</h1>",
+                          "node": 254
+                        },
+                        {
+                          "ref": "Meiri on Yevamot 62b:4",
+                          "heRef": "מאירי על יבמות ס״ב ב:ד׳",
+                          "text": {
+                            "en": "<div>\"They said about Rabbi Akiva that he had twelve thousand pairs of students and they all died in one period of time, because they did not treat each other with respect. And the world was desolate of Torah until Rabbi Akiva came to our Rabbis in the South and taught them - Rabbi Meir, Rabbi Yehudah, Rabbi Yosei, Rabbi Shimon, and Rabbi Elazar ben Shamua. And these are the very ones who upheld the time.\" And it is mentioned here that these [earlier] students all died from Pesach until Shavuot,<u> but it is a tradition in the hands of the Geonim that the dying stopped on the day of Lag BaOmer - so as a result of that, we are accustomed not to fast on it. And we are also accustomed, as a result of that, not to marry a woman from Pesach [only] until that time.</u> </div>",
+                            "he": "<div>אמרו על ר' עקיבא ששנים עשר אלף זוגות תלמידים היו לו וכלן מתו בפרק אחד על שלא נהגו כבוד זה לזה והיה העולם שמם בלא תורה עד שבא לו אצל רבותינו שבדרום ושנה להם לר' מאיר ור' שמעון ור' יהודה ור' יוסי ור' אלעזר בן שמוע והם הם העמידו את השעה ותלמידים אלו הוזכר כאן שכלם מתו מפסח ועד עצרת <u><b>וקבלה ביד הגאונים שביום ל\"ג בעומר פסקה המיתה ונוהגים מתוך כך שלא להתענות בו וכן נוהגים מתוך כך שלא לישא אשה מפסח עד אותו זמן:</b></u></div>"
+                          },
+                          "node": 1
+                        },
+                        {
+                          "outsideText": "<div><a href=\"\">Se</a><a href=\"https://hakirah.org/vol20first.pdf\">fer Ha-Manhig, vol. 2, p. 538 (Hilkhot Erusin ve-Nissuin). </a></div><div><a href=\"https://www.hebrewbooks.org/pdfpager.aspx?req=14615&amp;st=%d7%a4%d7%a8%d7%95%d7%a1&amp;pgnum=144&amp;hilite=8d7cbfe0-5e2c-4090-b04d-1900615c6ddd\\\">R. Abraham b. Nathan ha-Yarḥi, composed in Toledo in 1204.</a></div>",
+                          "node": 164
+                        },
+                        {
+                          "media": "https://storage.googleapis.com/sheet-user-uploaded-media/41841-974b5cee-249d-11f0-a83f-a6fe11f72b4e.png",
+                          "node": 22
+                        },
+                        {
+                          "outsideText": "<div><b>___________________________________________________</b></div><div><b>Hakira</b>:</div><div><a href=\"https://hakirah.org/vol20first.pdf\">There are many sources from the Geonic period in Palestine documenting that the 18th of Iyyar (Lag Ba-Omer) was observed there as a fast day commemorating the death of Joshua. These sources are collected by Shulamit Elitzur. For example, this fast day is mentioned by the paytannim R. Eleazar Kallir (c. 600) and R. Phinehas (8th century). It is mentioned in other sources from Palestine and Egypt in the subsequent centuries as well. The existence of this fast day is strong evidence that the concept of Lag Ba-Omer as a festive day was not yet in existence in the Tannaitic, Amoraic or Geonic periods.</a></div><div>___________________________________________________</div><div>Rabbi Chaim Vital born in 1543</div><div>Source here</div><div>--------</div><div><a href=\"https://www.chabad.org/therebbe/letters/default_cdo/aid/2279233/jewish/An-explanation-of-the-death-of-Rabbi-Shimon-bar-Yochai-on-Lag-BaOmer.htm/utm_source/chatgpt.com\">This letter was addressed to Rabbi Shlomo Yosef Zevin, one of the foremost Rabbinic scholars of the previous generation.</a></div>",
+                          "node": 206
+                        },
+                        {
+                          "outsideText": "<div>The Rebbe:</div><div>By chance I saw your book HaMoadim BeHalachah, 2nd edi­tion, in the library of my revered father-in-law, the Rebbe Shlita. In the section on Lag BaOmer, I found a quotation from the Pri Etz Chayim (as found in the Dubrovna and Lashtchov printing), Shaar Sefiras HaOmer, ch. 7, in the note: “The reason [for the celebration] is that Rabbi Shimon bar Yochai died on Lag BaOmer. He was one of the students of Rabbi Akiva who died during the Counting of the Omer.”</div><div>...</div><div>This [apparent contradiction] was already discussed in the responsa Divrei Nechemiah, Orach Chayim, Responsum 34, sec. 7, [which] concludes: “Perhaps there is a textual error in the Pri Etz Chayim, in the statement: ‘He was one [of the students]....’ Analysis is required. I heard that in the Karatz printing [of the Pri Etz Chayim], this passage was left out.”</div><div> </div>",
+                          "node": 225
+                        },
+                        {
+                          "outsideText": "<div><b>This is in fact true.</b></div><div>----</div><div>Chidah born in 1724</div>",
+                          "node": 212
+                        },
+                        {
+                          "ref": "Moreh BeEtzba 223:1",
+                          "heRef": "מורה באצבע רכ״ג:א׳",
+                          "text": {
+                            "en": "<div>One should add to the joy of the day of the thirty third of the Omer in honor of Rabbi Shimon bar Yochai, may his merit protect us - as it is the day of his memory (the day he died). And it is known that it was his will that [people] rejoice on this day - as is known from the story of our teacher, the Rabbi Avraham HaLevi (Amigo), may his memory be blessed for life in the world to come, and from other stories that we have heard. And we know them from the mouths of holy rabbis. And there is one who is accustomed to engaging in study on the night of the thirty third of the Omer with ten [men] to teach the praises of Rabbi Shimon bar Yochat that are scattered in the Zohar and the Idra Zuta; and that is a nice custom. </div>",
+                            "he": "<div><b>יום ל״ג לעומר ירבה שמחה לכבוד רשב״י זי״ע כי הוא יומא דהלולא דיליה.</b> ונודע שרצונו הוא שישמחו ביום זה כידוע ממעשה מהר״א הלוי זלה״ה ומעשים אחרים אשר שמענו ונדעם מפום רבנן קדישי. ויש מי שנהג לעשות לימוד בליל ל״ג לעומר בי עשרה ללמוד שבחי רשב״י המפוזרים בזהר ואדרא זוטא והוא מנהג יפה:</div>"
+                          },
+                          "node": 77
+                        },
+                        {
+                          "outsideText": "<div>___________________________________________________</div>",
+                          "node": 226
+                        },
+                        {
+                          "outsideText": "<div>Kaf Hachaim born in 1870  </div>",
+                          "node": 157
+                        },
+                        {
+                          "ref": "Kaf HaChayim on Shulchan Arukh, Orach Chayim 493:26:1",
+                          "heRef": "כף החיים על שולחן ערוך אורח חיים תצ״ג:כ״ו:א׳",
+                          "text": {
+                            "en": "<div>...</div>",
+                            "he": "<div><b>כו) שם. בהגה ומרבים בו קצת שמחה.  </b>לזכר שפסקו מלמות. דרשוא מהרי\"ל ר\"ז או' יהוה. מיהו הפר\"ח הקשה ע\"ז וכתב הטעם<b> שהשמחה היא על אותם תלמידים שהוסיף אח\"כ ר\"ע שלא מתו כאלו יעו\"ש.</b> ועיין בשער הכוו' דף פ\"ז ע\"א שכתב ובבוא יום ל\"ג לעומר אז נתגלה קטנות ב' של אי' שהוא שם אכדט\"ם אשר באי' והנה הוא חילוף שם אלהים (עיין לעיל או' ה') אשר הוא בחי' רחמים בסוד אלהים חיים וכו' ולכן סמך אח\"כ ר\"ע את יהוה תלמידיו הגדולים מבחי' יהוה גבורות דגדלות שהם כנגד יהוה אותיות אכדט\"ם שהם רחמים ואלו נתקיימו בעולם והרביצו תורה ברבים והם ר\"מ ור' יהודה ור' אלעזר בן שמוע ור\"ש ור' נחמיה יעו\"ש.</div>"
+                          },
+                          "node": 78
+                        },
+                        {
+                          "outsideText": "<div>Chtam Sofer born 1762</div>",
+                          "node": 246
+                        },
+                        {
+                          "ref": "Responsa Chatam Sofer, Yoreh De'ah 233:11",
+                          "heRef": "שו\"ת חתם סופר, יורה דעה רל״ג:י״א",
+                          "text": {
+                            "en": "<div>...</div>",
+                            "he": "<div><u>אמנם  ידעתי כי שמעתי שעכשיו אכשיר דרי וממרחק יבואו ידרושו את יהוה בע\"הק צפת ביום ל\"ג בעומר בהלולא דרשב\"י ז\"ל ואם כי כל כוונתם לש\"ש שכרם רב בלי ספק ע\"ד ודיגול\"ו ודליק\"ו נרות עלי אהב' כמ\"ש תוס' ר\"פ אין מעמידין אבל מטעם זה בעצמו הייתי אני מן הפרושים</u> ... בפר\"ח א\"ח סי' תצ\"ו בקונטרס מנהגי איסור שלו אות י\"ד על המקומות <u><b>שעושים י\"ט ביום שנעשה להם נס</b></u> מהא דאמרי' פ\"ק דר\"ה קמיית' בטיל אחריניית' מוסיפי' בתמי' [ובמקומו טרחתי הרב' לקיי' מנהג עיר מולדתי ק\"ק פפ\"דמ העושי' פורי' ביו' כ' אדר א'] ומנהג מצרי' ביו' כ\"ג  </div>"
+                          },
+                          "node": 103
+                        },
+                        {
+                          "outsideText": "<div>Can't make holidays after Charban, gemarah taanit, exception is local holidays for specific people who experienced holidays, what about purim (deoraita because kal vachomer slavery vs death), answer is purim is different because people thought it might lead to geulah</div>",
+                          "node": 104
+                        },
+                        {
+                          "ref": "Rosh Hashanah 19b:3",
+                          "heRef": "ראש השנה י״ט ב:ג׳",
+                          "text": {
+                            "en": "<div>The Gemara concludes: <b>And the </b><i><b>halakha</b></i><b> is</b> that these days <b>were nullified, and the </b><i><b>halakha</b></i><b> is</b> that <b>they were not nullified.</b> The Gemara asks: This <b>is difficult,</b> as one <i><b>halakha</b></i> contradicts <b>the</b> other <i><b>halakha</b></i><b>.</b> The Gemara answers: <b>It</b> is <b>not difficult. Here,</b> it is referring to <b>Hanukkah and Purim.</b> These Festival days were never nullified, and Hanukkah is listed among the Festivals of <i>Megillat Ta’anit</i>. <b>There,</b> the <i>halakha</i> is referring to <b>the rest of the days</b> listed in <i>Megillat Ta’anit</i>, all of which were nullified.</div>",
+                            "he": "<div>וְהִלְכְתָא בָּטְלוּ, וְהִלְכְתָא לֹא בָּטְלוּ. קַשְׁיָא הִלְכְתָא אַהִלְכְתָא! לָא קַשְׁיָא: כָּאן בַּחֲנוּכָּה וּפוּרִים, כָּאן בִּשְׁאָר יוֹמֵי.</div>"
+                          },
+                          "node": 227
+                        }
+                      ],
+                      "dateModified": "2025-05-04T00:12:38.737202",
+                      "dateCreated": "2025-04-28T18:07:11.866973",
+                      "status": "public",
+                      "owner": 41841,
+                      "views": 605,
+                      "nextNode": 259,
+                      "includedRefs": [
+                        "Leviticus 23:15-16",
+                        "Ramban on Leviticus 23:36:1",
+                        "Yevamot 62b:9-11",
+                        "Tur, Orach Chayim 493:1",
+                        "Shulchan Arukh, Orach Chayyim 493:1-2",
+                        "Meiri on Yevamot 62b:4",
+                        "Moreh BeEtzba 223:1",
+                        "Kaf HaChayim on Shulchan Arukh, Orach Chayim 493:26:1",
+                        "Responsa Chatam Sofer, Yoreh De'ah 233:11",
+                        "Rosh Hashanah 19b:3"
+                      ],
+                      "expandedRefs": [
+                        "Ramban on Leviticus 23:36:1",
+                        "Shulchan Arukh, Orach Chayim 493:1",
+                        "Rosh Hashanah 19b:3",
+                        "Yevamot 62b:11",
+                        "Kaf HaChayim on Shulchan Arukh, Orach Chayim 493:26:1",
+                        "Moreh BeEtzba 223:1",
+                        "Meiri on Yevamot 62b:4",
+                        "Responsa Chatam Sofer, Yoreh De'ah 233:11",
+                        "Leviticus 23:16",
+                        "Yevamot 62b:9",
+                        "Leviticus 23:15",
+                        "Yevamot 62b:10",
+                        "Shulchan Arukh, Orach Chayim 493:2",
+                        "Tur, Orach Chayim 493:1"
+                      ],
+                      "sheetLanguage": "english",
+                      "id": 643492,
+                      "summary": "Lag Baomer not having so much history",
+                      "tags": [],
+                      "displayedCollection": "",
+                      "likes": [],
+                      "topics": [
+                        {
+                          "asTyped": "Sefirat HaOmer",
+                          "slug": "sefirat-haomer",
+                          "en": "Sefirat HaOmer",
+                          "he": "ספירת העומר"
+                        },
+                        {
+                          "asTyped": "Lag BaOmer",
+                          "slug": "lag-baomer",
+                          "en": "Lag BaOmer",
+                          "he": "ל\"ג בעומר"
+                        }
+                      ],
+                      "collections": [],
+                      "ownerName": "Matthew Rosenberg",
+                      "ownerProfileUrl": "/profile/matthew-rosenberg1",
+                      "ownerImageUrl": "",
+                      "sheetNotice": null,
+                      "collectionImage": "https://storage.googleapis.com/sefaria-collection-images/117715-5c80031c-0a95-11ef-987a-ce6fa0b21c30.jpg",
+                      "collectionName": "한글타낙",
+                      "rebuild": true,
+                      "datePublished": "2025-05-02T20:06:45.841461",
+                      "llm_scoring": {
+                        "processed_datetime": "2026-01-26 09:32:54.042317",
+                        "sheet": {
+                          "ref_scores": {
+                            "Ramban on Leviticus 23:36:1": 6.9,
+                            "Shulchan Arukh, Orach Chayim 493:1": 10.34,
+                            "Rosh Hashanah 19b:3": 6.9,
+                            "Yevamot 62b:11": 3.44,
+                            "Kaf HaChayim on Shulchan Arukh, Orach Chayim 493:26:1": 6.9,
+                            "Moreh BeEtzba 223:1": 6.9,
+                            "Meiri on Yevamot 62b:4": 10.34,
+                            "Responsa Chatam Sofer, Yoreh De'ah 233:11": 10.34,
+                            "Leviticus 23:16": 3.44,
+                            "Yevamot 62b:9": 10.34,
+                            "Leviticus 23:15": 3.44,
+                            "Yevamot 62b:10": 3.44,
+                            "Shulchan Arukh, Orach Chayim 493:2": 6.9,
+                            "Tur, Orach Chayim 493:1": 10.34
+                          },
+                          "title_interest_level": 3,
+                          "title_interest_reason": "Lag Baomer is a significant Jewish holiday, attracting interest for its historical and cultural relevance.",
+                          "language": "en",
+                          "creativity_score": 0.38341968911917096
+                        }
+                      },
+                      "modified": true
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        }
+      }
+    },
+    "/api/sheets/user/{user_id}/": {
+      "summary": "User's Sheets",
+      "description": "Returns a user's public sheets. For anonymous callers, only public sheets are returned. An authenticated user requesting their own user_id additionally sees their private sheets.",
+      "get": {
+        "operationId": "get-user-sheets",
+        "tags": [
+          "Sheets"
+        ],
+        "parameters": [
+          {
+            "name": "user_id",
+            "description": "The numeric Sefaria user ID. To find a user_id, open the user's profile page (e.g. `https://voices.sefaria.org/profile/user-slug`), then call `GET /api/profile/{slug}` with the slug from the URL — the response contains the numeric `id`.",
+            "schema": {
+              "type": "integer"
+            },
+            "in": "path",
+            "required": true
+          }
+        ],
+        "description": "Returns a user's public sheets. For anonymous callers, only public sheets are returned. An authenticated user requesting their own user_id additionally sees their private sheets.",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserSheetsJSON"
+                },
+                "examples": {
+                  "User 1": {
+                    "value": {
+                      "sheets": [
+                        {
+                          "id": 102615,
+                          "title": "Uprooting Mountains",
+                          "summary": "Is it better to know things, or be to be able to do things with knowledge? For the Talmud, knowledge is likened to a mountain. So what would it mean to uproot a mountain? What would it mean to grind two uprooted mountains together?",
+                          "status": "public",
+                          "author": 1,
+                          "ownerName": "Brett Lockspeiser",
+                          "ownerImageUrl": "https://storage.googleapis.com/sefaria-profile-pictures/brett-lockspeiser-1602104013-small.png",
+                          "ownerProfileUrl": "/profile/brett-lockspeiser",
+                          "ownerOrganization": "Sefaria",
+                          "sheetUrl": "/sheets/102615",
+                          "views": 4004,
+                          "displayedCollection": "",
+                          "modified": "03/27/2026",
+                          "created": "2018-03-06T07:34:01.978959",
+                          "published": "2018-03-14T10:31:32.000666",
+                          "topics": [
+                            {
+                              "asTyped": "Uprooting Mountains",
+                              "slug": "uprooting-mountains",
+                              "en": "Uprooting Mountains",
+                              "he": ""
+                            },
+                            {
+                              "asTyped": "Skill",
+                              "slug": "skill",
+                              "en": "Skill",
+                              "he": ""
+                            },
+                            {
+                              "asTyped": "Mountains",
+                              "slug": "mountains",
+                              "en": "Mountains",
+                              "he": "הר"
+                            },
+                            {
+                              "asTyped": "Knowledge",
+                              "slug": "knowledge",
+                              "en": "Knowledge",
+                              "he": "ידע"
+                            },
+                            {
+                              "asTyped": "Learning",
+                              "slug": "learning",
+                              "en": "Learning",
+                              "he": "לימוד"
+                            },
+                            {
+                              "asTyped": "Fluency",
+                              "slug": "fluency",
+                              "en": "Fluency",
+                              "he": ""
+                            },
+                            {
+                              "asTyped": "Uprooting",
+                              "slug": "uprooting",
+                              "en": "Uprooting",
+                              "he": ""
+                            }
+                          ],
+                          "tags": [
+                            "Uprooting Mountains",
+                            "Skill",
+                            "Mountains",
+                            "Knowledge",
+                            "Learning",
+                            "Fluency",
+                            "Uprooting"
+                          ],
+                          "options": []
+                        },
+                        {
+                          "id": 830,
+                          "title": "π Psukim / π Verses",
+                          "summary": "",
+                          "status": "public",
+                          "author": 1,
+                          "ownerName": "Brett Lockspeiser",
+                          "ownerImageUrl": "https://storage.googleapis.com/sefaria-profile-pictures/brett-lockspeiser-1602104013-small.png",
+                          "ownerProfileUrl": "/profile/brett-lockspeiser",
+                          "ownerOrganization": "Sefaria",
+                          "sheetUrl": "/sheets/830",
+                          "views": 5336,
+                          "displayedCollection": "",
+                          "modified": "07/17/2024",
+                          "created": "2013-09-25T18:24:57.892833",
+                          "published": "2013-09-25T18:24:57.892833",
+                          "topics": [
+                            {
+                              "asTyped": "Pi",
+                              "slug": "pi",
+                              "en": "Pi",
+                              "he": "פאי"
+                            }
+                          ],
+                          "tags": [
+                            "Pi"
+                          ],
+                          "options": []
+                        },
+                        {
+                          "id": 137322,
+                          "title": "Green",
+                          "summary": "",
+                          "status": "public",
+                          "author": 1,
+                          "ownerName": "Brett Lockspeiser",
+                          "ownerImageUrl": "https://storage.googleapis.com/sefaria-profile-pictures/brett-lockspeiser-1602104013-small.png",
+                          "ownerProfileUrl": "/profile/brett-lockspeiser",
+                          "ownerOrganization": "Sefaria",
+                          "sheetUrl": "/sheets/137322",
+                          "views": 3264,
+                          "displayedCollection": "torah-by-the-colors",
+                          "modified": "02/10/2021",
+                          "created": "2018-10-22T10:42:40.990798",
+                          "published": "2018-10-22T10:53:16.220724",
+                          "topics": [],
+                          "tags": [],
+                          "options": [],
+                          "displayedCollectionName": "Torah by the Colors"
+                        },
+                        {
+                          "id": 67508,
+                          "title": "Top Sources by Category - May 2017",
+                          "summary": "",
+                          "status": "public",
+                          "author": 1,
+                          "ownerName": "Brett Lockspeiser",
+                          "ownerImageUrl": "https://storage.googleapis.com/sefaria-profile-pictures/brett-lockspeiser-1602104013-small.png",
+                          "ownerProfileUrl": "/profile/brett-lockspeiser",
+                          "ownerOrganization": "Sefaria",
+                          "sheetUrl": "/sheets/67508",
+                          "views": 2541,
+                          "displayedCollection": "sefaria-stats",
+                          "modified": "01/15/2021",
+                          "created": "2017-05-18T12:19:29.352762",
+                          "published": "2017-12-20T15:01:18.795522",
+                          "topics": [],
+                          "tags": [],
+                          "options": [],
+                          "displayedCollectionName": "Sefaria Stats"
+                        },
+                        {
+                          "id": 137952,
+                          "title": "Black",
+                          "summary": "",
+                          "status": "public",
+                          "author": 1,
+                          "ownerName": "Brett Lockspeiser",
+                          "ownerImageUrl": "https://storage.googleapis.com/sefaria-profile-pictures/brett-lockspeiser-1602104013-small.png",
+                          "ownerProfileUrl": "/profile/brett-lockspeiser",
+                          "ownerOrganization": "Sefaria",
+                          "sheetUrl": "/sheets/137952",
+                          "views": 3032,
+                          "displayedCollection": "torah-by-the-colors",
+                          "modified": "12/09/2020",
+                          "created": "2018-10-25T08:52:40.696819",
+                          "published": "2018-10-25T08:59:47.137846",
+                          "topics": [],
+                          "tags": [],
+                          "options": [],
+                          "displayedCollectionName": "Torah by the Colors"
+                        },
+                        {
+                          "id": 137334,
+                          "title": "Blue",
+                          "summary": "",
+                          "status": "public",
+                          "author": 1,
+                          "ownerName": "Brett Lockspeiser",
+                          "ownerImageUrl": "https://storage.googleapis.com/sefaria-profile-pictures/brett-lockspeiser-1602104013-small.png",
+                          "ownerProfileUrl": "/profile/brett-lockspeiser",
+                          "ownerOrganization": "Sefaria",
+                          "sheetUrl": "/sheets/137334",
+                          "views": 3176,
+                          "displayedCollection": "torah-by-the-colors",
+                          "modified": "11/05/2018",
+                          "created": "2018-10-22T11:55:33.453005",
+                          "published": "2018-10-22T12:12:01.460760",
+                          "topics": [],
+                          "tags": [],
+                          "options": [],
+                          "displayedCollectionName": "Torah by the Colors"
+                        },
+                        {
+                          "id": 137345,
+                          "title": "Purple",
+                          "summary": "",
+                          "status": "public",
+                          "author": 1,
+                          "ownerName": "Brett Lockspeiser",
+                          "ownerImageUrl": "https://storage.googleapis.com/sefaria-profile-pictures/brett-lockspeiser-1602104013-small.png",
+                          "ownerProfileUrl": "/profile/brett-lockspeiser",
+                          "ownerOrganization": "Sefaria",
+                          "sheetUrl": "/sheets/137345",
+                          "views": 4102,
+                          "displayedCollection": "torah-by-the-colors",
+                          "modified": "10/22/2018",
+                          "created": "2018-10-22T12:32:05.474778",
+                          "published": "2018-10-22T12:45:40.883508",
+                          "topics": [],
+                          "tags": [],
+                          "options": [],
+                          "displayedCollectionName": "Torah by the Colors"
+                        },
+                        {
+                          "id": 137342,
+                          "title": "White",
+                          "summary": "",
+                          "status": "public",
+                          "author": 1,
+                          "ownerName": "Brett Lockspeiser",
+                          "ownerImageUrl": "https://storage.googleapis.com/sefaria-profile-pictures/brett-lockspeiser-1602104013-small.png",
+                          "ownerProfileUrl": "/profile/brett-lockspeiser",
+                          "ownerOrganization": "Sefaria",
+                          "sheetUrl": "/sheets/137342",
+                          "views": 2889,
+                          "displayedCollection": "torah-by-the-colors",
+                          "modified": "10/22/2018",
+                          "created": "2018-10-22T12:12:39.486419",
+                          "published": "2018-10-22T12:26:32.411170",
+                          "topics": [],
+                          "tags": [],
+                          "options": [],
+                          "displayedCollectionName": "Torah by the Colors"
+                        },
+                        {
+                          "id": 137338,
+                          "title": "Yellow",
+                          "summary": "",
+                          "status": "public",
+                          "author": 1,
+                          "ownerName": "Brett Lockspeiser",
+                          "ownerImageUrl": "https://storage.googleapis.com/sefaria-profile-pictures/brett-lockspeiser-1602104013-small.png",
+                          "ownerProfileUrl": "/profile/brett-lockspeiser",
+                          "ownerOrganization": "Sefaria",
+                          "sheetUrl": "/sheets/137338",
+                          "views": 2708,
+                          "displayedCollection": "torah-by-the-colors",
+                          "modified": "10/22/2018",
+                          "created": "2018-10-22T12:03:21.370636",
+                          "published": "2018-10-22T12:07:30.109124",
+                          "topics": [],
+                          "tags": [],
+                          "options": [],
+                          "displayedCollectionName": "Torah by the Colors"
+                        },
+                        {
+                          "id": 137320,
+                          "title": "Red",
+                          "summary": "",
+                          "status": "public",
+                          "author": 1,
+                          "ownerName": "Brett Lockspeiser",
+                          "ownerImageUrl": "https://storage.googleapis.com/sefaria-profile-pictures/brett-lockspeiser-1602104013-small.png",
+                          "ownerProfileUrl": "/profile/brett-lockspeiser",
+                          "ownerOrganization": "Sefaria",
+                          "sheetUrl": "/sheets/137320",
+                          "views": 3233,
+                          "displayedCollection": "torah-by-the-colors",
+                          "modified": "10/22/2018",
+                          "created": "2018-10-22T10:37:25.899733",
+                          "published": "2018-10-22T10:53:24.090345",
+                          "topics": [],
+                          "tags": [],
+                          "options": [],
+                          "displayedCollectionName": "Torah by the Colors"
+                        },
+                        {
+                          "id": 105888,
+                          "title": "From A to Z via Be: \n\n Practical Advice in Torah",
+                          "summary": "",
+                          "status": "public",
+                          "author": 1,
+                          "ownerName": "Brett Lockspeiser",
+                          "ownerImageUrl": "https://storage.googleapis.com/sefaria-profile-pictures/brett-lockspeiser-1602104013-small.png",
+                          "ownerProfileUrl": "/profile/brett-lockspeiser",
+                          "ownerOrganization": "Sefaria",
+                          "sheetUrl": "/sheets/105888",
+                          "views": 1687,
+                          "displayedCollection": null,
+                          "modified": "09/26/2018",
+                          "created": "2018-03-26T20:02:50.195799",
+                          "published": "2018-03-26T22:37:52.261486",
+                          "topics": [
+                            {
+                              "slug": "acts",
+                              "asTyped": "Doing",
+                              "en": "Doing",
+                              "he": "מעשה"
+                            },
+                            {
+                              "slug": "kehillah",
+                              "asTyped": "Community",
+                              "en": "Community",
+                              "he": "קהילה"
+                            },
+                            {
+                              "slug": "spirtual-practice",
+                              "asTyped": "Spirtual Practice",
+                              "en": "Spirtual Practice",
+                              "he": ""
+                            },
+                            {
+                              "slug": "action",
+                              "asTyped": "Action",
+                              "en": "Action",
+                              "he": "פעולה"
+                            },
+                            {
+                              "slug": "work",
+                              "asTyped": "Work",
+                              "en": "Work",
+                              "he": "עֲבוֹדָה"
+                            },
+                            {
+                              "slug": "practice",
+                              "asTyped": "Practice",
+                              "en": "Practice",
+                              "he": "תרגול"
+                            },
+                            {
+                              "slug": "leadership",
+                              "asTyped": "Leadership",
+                              "en": "Leadership",
+                              "he": "מנהיגות"
+                            },
+                            {
+                              "slug": "pirkei-avot",
+                              "asTyped": "Pirkei Avot",
+                              "en": "Pirkei Avot",
+                              "he": "פרקי אבות"
+                            },
+                            {
+                              "slug": "being-a-mensch",
+                              "asTyped": "Being a Mensch",
+                              "en": "Being a Mensch",
+                              "he": ""
+                            },
+                            {
+                              "slug": "advice",
+                              "asTyped": "Advice",
+                              "en": "Advice",
+                              "he": ""
+                            },
+                            {
+                              "slug": "becoming-a-mensch",
+                              "asTyped": "Becoming a Mensch",
+                              "en": "Becoming a Mensch",
+                              "he": ""
+                            }
+                          ],
+                          "tags": [
+                            "Doing",
+                            "Community",
+                            "Spirtual Practice",
+                            "Action",
+                            "Work",
+                            "Practice",
+                            "Leadership",
+                            "Pirkei Avot",
+                            "Being a Mensch",
+                            "Advice",
+                            "Becoming a Mensch"
+                          ],
+                          "options": []
+                        },
+                        {
+                          "id": 67507,
+                          "title": "Top Sources by Tag - May 2017",
+                          "summary": "",
+                          "status": "public",
+                          "author": 1,
+                          "ownerName": "Brett Lockspeiser",
+                          "ownerImageUrl": "https://storage.googleapis.com/sefaria-profile-pictures/brett-lockspeiser-1602104013-small.png",
+                          "ownerProfileUrl": "/profile/brett-lockspeiser",
+                          "ownerOrganization": "Sefaria",
+                          "sheetUrl": "/sheets/67507",
+                          "views": 3083,
+                          "displayedCollection": "sefaria-stats",
+                          "modified": "12/20/2017",
+                          "created": "2017-05-18T12:19:29.350810",
+                          "published": "2017-12-20T15:02:52.785031",
+                          "topics": [],
+                          "tags": [],
+                          "options": [],
+                          "displayedCollectionName": "Sefaria Stats"
+                        },
+                        {
+                          "id": 13125,
+                          "title": "Top Sources - June 2015",
+                          "summary": "",
+                          "status": "public",
+                          "author": 1,
+                          "ownerName": "Brett Lockspeiser",
+                          "ownerImageUrl": "https://storage.googleapis.com/sefaria-profile-pictures/brett-lockspeiser-1602104013-small.png",
+                          "ownerProfileUrl": "/profile/brett-lockspeiser",
+                          "ownerOrganization": "Sefaria",
+                          "sheetUrl": "/sheets/13125",
+                          "views": 3940,
+                          "displayedCollection": "sefaria-stats",
+                          "modified": "12/20/2017",
+                          "created": "2015-06-24T11:59:51.043808",
+                          "published": "2015-06-24T12:08:18.111410",
+                          "topics": [],
+                          "tags": [],
+                          "options": [],
+                          "displayedCollectionName": "Sefaria Stats"
+                        },
+                        {
+                          "id": 67506,
+                          "title": "Top Sources in All Source Sheets - May 2017",
+                          "summary": "",
+                          "status": "public",
+                          "author": 1,
+                          "ownerName": "Brett Lockspeiser",
+                          "ownerImageUrl": "https://storage.googleapis.com/sefaria-profile-pictures/brett-lockspeiser-1602104013-small.png",
+                          "ownerProfileUrl": "/profile/brett-lockspeiser",
+                          "ownerOrganization": "Sefaria",
+                          "sheetUrl": "/sheets/67506",
+                          "views": 4027,
+                          "displayedCollection": "sefaria-stats",
+                          "modified": "12/20/2017",
+                          "created": "2017-05-18T12:19:29.348756",
+                          "published": "2017-05-18T18:59:34.709589",
+                          "topics": [
+                            {
+                              "slug": "top-sources",
+                              "asTyped": "Top Sources",
+                              "en": "Top Sources",
+                              "he": ""
+                            }
+                          ],
+                          "tags": [
+                            "Top Sources"
+                          ],
+                          "options": [],
+                          "displayedCollectionName": "Sefaria Stats"
+                        },
+                        {
+                          "id": 4,
+                          "title": "God Said",
+                          "summary": null,
+                          "status": "public",
+                          "author": 1,
+                          "ownerName": "Brett Lockspeiser",
+                          "ownerImageUrl": "https://storage.googleapis.com/sefaria-profile-pictures/brett-lockspeiser-1602104013-small.png",
+                          "ownerProfileUrl": "/profile/brett-lockspeiser",
+                          "ownerOrganization": "Sefaria",
+                          "sheetUrl": "/sheets/4",
+                          "views": 3237,
+                          "displayedCollection": null,
+                          "modified": "02/04/2017",
+                          "created": "2011-05-24T21:02:20.322739",
+                          "published": "2014-08-06T12:22:07.331620",
+                          "topics": [
+                            {
+                              "slug": "parashat-shemot",
+                              "asTyped": "Parashat Shemot",
+                              "en": "Parashat Shemot",
+                              "he": "פרשת שמות"
+                            },
+                            {
+                              "slug": "languages",
+                              "asTyped": "Language",
+                              "en": "Language",
+                              "he": "שפה"
+                            },
+                            {
+                              "slug": "god",
+                              "asTyped": "God",
+                              "en": "God",
+                              "he": "אלוהים"
+                            },
+                            {
+                              "slug": "creation",
+                              "asTyped": "Creation",
+                              "en": "Creation",
+                              "he": "בריאה"
+                            },
+                            {
+                              "slug": "statement",
+                              "asTyped": "Speech",
+                              "en": "Speech",
+                              "he": "דיבור"
+                            },
+                            {
+                              "slug": "parashat-bereshit",
+                              "asTyped": "Parashat Bereishit",
+                              "en": "Parashat Bereishit",
+                              "he": "פרשת בראשית"
+                            }
+                          ],
+                          "tags": [
+                            "Parashat Shemot",
+                            "Language",
+                            "God",
+                            "Creation",
+                            "Speech",
+                            "Parashat Bereishit"
+                          ],
+                          "options": []
+                        },
+                        {
+                          "id": 1952,
+                          "title": "Top Sources - February 2014",
+                          "summary": null,
+                          "status": "public",
+                          "author": 1,
+                          "ownerName": "Brett Lockspeiser",
+                          "ownerImageUrl": "https://storage.googleapis.com/sefaria-profile-pictures/brett-lockspeiser-1602104013-small.png",
+                          "ownerProfileUrl": "/profile/brett-lockspeiser",
+                          "ownerOrganization": "Sefaria",
+                          "sheetUrl": "/sheets/1952",
+                          "views": 2357,
+                          "displayedCollection": null,
+                          "modified": "06/23/2015",
+                          "created": "2014-02-10T08:55:51.513890",
+                          "published": "2015-06-01T22:37:44.978534",
+                          "topics": [
+                            {
+                              "slug": "mount-sinai",
+                              "asTyped": "Sinai",
+                              "en": "Sinai",
+                              "he": "הר סיני"
+                            },
+                            {
+                              "slug": "revelation",
+                              "asTyped": "Revelation",
+                              "en": "Revelation",
+                              "he": "התגלות"
+                            },
+                            {
+                              "slug": "creation",
+                              "asTyped": "Creation",
+                              "en": "Creation",
+                              "he": "בריאה"
+                            },
+                            {
+                              "slug": "slaves",
+                              "asTyped": "Slavery",
+                              "en": "Slavery",
+                              "he": "עבדים"
+                            },
+                            {
+                              "slug": "mitzvot",
+                              "asTyped": "Commandments",
+                              "en": "Commandments",
+                              "he": "מצוות"
+                            },
+                            {
+                              "slug": "sexuality",
+                              "asTyped": "Sex",
+                              "en": "Sex",
+                              "he": "מיניות"
+                            },
+                            {
+                              "slug": "sexuality",
+                              "asTyped": "Sexuality",
+                              "en": "Sexuality",
+                              "he": "מיניות"
+                            },
+                            {
+                              "slug": "marriage",
+                              "asTyped": "Marriage",
+                              "en": "Marriage",
+                              "he": "נישואים"
+                            },
+                            {
+                              "slug": "mitzvot",
+                              "asTyped": "Mitzvot",
+                              "en": "Mitzvot",
+                              "he": "מצוות"
+                            },
+                            {
+                              "slug": "obligations",
+                              "asTyped": "Obligation",
+                              "en": "Obligation",
+                              "he": "חובה"
+                            },
+                            {
+                              "slug": "middot",
+                              "asTyped": "Middot",
+                              "en": "Middot",
+                              "he": "מידות"
+                            }
+                          ],
+                          "tags": [
+                            "Sinai",
+                            "Revelation",
+                            "Creation",
+                            "Slavery",
+                            "Commandments",
+                            "Sex",
+                            "Sexuality",
+                            "Marriage",
+                            "Mitzvot",
+                            "Obligation",
+                            "Middot"
+                          ],
+                          "options": []
+                        },
+                        {
+                          "id": 9067,
+                          "title": "Pesach Haggadah with Yismach Yisrael",
+                          "summary": null,
+                          "status": "public",
+                          "author": 1,
+                          "ownerName": "Brett Lockspeiser",
+                          "ownerImageUrl": "https://storage.googleapis.com/sefaria-profile-pictures/brett-lockspeiser-1602104013-small.png",
+                          "ownerProfileUrl": "/profile/brett-lockspeiser",
+                          "ownerOrganization": "Sefaria",
+                          "sheetUrl": "/sheets/9067",
+                          "views": 10654,
+                          "displayedCollection": null,
+                          "modified": "03/26/2015",
+                          "created": "2015-03-25T15:21:24.024317",
+                          "published": "2015-03-26T08:38:51.333721",
+                          "topics": [
+                            {
+                              "slug": "seder",
+                              "asTyped": "Seder",
+                              "en": "Seder",
+                              "he": "ליל הסֵדֶר"
+                            },
+                            {
+                              "slug": "passover",
+                              "asTyped": "Passover",
+                              "en": "Passover",
+                              "he": "פסח"
+                            },
+                            {
+                              "slug": "passover",
+                              "asTyped": "Pesach",
+                              "en": "Pesach",
+                              "he": "פסח"
+                            },
+                            {
+                              "slug": "haggadah",
+                              "asTyped": "Haggadah",
+                              "en": "Haggadah",
+                              "he": "הגדה"
+                            }
+                          ],
+                          "tags": [
+                            "Seder",
+                            "Passover",
+                            "Pesach",
+                            "Haggadah"
+                          ],
+                          "options": []
+                        },
+                        {
+                          "id": 9059,
+                          "title": "Pesach Haggadah",
+                          "summary": null,
+                          "status": "public",
+                          "author": 1,
+                          "ownerName": "Brett Lockspeiser",
+                          "ownerImageUrl": "https://storage.googleapis.com/sefaria-profile-pictures/brett-lockspeiser-1602104013-small.png",
+                          "ownerProfileUrl": "/profile/brett-lockspeiser",
+                          "ownerOrganization": "Sefaria",
+                          "sheetUrl": "/sheets/9059",
+                          "views": 11797,
+                          "displayedCollection": null,
+                          "modified": "03/26/2015",
+                          "created": "2015-03-25T15:21:21.076614",
+                          "published": "2015-03-26T08:37:46.897739",
+                          "topics": [
+                            {
+                              "slug": "seder",
+                              "asTyped": "Seder",
+                              "en": "Seder",
+                              "he": "ליל הסֵדֶר"
+                            },
+                            {
+                              "slug": "passover",
+                              "asTyped": "Passover",
+                              "en": "Passover",
+                              "he": "פסח"
+                            },
+                            {
+                              "slug": "passover",
+                              "asTyped": "Pesach",
+                              "en": "Pesach",
+                              "he": "פסח"
+                            },
+                            {
+                              "slug": "haggadah",
+                              "asTyped": "Haggadah",
+                              "en": "Haggadah",
+                              "he": "הגדה"
+                            }
+                          ],
+                          "tags": [
+                            "Seder",
+                            "Passover",
+                            "Pesach",
+                            "Haggadah"
+                          ],
+                          "options": []
+                        },
+                        {
+                          "id": 9065,
+                          "title": "Pesach Haggadah with Marbeh Lisaper",
+                          "summary": null,
+                          "status": "public",
+                          "author": 1,
+                          "ownerName": "Brett Lockspeiser",
+                          "ownerImageUrl": "https://storage.googleapis.com/sefaria-profile-pictures/brett-lockspeiser-1602104013-small.png",
+                          "ownerProfileUrl": "/profile/brett-lockspeiser",
+                          "ownerOrganization": "Sefaria",
+                          "sheetUrl": "/sheets/9065",
+                          "views": 15174,
+                          "displayedCollection": null,
+                          "modified": "03/26/2015",
+                          "created": "2015-03-25T15:21:23.391555",
+                          "published": "2015-03-26T08:37:20.420130",
+                          "topics": [
+                            {
+                              "slug": "seder",
+                              "asTyped": "Seder",
+                              "en": "Seder",
+                              "he": "ליל הסֵדֶר"
+                            },
+                            {
+                              "slug": "passover",
+                              "asTyped": "Passover",
+                              "en": "Passover",
+                              "he": "פסח"
+                            },
+                            {
+                              "slug": "passover",
+                              "asTyped": "Pesach",
+                              "en": "Pesach",
+                              "he": "פסח"
+                            },
+                            {
+                              "slug": "haggadah",
+                              "asTyped": "Haggadah",
+                              "en": "Haggadah",
+                              "he": "הגדה"
+                            }
+                          ],
+                          "tags": [
+                            "Seder",
+                            "Passover",
+                            "Pesach",
+                            "Haggadah"
+                          ],
+                          "options": []
+                        },
+                        {
+                          "id": 9066,
+                          "title": "Pesach Haggadah with Naftali Seva Ratzon",
+                          "summary": null,
+                          "status": "public",
+                          "author": 1,
+                          "ownerName": "Brett Lockspeiser",
+                          "ownerImageUrl": "https://storage.googleapis.com/sefaria-profile-pictures/brett-lockspeiser-1602104013-small.png",
+                          "ownerProfileUrl": "/profile/brett-lockspeiser",
+                          "ownerOrganization": "Sefaria",
+                          "sheetUrl": "/sheets/9066",
+                          "views": 6967,
+                          "displayedCollection": null,
+                          "modified": "03/26/2015",
+                          "created": "2015-03-25T15:21:23.695450",
+                          "published": "2015-03-26T08:35:57.767657",
+                          "topics": [
+                            {
+                              "slug": "seder",
+                              "asTyped": "Seder",
+                              "en": "Seder",
+                              "he": "ליל הסֵדֶר"
+                            },
+                            {
+                              "slug": "passover",
+                              "asTyped": "Passover",
+                              "en": "Passover",
+                              "he": "פסח"
+                            },
+                            {
+                              "slug": "passover",
+                              "asTyped": "Pesach",
+                              "en": "Pesach",
+                              "he": "פסח"
+                            },
+                            {
+                              "slug": "haggadah",
+                              "asTyped": "Haggadah",
+                              "en": "Haggadah",
+                              "he": "הגדה"
+                            }
+                          ],
+                          "tags": [
+                            "Seder",
+                            "Passover",
+                            "Pesach",
+                            "Haggadah"
+                          ],
+                          "options": []
+                        },
+                        {
+                          "id": 9064,
+                          "title": "Pesach Haggadah with Maaseh Nissim",
+                          "summary": null,
+                          "status": "public",
+                          "author": 1,
+                          "ownerName": "Brett Lockspeiser",
+                          "ownerImageUrl": "https://storage.googleapis.com/sefaria-profile-pictures/brett-lockspeiser-1602104013-small.png",
+                          "ownerProfileUrl": "/profile/brett-lockspeiser",
+                          "ownerOrganization": "Sefaria",
+                          "sheetUrl": "/sheets/9064",
+                          "views": 9858,
+                          "displayedCollection": null,
+                          "modified": "03/26/2015",
+                          "created": "2015-03-25T15:21:22.990411",
+                          "published": "2015-03-26T08:35:29.102818",
+                          "topics": [
+                            {
+                              "slug": "seder",
+                              "asTyped": "Seder",
+                              "en": "Seder",
+                              "he": "ליל הסֵדֶר"
+                            },
+                            {
+                              "slug": "passover",
+                              "asTyped": "Passover",
+                              "en": "Passover",
+                              "he": "פסח"
+                            },
+                            {
+                              "slug": "passover",
+                              "asTyped": "Pesach",
+                              "en": "Pesach",
+                              "he": "פסח"
+                            },
+                            {
+                              "slug": "haggadah",
+                              "asTyped": "Haggadah",
+                              "en": "Haggadah",
+                              "he": "הגדה"
+                            }
+                          ],
+                          "tags": [
+                            "Seder",
+                            "Passover",
+                            "Pesach",
+                            "Haggadah"
+                          ],
+                          "options": []
+                        },
+                        {
+                          "id": 9063,
+                          "title": "Pesach Haggadah with Maarechet Heidenheim",
+                          "summary": null,
+                          "status": "public",
+                          "author": 1,
+                          "ownerName": "Brett Lockspeiser",
+                          "ownerImageUrl": "https://storage.googleapis.com/sefaria-profile-pictures/brett-lockspeiser-1602104013-small.png",
+                          "ownerProfileUrl": "/profile/brett-lockspeiser",
+                          "ownerOrganization": "Sefaria",
+                          "sheetUrl": "/sheets/9063",
+                          "views": 8597,
+                          "displayedCollection": null,
+                          "modified": "03/26/2015",
+                          "created": "2015-03-25T15:21:22.657675",
+                          "published": "2015-03-26T08:35:13.021285",
+                          "topics": [
+                            {
+                              "slug": "seder",
+                              "asTyped": "Seder",
+                              "en": "Seder",
+                              "he": "ליל הסֵדֶר"
+                            },
+                            {
+                              "slug": "passover",
+                              "asTyped": "Passover",
+                              "en": "Passover",
+                              "he": "פסח"
+                            },
+                            {
+                              "slug": "passover",
+                              "asTyped": "Pesach",
+                              "en": "Pesach",
+                              "he": "פסח"
+                            },
+                            {
+                              "slug": "haggadah",
+                              "asTyped": "Haggadah",
+                              "en": "Haggadah",
+                              "he": "הגדה"
+                            }
+                          ],
+                          "tags": [
+                            "Seder",
+                            "Passover",
+                            "Pesach",
+                            "Haggadah"
+                          ],
+                          "options": []
+                        },
+                        {
+                          "id": 9060,
+                          "title": "Pesach Haggadah with Ephod Bad",
+                          "summary": null,
+                          "status": "public",
+                          "author": 1,
+                          "ownerName": "Brett Lockspeiser",
+                          "ownerImageUrl": "https://storage.googleapis.com/sefaria-profile-pictures/brett-lockspeiser-1602104013-small.png",
+                          "ownerProfileUrl": "/profile/brett-lockspeiser",
+                          "ownerOrganization": "Sefaria",
+                          "sheetUrl": "/sheets/9060",
+                          "views": 7296,
+                          "displayedCollection": null,
+                          "modified": "03/26/2015",
+                          "created": "2015-03-25T15:21:21.714115",
+                          "published": "2015-03-26T08:34:52.365828",
+                          "topics": [
+                            {
+                              "slug": "seder",
+                              "asTyped": "Seder",
+                              "en": "Seder",
+                              "he": "ליל הסֵדֶר"
+                            },
+                            {
+                              "slug": "passover",
+                              "asTyped": "Passover",
+                              "en": "Passover",
+                              "he": "פסח"
+                            },
+                            {
+                              "slug": "passover",
+                              "asTyped": "Pesach",
+                              "en": "Pesach",
+                              "he": "פסח"
+                            },
+                            {
+                              "slug": "haggadah",
+                              "asTyped": "Haggadah",
+                              "en": "Haggadah",
+                              "he": "הגדה"
+                            }
+                          ],
+                          "tags": [
+                            "Seder",
+                            "Passover",
+                            "Pesach",
+                            "Haggadah"
+                          ],
+                          "options": []
+                        },
+                        {
+                          "id": 9062,
+                          "title": "Pesach Haggadah with Kos Shel Eliyahu",
+                          "summary": null,
+                          "status": "public",
+                          "author": 1,
+                          "ownerName": "Brett Lockspeiser",
+                          "ownerImageUrl": "https://storage.googleapis.com/sefaria-profile-pictures/brett-lockspeiser-1602104013-small.png",
+                          "ownerProfileUrl": "/profile/brett-lockspeiser",
+                          "ownerOrganization": "Sefaria",
+                          "sheetUrl": "/sheets/9062",
+                          "views": 11194,
+                          "displayedCollection": null,
+                          "modified": "03/26/2015",
+                          "created": "2015-03-25T15:21:22.362931",
+                          "published": "2015-03-26T08:34:40.081080",
+                          "topics": [
+                            {
+                              "slug": "seder",
+                              "asTyped": "Seder",
+                              "en": "Seder",
+                              "he": "ליל הסֵדֶר"
+                            },
+                            {
+                              "slug": "passover",
+                              "asTyped": "Passover",
+                              "en": "Passover",
+                              "he": "פסח"
+                            },
+                            {
+                              "slug": "passover",
+                              "asTyped": "Pesach",
+                              "en": "Pesach",
+                              "he": "פסח"
+                            },
+                            {
+                              "slug": "haggadah",
+                              "asTyped": "Haggadah",
+                              "en": "Haggadah",
+                              "he": "הגדה"
+                            }
+                          ],
+                          "tags": [
+                            "Seder",
+                            "Passover",
+                            "Pesach",
+                            "Haggadah"
+                          ],
+                          "options": []
+                        },
+                        {
+                          "id": 9061,
+                          "title": "Pesach Haggadah with Kimcha Davshuna",
+                          "summary": null,
+                          "status": "public",
+                          "author": 1,
+                          "ownerName": "Brett Lockspeiser",
+                          "ownerImageUrl": "https://storage.googleapis.com/sefaria-profile-pictures/brett-lockspeiser-1602104013-small.png",
+                          "ownerProfileUrl": "/profile/brett-lockspeiser",
+                          "ownerOrganization": "Sefaria",
+                          "sheetUrl": "/sheets/9061",
+                          "views": 6756,
+                          "displayedCollection": null,
+                          "modified": "03/26/2015",
+                          "created": "2015-03-25T15:21:22.031999",
+                          "published": "2015-03-26T08:33:40.378847",
+                          "topics": [
+                            {
+                              "slug": "seder",
+                              "asTyped": "Seder",
+                              "en": "Seder",
+                              "he": "ליל הסֵדֶר"
+                            },
+                            {
+                              "slug": "passover",
+                              "asTyped": "Passover",
+                              "en": "Passover",
+                              "he": "פסח"
+                            },
+                            {
+                              "slug": "passover",
+                              "asTyped": "Pesach",
+                              "en": "Pesach",
+                              "he": "פסח"
+                            },
+                            {
+                              "slug": "haggadah",
+                              "asTyped": "Haggadah",
+                              "en": "Haggadah",
+                              "he": "הגדה"
+                            }
+                          ],
+                          "tags": [
+                            "Seder",
+                            "Passover",
+                            "Pesach",
+                            "Haggadah"
+                          ],
+                          "options": []
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        }
+      }
+    },
+    "/api/sheets/user/{user_id}/{sort_by}/{limiter}/{offset}": {
+      "summary": "User's Sheets (Paginated)",
+      "description": "Returns a user's public sheets, paginated and sorted. Same response shape as the unparameterized variant.",
+      "get": {
+        "operationId": "get-user-sheets-paginated",
+        "tags": [
+          "Sheets"
+        ],
+        "parameters": [
+          {
+            "name": "user_id",
+            "description": "The numeric Sefaria user ID. To find a user_id, open the user's profile page (e.g. `https://voices.sefaria.org/profile/user-slug`), then call `GET /api/profile/{slug}` with the slug from the URL — the response contains the numeric `id`.",
+            "schema": {
+              "type": "integer"
+            },
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "sort_by",
+            "description": "Sort key. `date` orders by most recent modification; `views` orders by view count.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "date",
+                "views"
+              ]
+            },
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "limiter",
+            "description": "Maximum number of sheets to return.",
+            "schema": {
+              "type": "integer"
+            },
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "offset",
+            "description": "Offset into the result set, used for pagination.",
+            "schema": {
+              "type": "integer"
+            },
+            "in": "path",
+            "required": true
+          }
+        ],
+        "description": "Returns a user's public sheets, paginated and sorted. Same response shape as the unparameterized variant.",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserSheetsJSON"
+                },
+                "examples": {
+                  "User 1 by date, 5 per page": {
+                    "value": {
+                      "sheets": [
+                        {
+                          "id": 102615,
+                          "title": "Uprooting Mountains",
+                          "summary": "Is it better to know things, or be to be able to do things with knowledge? For the Talmud, knowledge is likened to a mountain. So what would it mean to uproot a mountain? What would it mean to grind two uprooted mountains together?",
+                          "status": "public",
+                          "author": 1,
+                          "ownerName": "Brett Lockspeiser",
+                          "ownerImageUrl": "https://storage.googleapis.com/sefaria-profile-pictures/brett-lockspeiser-1602104013-small.png",
+                          "ownerProfileUrl": "/profile/brett-lockspeiser",
+                          "ownerOrganization": "Sefaria",
+                          "sheetUrl": "/sheets/102615",
+                          "views": 4004,
+                          "displayedCollection": "",
+                          "modified": "03/27/2026",
+                          "created": "2018-03-06T07:34:01.978959",
+                          "published": "2018-03-14T10:31:32.000666",
+                          "topics": [
+                            {
+                              "asTyped": "Uprooting Mountains",
+                              "slug": "uprooting-mountains",
+                              "en": "Uprooting Mountains",
+                              "he": ""
+                            },
+                            {
+                              "asTyped": "Skill",
+                              "slug": "skill",
+                              "en": "Skill",
+                              "he": ""
+                            },
+                            {
+                              "asTyped": "Mountains",
+                              "slug": "mountains",
+                              "en": "Mountains",
+                              "he": "הר"
+                            },
+                            {
+                              "asTyped": "Knowledge",
+                              "slug": "knowledge",
+                              "en": "Knowledge",
+                              "he": "ידע"
+                            },
+                            {
+                              "asTyped": "Learning",
+                              "slug": "learning",
+                              "en": "Learning",
+                              "he": "לימוד"
+                            },
+                            {
+                              "asTyped": "Fluency",
+                              "slug": "fluency",
+                              "en": "Fluency",
+                              "he": ""
+                            },
+                            {
+                              "asTyped": "Uprooting",
+                              "slug": "uprooting",
+                              "en": "Uprooting",
+                              "he": ""
+                            }
+                          ],
+                          "tags": [
+                            "Uprooting Mountains",
+                            "Skill",
+                            "Mountains",
+                            "Knowledge",
+                            "Learning",
+                            "Fluency",
+                            "Uprooting"
+                          ],
+                          "options": []
+                        },
+                        {
+                          "id": 830,
+                          "title": "π Psukim / π Verses",
+                          "summary": "",
+                          "status": "public",
+                          "author": 1,
+                          "ownerName": "Brett Lockspeiser",
+                          "ownerImageUrl": "https://storage.googleapis.com/sefaria-profile-pictures/brett-lockspeiser-1602104013-small.png",
+                          "ownerProfileUrl": "/profile/brett-lockspeiser",
+                          "ownerOrganization": "Sefaria",
+                          "sheetUrl": "/sheets/830",
+                          "views": 5336,
+                          "displayedCollection": "",
+                          "modified": "07/17/2024",
+                          "created": "2013-09-25T18:24:57.892833",
+                          "published": "2013-09-25T18:24:57.892833",
+                          "topics": [
+                            {
+                              "asTyped": "Pi",
+                              "slug": "pi",
+                              "en": "Pi",
+                              "he": "פאי"
+                            }
+                          ],
+                          "tags": [
+                            "Pi"
+                          ],
+                          "options": []
+                        },
+                        {
+                          "id": 137322,
+                          "title": "Green",
+                          "summary": "",
+                          "status": "public",
+                          "author": 1,
+                          "ownerName": "Brett Lockspeiser",
+                          "ownerImageUrl": "https://storage.googleapis.com/sefaria-profile-pictures/brett-lockspeiser-1602104013-small.png",
+                          "ownerProfileUrl": "/profile/brett-lockspeiser",
+                          "ownerOrganization": "Sefaria",
+                          "sheetUrl": "/sheets/137322",
+                          "views": 3264,
+                          "displayedCollection": "torah-by-the-colors",
+                          "modified": "02/10/2021",
+                          "created": "2018-10-22T10:42:40.990798",
+                          "published": "2018-10-22T10:53:16.220724",
+                          "topics": [],
+                          "tags": [],
+                          "options": [],
+                          "displayedCollectionName": "Torah by the Colors"
+                        },
+                        {
+                          "id": 67508,
+                          "title": "Top Sources by Category - May 2017",
+                          "summary": "",
+                          "status": "public",
+                          "author": 1,
+                          "ownerName": "Brett Lockspeiser",
+                          "ownerImageUrl": "https://storage.googleapis.com/sefaria-profile-pictures/brett-lockspeiser-1602104013-small.png",
+                          "ownerProfileUrl": "/profile/brett-lockspeiser",
+                          "ownerOrganization": "Sefaria",
+                          "sheetUrl": "/sheets/67508",
+                          "views": 2541,
+                          "displayedCollection": "sefaria-stats",
+                          "modified": "01/15/2021",
+                          "created": "2017-05-18T12:19:29.352762",
+                          "published": "2017-12-20T15:01:18.795522",
+                          "topics": [],
+                          "tags": [],
+                          "options": [],
+                          "displayedCollectionName": "Sefaria Stats"
+                        },
+                        {
+                          "id": 137952,
+                          "title": "Black",
+                          "summary": "",
+                          "status": "public",
+                          "author": 1,
+                          "ownerName": "Brett Lockspeiser",
+                          "ownerImageUrl": "https://storage.googleapis.com/sefaria-profile-pictures/brett-lockspeiser-1602104013-small.png",
+                          "ownerProfileUrl": "/profile/brett-lockspeiser",
+                          "ownerOrganization": "Sefaria",
+                          "sheetUrl": "/sheets/137952",
+                          "views": 3032,
+                          "displayedCollection": "torah-by-the-colors",
+                          "modified": "12/09/2020",
+                          "created": "2018-10-25T08:52:40.696819",
+                          "published": "2018-10-25T08:59:47.137846",
+                          "topics": [],
+                          "tags": [],
+                          "options": [],
+                          "displayedCollectionName": "Torah by the Colors"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        }
+      }
+    },
+    "/api/v2/sheets/bulk/{sheet_id_list}": {
+      "summary": "Bulk Sheets",
+      "description": "Fetches lightweight summaries for many sheets at once. The path parameter is a pipe-delimited (`|`) list of sheet IDs. Each ID is found the same way as for single-sheet endpoints (the number in the sheet's URL on `voices.sefaria.org`).",
+      "get": {
+        "operationId": "get-sheets-bulk",
+        "tags": [
+          "Sheets"
+        ],
+        "parameters": [
+          {
+            "name": "sheet_id_list",
+            "description": "Pipe-delimited list of sheet IDs, e.g. `643492|643493`. Each ID is the numeric segment from the sheet's URL on `voices.sefaria.org`.",
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "required": true
+          }
+        ],
+        "description": "Fetches lightweight summaries for many sheets at once. The path parameter is a pipe-delimited (`|`) list of sheet IDs. Each ID is found the same way as for single-sheet endpoints (the number in the sheet's URL on `voices.sefaria.org`).",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BulkSheetEntryJSON"
+                },
+                "examples": {
+                  "Sheet 643492": {
+                    "value": {
+                      "643492": {
+                        "sheet_title": "Lag Baomer",
+                        "sheet_summary": "Lag Baomer not having so much history",
+                        "publisher_id": 41841,
+                        "sheet_via": null,
+                        "sheet_id": 643492,
+                        "publisher_name": "Matthew Rosenberg",
+                        "publisher_url": "/profile/matthew-rosenberg1",
+                        "publisher_image": "",
+                        "publisher_position": "",
+                        "publisher_organization": ""
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        }
+      }
+    },
+    "/api/sheets/tag-list": {
+      "summary": "Sheet Tag List",
+      "description": "Returns all sheet tags with their usage counts. Sorted by count (descending) by default.",
+      "get": {
+        "operationId": "get-sheets-tag-list",
+        "tags": [
+          "Sheets"
+        ],
+        "description": "Returns all sheet tags with their usage counts. Sorted by count (descending) by default.",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SheetTagCountJSON"
+                  }
+                },
+                "examples": {
+                  "All sheet tags": {
+                    "value": [
+                      {
+                        "tag": "Rabbi Yochanan b. Napacha",
+                        "count": 24353
+                      },
+                      {
+                        "tag": "Rabbi Yehudah [b. Il'ai]",
+                        "count": 21706
+                      },
+                      {
+                        "tag": "Rava",
+                        "count": 20950
+                      },
+                      {
+                        "tag": "Rav",
+                        "count": 19099
+                      },
+                      {
+                        "tag": "Rabbi Yose b. Chalafta",
+                        "count": 14265
+                      },
+                      {
+                        "tag": "Rabbi Meir",
+                        "count": 13655
+                      },
+                      {
+                        "tag": "Rabbi Shimon bar Yochai",
+                        "count": 13616
+                      },
+                      {
+                        "tag": "Shmuel (Amora)",
+                        "count": 12530
+                      },
+                      {
+                        "tag": "Abaye",
+                        "count": 12457
+                      },
+                      {
+                        "tag": "Rabbi Eliezer b. Hyrcanus",
+                        "count": 11042
+                      },
+                      {
+                        "tag": "Rabbi Akiva",
+                        "count": 10478
+                      },
+                      {
+                        "tag": "Rabi",
+                        "count": 10241
+                      },
+                      {
+                        "tag": "Rabbi Shimon b. Lakish",
+                        "count": 8154
+                      },
+                      {
+                        "tag": "Rav Yehudah [b. Yechezkel]",
+                        "count": 8046
+                      },
+                      {
+                        "tag": "Jewish People",
+                        "count": 6807
+                      },
+                      {
+                        "tag": "Rav Nachman [b. Ya'akov]",
+                        "count": 6756
+                      },
+                      {
+                        "tag": "Beit Shammai",
+                        "count": 6635
+                      },
+                      {
+                        "tag": "Rav Ashi",
+                        "count": 6562
+                      },
+                      {
+                        "tag": "Rabbi Zeira",
+                        "count": 6544
+                      },
+                      {
+                        "tag": "Moses",
+                        "count": 6358
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        }
+      }
+    },
+    "/api/sheets/tag-list/{sort_by}": {
+      "summary": "Sheet Tag List (Sorted)",
+      "description": "Returns all sheet tags with their usage counts, sorted by the given key.",
+      "get": {
+        "operationId": "get-sheets-tag-list-sorted",
+        "tags": [
+          "Sheets"
+        ],
+        "parameters": [
+          {
+            "name": "sort_by",
+            "description": "Sort key. `count` orders by usage count (descending); `alpha` orders alphabetically.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "count",
+                "alpha"
+              ]
+            },
+            "in": "path",
+            "required": true
+          }
+        ],
+        "description": "Returns all sheet tags with their usage counts, sorted by the given key.",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SheetTagCountJSON"
+                  }
+                },
+                "examples": {
+                  "Tags sorted alphabetically": {
+                    "value": [
+                      {
+                        "tag": "Aaron",
+                        "count": 2546
+                      },
+                      {
+                        "tag": "Aaron and the Golden Calf",
+                        "count": 94
+                      },
+                      {
+                        "tag": "Abaye",
+                        "count": 12457
+                      },
+                      {
+                        "tag": "Abba Shaul",
+                        "count": 817
+                      },
+                      {
+                        "tag": "Abba and Imma Ila’in (Kabbalah)",
+                        "count": 253
+                      },
+                      {
+                        "tag": "Abel",
+                        "count": 110
+                      },
+                      {
+                        "tag": "Abigail",
+                        "count": 115
+                      },
+                      {
+                        "tag": "Abner",
+                        "count": 149
+                      },
+                      {
+                        "tag": "Abortion",
+                        "count": 91
+                      },
+                      {
+                        "tag": "Abraham",
+                        "count": 2613
+                      },
+                      {
+                        "tag": "Abraham and Lot",
+                        "count": 94
+                      },
+                      {
+                        "tag": "Abraham and Sodom",
+                        "count": 101
+                      },
+                      {
+                        "tag": "Abraham ibn Ezra",
+                        "count": 127
+                      },
+                      {
+                        "tag": "Absalom",
+                        "count": 319
+                      },
+                      {
+                        "tag": "Achan",
+                        "count": 140
+                      },
+                      {
+                        "tag": "Achitofel",
+                        "count": 204
+                      },
+                      {
+                        "tag": "Adam",
+                        "count": 801
+                      },
+                      {
+                        "tag": "Adam Kadmon (Kabbalah)",
+                        "count": 122
+                      },
+                      {
+                        "tag": "Adam and Eve",
+                        "count": 104
+                      },
+                      {
+                        "tag": "Additional Gifts to the Priesthood",
+                        "count": 93
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        }
+      }
+    },
+    "/api/sheets/tag-list/user/{user_id}": {
+      "summary": "User's Sheet Tags",
+      "description": "Returns the topic tags used on a specific user's public sheets.",
+      "get": {
+        "operationId": "get-user-sheet-tags",
+        "tags": [
+          "Sheets"
+        ],
+        "parameters": [
+          {
+            "name": "user_id",
+            "description": "The numeric Sefaria user ID. To find a user_id, open the user's profile page (e.g. `https://voices.sefaria.org/profile/user-slug`), then call `GET /api/profile/{slug}` with the slug from the URL — the response contains the numeric `id`.",
+            "schema": {
+              "type": "integer"
+            },
+            "in": "path",
+            "required": true
+          }
+        ],
+        "description": "Returns the topic tags used on a specific user's public sheets.",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/UserSheetTagJSON"
+                  }
+                },
+                "examples": {
+                  "User 1 tags": {
+                    "value": [
+                      {
+                        "slug": "passover",
+                        "count": 18,
+                        "asTyped": "Passover",
+                        "en": "Passover",
+                        "he": "פסח"
+                      },
+                      {
+                        "slug": "seder",
+                        "count": 9,
+                        "asTyped": "Seder",
+                        "en": "Seder",
+                        "he": "ליל הסֵדֶר"
+                      },
+                      {
+                        "slug": "haggadah",
+                        "count": 9,
+                        "asTyped": "Haggadah",
+                        "en": "Haggadah",
+                        "he": "הגדה"
+                      },
+                      {
+                        "slug": "mitzvot",
+                        "count": 4,
+                        "asTyped": "Mitzvot",
+                        "en": "Mitzvot",
+                        "he": "מצוות"
+                      },
+                      {
+                        "slug": "statement",
+                        "count": 3,
+                        "asTyped": "Speech",
+                        "en": "Speech",
+                        "he": "דיבור"
+                      },
+                      {
+                        "slug": "parashat-shelach",
+                        "count": 3,
+                        "asTyped": "Parashat Shelach",
+                        "en": "Parashat Shelach",
+                        "he": "שלח לך"
+                      },
+                      {
+                        "slug": "divorce",
+                        "count": 3,
+                        "asTyped": "Divorce",
+                        "en": "Divorce",
+                        "he": "גירושין"
+                      },
+                      {
+                        "slug": "womens-empowerment",
+                        "count": 2,
+                        "asTyped": "Women’s Empowerment",
+                        "en": "Women’s Empowerment",
+                        "he": ""
+                      },
+                      {
+                        "slug": "sexuality",
+                        "count": 2,
+                        "asTyped": "Sex",
+                        "en": "Sex",
+                        "he": "מיניות"
+                      },
+                      {
+                        "slug": "languages",
+                        "count": 2,
+                        "asTyped": "Language",
+                        "en": "Language",
+                        "he": "שפה"
+                      },
+                      {
+                        "slug": "creation",
+                        "count": 2,
+                        "asTyped": "Creation",
+                        "en": "Creation",
+                        "he": "בריאה"
+                      },
+                      {
+                        "slug": "work",
+                        "count": 1,
+                        "asTyped": "Work",
+                        "en": "Work",
+                        "he": "עֲבוֹדָה"
+                      },
+                      {
+                        "slug": "wisdom",
+                        "count": 1,
+                        "asTyped": "Wisdom",
+                        "en": "Wisdom",
+                        "he": "חכמה"
+                      },
+                      {
+                        "slug": "uprooting-mountains",
+                        "count": 1,
+                        "asTyped": "Uprooting Mountains",
+                        "en": "Uprooting Mountains",
+                        "he": ""
+                      },
+                      {
+                        "slug": "uprooting",
+                        "count": 1,
+                        "asTyped": "Uprooting",
+                        "en": "Uprooting",
+                        "he": ""
+                      },
+                      {
+                        "slug": "two",
+                        "count": 1,
+                        "asTyped": "Two",
+                        "en": "Two",
+                        "he": "שניים"
+                      },
+                      {
+                        "slug": "top-sources",
+                        "count": 1,
+                        "asTyped": "Top Sources",
+                        "en": "Top Sources",
+                        "he": ""
+                      },
+                      {
+                        "slug": "text",
+                        "count": 1,
+                        "asTyped": "Text",
+                        "en": "Text",
+                        "he": ""
+                      },
+                      {
+                        "slug": "test",
+                        "count": 1,
+                        "asTyped": "Test",
+                        "en": "Test",
+                        "he": ""
+                      },
+                      {
+                        "slug": "taharah",
+                        "count": 1,
+                        "asTyped": "Purity",
+                        "en": "Purity",
+                        "he": "טהרה"
+                      },
+                      {
+                        "slug": "spirtual-practice",
+                        "count": 1,
+                        "asTyped": "Spirtual Practice",
+                        "en": "Spirtual Practice",
+                        "he": ""
+                      },
+                      {
+                        "slug": "slaves",
+                        "count": 1,
+                        "asTyped": "Slavery",
+                        "en": "Slavery",
+                        "he": "עבדים"
+                      },
+                      {
+                        "slug": "skill",
+                        "count": 1,
+                        "asTyped": "Skill",
+                        "en": "Skill",
+                        "he": ""
+                      },
+                      {
+                        "slug": "shavuot",
+                        "count": 1,
+                        "asTyped": "Shavuot",
+                        "en": "Shavuot",
+                        "he": "שבועות"
+                      },
+                      {
+                        "slug": "revelation",
+                        "count": 1,
+                        "asTyped": "Revelation",
+                        "en": "Revelation",
+                        "he": "התגלות"
+                      },
+                      {
+                        "slug": "practice",
+                        "count": 1,
+                        "asTyped": "Practice",
+                        "en": "Practice",
+                        "he": "תרגול"
+                      },
+                      {
+                        "slug": "pirkei-avot",
+                        "count": 1,
+                        "asTyped": "Pirkei Avot",
+                        "en": "Pirkei Avot",
+                        "he": "פרקי אבות"
+                      },
+                      {
+                        "slug": "pi",
+                        "count": 1,
+                        "asTyped": "Pi",
+                        "en": "Pi",
+                        "he": "פאי"
+                      },
+                      {
+                        "slug": "parashat-shemot",
+                        "count": 1,
+                        "asTyped": "Parashat Shemot",
+                        "en": "Parashat Shemot",
+                        "he": "פרשת שמות"
+                      },
+                      {
+                        "slug": "parashat-bereshit",
+                        "count": 1,
+                        "asTyped": "Parashat Bereishit",
+                        "en": "Parashat Bereishit",
+                        "he": "פרשת בראשית"
+                      },
+                      {
+                        "slug": "one",
+                        "count": 1,
+                        "asTyped": "One",
+                        "en": "One",
+                        "he": "אחד"
+                      },
+                      {
+                        "slug": "obligations",
+                        "count": 1,
+                        "asTyped": "Obligation",
+                        "en": "Obligation",
+                        "he": "חובה"
+                      },
+                      {
+                        "slug": "mountains",
+                        "count": 1,
+                        "asTyped": "Mountains",
+                        "en": "Mountains",
+                        "he": "הר"
+                      },
+                      {
+                        "slug": "mount-sinai",
+                        "count": 1,
+                        "asTyped": "Sinai",
+                        "en": "Sinai",
+                        "he": "הר סיני"
+                      },
+                      {
+                        "slug": "middot",
+                        "count": 1,
+                        "asTyped": "Middot",
+                        "en": "Middot",
+                        "he": "מידות"
+                      },
+                      {
+                        "slug": "measurement",
+                        "count": 1,
+                        "asTyped": "Measurement",
+                        "en": "Measurement",
+                        "he": ""
+                      },
+                      {
+                        "slug": "marriage",
+                        "count": 1,
+                        "asTyped": "Marriage",
+                        "en": "Marriage",
+                        "he": "נישואים"
+                      },
+                      {
+                        "slug": "learning",
+                        "count": 1,
+                        "asTyped": "Learning",
+                        "en": "Learning",
+                        "he": "לימוד"
+                      },
+                      {
+                        "slug": "leadership",
+                        "count": 1,
+                        "asTyped": "Leadership",
+                        "en": "Leadership",
+                        "he": "מנהיגות"
+                      },
+                      {
+                        "slug": "knowledge",
+                        "count": 1,
+                        "asTyped": "Knowledge",
+                        "en": "Knowledge",
+                        "he": "ידע"
+                      },
+                      {
+                        "slug": "kehillah",
+                        "count": 1,
+                        "asTyped": "Community",
+                        "en": "Community",
+                        "he": "קהילה"
+                      },
+                      {
+                        "slug": "judaism-and-art",
+                        "count": 1,
+                        "asTyped": "Judaism and Art",
+                        "en": "Judaism and Art",
+                        "he": "יהדות ואמנות"
+                      },
+                      {
+                        "slug": "god",
+                        "count": 1,
+                        "asTyped": "God",
+                        "en": "God",
+                        "he": "אלוהים"
+                      },
+                      {
+                        "slug": "fluency",
+                        "count": 1,
+                        "asTyped": "Fluency",
+                        "en": "Fluency",
+                        "he": ""
+                      },
+                      {
+                        "slug": "elisha-ben-abuya",
+                        "count": 1,
+                        "asTyped": "The Other",
+                        "en": "The Other",
+                        "he": "אלישע בן אבויה"
+                      },
+                      {
+                        "slug": "discrimination-diversity",
+                        "count": 1,
+                        "asTyped": "Discrimination & Diversity",
+                        "en": "Discrimination & Diversity",
+                        "he": ""
+                      },
+                      {
+                        "slug": "conversion",
+                        "count": 1,
+                        "asTyped": "Conversion",
+                        "en": "Conversion",
+                        "he": "גיור"
+                      },
+                      {
+                        "slug": "commentaries",
+                        "count": 1,
+                        "asTyped": "Commentary",
+                        "en": "Commentary",
+                        "he": "מפרשים"
+                      },
+                      {
+                        "slug": "civil-human-rights",
+                        "count": 1,
+                        "asTyped": "Civil/Human Rights",
+                        "en": "Civil/Human Rights",
+                        "he": ""
+                      },
+                      {
+                        "slug": "being-a-mensch",
+                        "count": 1,
+                        "asTyped": "Being a Mensch",
+                        "en": "Being a Mensch",
+                        "he": ""
+                      },
+                      {
+                        "slug": "becoming-a-mensch",
+                        "count": 1,
+                        "asTyped": "Becoming a Mensch",
+                        "en": "Becoming a Mensch",
+                        "he": ""
+                      },
+                      {
+                        "slug": "art",
+                        "count": 1,
+                        "asTyped": "Art",
+                        "en": "Art",
+                        "he": "אמנות"
+                      },
+                      {
+                        "slug": "aramaic-targum",
+                        "count": 1,
+                        "asTyped": "Translation",
+                        "en": "Translation",
+                        "he": "תרגום"
+                      },
+                      {
+                        "slug": "annulment",
+                        "count": 1,
+                        "asTyped": "Annulment",
+                        "en": "Annulment",
+                        "he": "התרה"
+                      },
+                      {
+                        "slug": "advice",
+                        "count": 1,
+                        "asTyped": "Advice",
+                        "en": "Advice",
+                        "he": ""
+                      },
+                      {
+                        "slug": "acts",
+                        "count": 1,
+                        "asTyped": "Doing",
+                        "en": "Doing",
+                        "he": "מעשה"
+                      },
+                      {
+                        "slug": "action",
+                        "count": 1,
+                        "asTyped": "Action",
+                        "en": "Action",
+                        "he": "פעולה"
+                      },
+                      {
+                        "slug": "5781",
+                        "count": 1,
+                        "asTyped": "5781",
+                        "en": "5781",
+                        "he": ""
+                      },
+                      {
+                        "slug": "2021",
+                        "count": 1,
+                        "asTyped": "2021",
+                        "en": "2021",
+                        "he": ""
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        }
+      }
+    },
+    "/api/sheets/ref/{ref}": {
+      "summary": "Sheets by Ref",
+      "description": "Returns public sheets that cite the given Sefaria ref.",
+      "get": {
+        "operationId": "get-sheets-by-ref",
+        "tags": [
+          "Sheets"
+        ],
+        "parameters": [
+          {
+            "name": "ref",
+            "description": "Sefaria ref, e.g. `Genesis.1.1`. Use dots for section separators in the URL.",
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "required": true
+          }
+        ],
+        "description": "Returns public sheets that cite the given Sefaria ref.",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SheetsJSON"
+                  }
+                },
+                "examples": {
+                  "Sheets citing Genesis 1:1": {
+                    "value": [
+                      {
+                        "owner": 176,
+                        "_id": "5134e7e7f8af4f5062356eea",
+                        "id": "124",
+                        "public": true,
+                        "title": "Time",
+                        "sheetUrl": "/sheets/124",
+                        "anchorRef": "Genesis 1:1",
+                        "anchorRefExpanded": [
+                          "Genesis 1:1"
+                        ],
+                        "options": {
+                          "language": "bilingual",
+                          "numbered": 1,
+                          "layout": "sideBySide"
+                        },
+                        "collectionTOC": null,
+                        "ownerName": "Dovid Birk",
+                        "via": null,
+                        "viaOwnerName": null,
+                        "assignerName": null,
+                        "viaOwnerProfileUrl": null,
+                        "assignerProfileUrl": null,
+                        "ownerProfileUrl": "/profile/dovid-birk",
+                        "ownerImageUrl": "https://storage.googleapis.com/sefaria-profile-pictures/dovid-birk-1626299666-small.png",
+                        "status": "public",
+                        "views": 2093,
+                        "topics": [
+                          {
+                            "slug": "time",
+                            "asTyped": "Time",
+                            "en": "Time",
+                            "he": "זמן"
+                          }
+                        ],
+                        "likes": [],
+                        "summary": null,
+                        "attribution": null,
+                        "is_featured": false,
+                        "category": "Sheets",
+                        "type": "sheet",
+                        "dateCreated": "2013-03-04T10:28:55.912635",
+                        "combined_score": 0.6580043610647954
+                      },
+                      {
+                        "owner": 365,
+                        "_id": "52728622c38b61c84732314f",
+                        "id": "1102",
+                        "public": true,
+                        "title": "The Creation of Light",
+                        "sheetUrl": "/sheets/1102",
+                        "anchorRef": "Genesis 1:1-5",
+                        "anchorRefExpanded": [
+                          "Genesis 1:1"
+                        ],
+                        "options": {
+                          "numbered": 0,
+                          "divineNames": "noSub",
+                          "language": "bilingual",
+                          "layout": "sideBySide"
+                        },
+                        "collectionTOC": null,
+                        "ownerName": "Rabbi Jill Zimmerman",
+                        "via": null,
+                        "viaOwnerName": null,
+                        "assignerName": null,
+                        "viaOwnerProfileUrl": null,
+                        "assignerProfileUrl": null,
+                        "ownerProfileUrl": "/profile/rabbi-jill-zimmerman",
+                        "ownerImageUrl": "https://storage.googleapis.com/sefaria-profile-pictures/rabbi-jill-zimmerman-1626299681-small.png",
+                        "status": "public",
+                        "views": 4048,
+                        "topics": [
+                          {
+                            "slug": "light",
+                            "asTyped": "Light",
+                            "en": "Light",
+                            "he": "אור"
+                          },
+                          {
+                            "slug": "creation",
+                            "asTyped": "Creation",
+                            "en": "Creation",
+                            "he": "בריאה"
+                          },
+                          {
+                            "slug": "parashat-bereshit",
+                            "asTyped": "Parashat Bereishit",
+                            "en": "Parashat Bereishit",
+                            "he": "פרשת בראשית"
+                          }
+                        ],
+                        "likes": [],
+                        "summary": null,
+                        "attribution": null,
+                        "is_featured": false,
+                        "category": "Sheets",
+                        "type": "sheet",
+                        "dateCreated": "2013-10-31T09:32:34.797864",
+                        "combined_score": 0.22914507772020723
+                      },
+                      {
+                        "owner": 365,
+                        "_id": "52728651c38b61c847323150",
+                        "id": "1103",
+                        "public": true,
+                        "title": "HINENI: The Mindful Heart Community \n\n Light and Darkness  •   Dec. 8, 2015 Phone Call \n\n Rabbi Jill Berkson Zimmerman",
+                        "sheetUrl": "/sheets/1103",
+                        "anchorRef": "Genesis 1:1-5",
+                        "anchorRefExpanded": [
+                          "Genesis 1:1"
+                        ],
+                        "options": {
+                          "numbered": 0,
+                          "boxed": 1,
+                          "assignable": 0,
+                          "bsd": 0,
+                          "language": "bilingual",
+                          "layout": "sideBySide",
+                          "langLayout": "heRight",
+                          "divineNames": "noSub",
+                          "highlightMode": 0,
+                          "collaboration": "anyone-can-edit"
+                        },
+                        "collectionTOC": null,
+                        "ownerName": "Rabbi Jill Zimmerman",
+                        "via": null,
+                        "viaOwnerName": null,
+                        "assignerName": null,
+                        "viaOwnerProfileUrl": null,
+                        "assignerProfileUrl": null,
+                        "ownerProfileUrl": "/profile/rabbi-jill-zimmerman",
+                        "ownerImageUrl": "https://storage.googleapis.com/sefaria-profile-pictures/rabbi-jill-zimmerman-1626299681-small.png",
+                        "status": "public",
+                        "views": 2794,
+                        "topics": [
+                          {
+                            "slug": "chanukkah",
+                            "asTyped": "Chanukah",
+                            "en": "Chanukah",
+                            "he": "חנוכה"
+                          },
+                          {
+                            "slug": "light",
+                            "asTyped": "Light",
+                            "en": "Light",
+                            "he": "אור"
+                          },
+                          {
+                            "slug": "light-and-darkness",
+                            "asTyped": "Light and Darkness",
+                            "en": "Light and Darkness",
+                            "he": ""
+                          },
+                          {
+                            "slug": "creation",
+                            "asTyped": "Creation",
+                            "en": "Creation",
+                            "he": "בריאה"
+                          },
+                          {
+                            "slug": "kabbalah",
+                            "asTyped": "Kabbalah",
+                            "en": "Kabbalah",
+                            "he": "קבלה"
+                          },
+                          {
+                            "slug": "darkness",
+                            "asTyped": "Darkness",
+                            "en": "Darkness",
+                            "he": "חושך"
+                          }
+                        ],
+                        "likes": [],
+                        "summary": "",
+                        "attribution": null,
+                        "is_featured": false,
+                        "category": "Sheets",
+                        "type": "sheet",
+                        "dateCreated": "2013-10-31T09:33:21.970253",
+                        "combined_score": 0.670361201108299
+                      },
+                      {
+                        "owner": 365,
+                        "_id": "52728651c38b61c847323150",
+                        "id": "1103",
+                        "public": true,
+                        "title": "HINENI: The Mindful Heart Community \n\n Light and Darkness  •   Dec. 8, 2015 Phone Call \n\n Rabbi Jill Berkson Zimmerman",
+                        "sheetUrl": "/sheets/1103",
+                        "anchorRef": "Genesis 1:1-5",
+                        "anchorRefExpanded": [
+                          "Genesis 1:1"
+                        ],
+                        "options": {
+                          "numbered": 0,
+                          "boxed": 1,
+                          "assignable": 0,
+                          "bsd": 0,
+                          "language": "bilingual",
+                          "layout": "sideBySide",
+                          "langLayout": "heRight",
+                          "divineNames": "noSub",
+                          "highlightMode": 0,
+                          "collaboration": "anyone-can-edit"
+                        },
+                        "collectionTOC": null,
+                        "ownerName": "Rabbi Jill Zimmerman",
+                        "via": null,
+                        "viaOwnerName": null,
+                        "assignerName": null,
+                        "viaOwnerProfileUrl": null,
+                        "assignerProfileUrl": null,
+                        "ownerProfileUrl": "/profile/rabbi-jill-zimmerman",
+                        "ownerImageUrl": "https://storage.googleapis.com/sefaria-profile-pictures/rabbi-jill-zimmerman-1626299681-small.png",
+                        "status": "public",
+                        "views": 2794,
+                        "topics": [
+                          {
+                            "slug": "chanukkah",
+                            "asTyped": "Chanukah",
+                            "en": "Chanukah",
+                            "he": "חנוכה"
+                          },
+                          {
+                            "slug": "light",
+                            "asTyped": "Light",
+                            "en": "Light",
+                            "he": "אור"
+                          },
+                          {
+                            "slug": "light-and-darkness",
+                            "asTyped": "Light and Darkness",
+                            "en": "Light and Darkness",
+                            "he": ""
+                          },
+                          {
+                            "slug": "creation",
+                            "asTyped": "Creation",
+                            "en": "Creation",
+                            "he": "בריאה"
+                          },
+                          {
+                            "slug": "kabbalah",
+                            "asTyped": "Kabbalah",
+                            "en": "Kabbalah",
+                            "he": "קבלה"
+                          },
+                          {
+                            "slug": "darkness",
+                            "asTyped": "Darkness",
+                            "en": "Darkness",
+                            "he": "חושך"
+                          }
+                        ],
+                        "likes": [],
+                        "summary": "",
+                        "attribution": null,
+                        "is_featured": false,
+                        "category": "Sheets",
+                        "type": "sheet",
+                        "dateCreated": "2013-10-31T09:33:21.970253",
+                        "combined_score": 0.670361201108299
+                      },
+                      {
+                        "owner": 2496,
+                        "_id": "52a4a7749b63071073ca0320",
+                        "id": "1414",
+                        "public": true,
+                        "title": "Learning to Rest and Resting to Learn",
+                        "sheetUrl": "/sheets/1414",
+                        "anchorRef": "Genesis 1:1-5",
+                        "anchorRefExpanded": [
+                          "Genesis 1:1"
+                        ],
+                        "options": {
+                          "layout": "sideBySide",
+                          "bsd": 0,
+                          "collaboration": "none",
+                          "language": "bilingual",
+                          "boxed": 0,
+                          "langLayout": "enLeft",
+                          "numbered": 0,
+                          "divineNames": "ykvk"
+                        },
+                        "collectionTOC": null,
+                        "ownerName": "Daniella Pressner",
+                        "via": null,
+                        "viaOwnerName": null,
+                        "assignerName": null,
+                        "viaOwnerProfileUrl": null,
+                        "assignerProfileUrl": null,
+                        "ownerProfileUrl": "/profile/daniella-pressner",
+                        "ownerImageUrl": "",
+                        "status": "public",
+                        "views": 2163,
+                        "topics": [
+                          {
+                            "slug": "parashat-bereshit",
+                            "asTyped": "Parashat Bereishit",
+                            "en": "Parashat Bereishit",
+                            "he": "פרשת בראשית"
+                          },
+                          {
+                            "slug": "shabbat",
+                            "asTyped": "Shabbat",
+                            "en": "Shabbat",
+                            "he": "שבת"
+                          },
+                          {
+                            "slug": "creation",
+                            "asTyped": "Creation",
+                            "en": "Creation",
+                            "he": "בריאה"
+                          }
+                        ],
+                        "likes": [],
+                        "summary": null,
+                        "attribution": null,
+                        "is_featured": false,
+                        "category": "Sheets",
+                        "type": "sheet",
+                        "dateCreated": "2013-12-08T09:08:04.740860",
+                        "combined_score": 0.4125231172976482
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        }
+      }
+    },
+    "/api/sheets/all-sheets/{limiter}/{offset}": {
+      "summary": "All Public Sheets",
+      "description": "Returns a paginated list of all public sheets.",
+      "get": {
+        "operationId": "get-all-sheets",
+        "tags": [
+          "Sheets"
+        ],
+        "parameters": [
+          {
+            "name": "limiter",
+            "description": "Maximum number of sheets to return.",
+            "schema": {
+              "type": "integer"
+            },
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "offset",
+            "description": "Offset into the result set, used for pagination.",
+            "schema": {
+              "type": "integer"
+            },
+            "in": "path",
+            "required": true
+          }
+        ],
+        "description": "Returns a paginated list of all public sheets.",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AllSheetsJSON"
+                },
+                "examples": {
+                  "First 5 sheets": {
+                    "value": {
+                      "sheets": [
+                        {
+                          "id": 723976,
+                          "title": "The Sabbath of the land and the prohibition of idols equals the Good Life",
+                          "summary": "Mei Hashiloach shows us guidelines for a good and spiritual life in the rules of the sabbatical year and forbidden idol types",
+                          "status": "public",
+                          "author": 11376,
+                          "ownerName": "Robert  Rhodes",
+                          "ownerImageUrl": "https://storage.googleapis.com/sefaria-profile-pictures/robert-rhodes-1591617862-small.png",
+                          "ownerProfileUrl": "/profile/robert-rhodes",
+                          "ownerOrganization": "",
+                          "sheetUrl": "/sheets/723976",
+                          "views": 5,
+                          "displayedCollection": "",
+                          "modified": "05/05/2026",
+                          "created": "2026-05-05T09:06:43.205143",
+                          "published": "2026-05-05T09:28:14.954059",
+                          "topics": [
+                            {
+                              "asTyped": "Shabbat",
+                              "slug": "shabbat",
+                              "en": "Shabbat",
+                              "he": "שבת"
+                            },
+                            {
+                              "asTyped": "Sabbatical",
+                              "slug": "shemitah",
+                              "en": "Sabbatical",
+                              "he": "שמיטה"
+                            },
+                            {
+                              "asTyped": "Shemittah",
+                              "slug": "shemitah",
+                              "en": "Shemittah",
+                              "he": "שמיטה"
+                            },
+                            {
+                              "asTyped": "Yaakov Leiner of Izhbitz",
+                              "slug": "yaakov-leiner-of-izhbitz",
+                              "en": "Yaakov Leiner of Izhbitz",
+                              "he": "יעקב ליינר מאיזביץ"
+                            },
+                            {
+                              "asTyped": "Life",
+                              "slug": "life",
+                              "en": "Life",
+                              "he": "חיים"
+                            },
+                            {
+                              "asTyped": "Idols",
+                              "slug": "idols",
+                              "en": "Idols",
+                              "he": "פסל"
+                            },
+                            {
+                              "asTyped": "Behar",
+                              "slug": "parashat-behar",
+                              "en": "Behar",
+                              "he": "פרשת בהר"
+                            },
+                            {
+                              "asTyped": "Good",
+                              "slug": "good",
+                              "en": "Good",
+                              "he": "טוב"
+                            },
+                            {
+                              "asTyped": "Chassidut",
+                              "slug": "chassidut",
+                              "en": "Chassidut",
+                              "he": ""
+                            }
+                          ],
+                          "tags": [
+                            "Shabbat",
+                            "Sabbatical",
+                            "Shemittah",
+                            "Yaakov Leiner of Izhbitz",
+                            "Life",
+                            "Idols",
+                            "Behar",
+                            "Good",
+                            "Chassidut"
+                          ],
+                          "options": []
+                        },
+                        {
+                          "id": 723934,
+                          "title": "בעניין מיצוות שלפני מתן תורה",
+                          "summary": "מיצוות שלפני מתן תורה רק שתים",
+                          "status": "public",
+                          "author": 111585,
+                          "ownerName": "noam tal",
+                          "ownerImageUrl": "https://storage.googleapis.com/sefaria-profile-pictures/noam-tal-1686988600-small.png",
+                          "ownerProfileUrl": "/profile/noam-tal",
+                          "ownerOrganization": "רחמים לתינוק ",
+                          "sheetUrl": "/sheets/723934",
+                          "views": 5,
+                          "displayedCollection": "",
+                          "modified": "05/05/2026",
+                          "created": "2026-05-05T03:31:03.648834",
+                          "published": "2026-05-05T05:29:27.447846",
+                          "topics": [
+                            {
+                              "asTyped": "Commandments",
+                              "slug": "mitzvot",
+                              "en": "Commandments",
+                              "he": "מצוות"
+                            },
+                            {
+                              "asTyped": "הלכה",
+                              "slug": "halakhah",
+                              "he": "הלכה",
+                              "en": "Halakhah"
+                            },
+                            {
+                              "asTyped": "Jewish Law",
+                              "slug": "halakhah",
+                              "en": "Jewish Law",
+                              "he": "הלכה"
+                            },
+                            {
+                              "asTyped": "תורה שבכתב ושבעל פה",
+                              "slug": "the-written-torah-and-the-oral-torah",
+                              "he": "תורה שבכתב ושבעל פה",
+                              "en": "The Written Torah and the Oral Torah"
+                            }
+                          ],
+                          "tags": [
+                            "Commandments",
+                            "הלכה",
+                            "Jewish Law",
+                            "תורה שבכתב ושבעל פה"
+                          ],
+                          "options": []
+                        },
+                        {
+                          "id": 651945,
+                          "title": "Threads, Tassels, and Tosafot: Whether Women Wear Their Mitzvot",
+                          "summary": "An in-depth examination of women's obligation in tzitzit through the eyes of Tosafot to Yevamot 4a.",
+                          "status": "public",
+                          "author": 82744,
+                          "ownerName": "Isaac Deutsch",
+                          "ownerImageUrl": "",
+                          "ownerProfileUrl": "/profile/isaac-deutsch",
+                          "ownerOrganization": "",
+                          "sheetUrl": "/sheets/651945",
+                          "views": 14,
+                          "displayedCollection": "",
+                          "modified": "05/04/2026",
+                          "created": "2025-05-27T17:57:18.599966",
+                          "published": "2026-05-04T22:09:18.738274",
+                          "topics": [
+                            {
+                              "asTyped": "Tzitzit",
+                              "slug": "tzitzit",
+                              "en": "Tzitzit",
+                              "he": "ציצית"
+                            },
+                            {
+                              "asTyped": "Tosafot",
+                              "slug": "tosafot",
+                              "en": "Tosafot",
+                              "he": "תוספות"
+                            },
+                            {
+                              "asTyped": "Women",
+                              "slug": "women",
+                              "en": "Women",
+                              "he": "נשים"
+                            },
+                            {
+                              "asTyped": "Sha'atnez",
+                              "slug": "shaatnez",
+                              "en": "Sha'atnez",
+                              "he": "שעטנז"
+                            }
+                          ],
+                          "tags": [
+                            "Tzitzit",
+                            "Tosafot",
+                            "Women",
+                            "Sha'atnez"
+                          ],
+                          "options": []
+                        },
+                        {
+                          "id": 723888,
+                          "title": "Voice of the Divine Feminine",
+                          "summary": "Chokhma, the Wisdom Goddess",
+                          "status": "public",
+                          "author": 124993,
+                          "ownerName": "Miriam Katz",
+                          "ownerImageUrl": "https://storage.googleapis.com/sefaria-profile-pictures/miriam-katz-1652667444-small.png",
+                          "ownerProfileUrl": "/profile/miriam-katz",
+                          "ownerOrganization": "",
+                          "sheetUrl": "/sheets/723888",
+                          "views": 6,
+                          "displayedCollection": "",
+                          "modified": "05/04/2026",
+                          "created": "2026-05-04T19:36:23.131374",
+                          "published": "2026-05-04T20:18:47.878527",
+                          "topics": [
+                            {
+                              "asTyped": "Proverbs",
+                              "slug": "proverbs",
+                              "en": "Proverbs",
+                              "he": "משלי"
+                            },
+                            {
+                              "asTyped": "Sefer Yetzirah",
+                              "slug": "sefer-yetzirah",
+                              "en": "Sefer Yetzirah",
+                              "he": ""
+                            }
+                          ],
+                          "tags": [
+                            "Proverbs",
+                            "Sefer Yetzirah"
+                          ],
+                          "options": []
+                        },
+                        {
+                          "id": 723730,
+                          "title": "רבי נחוניה בר הקנה Rabbi Nahuniah bar HaKanah",
+                          "summary": "לימוד קצת על הפנומנולוגיה של התפילה באמצעות תפילתו של רבי נחוניה בר הקנה",
+                          "status": "public",
+                          "author": 95517,
+                          "ownerName": "דליה מרקס Dalia Marx",
+                          "ownerImageUrl": "https://storage.googleapis.com/sefaria-profile-pictures/-6550-1597237148-small.png",
+                          "ownerProfileUrl": "/profile/-6550",
+                          "ownerOrganization": "Hebrew Union College",
+                          "sheetUrl": "/sheets/723730",
+                          "views": 9,
+                          "displayedCollection": "",
+                          "modified": "05/04/2026",
+                          "created": "2026-05-04T02:54:37.782427",
+                          "published": "2026-05-04T18:54:33.710331",
+                          "topics": [
+                            {
+                              "asTyped": "כוונה",
+                              "slug": "kavanah",
+                              "he": "כוונה",
+                              "en": "Kavanah"
+                            },
+                            {
+                              "asTyped": "רבי נחוניא בן הקנה",
+                              "slug": "rabbi-nehunya-b-hakanah",
+                              "he": "רבי נחוניא בן הקנה",
+                              "en": "Rabbi Nechunya b. haKanah"
+                            },
+                            {
+                              "asTyped": "תפילה",
+                              "slug": "prayer",
+                              "he": "תפילה",
+                              "en": "Prayer"
+                            },
+                            {
+                              "asTyped": "בית מדרש",
+                              "slug": "beit-midrash",
+                              "he": "בית מדרש",
+                              "en": "Beit Midrash"
+                            }
+                          ],
+                          "tags": [
+                            "כוונה",
+                            "רבי נחוניא בן הקנה",
+                            "תפילה",
+                            "בית מדרש"
+                          ],
+                          "options": []
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        }
+      }
+    },
+    "/api/sheets/{parasha}/get_aliyot": {
+      "summary": "Aliyot for Parasha",
+      "description": "Returns the seven aliyot ranges for a given parasha. Used by the source sheet builder when seeding a sheet from a weekly reading.",
+      "get": {
+        "operationId": "get-aliyot-by-parasha",
+        "tags": [
+          "Sheets"
+        ],
+        "parameters": [
+          {
+            "name": "parasha",
+            "description": "Parasha name in transliteration, e.g. `Bereshit`.",
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "required": true
+          }
+        ],
+        "description": "Returns the seven aliyot ranges for a given parasha. Used by the source sheet builder when seeding a sheet from a weekly reading.",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AliyotJSON"
+                },
+                "examples": {
+                  "Bereshit": {
+                    "value": {
+                      "ref": [
+                        "Genesis 1:1-2:3",
+                        "Genesis 2:4-2:19",
+                        "Genesis 2:20-3:21",
+                        "Genesis 3:22-4:18",
+                        "Genesis 4:19-4:22",
+                        "Genesis 4:23-5:24",
+                        "Genesis 5:25-6:8",
+                        "Genesis 6:5-6:8"
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        }
+      }
+    },
+    "/api/collections": {
+      "summary": "Collections",
+      "description": "Returns the list of Sefaria collections. Unauthenticated callers see only publicly-listed collections in `public`; the `private` array is empty. Authenticated users additionally see private collections they belong to.",
+      "get": {
+        "operationId": "get-collections",
+        "tags": [
+          "Collections"
+        ],
+        "description": "Returns the list of Sefaria collections. Unauthenticated callers see only publicly-listed collections in `public`; the `private` array is empty. Authenticated users additionally see private collections they belong to.",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CollectionsListJSON"
+                },
+                "examples": {
+                  "First page of collections": {
+                    "value": {
+                      "private": [],
+                      "public": [
+                        {
+                          "name": "  🗓️ Midrash Calendar",
+                          "slug": "-midrash-calendar",
+                          "description": null,
+                          "imageUrl": "https://storage.googleapis.com/sefaria-collection-images/149105-fad04a9c-66e7-11ee-92ca-aefcd64297b0.jpg",
+                          "headerUrl": null,
+                          "memberCount": 1,
+                          "sheetCount": 3,
+                          "lastModified": "2023-10-09 18:10:56.323000",
+                          "listed": true
+                        },
+                        {
+                          "name": " A Year of Torah (Rabbi Menachem Creditor)",
+                          "slug": "a-year-of-torah-rabbi-menachem-creditor",
+                          "description": "This contemporary Torah commentary is dedicated to the kind souls who turned screens into portals every day to build something sacred together during a very difficult time.\n\nFor a paperback copy of the complete work, including commentary from a diverse array of American Jewish rabbinical school students, visit: https://www.amazon.com/dp/B09KDSYTYT",
+                          "imageUrl": "https://storage.googleapis.com/sefaria-collection-images/0025814a-942d-4686-ba27-ef68ed2e3f54.jpeg",
+                          "headerUrl": null,
+                          "memberCount": 1,
+                          "sheetCount": 5,
+                          "lastModified": "2022-09-21 11:23:51.318000",
+                          "listed": true
+                        },
+                        {
+                          "name": "\"As it is Written\" Series",
+                          "slug": "as-it-is-written-source-sheets",
+                          "description": "Source sheets used for sessions of JSP's \"As it is Written\" series (May 2020-June 2021)",
+                          "imageUrl": "https://storage.googleapis.com/sefaria-collection-images/7c4fbb4c-b252-4092-ab94-93426f3a8dbc.png",
+                          "headerUrl": null,
+                          "memberCount": 1,
+                          "sheetCount": 4,
+                          "lastModified": "2023-12-05 15:05:10.653000",
+                          "listed": true
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        }
+      }
+    },
+    "/api/collections/{slug}": {
+      "summary": "Collection",
+      "description": "Returns the full content of a single collection, including its member sheets. For unauthenticated callers, only publicly-listed collections are accessible.",
+      "get": {
+        "operationId": "get-collection",
+        "tags": [
+          "Collections"
+        ],
+        "parameters": [
+          {
+            "name": "slug",
+            "description": "URL slug for the collection, e.g. `parshawisdom`. The slug appears in the collection's URL on Sefaria.",
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "required": true
+          }
+        ],
+        "description": "Returns the full content of a single collection, including its member sheets. For unauthenticated callers, only publicly-listed collections are accessible.",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CollectionDetailJSON"
+                },
+                "examples": {
+                  "#ParshaWisdom": {
+                    "value": {
+                      "name": "#ParshaWisdom",
+                      "sheets": [
+                        {
+                          "id": 298111,
+                          "title": "#ParshaWisdom - Yitro - The Discernment of Outsiders",
+                          "summary": "",
+                          "status": "public",
+                          "author": 119559,
+                          "ownerName": "Yeshivat Chovevei Torah",
+                          "ownerImageUrl": "https://storage.googleapis.com/sefaria-profile-pictures/yeshivat-chovevei-torah-1611941333-small.png",
+                          "ownerProfileUrl": "/profile/yeshivat-chovevei-torah",
+                          "ownerOrganization": "",
+                          "sheetUrl": "/sheets/298111",
+                          "views": 2502,
+                          "displayedCollection": "parshawisdom",
+                          "modified": "02/05/2021",
+                          "created": "2021-02-05T12:03:53.552765",
+                          "published": "2021-02-05T12:05:21.120129",
+                          "topics": [
+                            {
+                              "asTyped": "Perspectives",
+                              "slug": "perspectives",
+                              "en": "Perspectives",
+                              "he": ""
+                            },
+                            {
+                              "asTyped": "Rabbi Dov Linzer",
+                              "slug": "rabbi-dov-linzer",
+                              "en": "Rabbi Dov Linzer",
+                              "he": ""
+                            },
+                            {
+                              "asTyped": "Yitro",
+                              "slug": "yitro",
+                              "en": "Yitro",
+                              "he": "יתרו"
+                            },
+                            {
+                              "asTyped": "Parshat Yitro",
+                              "slug": "yitro",
+                              "en": "Parshat Yitro",
+                              "he": "יתרו"
+                            }
+                          ],
+                          "tags": [
+                            "Perspectives",
+                            "Rabbi Dov Linzer",
+                            "Yitro",
+                            "Parshat Yitro"
+                          ],
+                          "options": []
+                        },
+                        {
+                          "id": 296334,
+                          "title": "#ParshaWisdom - Beshalach - Watering Our Faith",
+                          "summary": "",
+                          "status": "public",
+                          "author": 119559,
+                          "ownerName": "Yeshivat Chovevei Torah",
+                          "ownerImageUrl": "https://storage.googleapis.com/sefaria-profile-pictures/yeshivat-chovevei-torah-1611941333-small.png",
+                          "ownerProfileUrl": "/profile/yeshivat-chovevei-torah",
+                          "ownerOrganization": "",
+                          "sheetUrl": "/sheets/296334",
+                          "views": 1845,
+                          "displayedCollection": "parshawisdom",
+                          "modified": "01/29/2021",
+                          "created": "2021-01-29T13:31:34.873917",
+                          "published": "2021-01-29T13:32:00.190188",
+                          "topics": [
+                            {
+                              "asTyped": "Rabbi Dov Linzer",
+                              "slug": "rabbi-dov-linzer",
+                              "en": "Rabbi Dov Linzer",
+                              "he": ""
+                            },
+                            {
+                              "asTyped": "Faith",
+                              "slug": "faith",
+                              "en": "Faith",
+                              "he": "אמונה"
+                            },
+                            {
+                              "asTyped": "Parashat Beshalach",
+                              "slug": "parashat-beshalach",
+                              "en": "Parashat Beshalach",
+                              "he": "פרשת בשלח"
+                            },
+                            {
+                              "asTyped": "Emunah",
+                              "slug": "faith",
+                              "en": "Emunah",
+                              "he": "אמונה"
+                            },
+                            {
+                              "asTyped": "Beshalach",
+                              "slug": "parashat-beshalach",
+                              "en": "Beshalach",
+                              "he": "פרשת בשלח"
+                            }
+                          ],
+                          "tags": [
+                            "Rabbi Dov Linzer",
+                            "Faith",
+                            "Parashat Beshalach",
+                            "Emunah",
+                            "Beshalach"
+                          ],
+                          "options": []
+                        },
+                        {
+                          "id": 296335,
+                          "title": "#ParshaWisdom - Bo - Commemorating the Corona",
+                          "summary": "",
+                          "status": "public",
+                          "author": 119559,
+                          "ownerName": "Yeshivat Chovevei Torah",
+                          "ownerImageUrl": "https://storage.googleapis.com/sefaria-profile-pictures/yeshivat-chovevei-torah-1611941333-small.png",
+                          "ownerProfileUrl": "/profile/yeshivat-chovevei-torah",
+                          "ownerOrganization": "",
+                          "sheetUrl": "/sheets/296335",
+                          "views": 1994,
+                          "displayedCollection": "parshawisdom",
+                          "modified": "01/29/2021",
+                          "created": "2021-01-29T13:33:59.303079",
+                          "published": "2021-01-29T13:34:39.263645",
+                          "topics": [
+                            {
+                              "asTyped": "Rabbi Dov Linzer",
+                              "slug": "rabbi-dov-linzer",
+                              "en": "Rabbi Dov Linzer",
+                              "he": ""
+                            },
+                            {
+                              "asTyped": "Parashat Bo",
+                              "slug": "parashat-bo",
+                              "en": "Parashat Bo",
+                              "he": "פרשת בא"
+                            },
+                            {
+                              "asTyped": "Bo",
+                              "slug": "parashat-bo",
+                              "en": "Bo",
+                              "he": "פרשת בא"
+                            },
+                            {
+                              "asTyped": "Covid-19",
+                              "slug": "coronavirus",
+                              "en": "Covid-19",
+                              "he": "נגיף הקורונה"
+                            },
+                            {
+                              "asTyped": "Coronavirus",
+                              "slug": "coronavirus",
+                              "en": "Coronavirus",
+                              "he": "נגיף הקורונה"
+                            }
+                          ],
+                          "tags": [
+                            "Rabbi Dov Linzer",
+                            "Parashat Bo",
+                            "Bo",
+                            "Covid-19",
+                            "Coronavirus"
+                          ],
+                          "options": []
+                        },
+                        {
+                          "id": 296336,
+                          "title": "#ParshaWisdom - Va'era - Speech in Exile",
+                          "summary": "",
+                          "status": "public",
+                          "author": 119559,
+                          "ownerName": "Yeshivat Chovevei Torah",
+                          "ownerImageUrl": "https://storage.googleapis.com/sefaria-profile-pictures/yeshivat-chovevei-torah-1611941333-small.png",
+                          "ownerProfileUrl": "/profile/yeshivat-chovevei-torah",
+                          "ownerOrganization": "",
+                          "sheetUrl": "/sheets/296336",
+                          "views": 3054,
+                          "displayedCollection": "parshawisdom",
+                          "modified": "01/29/2021",
+                          "created": "2021-01-29T13:35:25.007189",
+                          "published": "2021-01-29T13:36:00.512092",
+                          "topics": [
+                            {
+                              "asTyped": "Rabbi Dov Linzer",
+                              "slug": "rabbi-dov-linzer",
+                              "en": "Rabbi Dov Linzer",
+                              "he": ""
+                            },
+                            {
+                              "asTyped": "Parashat Va'era",
+                              "slug": "parashat-vaera",
+                              "en": "Parashat Va'era",
+                              "he": "פרשת וארא"
+                            },
+                            {
+                              "asTyped": "Vaera",
+                              "slug": "parashat-vaera",
+                              "en": "Vaera",
+                              "he": "פרשת וארא"
+                            },
+                            {
+                              "asTyped": "Speech",
+                              "slug": "speeches1",
+                              "en": "Speech",
+                              "he": "שיחה"
+                            },
+                            {
+                              "asTyped": "Parashat Vaera",
+                              "slug": "parashat-vaera",
+                              "en": "Parashat Vaera",
+                              "he": "פרשת וארא"
+                            },
+                            {
+                              "asTyped": "Va'era",
+                              "slug": "parashat-vaera",
+                              "en": "Va'era",
+                              "he": "פרשת וארא"
+                            }
+                          ],
+                          "tags": [
+                            "Rabbi Dov Linzer",
+                            "Parashat Va'era",
+                            "Vaera",
+                            "Speech",
+                            "Parashat Vaera",
+                            "Va'era"
+                          ],
+                          "options": []
+                        },
+                        {
+                          "id": 296337,
+                          "title": "#ParshaWisdom - Shemot - Who (or What) Defines Us As a People?",
+                          "summary": "",
+                          "status": "public",
+                          "author": 119559,
+                          "ownerName": "Yeshivat Chovevei Torah",
+                          "ownerImageUrl": "https://storage.googleapis.com/sefaria-profile-pictures/yeshivat-chovevei-torah-1611941333-small.png",
+                          "ownerProfileUrl": "/profile/yeshivat-chovevei-torah",
+                          "ownerOrganization": "",
+                          "sheetUrl": "/sheets/296337",
+                          "views": 2044,
+                          "displayedCollection": "parshawisdom",
+                          "modified": "01/29/2021",
+                          "created": "2021-01-29T13:36:38.161674",
+                          "published": "2021-01-29T13:37:11.022209",
+                          "topics": [
+                            {
+                              "asTyped": "Rabbi Dov Linzer",
+                              "slug": "rabbi-dov-linzer",
+                              "en": "Rabbi Dov Linzer",
+                              "he": ""
+                            },
+                            {
+                              "asTyped": "Shemot",
+                              "slug": "parashat-shemot",
+                              "en": "Shemot",
+                              "he": "פרשת שמות"
+                            },
+                            {
+                              "asTyped": "Peoplehood",
+                              "slug": "peoplehood",
+                              "en": "Peoplehood",
+                              "he": "לאומיות"
+                            },
+                            {
+                              "asTyped": "Parashat Shemot",
+                              "slug": "parashat-shemot",
+                              "en": "Parashat Shemot",
+                              "he": "פרשת שמות"
+                            },
+                            {
+                              "asTyped": "Identity",
+                              "slug": "identity",
+                              "en": "Identity",
+                              "he": "זהות"
+                            }
+                          ],
+                          "tags": [
+                            "Rabbi Dov Linzer",
+                            "Shemot",
+                            "Peoplehood",
+                            "Parashat Shemot",
+                            "Identity"
+                          ],
+                          "options": []
+                        },
+                        {
+                          "id": 296338,
+                          "title": "#ParshaWisdom - Vayechi - Preparing for Our Final Moments",
+                          "summary": "",
+                          "status": "public",
+                          "author": 119559,
+                          "ownerName": "Yeshivat Chovevei Torah",
+                          "ownerImageUrl": "https://storage.googleapis.com/sefaria-profile-pictures/yeshivat-chovevei-torah-1611941333-small.png",
+                          "ownerProfileUrl": "/profile/yeshivat-chovevei-torah",
+                          "ownerOrganization": "",
+                          "sheetUrl": "/sheets/296338",
+                          "views": 1843,
+                          "displayedCollection": "parshawisdom",
+                          "modified": "01/29/2021",
+                          "created": "2021-01-29T13:37:59.153267",
+                          "published": "2021-01-29T13:38:38.394807",
+                          "topics": [
+                            {
+                              "asTyped": "Rabbi Dov Linzer",
+                              "slug": "rabbi-dov-linzer",
+                              "en": "Rabbi Dov Linzer",
+                              "he": ""
+                            },
+                            {
+                              "asTyped": "Burial",
+                              "slug": "burial",
+                              "en": "Burial",
+                              "he": "קבורה"
+                            },
+                            {
+                              "asTyped": "Covid-10",
+                              "slug": "covid-101",
+                              "en": "Covid-10",
+                              "he": ""
+                            },
+                            {
+                              "asTyped": "Vayechi",
+                              "slug": "parashat-vayechi",
+                              "en": "Vayechi",
+                              "he": "פרשת ויחי"
+                            },
+                            {
+                              "asTyped": "Death",
+                              "slug": "death",
+                              "en": "Death",
+                              "he": "מוות"
+                            },
+                            {
+                              "asTyped": "Coronavirus",
+                              "slug": "coronavirus",
+                              "en": "Coronavirus",
+                              "he": "נגיף הקורונה"
+                            },
+                            {
+                              "asTyped": "Parashat Vayechi",
+                              "slug": "parashat-vayechi",
+                              "en": "Parashat Vayechi",
+                              "he": "פרשת ויחי"
+                            }
+                          ],
+                          "tags": [
+                            "Rabbi Dov Linzer",
+                            "Burial",
+                            "Covid-10",
+                            "Vayechi",
+                            "Death",
+                            "Coronavirus",
+                            "Parashat Vayechi"
+                          ],
+                          "options": []
+                        },
+                        {
+                          "id": 296339,
+                          "title": "#ParshaWisdom - Vayigash - The Sound of Silence",
+                          "summary": "",
+                          "status": "public",
+                          "author": 119559,
+                          "ownerName": "Yeshivat Chovevei Torah",
+                          "ownerImageUrl": "https://storage.googleapis.com/sefaria-profile-pictures/yeshivat-chovevei-torah-1611941333-small.png",
+                          "ownerProfileUrl": "/profile/yeshivat-chovevei-torah",
+                          "ownerOrganization": "",
+                          "sheetUrl": "/sheets/296339",
+                          "views": 1641,
+                          "displayedCollection": "parshawisdom",
+                          "modified": "01/29/2021",
+                          "created": "2021-01-29T13:39:30.853868",
+                          "published": "2021-01-29T13:39:59.373834",
+                          "topics": [
+                            {
+                              "asTyped": "Parashat Vayigash",
+                              "slug": "parashat-vayigash",
+                              "en": "Parashat Vayigash",
+                              "he": "פרשת ויגש"
+                            },
+                            {
+                              "asTyped": "Rabbi Dov Linzer",
+                              "slug": "rabbi-dov-linzer",
+                              "en": "Rabbi Dov Linzer",
+                              "he": ""
+                            },
+                            {
+                              "asTyped": "Silence",
+                              "slug": "silence",
+                              "en": "Silence",
+                              "he": "שתיקה"
+                            },
+                            {
+                              "asTyped": "Vayigash",
+                              "slug": "parashat-vayigash",
+                              "en": "Vayigash",
+                              "he": "פרשת ויגש"
+                            },
+                            {
+                              "asTyped": "Speech",
+                              "slug": "speeches1",
+                              "en": "Speech",
+                              "he": "שיחה"
+                            }
+                          ],
+                          "tags": [
+                            "Parashat Vayigash",
+                            "Rabbi Dov Linzer",
+                            "Silence",
+                            "Vayigash",
+                            "Speech"
+                          ],
+                          "options": []
+                        }
+                      ],
+                      "slug": "parshawisdom",
+                      "lastModified": "2022-09-21 11:23:46.510000",
+                      "admins": [
+                        {
+                          "name": "Yeshivat Chovevei Torah",
+                          "profileUrl": "/profile/yeshivat-chovevei-torah",
+                          "imageUrl": "https://storage.googleapis.com/sefaria-profile-pictures/yeshivat-chovevei-torah-1611941333-small.png",
+                          "position": "",
+                          "organization": "",
+                          "isStaff": false,
+                          "uid": 119559
+                        }
+                      ],
+                      "members": [],
+                      "privateSlug": "PHnC3HdE",
+                      "description": null,
+                      "websiteUrl": "https://www.youtube.com/hashtag/parshawisdom",
+                      "headerUrl": null,
+                      "imageUrl": "https://storage.googleapis.com/sefaria-collection-images/92f1e7c9-d695-406f-b699-0e08f298d69c.png",
+                      "listed": true,
+                      "invitations": [],
+                      "pinnedSheets": [],
+                      "pinnedTags": []
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        }
+      }
+    },
+    "/api/collections/user-collections/{user_id}": {
+      "summary": "User's Collections",
+      "description": "Returns the collections that a specific user owns or belongs to.",
+      "get": {
+        "operationId": "get-user-collections",
+        "tags": [
+          "Collections"
+        ],
+        "parameters": [
+          {
+            "name": "user_id",
+            "description": "The numeric Sefaria user ID. To find a user_id, open the user's profile page (e.g. `https://voices.sefaria.org/profile/user-slug`), then call `GET /api/profile/{slug}` with the slug from the URL — the response contains the numeric `id`.",
+            "schema": {
+              "type": "integer"
+            },
+            "in": "path",
+            "required": true
+          }
+        ],
+        "description": "Returns the collections that a specific user owns or belongs to.",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CollectionSummaryJSON"
+                  }
+                },
+                "examples": {
+                  "User 1's collections": {
+                    "value": [
+                      {
+                        "name": "Tutorials for Educators",
+                        "slug": "tutorials-for-educators",
+                        "description": "Step-by-step instructions for Sefaria's special features",
+                        "imageUrl": "https://storage.googleapis.com/sefaria-collection-images/9e4b901f-22f6-46ea-8772-12a6369e403f.png",
+                        "headerUrl": "http://i.imgur.com/6FE29wK.png",
+                        "memberCount": 8,
+                        "sheetCount": 4,
+                        "lastModified": "2025-04-27 02:55:15.711000",
+                        "listed": true,
+                        "membership": "admin"
+                      },
+                      {
+                        "name": "Romemu, NYC",
+                        "slug": "romemu-nyc",
+                        "description": "",
+                        "imageUrl": "https://www.romemu.org/wp-content/themes/romemu/icons/apple-touch-icon-144-precomposed.png",
+                        "headerUrl": "https://storage.googleapis.com/sefaria-collection-images/c977b440-6db5-47bf-96a2-675f4578dc93.png",
+                        "memberCount": 6,
+                        "sheetCount": 97,
+                        "lastModified": "2025-02-04 14:54:07.540000",
+                        "listed": true,
+                        "membership": "admin"
+                      },
+                      {
+                        "name": "Moishe House",
+                        "slug": "moishe-house",
+                        "description": "Moishe House provides vibrant Jewish community for young adults by supporting leaders in their 20s as they create meaningful home-based Jewish experiences for themselves and their peers.We envision Moishe House as the global leader of pluralistic Jewish life for adults in their 20s. We facilitate a wide range of experiences, so that they have the leadership, knowledge and community to enrich their Jewish journeys.\n\nIn this Sefaria group, you will find great Jewish content by Moishe House people, for Moishe House people and beyond!",
+                        "imageUrl": "https://storage.googleapis.com/sefaria-collection-images/dcee305d-be70-496b-985f-2015fa86f343.png",
+                        "headerUrl": "https://storage.googleapis.com/sefaria-collection-images/63c90022-11f6-4882-8884-3b1fda8396dc.jpg",
+                        "memberCount": 36,
+                        "sheetCount": 156,
+                        "lastModified": "2024-03-19 16:33:04.611000",
+                        "listed": true,
+                        "membership": "member"
+                      },
+                      {
+                        "name": "Limmud Festival 2019",
+                        "slug": "limmud-festival-2019",
+                        "description": "Welcome to the Limmud Festival Sefaria group! And for those of you joining us from Birmingham, welcome to Festival!\n\nHere you can find source sheets from sessions happening across Festival. Please feel free to use them to follow along in sessions - or alternatively, you can use them to learn at your leisure if you weren't able to catch the session in person.\n\nThe Limmud Beit Midrash will be open from 13:30 - 15:30 from Monday - Wednesday for open learning, which would be a great time to use this group. Come and learn!\n",
+                        "imageUrl": "https://storage.googleapis.com/sefaria-collection-images/bb2034df-8f3c-47e4-8c79-7c1b00041154.png",
+                        "headerUrl": "https://storage.googleapis.com/sefaria-collection-images/cb3b35cf-bb8c-45aa-bfff-f18630728fa7.jpg",
+                        "memberCount": 22,
+                        "sheetCount": 18,
+                        "lastModified": "2022-10-24 02:31:28.938000",
+                        "listed": true,
+                        "membership": "admin"
+                      },
+                      {
+                        "name": "The Fours of Passover",
+                        "slug": "the-fours-of-passover",
+                        "description": "Source sheets exploring things that come in fours during Passover, chosen by Sefaria co-founder and CTO Brett Lockspeiser. --- \"I've always been fascinated and puzzled by the repetition of this number in the seder. As I started to dig through public sources sheets on the topic, I found that there were even more fours than I knew.\"  \n\n",
+                        "imageUrl": "https://storage.googleapis.com/sefaria-collection-images/8477b71f-0759-473d-8cac-80e88c40f1ca.png",
+                        "headerUrl": null,
+                        "memberCount": 1,
+                        "sheetCount": 11,
+                        "lastModified": "2022-09-21 11:23:46.817000",
+                        "listed": true,
+                        "membership": "admin"
+                      },
+                      {
+                        "name": "Torah by the Colors",
+                        "slug": "torah-by-the-colors",
+                        "description": "Exploring the usage of color words in Torah. ",
+                        "imageUrl": "https://storage.googleapis.com/sefaria-collection-images/96defb01-8f23-4ae2-9cf3-274d57b1a62c.jpeg",
+                        "headerUrl": "https://storage.googleapis.com/sefaria-collection-images/c79018e9-ec0d-4ec3-9d1e-54b879bfc15f.jpeg",
+                        "memberCount": 2,
+                        "sheetCount": 7,
+                        "lastModified": "2022-09-21 11:23:37.211000",
+                        "listed": true,
+                        "membership": "admin"
+                      },
+                      {
+                        "name": "Pedagogy on Sefaria: Exemplary Lesson Plans",
+                        "slug": "pedagogy-on-sefaria-exemplary-lesson-plans",
+                        "description": "Sefaria's education team curates sample lessons that showcase innovative ways to leverage Sefaria's technology in the classroom. Our goal is to cultivate a constructivist approach to education in the Judaic studies classroom, and to explore the ways in which new digital tools can enhance learning.",
+                        "imageUrl": "https://storage.googleapis.com/sefaria-collection-images/4de50850-de8b-4fa3-946a-f144fe29b3bb.png",
+                        "headerUrl": "https://storage.googleapis.com/sefaria-collection-images/14ec39fb-8299-45e1-84d9-fcf153182d39.png",
+                        "memberCount": 8,
+                        "sheetCount": 17,
+                        "lastModified": "2022-09-21 11:23:36.925000",
+                        "listed": true,
+                        "membership": "member"
+                      },
+                      {
+                        "name": "Sefaria Stats",
+                        "slug": "sefaria-stats",
+                        "description": "Source Sheets created algorithmically by looking at usages patterns across Sefaria users.",
+                        "imageUrl": "https://storage.googleapis.com/sefaria-collection-images/e3404697-f0f5-4b74-9066-8c69496fb618.jpg",
+                        "headerUrl": null,
+                        "memberCount": 2,
+                        "sheetCount": 5,
+                        "lastModified": "2022-09-21 11:23:34.744000",
+                        "listed": true,
+                        "membership": "admin"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        }
+      }
+    },
+    "/api/bulktext/{refs}": {
+      "summary": "Bulk Text",
+      "description": "Returns the English and Hebrew text plus version metadata for many refs at once. The path parameter is a pipe-delimited list of refs.",
+      "get": {
+        "operationId": "get-bulktext",
+        "tags": [
+          "Text"
+        ],
+        "parameters": [
+          {
+            "name": "refs",
+            "description": "Pipe-delimited list of Sefaria refs, e.g. `Genesis.1.1|Exodus.1.1`. Use dots for section separators.",
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "required": true
+          }
+        ],
+        "description": "Returns the English and Hebrew text plus version metadata for many refs at once. The path parameter is a pipe-delimited list of refs.",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BulktextJSON"
+                },
+                "examples": {
+                  "Genesis 1:1 and Exodus 1:1": {
+                    "value": {
+                      "Exodus.1.1": {
+                        "he": "וְאֵ֗לֶּה שְׁמוֹת֙ בְּנֵ֣י יִשְׂרָאֵ֔ל הַבָּאִ֖ים מִצְרָ֑יְמָה אֵ֣ת יַעֲקֹ֔ב אִ֥ישׁ וּבֵית֖וֹ בָּֽאוּ׃",
+                        "en": "These are the names of the sons of Israel who came to Egypt with Jacob, each coming with his household: ",
+                        "lang": "en",
+                        "ref": "Exodus 1:1",
+                        "heRef": "שמות א׳:א׳",
+                        "url": "Exodus.1.1"
+                      },
+                      "Genesis.1.1": {
+                        "he": "<big>בְּ</big>רֵאשִׁ֖ית בָּרָ֣א אֱלֹהִ֑ים אֵ֥ת הַשָּׁמַ֖יִם וְאֵ֥ת הָאָֽרֶץ׃",
+                        "en": "When God began to create<sup class=\"footnote-marker\">a</sup><i class=\"footnote\"><b>When God began to create </b>In contrast to others “In the beginning God created.”</i> heaven and earth— ",
+                        "lang": "en",
+                        "ref": "Genesis 1:1",
+                        "heRef": "בראשית א׳:א׳",
+                        "url": "Genesis.1.1"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        }
+      }
+    },
+    "/api/passages/{refs}": {
+      "summary": "Passages",
+      "description": "Maps each requested ref to the canonical passage that contains it (e.g. a single verse mapped to its three-verse parasha-style passage).",
+      "get": {
+        "operationId": "get-passages",
+        "tags": [
+          "Text"
+        ],
+        "parameters": [
+          {
+            "name": "refs",
+            "description": "Pipe-delimited list of Sefaria refs, e.g. `Genesis.1.1`.",
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "required": true
+          }
+        ],
+        "description": "Maps each requested ref to the canonical passage that contains it (e.g. a single verse mapped to its three-verse parasha-style passage).",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PassagesJSON"
+                },
+                "examples": {
+                  "Genesis 1:1": {
+                    "value": {
+                      "Genesis.1.1": "Genesis 1:1-3"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        }
+      }
+    },
+    "/api/index/titles": {
+      "summary": "Index Titles",
+      "description": "Returns the complete list of recognized title strings on Sefaria, including alternate titles and abbreviations. Useful for client-side autocomplete and ref recognition. Note: this response is multiple megabytes.",
+      "get": {
+        "operationId": "get-index-titles",
+        "tags": [
+          "Index"
+        ],
+        "description": "Returns the complete list of recognized title strings on Sefaria, including alternate titles and abbreviations. Useful for client-side autocomplete and ref recognition. Note: this response is multiple megabytes.",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IndexTitlesJSON"
+                },
+                "examples": {
+                  "First 10 titles": {
+                    "value": {
+                      "books": [
+                        "Bereshit",
+                        "Gen",
+                        "Gen.",
+                        "Breishit",
+                        "Bereishit",
+                        "Beresheet",
+                        "Bereshith",
+                        "Bereishis",
+                        "B’resh.",
+                        "B’reshith"
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        }
+      }
+    },
+    "/api/index/{title}": {
+      "summary": "Index Metadata",
+      "description": "Returns metadata for a single index (work) by title — categories, schema (text structure), authors, descriptive copy, and ordering hints.",
+      "get": {
+        "operationId": "get-index-by-title",
+        "tags": [
+          "Index"
+        ],
+        "parameters": [
+          {
+            "name": "title",
+            "description": "The index title, e.g. `Genesis`. Use the canonical English title; check `GET /api/index/titles` for valid values.",
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "required": true
+          }
+        ],
+        "description": "Returns metadata for a single index (work) by title — categories, schema (text structure), authors, descriptive copy, and ordering hints.",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IndexJSON"
+                },
+                "examples": {
+                  "Genesis": {
+                    "value": {
+                      "title": "Genesis",
+                      "categories": [
+                        "Tanakh",
+                        "Torah"
+                      ],
+                      "schema": {
+                        "nodeType": "JaggedArrayNode",
+                        "depth": 2,
+                        "addressTypes": [
+                          "Perek",
+                          "Pasuk"
+                        ],
+                        "sectionNames": [
+                          "Chapter",
+                          "Verse"
+                        ],
+                        "match_templates": [
+                          {
+                            "term_slugs": [
+                              "sefer",
+                              "genesis"
+                            ]
+                          },
+                          {
+                            "term_slugs": [
+                              "torah",
+                              "genesis"
+                            ]
+                          },
+                          {
+                            "term_slugs": [
+                              "torah",
+                              "sefer",
+                              "genesis"
+                            ]
+                          },
+                          {
+                            "term_slugs": [
+                              "genesis"
+                            ]
+                          }
+                        ],
+                        "lengths": [
+                          50,
+                          1533
+                        ],
+                        "titles": [
+                          {
+                            "text": "Bereshit",
+                            "lang": "en"
+                          },
+                          {
+                            "text": "Gen",
+                            "lang": "en"
+                          },
+                          {
+                            "text": "Gen.",
+                            "lang": "en"
+                          },
+                          {
+                            "text": "Breishit",
+                            "lang": "en"
+                          },
+                          {
+                            "text": "Bereishit",
+                            "lang": "en"
+                          },
+                          {
+                            "text": "Beresheet",
+                            "lang": "en"
+                          },
+                          {
+                            "text": "Bereshith",
+                            "lang": "en"
+                          },
+                          {
+                            "text": "Bereishis",
+                            "lang": "en"
+                          },
+                          {
+                            "text": "B’resh.",
+                            "lang": "en"
+                          },
+                          {
+                            "text": "B’reshith",
+                            "lang": "en"
+                          },
+                          {
+                            "text": "Genèse",
+                            "lang": "en"
+                          },
+                          {
+                            "text": "Beresheit",
+                            "lang": "en"
+                          },
+                          {
+                            "text": "ברא'",
+                            "lang": "he"
+                          },
+                          {
+                            "text": "בר'",
+                            "lang": "he"
+                          },
+                          {
+                            "text": "בר׳",
+                            "lang": "he"
+                          },
+                          {
+                            "text": "ברא׳",
+                            "lang": "he"
+                          },
+                          {
+                            "text": "בְּרֵאשִׁית",
+                            "lang": "he"
+                          },
+                          {
+                            "text": "בראשית",
+                            "lang": "he",
+                            "primary": true
+                          },
+                          {
+                            "text": "Genesis",
+                            "lang": "en",
+                            "primary": true
+                          }
+                        ],
+                        "title": "Genesis",
+                        "heTitle": "בראשית",
+                        "heSectionNames": [
+                          "פרק",
+                          "פסוק"
+                        ],
+                        "key": "Genesis"
+                      },
+                      "order": [
+                        1,
+                        1
+                      ],
+                      "authors": [],
+                      "enDesc": "Genesis (“Bereshit”) is the first book of the Torah, Judaism’s foundational text, and the only one consisting almost entirely of stories, with just three explicit laws. It tells of the origins of mankind and the Israelites, with stories on creation, Adam and Eve, Noah’s ark, the patriarchs and matriarchs - Abraham and Sarah, Isaac and Rebecca, Jacob, Leah and Rachel - and Joseph and his brothers. Its narratives depict figures as they encounter God, face wandering and exile, and grapple with conflict in family relationships",
+                      "heDesc": "ספר בראשית הוא הספר הראשון בחמשת חומשי התורה והיחיד הכולל כמעט אך ורק סיפורים - ורק שלושה חוקים מפורשים. הוא מספר על תולדות האדם ועם ישראל בסיפורי הבריאה, אדם חוה, תיבת נח, האבות והאימהות - אברהם ושרה, יצחק ורבקה, יעקב, רחל ולאה ויוסף ואחיו. עלילותיו מתארות דמויות המתעמתות עם אלוהים ומתמודדות עם אתגרי גלות ונדודים ועם מאבקים פנים-משפחתיים.",
+                      "enShortDesc": "Creation, the beginning of mankind, and stories of the patriarchs and matriarchs.",
+                      "heShortDesc": "בריאת העולם, תחילתה של האנושות וסיפורי האבות והאמהות.",
+                      "pubDate": [
+                        1488
+                      ],
+                      "hasErrorMargin": true,
+                      "compDate": [
+                        -1400,
+                        -400
+                      ],
+                      "compPlace": "Sinai/Canaan",
+                      "pubPlace": "Soncino",
+                      "is_cited": true,
+                      "corpora": [
+                        "Tanakh"
+                      ],
+                      "heTitle": "בראשית",
+                      "titleVariants": [
+                        "Bereshit",
+                        "Gen",
+                        "Gen.",
+                        "Breishit",
+                        "Bereishit",
+                        "Beresheet",
+                        "Bereshith",
+                        "Bereishis",
+                        "B’resh.",
+                        "B’reshith",
+                        "Genèse",
+                        "Beresheit",
+                        "Genesis"
+                      ],
+                      "heTitleVariants": [
+                        "ברא'",
+                        "בר'",
+                        "בר׳",
+                        "ברא׳",
+                        "בְּרֵאשִׁית",
+                        "בראשית"
+                      ],
+                      "alts": {
+                        "Parasha": {
+                          "nodes": [
+                            {
+                              "nodeType": "ArrayMapNode",
+                              "depth": 1,
+                              "wholeRef": "Genesis 1:1-6:8",
+                              "addressTypes": [
+                                "Aliyah"
+                              ],
+                              "sectionNames": [
+                                "Aliyah"
+                              ],
+                              "refs": [
+                                "Genesis 1:1-2:3",
+                                "Genesis 2:4-2:19",
+                                "Genesis 2:20-3:21",
+                                "Genesis 3:22-4:18",
+                                "Genesis 4:19-4:22",
+                                "Genesis 4:23-5:24",
+                                "Genesis 5:25-6:8"
+                              ],
+                              "match_templates": [
+                                {
+                                  "term_slugs": [
+                                    "parasha",
+                                    "bereshit"
+                                  ],
+                                  "scope": "any"
+                                },
+                                {
+                                  "term_slugs": [
+                                    "bereshit"
+                                  ],
+                                  "scope": "any"
+                                }
+                              ],
+                              "isMapReferenceable": false,
+                              "sharedTitle": "Bereshit",
+                              "titles": [
+                                {
+                                  "primary": true,
+                                  "text": "Bereshit",
+                                  "lang": "en"
+                                },
+                                {
+                                  "primary": true,
+                                  "text": "בראשית",
+                                  "lang": "he"
+                                },
+                                {
+                                  "text": "Parashat Bereshit",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "פרשת בראשית",
+                                  "lang": "he"
+                                },
+                                {
+                                  "text": "Parashat Bereishit",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "Parashat Genesis",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "Genesis",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "Bereishit",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "Breishit",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "Bereshis",
+                                  "lang": "en"
+                                }
+                              ],
+                              "title": "Bereshit",
+                              "heTitle": "בראשית"
+                            },
+                            {
+                              "nodeType": "ArrayMapNode",
+                              "depth": 1,
+                              "wholeRef": "Genesis 6:9-11:32",
+                              "addressTypes": [
+                                "Aliyah"
+                              ],
+                              "sectionNames": [
+                                "Aliyah"
+                              ],
+                              "refs": [
+                                "Genesis 6:9-6:22",
+                                "Genesis 7:1-7:16",
+                                "Genesis 7:17-8:14",
+                                "Genesis 8:15-9:7",
+                                "Genesis 9:8-9:17",
+                                "Genesis 9:18-10:32",
+                                "Genesis 11:1-11:32"
+                              ],
+                              "match_templates": [
+                                {
+                                  "term_slugs": [
+                                    "parasha",
+                                    "noach"
+                                  ],
+                                  "scope": "any"
+                                },
+                                {
+                                  "term_slugs": [
+                                    "noach"
+                                  ],
+                                  "scope": "any"
+                                }
+                              ],
+                              "isMapReferenceable": false,
+                              "sharedTitle": "Noach",
+                              "titles": [
+                                {
+                                  "primary": true,
+                                  "text": "Noach",
+                                  "lang": "en"
+                                },
+                                {
+                                  "primary": true,
+                                  "text": "נח",
+                                  "lang": "he"
+                                },
+                                {
+                                  "text": "Parashat Noach",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "פרשת נח",
+                                  "lang": "he"
+                                },
+                                {
+                                  "text": "Noah",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "Parshat Noah",
+                                  "lang": "en"
+                                }
+                              ],
+                              "title": "Noach",
+                              "heTitle": "נח"
+                            },
+                            {
+                              "nodeType": "ArrayMapNode",
+                              "depth": 1,
+                              "wholeRef": "Genesis 12:1-17:27",
+                              "addressTypes": [
+                                "Aliyah"
+                              ],
+                              "sectionNames": [
+                                "Aliyah"
+                              ],
+                              "refs": [
+                                "Genesis 12:1-12:13",
+                                "Genesis 12:14-13:4",
+                                "Genesis 13:5-13:18",
+                                "Genesis 14:1-14:20",
+                                "Genesis 14:21-15:6",
+                                "Genesis 15:7-17:6",
+                                "Genesis 17:7-17:27"
+                              ],
+                              "match_templates": [
+                                {
+                                  "term_slugs": [
+                                    "parasha",
+                                    "lech-lecha"
+                                  ],
+                                  "scope": "any"
+                                },
+                                {
+                                  "term_slugs": [
+                                    "lech-lecha"
+                                  ],
+                                  "scope": "any"
+                                }
+                              ],
+                              "isMapReferenceable": false,
+                              "sharedTitle": "Lech Lecha",
+                              "titles": [
+                                {
+                                  "primary": true,
+                                  "text": "Lech Lecha",
+                                  "lang": "en"
+                                },
+                                {
+                                  "primary": true,
+                                  "text": "לך לך",
+                                  "lang": "he"
+                                },
+                                {
+                                  "text": "Parashat Lech Lecha",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "פרשת לך לך",
+                                  "lang": "he"
+                                },
+                                {
+                                  "text": "Parashat Lekh Lekha",
+                                  "lang": "en"
+                                }
+                              ],
+                              "title": "Lech Lecha",
+                              "heTitle": "לך לך"
+                            },
+                            {
+                              "nodeType": "ArrayMapNode",
+                              "depth": 1,
+                              "wholeRef": "Genesis 18:1-22:24",
+                              "addressTypes": [
+                                "Aliyah"
+                              ],
+                              "sectionNames": [
+                                "Aliyah"
+                              ],
+                              "refs": [
+                                "Genesis 18:1-18:14",
+                                "Genesis 18:15-18:33",
+                                "Genesis 19:1-19:20",
+                                "Genesis 19:21-21:4",
+                                "Genesis 21:5-21:21",
+                                "Genesis 21:22-21:34",
+                                "Genesis 22:1-22:24"
+                              ],
+                              "match_templates": [
+                                {
+                                  "term_slugs": [
+                                    "parasha",
+                                    "vayera"
+                                  ],
+                                  "scope": "any"
+                                },
+                                {
+                                  "term_slugs": [
+                                    "vayera"
+                                  ],
+                                  "scope": "any"
+                                }
+                              ],
+                              "isMapReferenceable": false,
+                              "sharedTitle": "Vayera",
+                              "titles": [
+                                {
+                                  "primary": true,
+                                  "text": "Vayera",
+                                  "lang": "en"
+                                },
+                                {
+                                  "primary": true,
+                                  "text": "וירא",
+                                  "lang": "he"
+                                },
+                                {
+                                  "text": "Parashat Vayera",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "פרשת וירא",
+                                  "lang": "he"
+                                },
+                                {
+                                  "text": "Parashat Vayeira",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "Parshat Vayera",
+                                  "lang": "en"
+                                }
+                              ],
+                              "title": "Vayera",
+                              "heTitle": "וירא"
+                            },
+                            {
+                              "nodeType": "ArrayMapNode",
+                              "depth": 1,
+                              "wholeRef": "Genesis 23:1-25:18",
+                              "addressTypes": [
+                                "Aliyah"
+                              ],
+                              "sectionNames": [
+                                "Aliyah"
+                              ],
+                              "refs": [
+                                "Genesis 23:1-23:16",
+                                "Genesis 23:17-24:9",
+                                "Genesis 24:10-24:26",
+                                "Genesis 24:27-24:52",
+                                "Genesis 24:53-24:67",
+                                "Genesis 25:1-25:11",
+                                "Genesis 25:12-25:18"
+                              ],
+                              "match_templates": [
+                                {
+                                  "term_slugs": [
+                                    "parasha",
+                                    "chayei-sara"
+                                  ],
+                                  "scope": "any"
+                                },
+                                {
+                                  "term_slugs": [
+                                    "chayei-sara"
+                                  ],
+                                  "scope": "any"
+                                }
+                              ],
+                              "isMapReferenceable": false,
+                              "sharedTitle": "Chayei Sara",
+                              "titles": [
+                                {
+                                  "primary": true,
+                                  "text": "Chayei Sara",
+                                  "lang": "en"
+                                },
+                                {
+                                  "primary": true,
+                                  "text": "חיי שרה",
+                                  "lang": "he"
+                                },
+                                {
+                                  "text": "Parashat Chayei Sara",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "פרשת חיי שרה",
+                                  "lang": "he"
+                                },
+                                {
+                                  "text": "Parashat Chayei Sarah",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "Parashat Chaye Sarah",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "Parshat Chayei Sarah",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "Chayei Sarah",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "Hayei Sarah",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "Hayye Sarah",
+                                  "lang": "en"
+                                }
+                              ],
+                              "title": "Chayei Sara",
+                              "heTitle": "חיי שרה"
+                            },
+                            {
+                              "nodeType": "ArrayMapNode",
+                              "depth": 1,
+                              "wholeRef": "Genesis 25:19-28:9",
+                              "addressTypes": [
+                                "Aliyah"
+                              ],
+                              "sectionNames": [
+                                "Aliyah"
+                              ],
+                              "refs": [
+                                "Genesis 25:19-26:5",
+                                "Genesis 26:6-26:12",
+                                "Genesis 26:13-26:22",
+                                "Genesis 26:23-26:29",
+                                "Genesis 26:30-27:27",
+                                "Genesis 27:28-28:4",
+                                "Genesis 28:5-28:9"
+                              ],
+                              "match_templates": [
+                                {
+                                  "term_slugs": [
+                                    "parasha",
+                                    "toldot"
+                                  ],
+                                  "scope": "any"
+                                },
+                                {
+                                  "term_slugs": [
+                                    "toldot"
+                                  ],
+                                  "scope": "any"
+                                }
+                              ],
+                              "isMapReferenceable": false,
+                              "sharedTitle": "Toldot",
+                              "titles": [
+                                {
+                                  "primary": true,
+                                  "text": "Toldot",
+                                  "lang": "en"
+                                },
+                                {
+                                  "primary": true,
+                                  "text": "תולדות",
+                                  "lang": "he"
+                                },
+                                {
+                                  "text": "Parashat Toldot",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "פרשת תולדות",
+                                  "lang": "he"
+                                },
+                                {
+                                  "text": "Parashat Toledot",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "Parshat Toledot",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "Toldos",
+                                  "lang": "en"
+                                }
+                              ],
+                              "title": "Toldot",
+                              "heTitle": "תולדות"
+                            },
+                            {
+                              "nodeType": "ArrayMapNode",
+                              "depth": 1,
+                              "wholeRef": "Genesis 28:10-32:3",
+                              "addressTypes": [
+                                "Aliyah"
+                              ],
+                              "sectionNames": [
+                                "Aliyah"
+                              ],
+                              "refs": [
+                                "Genesis 28:10-28:22",
+                                "Genesis 29:1-29:17",
+                                "Genesis 29:18-30:13",
+                                "Genesis 30:14-30:27",
+                                "Genesis 30:28-31:16",
+                                "Genesis 31:17-31:42",
+                                "Genesis 31:43-32:3"
+                              ],
+                              "match_templates": [
+                                {
+                                  "term_slugs": [
+                                    "parasha",
+                                    "vayetzei"
+                                  ],
+                                  "scope": "any"
+                                },
+                                {
+                                  "term_slugs": [
+                                    "vayetzei"
+                                  ],
+                                  "scope": "any"
+                                }
+                              ],
+                              "isMapReferenceable": false,
+                              "sharedTitle": "Vayetzei",
+                              "titles": [
+                                {
+                                  "primary": true,
+                                  "text": "Vayetzei",
+                                  "lang": "en"
+                                },
+                                {
+                                  "primary": true,
+                                  "text": "ויצא",
+                                  "lang": "he"
+                                },
+                                {
+                                  "text": "Parashat Vayetzei",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "פרשת ויצא",
+                                  "lang": "he"
+                                },
+                                {
+                                  "text": "Parashat Vayeitzey",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "Vayetze",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "Parashat Vayetze",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "Parashat Vayetzey",
+                                  "lang": "en"
+                                }
+                              ],
+                              "title": "Vayetzei",
+                              "heTitle": "ויצא"
+                            },
+                            {
+                              "nodeType": "ArrayMapNode",
+                              "depth": 1,
+                              "wholeRef": "Genesis 32:4-36:43",
+                              "addressTypes": [
+                                "Aliyah"
+                              ],
+                              "sectionNames": [
+                                "Aliyah"
+                              ],
+                              "refs": [
+                                "Genesis 32:4-32:13",
+                                "Genesis 32:14-32:30",
+                                "Genesis 32:31-33:5",
+                                "Genesis 33:6-33:20",
+                                "Genesis 34:1-35:11",
+                                "Genesis 35:12-36:19",
+                                "Genesis 36:20-36:43"
+                              ],
+                              "match_templates": [
+                                {
+                                  "term_slugs": [
+                                    "parasha",
+                                    "vayishlach"
+                                  ],
+                                  "scope": "any"
+                                },
+                                {
+                                  "term_slugs": [
+                                    "vayishlach"
+                                  ],
+                                  "scope": "any"
+                                }
+                              ],
+                              "isMapReferenceable": false,
+                              "sharedTitle": "Vayishlach",
+                              "titles": [
+                                {
+                                  "primary": true,
+                                  "text": "Vayishlach",
+                                  "lang": "en"
+                                },
+                                {
+                                  "primary": true,
+                                  "text": "וישלח",
+                                  "lang": "he"
+                                },
+                                {
+                                  "text": "Parashat Vayishlach",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "פרשת וישלח",
+                                  "lang": "he"
+                                }
+                              ],
+                              "title": "Vayishlach",
+                              "heTitle": "וישלח"
+                            },
+                            {
+                              "nodeType": "ArrayMapNode",
+                              "depth": 1,
+                              "wholeRef": "Genesis 37:1-40:23",
+                              "addressTypes": [
+                                "Aliyah"
+                              ],
+                              "sectionNames": [
+                                "Aliyah"
+                              ],
+                              "refs": [
+                                "Genesis 37:1-37:11",
+                                "Genesis 37:12-37:22",
+                                "Genesis 37:23-37:36",
+                                "Genesis 38:1-38:30",
+                                "Genesis 39:1-39:6",
+                                "Genesis 39:7-39:23",
+                                "Genesis 40:1-40:23"
+                              ],
+                              "match_templates": [
+                                {
+                                  "term_slugs": [
+                                    "parasha",
+                                    "vayeshev"
+                                  ],
+                                  "scope": "any"
+                                },
+                                {
+                                  "term_slugs": [
+                                    "vayeshev"
+                                  ],
+                                  "scope": "any"
+                                }
+                              ],
+                              "isMapReferenceable": false,
+                              "sharedTitle": "Vayeshev",
+                              "titles": [
+                                {
+                                  "primary": true,
+                                  "text": "Vayeshev",
+                                  "lang": "en"
+                                },
+                                {
+                                  "primary": true,
+                                  "text": "וישב",
+                                  "lang": "he"
+                                },
+                                {
+                                  "text": "Parashat Vayeshev",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "פרשת וישב",
+                                  "lang": "he"
+                                },
+                                {
+                                  "text": "Parashat Veyeshev",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "Parshat Vayeshev",
+                                  "lang": "en"
+                                }
+                              ],
+                              "title": "Vayeshev",
+                              "heTitle": "וישב"
+                            },
+                            {
+                              "nodeType": "ArrayMapNode",
+                              "depth": 1,
+                              "wholeRef": "Genesis 41:1-44:17",
+                              "addressTypes": [
+                                "Aliyah"
+                              ],
+                              "sectionNames": [
+                                "Aliyah"
+                              ],
+                              "refs": [
+                                "Genesis 41:1-41:14",
+                                "Genesis 41:15-41:38",
+                                "Genesis 41:39-41:52",
+                                "Genesis 41:53-42:18",
+                                "Genesis 42:19-43:15",
+                                "Genesis 43:16-43:29",
+                                "Genesis 43:30-44:17"
+                              ],
+                              "match_templates": [
+                                {
+                                  "term_slugs": [
+                                    "parasha",
+                                    "miketz"
+                                  ],
+                                  "scope": "any"
+                                },
+                                {
+                                  "term_slugs": [
+                                    "miketz"
+                                  ],
+                                  "scope": "any"
+                                }
+                              ],
+                              "isMapReferenceable": false,
+                              "sharedTitle": "Miketz",
+                              "titles": [
+                                {
+                                  "primary": true,
+                                  "text": "Miketz",
+                                  "lang": "en"
+                                },
+                                {
+                                  "primary": true,
+                                  "text": "מקץ",
+                                  "lang": "he"
+                                },
+                                {
+                                  "text": "Parashat Miketz",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "פרשת מקץ",
+                                  "lang": "he"
+                                }
+                              ],
+                              "title": "Miketz",
+                              "heTitle": "מקץ"
+                            },
+                            {
+                              "nodeType": "ArrayMapNode",
+                              "depth": 1,
+                              "wholeRef": "Genesis 44:18-47:27",
+                              "addressTypes": [
+                                "Aliyah"
+                              ],
+                              "sectionNames": [
+                                "Aliyah"
+                              ],
+                              "refs": [
+                                "Genesis 44:18-44:30",
+                                "Genesis 44:31-45:7",
+                                "Genesis 45:8-45:18",
+                                "Genesis 45:19-45:27",
+                                "Genesis 45:28-46:27",
+                                "Genesis 46:28-47:10",
+                                "Genesis 47:11-47:27"
+                              ],
+                              "match_templates": [
+                                {
+                                  "term_slugs": [
+                                    "parasha",
+                                    "vayigash"
+                                  ],
+                                  "scope": "any"
+                                },
+                                {
+                                  "term_slugs": [
+                                    "vayigash"
+                                  ],
+                                  "scope": "any"
+                                }
+                              ],
+                              "isMapReferenceable": false,
+                              "sharedTitle": "Vayigash",
+                              "titles": [
+                                {
+                                  "primary": true,
+                                  "text": "Vayigash",
+                                  "lang": "en"
+                                },
+                                {
+                                  "primary": true,
+                                  "text": "ויגש",
+                                  "lang": "he"
+                                },
+                                {
+                                  "text": "Parashat Vayigash",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "פרשת ויגש",
+                                  "lang": "he"
+                                }
+                              ],
+                              "title": "Vayigash",
+                              "heTitle": "ויגש"
+                            },
+                            {
+                              "nodeType": "ArrayMapNode",
+                              "depth": 1,
+                              "wholeRef": "Genesis 47:28-50:26",
+                              "addressTypes": [
+                                "Aliyah"
+                              ],
+                              "sectionNames": [
+                                "Aliyah"
+                              ],
+                              "refs": [
+                                "Genesis 47:28-48:9",
+                                "Genesis 48:10-48:16",
+                                "Genesis 48:17-48:22",
+                                "Genesis 49:1-49:18",
+                                "Genesis 49:19-49:26",
+                                "Genesis 49:27-50:20",
+                                "Genesis 50:21-50:26"
+                              ],
+                              "match_templates": [
+                                {
+                                  "term_slugs": [
+                                    "parasha",
+                                    "vayechi"
+                                  ],
+                                  "scope": "any"
+                                },
+                                {
+                                  "term_slugs": [
+                                    "vayechi"
+                                  ],
+                                  "scope": "any"
+                                }
+                              ],
+                              "isMapReferenceable": false,
+                              "sharedTitle": "Vayechi",
+                              "titles": [
+                                {
+                                  "primary": true,
+                                  "text": "Vayechi",
+                                  "lang": "en"
+                                },
+                                {
+                                  "primary": true,
+                                  "text": "ויחי",
+                                  "lang": "he"
+                                },
+                                {
+                                  "text": "Parashat Vayechi",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "פרשת ויחי",
+                                  "lang": "he"
+                                },
+                                {
+                                  "text": "Parashat Vayehi",
+                                  "lang": "en"
+                                }
+                              ],
+                              "title": "Vayechi",
+                              "heTitle": "ויחי"
+                            }
+                          ],
+                          "titles": [
+                            {
+                              "text": "Bereshit",
+                              "lang": "en"
+                            },
+                            {
+                              "text": "Gen",
+                              "lang": "en"
+                            },
+                            {
+                              "text": "Gen.",
+                              "lang": "en"
+                            },
+                            {
+                              "text": "Breishit",
+                              "lang": "en"
+                            },
+                            {
+                              "text": "Bereishit",
+                              "lang": "en"
+                            },
+                            {
+                              "text": "Beresheet",
+                              "lang": "en"
+                            },
+                            {
+                              "text": "Bereshith",
+                              "lang": "en"
+                            },
+                            {
+                              "text": "Bereishis",
+                              "lang": "en"
+                            },
+                            {
+                              "text": "B’resh.",
+                              "lang": "en"
+                            },
+                            {
+                              "text": "B’reshith",
+                              "lang": "en"
+                            },
+                            {
+                              "text": "Genèse",
+                              "lang": "en"
+                            },
+                            {
+                              "text": "Beresheit",
+                              "lang": "en"
+                            },
+                            {
+                              "text": "ברא'",
+                              "lang": "he"
+                            },
+                            {
+                              "text": "בר'",
+                              "lang": "he"
+                            },
+                            {
+                              "text": "בר׳",
+                              "lang": "he"
+                            },
+                            {
+                              "text": "ברא׳",
+                              "lang": "he"
+                            },
+                            {
+                              "text": "בְּרֵאשִׁית",
+                              "lang": "he"
+                            },
+                            {
+                              "text": "בראשית",
+                              "lang": "he",
+                              "primary": true
+                            },
+                            {
+                              "text": "Genesis",
+                              "lang": "en",
+                              "primary": true
+                            }
+                          ],
+                          "title": "Genesis",
+                          "heTitle": "בראשית"
+                        }
+                      },
+                      "sectionNames": [
+                        "Chapter",
+                        "Verse"
+                      ],
+                      "depth": 2,
+                      "heCategories": [
+                        "תנ\"ך",
+                        "תורה"
+                      ],
+                      "compDateString": {
+                        "en": " (c.1400  – c.400 BCE)",
+                        "he": " (1400 – 400 לפנה\"ס בקירוב)"
+                      },
+                      "pubDateString": {
+                        "en": " (1488 CE)",
+                        "he": " (1488 לספירה)"
+                      },
+                      "compPlaceString": {
+                        "en": "Sinai/Canaan",
+                        "he": "סיני / כנען"
+                      },
+                      "pubPlaceString": {
+                        "en": "Soncino",
+                        "he": "שונצינו"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        }
+      }
+    },
+    "/api/v2/index/{title}": {
+      "summary": "Index Metadata (v2)",
+      "description": "Same as `GET /api/index/{title}`. Returns metadata for a single index (work) by title.",
+      "get": {
+        "operationId": "get-index-v2",
+        "tags": [
+          "Index"
+        ],
+        "parameters": [
+          {
+            "name": "title",
+            "description": "The index title, e.g. `Genesis`.",
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "required": true
+          }
+        ],
+        "description": "Same as `GET /api/index/{title}`. Returns metadata for a single index (work) by title.",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IndexJSON"
+                },
+                "examples": {
+                  "Genesis (v2)": {
+                    "value": {
+                      "title": "Genesis",
+                      "categories": [
+                        "Tanakh",
+                        "Torah"
+                      ],
+                      "schema": {
+                        "nodeType": "JaggedArrayNode",
+                        "depth": 2,
+                        "addressTypes": [
+                          "Perek",
+                          "Pasuk"
+                        ],
+                        "sectionNames": [
+                          "Chapter",
+                          "Verse"
+                        ],
+                        "match_templates": [
+                          {
+                            "term_slugs": [
+                              "sefer",
+                              "genesis"
+                            ]
+                          },
+                          {
+                            "term_slugs": [
+                              "torah",
+                              "genesis"
+                            ]
+                          },
+                          {
+                            "term_slugs": [
+                              "torah",
+                              "sefer",
+                              "genesis"
+                            ]
+                          },
+                          {
+                            "term_slugs": [
+                              "genesis"
+                            ]
+                          }
+                        ],
+                        "lengths": [
+                          50,
+                          1533
+                        ],
+                        "titles": [
+                          {
+                            "text": "Bereshit",
+                            "lang": "en"
+                          },
+                          {
+                            "text": "Gen",
+                            "lang": "en"
+                          },
+                          {
+                            "text": "Gen.",
+                            "lang": "en"
+                          },
+                          {
+                            "text": "Breishit",
+                            "lang": "en"
+                          },
+                          {
+                            "text": "Bereishit",
+                            "lang": "en"
+                          },
+                          {
+                            "text": "Beresheet",
+                            "lang": "en"
+                          },
+                          {
+                            "text": "Bereshith",
+                            "lang": "en"
+                          },
+                          {
+                            "text": "Bereishis",
+                            "lang": "en"
+                          },
+                          {
+                            "text": "B’resh.",
+                            "lang": "en"
+                          },
+                          {
+                            "text": "B’reshith",
+                            "lang": "en"
+                          },
+                          {
+                            "text": "Genèse",
+                            "lang": "en"
+                          },
+                          {
+                            "text": "Beresheit",
+                            "lang": "en"
+                          },
+                          {
+                            "text": "ברא'",
+                            "lang": "he"
+                          },
+                          {
+                            "text": "בר'",
+                            "lang": "he"
+                          },
+                          {
+                            "text": "בר׳",
+                            "lang": "he"
+                          },
+                          {
+                            "text": "ברא׳",
+                            "lang": "he"
+                          },
+                          {
+                            "text": "בְּרֵאשִׁית",
+                            "lang": "he"
+                          },
+                          {
+                            "text": "בראשית",
+                            "lang": "he",
+                            "primary": true
+                          },
+                          {
+                            "text": "Genesis",
+                            "lang": "en",
+                            "primary": true
+                          }
+                        ],
+                        "title": "Genesis",
+                        "heTitle": "בראשית",
+                        "heSectionNames": [
+                          "פרק",
+                          "פסוק"
+                        ],
+                        "key": "Genesis"
+                      },
+                      "order": [
+                        1,
+                        1
+                      ],
+                      "authors": [],
+                      "enDesc": "Genesis (“Bereshit”) is the first book of the Torah, Judaism’s foundational text, and the only one consisting almost entirely of stories, with just three explicit laws. It tells of the origins of mankind and the Israelites, with stories on creation, Adam and Eve, Noah’s ark, the patriarchs and matriarchs - Abraham and Sarah, Isaac and Rebecca, Jacob, Leah and Rachel - and Joseph and his brothers. Its narratives depict figures as they encounter God, face wandering and exile, and grapple with conflict in family relationships",
+                      "heDesc": "ספר בראשית הוא הספר הראשון בחמשת חומשי התורה והיחיד הכולל כמעט אך ורק סיפורים - ורק שלושה חוקים מפורשים. הוא מספר על תולדות האדם ועם ישראל בסיפורי הבריאה, אדם חוה, תיבת נח, האבות והאימהות - אברהם ושרה, יצחק ורבקה, יעקב, רחל ולאה ויוסף ואחיו. עלילותיו מתארות דמויות המתעמתות עם אלוהים ומתמודדות עם אתגרי גלות ונדודים ועם מאבקים פנים-משפחתיים.",
+                      "enShortDesc": "Creation, the beginning of mankind, and stories of the patriarchs and matriarchs.",
+                      "heShortDesc": "בריאת העולם, תחילתה של האנושות וסיפורי האבות והאמהות.",
+                      "pubDate": [
+                        1488
+                      ],
+                      "hasErrorMargin": true,
+                      "compDate": [
+                        -1400,
+                        -400
+                      ],
+                      "compPlace": "Sinai/Canaan",
+                      "pubPlace": "Soncino",
+                      "is_cited": true,
+                      "corpora": [
+                        "Tanakh"
+                      ],
+                      "heTitle": "בראשית",
+                      "titleVariants": [
+                        "Bereshit",
+                        "Gen",
+                        "Gen.",
+                        "Breishit",
+                        "Bereishit",
+                        "Beresheet",
+                        "Bereshith",
+                        "Bereishis",
+                        "B’resh.",
+                        "B’reshith",
+                        "Genèse",
+                        "Beresheit",
+                        "Genesis"
+                      ],
+                      "heTitleVariants": [
+                        "ברא'",
+                        "בר'",
+                        "בר׳",
+                        "ברא׳",
+                        "בְּרֵאשִׁית",
+                        "בראשית"
+                      ],
+                      "alts": {
+                        "Parasha": {
+                          "nodes": [
+                            {
+                              "nodeType": "ArrayMapNode",
+                              "depth": 1,
+                              "wholeRef": "Genesis 1:1-6:8",
+                              "addressTypes": [
+                                "Aliyah"
+                              ],
+                              "sectionNames": [
+                                "Aliyah"
+                              ],
+                              "refs": [
+                                "Genesis 1:1-2:3",
+                                "Genesis 2:4-2:19",
+                                "Genesis 2:20-3:21",
+                                "Genesis 3:22-4:18",
+                                "Genesis 4:19-4:22",
+                                "Genesis 4:23-5:24",
+                                "Genesis 5:25-6:8"
+                              ],
+                              "match_templates": [
+                                {
+                                  "term_slugs": [
+                                    "parasha",
+                                    "bereshit"
+                                  ],
+                                  "scope": "any"
+                                },
+                                {
+                                  "term_slugs": [
+                                    "bereshit"
+                                  ],
+                                  "scope": "any"
+                                }
+                              ],
+                              "isMapReferenceable": false,
+                              "sharedTitle": "Bereshit",
+                              "titles": [
+                                {
+                                  "primary": true,
+                                  "text": "Bereshit",
+                                  "lang": "en"
+                                },
+                                {
+                                  "primary": true,
+                                  "text": "בראשית",
+                                  "lang": "he"
+                                },
+                                {
+                                  "text": "Parashat Bereshit",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "פרשת בראשית",
+                                  "lang": "he"
+                                },
+                                {
+                                  "text": "Parashat Bereishit",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "Parashat Genesis",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "Genesis",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "Bereishit",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "Breishit",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "Bereshis",
+                                  "lang": "en"
+                                }
+                              ],
+                              "title": "Bereshit",
+                              "heTitle": "בראשית"
+                            },
+                            {
+                              "nodeType": "ArrayMapNode",
+                              "depth": 1,
+                              "wholeRef": "Genesis 6:9-11:32",
+                              "addressTypes": [
+                                "Aliyah"
+                              ],
+                              "sectionNames": [
+                                "Aliyah"
+                              ],
+                              "refs": [
+                                "Genesis 6:9-6:22",
+                                "Genesis 7:1-7:16",
+                                "Genesis 7:17-8:14",
+                                "Genesis 8:15-9:7",
+                                "Genesis 9:8-9:17",
+                                "Genesis 9:18-10:32",
+                                "Genesis 11:1-11:32"
+                              ],
+                              "match_templates": [
+                                {
+                                  "term_slugs": [
+                                    "parasha",
+                                    "noach"
+                                  ],
+                                  "scope": "any"
+                                },
+                                {
+                                  "term_slugs": [
+                                    "noach"
+                                  ],
+                                  "scope": "any"
+                                }
+                              ],
+                              "isMapReferenceable": false,
+                              "sharedTitle": "Noach",
+                              "titles": [
+                                {
+                                  "primary": true,
+                                  "text": "Noach",
+                                  "lang": "en"
+                                },
+                                {
+                                  "primary": true,
+                                  "text": "נח",
+                                  "lang": "he"
+                                },
+                                {
+                                  "text": "Parashat Noach",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "פרשת נח",
+                                  "lang": "he"
+                                },
+                                {
+                                  "text": "Noah",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "Parshat Noah",
+                                  "lang": "en"
+                                }
+                              ],
+                              "title": "Noach",
+                              "heTitle": "נח"
+                            },
+                            {
+                              "nodeType": "ArrayMapNode",
+                              "depth": 1,
+                              "wholeRef": "Genesis 12:1-17:27",
+                              "addressTypes": [
+                                "Aliyah"
+                              ],
+                              "sectionNames": [
+                                "Aliyah"
+                              ],
+                              "refs": [
+                                "Genesis 12:1-12:13",
+                                "Genesis 12:14-13:4",
+                                "Genesis 13:5-13:18",
+                                "Genesis 14:1-14:20",
+                                "Genesis 14:21-15:6",
+                                "Genesis 15:7-17:6",
+                                "Genesis 17:7-17:27"
+                              ],
+                              "match_templates": [
+                                {
+                                  "term_slugs": [
+                                    "parasha",
+                                    "lech-lecha"
+                                  ],
+                                  "scope": "any"
+                                },
+                                {
+                                  "term_slugs": [
+                                    "lech-lecha"
+                                  ],
+                                  "scope": "any"
+                                }
+                              ],
+                              "isMapReferenceable": false,
+                              "sharedTitle": "Lech Lecha",
+                              "titles": [
+                                {
+                                  "primary": true,
+                                  "text": "Lech Lecha",
+                                  "lang": "en"
+                                },
+                                {
+                                  "primary": true,
+                                  "text": "לך לך",
+                                  "lang": "he"
+                                },
+                                {
+                                  "text": "Parashat Lech Lecha",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "פרשת לך לך",
+                                  "lang": "he"
+                                },
+                                {
+                                  "text": "Parashat Lekh Lekha",
+                                  "lang": "en"
+                                }
+                              ],
+                              "title": "Lech Lecha",
+                              "heTitle": "לך לך"
+                            },
+                            {
+                              "nodeType": "ArrayMapNode",
+                              "depth": 1,
+                              "wholeRef": "Genesis 18:1-22:24",
+                              "addressTypes": [
+                                "Aliyah"
+                              ],
+                              "sectionNames": [
+                                "Aliyah"
+                              ],
+                              "refs": [
+                                "Genesis 18:1-18:14",
+                                "Genesis 18:15-18:33",
+                                "Genesis 19:1-19:20",
+                                "Genesis 19:21-21:4",
+                                "Genesis 21:5-21:21",
+                                "Genesis 21:22-21:34",
+                                "Genesis 22:1-22:24"
+                              ],
+                              "match_templates": [
+                                {
+                                  "term_slugs": [
+                                    "parasha",
+                                    "vayera"
+                                  ],
+                                  "scope": "any"
+                                },
+                                {
+                                  "term_slugs": [
+                                    "vayera"
+                                  ],
+                                  "scope": "any"
+                                }
+                              ],
+                              "isMapReferenceable": false,
+                              "sharedTitle": "Vayera",
+                              "titles": [
+                                {
+                                  "primary": true,
+                                  "text": "Vayera",
+                                  "lang": "en"
+                                },
+                                {
+                                  "primary": true,
+                                  "text": "וירא",
+                                  "lang": "he"
+                                },
+                                {
+                                  "text": "Parashat Vayera",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "פרשת וירא",
+                                  "lang": "he"
+                                },
+                                {
+                                  "text": "Parashat Vayeira",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "Parshat Vayera",
+                                  "lang": "en"
+                                }
+                              ],
+                              "title": "Vayera",
+                              "heTitle": "וירא"
+                            },
+                            {
+                              "nodeType": "ArrayMapNode",
+                              "depth": 1,
+                              "wholeRef": "Genesis 23:1-25:18",
+                              "addressTypes": [
+                                "Aliyah"
+                              ],
+                              "sectionNames": [
+                                "Aliyah"
+                              ],
+                              "refs": [
+                                "Genesis 23:1-23:16",
+                                "Genesis 23:17-24:9",
+                                "Genesis 24:10-24:26",
+                                "Genesis 24:27-24:52",
+                                "Genesis 24:53-24:67",
+                                "Genesis 25:1-25:11",
+                                "Genesis 25:12-25:18"
+                              ],
+                              "match_templates": [
+                                {
+                                  "term_slugs": [
+                                    "parasha",
+                                    "chayei-sara"
+                                  ],
+                                  "scope": "any"
+                                },
+                                {
+                                  "term_slugs": [
+                                    "chayei-sara"
+                                  ],
+                                  "scope": "any"
+                                }
+                              ],
+                              "isMapReferenceable": false,
+                              "sharedTitle": "Chayei Sara",
+                              "titles": [
+                                {
+                                  "primary": true,
+                                  "text": "Chayei Sara",
+                                  "lang": "en"
+                                },
+                                {
+                                  "primary": true,
+                                  "text": "חיי שרה",
+                                  "lang": "he"
+                                },
+                                {
+                                  "text": "Parashat Chayei Sara",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "פרשת חיי שרה",
+                                  "lang": "he"
+                                },
+                                {
+                                  "text": "Parashat Chayei Sarah",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "Parashat Chaye Sarah",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "Parshat Chayei Sarah",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "Chayei Sarah",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "Hayei Sarah",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "Hayye Sarah",
+                                  "lang": "en"
+                                }
+                              ],
+                              "title": "Chayei Sara",
+                              "heTitle": "חיי שרה"
+                            },
+                            {
+                              "nodeType": "ArrayMapNode",
+                              "depth": 1,
+                              "wholeRef": "Genesis 25:19-28:9",
+                              "addressTypes": [
+                                "Aliyah"
+                              ],
+                              "sectionNames": [
+                                "Aliyah"
+                              ],
+                              "refs": [
+                                "Genesis 25:19-26:5",
+                                "Genesis 26:6-26:12",
+                                "Genesis 26:13-26:22",
+                                "Genesis 26:23-26:29",
+                                "Genesis 26:30-27:27",
+                                "Genesis 27:28-28:4",
+                                "Genesis 28:5-28:9"
+                              ],
+                              "match_templates": [
+                                {
+                                  "term_slugs": [
+                                    "parasha",
+                                    "toldot"
+                                  ],
+                                  "scope": "any"
+                                },
+                                {
+                                  "term_slugs": [
+                                    "toldot"
+                                  ],
+                                  "scope": "any"
+                                }
+                              ],
+                              "isMapReferenceable": false,
+                              "sharedTitle": "Toldot",
+                              "titles": [
+                                {
+                                  "primary": true,
+                                  "text": "Toldot",
+                                  "lang": "en"
+                                },
+                                {
+                                  "primary": true,
+                                  "text": "תולדות",
+                                  "lang": "he"
+                                },
+                                {
+                                  "text": "Parashat Toldot",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "פרשת תולדות",
+                                  "lang": "he"
+                                },
+                                {
+                                  "text": "Parashat Toledot",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "Parshat Toledot",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "Toldos",
+                                  "lang": "en"
+                                }
+                              ],
+                              "title": "Toldot",
+                              "heTitle": "תולדות"
+                            },
+                            {
+                              "nodeType": "ArrayMapNode",
+                              "depth": 1,
+                              "wholeRef": "Genesis 28:10-32:3",
+                              "addressTypes": [
+                                "Aliyah"
+                              ],
+                              "sectionNames": [
+                                "Aliyah"
+                              ],
+                              "refs": [
+                                "Genesis 28:10-28:22",
+                                "Genesis 29:1-29:17",
+                                "Genesis 29:18-30:13",
+                                "Genesis 30:14-30:27",
+                                "Genesis 30:28-31:16",
+                                "Genesis 31:17-31:42",
+                                "Genesis 31:43-32:3"
+                              ],
+                              "match_templates": [
+                                {
+                                  "term_slugs": [
+                                    "parasha",
+                                    "vayetzei"
+                                  ],
+                                  "scope": "any"
+                                },
+                                {
+                                  "term_slugs": [
+                                    "vayetzei"
+                                  ],
+                                  "scope": "any"
+                                }
+                              ],
+                              "isMapReferenceable": false,
+                              "sharedTitle": "Vayetzei",
+                              "titles": [
+                                {
+                                  "primary": true,
+                                  "text": "Vayetzei",
+                                  "lang": "en"
+                                },
+                                {
+                                  "primary": true,
+                                  "text": "ויצא",
+                                  "lang": "he"
+                                },
+                                {
+                                  "text": "Parashat Vayetzei",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "פרשת ויצא",
+                                  "lang": "he"
+                                },
+                                {
+                                  "text": "Parashat Vayeitzey",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "Vayetze",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "Parashat Vayetze",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "Parashat Vayetzey",
+                                  "lang": "en"
+                                }
+                              ],
+                              "title": "Vayetzei",
+                              "heTitle": "ויצא"
+                            },
+                            {
+                              "nodeType": "ArrayMapNode",
+                              "depth": 1,
+                              "wholeRef": "Genesis 32:4-36:43",
+                              "addressTypes": [
+                                "Aliyah"
+                              ],
+                              "sectionNames": [
+                                "Aliyah"
+                              ],
+                              "refs": [
+                                "Genesis 32:4-32:13",
+                                "Genesis 32:14-32:30",
+                                "Genesis 32:31-33:5",
+                                "Genesis 33:6-33:20",
+                                "Genesis 34:1-35:11",
+                                "Genesis 35:12-36:19",
+                                "Genesis 36:20-36:43"
+                              ],
+                              "match_templates": [
+                                {
+                                  "term_slugs": [
+                                    "parasha",
+                                    "vayishlach"
+                                  ],
+                                  "scope": "any"
+                                },
+                                {
+                                  "term_slugs": [
+                                    "vayishlach"
+                                  ],
+                                  "scope": "any"
+                                }
+                              ],
+                              "isMapReferenceable": false,
+                              "sharedTitle": "Vayishlach",
+                              "titles": [
+                                {
+                                  "primary": true,
+                                  "text": "Vayishlach",
+                                  "lang": "en"
+                                },
+                                {
+                                  "primary": true,
+                                  "text": "וישלח",
+                                  "lang": "he"
+                                },
+                                {
+                                  "text": "Parashat Vayishlach",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "פרשת וישלח",
+                                  "lang": "he"
+                                }
+                              ],
+                              "title": "Vayishlach",
+                              "heTitle": "וישלח"
+                            },
+                            {
+                              "nodeType": "ArrayMapNode",
+                              "depth": 1,
+                              "wholeRef": "Genesis 37:1-40:23",
+                              "addressTypes": [
+                                "Aliyah"
+                              ],
+                              "sectionNames": [
+                                "Aliyah"
+                              ],
+                              "refs": [
+                                "Genesis 37:1-37:11",
+                                "Genesis 37:12-37:22",
+                                "Genesis 37:23-37:36",
+                                "Genesis 38:1-38:30",
+                                "Genesis 39:1-39:6",
+                                "Genesis 39:7-39:23",
+                                "Genesis 40:1-40:23"
+                              ],
+                              "match_templates": [
+                                {
+                                  "term_slugs": [
+                                    "parasha",
+                                    "vayeshev"
+                                  ],
+                                  "scope": "any"
+                                },
+                                {
+                                  "term_slugs": [
+                                    "vayeshev"
+                                  ],
+                                  "scope": "any"
+                                }
+                              ],
+                              "isMapReferenceable": false,
+                              "sharedTitle": "Vayeshev",
+                              "titles": [
+                                {
+                                  "primary": true,
+                                  "text": "Vayeshev",
+                                  "lang": "en"
+                                },
+                                {
+                                  "primary": true,
+                                  "text": "וישב",
+                                  "lang": "he"
+                                },
+                                {
+                                  "text": "Parashat Vayeshev",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "פרשת וישב",
+                                  "lang": "he"
+                                },
+                                {
+                                  "text": "Parashat Veyeshev",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "Parshat Vayeshev",
+                                  "lang": "en"
+                                }
+                              ],
+                              "title": "Vayeshev",
+                              "heTitle": "וישב"
+                            },
+                            {
+                              "nodeType": "ArrayMapNode",
+                              "depth": 1,
+                              "wholeRef": "Genesis 41:1-44:17",
+                              "addressTypes": [
+                                "Aliyah"
+                              ],
+                              "sectionNames": [
+                                "Aliyah"
+                              ],
+                              "refs": [
+                                "Genesis 41:1-41:14",
+                                "Genesis 41:15-41:38",
+                                "Genesis 41:39-41:52",
+                                "Genesis 41:53-42:18",
+                                "Genesis 42:19-43:15",
+                                "Genesis 43:16-43:29",
+                                "Genesis 43:30-44:17"
+                              ],
+                              "match_templates": [
+                                {
+                                  "term_slugs": [
+                                    "parasha",
+                                    "miketz"
+                                  ],
+                                  "scope": "any"
+                                },
+                                {
+                                  "term_slugs": [
+                                    "miketz"
+                                  ],
+                                  "scope": "any"
+                                }
+                              ],
+                              "isMapReferenceable": false,
+                              "sharedTitle": "Miketz",
+                              "titles": [
+                                {
+                                  "primary": true,
+                                  "text": "Miketz",
+                                  "lang": "en"
+                                },
+                                {
+                                  "primary": true,
+                                  "text": "מקץ",
+                                  "lang": "he"
+                                },
+                                {
+                                  "text": "Parashat Miketz",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "פרשת מקץ",
+                                  "lang": "he"
+                                }
+                              ],
+                              "title": "Miketz",
+                              "heTitle": "מקץ"
+                            },
+                            {
+                              "nodeType": "ArrayMapNode",
+                              "depth": 1,
+                              "wholeRef": "Genesis 44:18-47:27",
+                              "addressTypes": [
+                                "Aliyah"
+                              ],
+                              "sectionNames": [
+                                "Aliyah"
+                              ],
+                              "refs": [
+                                "Genesis 44:18-44:30",
+                                "Genesis 44:31-45:7",
+                                "Genesis 45:8-45:18",
+                                "Genesis 45:19-45:27",
+                                "Genesis 45:28-46:27",
+                                "Genesis 46:28-47:10",
+                                "Genesis 47:11-47:27"
+                              ],
+                              "match_templates": [
+                                {
+                                  "term_slugs": [
+                                    "parasha",
+                                    "vayigash"
+                                  ],
+                                  "scope": "any"
+                                },
+                                {
+                                  "term_slugs": [
+                                    "vayigash"
+                                  ],
+                                  "scope": "any"
+                                }
+                              ],
+                              "isMapReferenceable": false,
+                              "sharedTitle": "Vayigash",
+                              "titles": [
+                                {
+                                  "primary": true,
+                                  "text": "Vayigash",
+                                  "lang": "en"
+                                },
+                                {
+                                  "primary": true,
+                                  "text": "ויגש",
+                                  "lang": "he"
+                                },
+                                {
+                                  "text": "Parashat Vayigash",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "פרשת ויגש",
+                                  "lang": "he"
+                                }
+                              ],
+                              "title": "Vayigash",
+                              "heTitle": "ויגש"
+                            },
+                            {
+                              "nodeType": "ArrayMapNode",
+                              "depth": 1,
+                              "wholeRef": "Genesis 47:28-50:26",
+                              "addressTypes": [
+                                "Aliyah"
+                              ],
+                              "sectionNames": [
+                                "Aliyah"
+                              ],
+                              "refs": [
+                                "Genesis 47:28-48:9",
+                                "Genesis 48:10-48:16",
+                                "Genesis 48:17-48:22",
+                                "Genesis 49:1-49:18",
+                                "Genesis 49:19-49:26",
+                                "Genesis 49:27-50:20",
+                                "Genesis 50:21-50:26"
+                              ],
+                              "match_templates": [
+                                {
+                                  "term_slugs": [
+                                    "parasha",
+                                    "vayechi"
+                                  ],
+                                  "scope": "any"
+                                },
+                                {
+                                  "term_slugs": [
+                                    "vayechi"
+                                  ],
+                                  "scope": "any"
+                                }
+                              ],
+                              "isMapReferenceable": false,
+                              "sharedTitle": "Vayechi",
+                              "titles": [
+                                {
+                                  "primary": true,
+                                  "text": "Vayechi",
+                                  "lang": "en"
+                                },
+                                {
+                                  "primary": true,
+                                  "text": "ויחי",
+                                  "lang": "he"
+                                },
+                                {
+                                  "text": "Parashat Vayechi",
+                                  "lang": "en"
+                                },
+                                {
+                                  "text": "פרשת ויחי",
+                                  "lang": "he"
+                                },
+                                {
+                                  "text": "Parashat Vayehi",
+                                  "lang": "en"
+                                }
+                              ],
+                              "title": "Vayechi",
+                              "heTitle": "ויחי"
+                            }
+                          ],
+                          "titles": [
+                            {
+                              "text": "Bereshit",
+                              "lang": "en"
+                            },
+                            {
+                              "text": "Gen",
+                              "lang": "en"
+                            },
+                            {
+                              "text": "Gen.",
+                              "lang": "en"
+                            },
+                            {
+                              "text": "Breishit",
+                              "lang": "en"
+                            },
+                            {
+                              "text": "Bereishit",
+                              "lang": "en"
+                            },
+                            {
+                              "text": "Beresheet",
+                              "lang": "en"
+                            },
+                            {
+                              "text": "Bereshith",
+                              "lang": "en"
+                            },
+                            {
+                              "text": "Bereishis",
+                              "lang": "en"
+                            },
+                            {
+                              "text": "B’resh.",
+                              "lang": "en"
+                            },
+                            {
+                              "text": "B’reshith",
+                              "lang": "en"
+                            },
+                            {
+                              "text": "Genèse",
+                              "lang": "en"
+                            },
+                            {
+                              "text": "Beresheit",
+                              "lang": "en"
+                            },
+                            {
+                              "text": "ברא'",
+                              "lang": "he"
+                            },
+                            {
+                              "text": "בר'",
+                              "lang": "he"
+                            },
+                            {
+                              "text": "בר׳",
+                              "lang": "he"
+                            },
+                            {
+                              "text": "ברא׳",
+                              "lang": "he"
+                            },
+                            {
+                              "text": "בְּרֵאשִׁית",
+                              "lang": "he"
+                            },
+                            {
+                              "text": "בראשית",
+                              "lang": "he",
+                              "primary": true
+                            },
+                            {
+                              "text": "Genesis",
+                              "lang": "en",
+                              "primary": true
+                            }
+                          ],
+                          "title": "Genesis",
+                          "heTitle": "בראשית"
+                        }
+                      },
+                      "sectionNames": [
+                        "Chapter",
+                        "Verse"
+                      ],
+                      "depth": 2,
+                      "heCategories": [
+                        "תנ\"ך",
+                        "תורה"
+                      ],
+                      "compDateString": {
+                        "en": " (c.1400  – c.400 BCE)",
+                        "he": " (1400 – 400 לפנה\"ס בקירוב)"
+                      },
+                      "pubDateString": {
+                        "en": " (1488 CE)",
+                        "he": " (1488 לספירה)"
+                      },
+                      "compPlaceString": {
+                        "en": "Sinai/Canaan",
+                        "he": "סיני / כנען"
+                      },
+                      "pubPlaceString": {
+                        "en": "Soncino",
+                        "he": "שונצינו"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        }
+      }
+    },
+    "/api/counts/{title}": {
+      "summary": "Counts",
+      "description": "Returns word and segment counts for a text, broken down by language.",
+      "get": {
+        "operationId": "get-counts",
+        "tags": [
+          "Index"
+        ],
+        "parameters": [
+          {
+            "name": "title",
+            "description": "The index title, e.g. `Genesis`.",
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "required": true
+          }
+        ],
+        "description": "Returns word and segment counts for a text, broken down by language.",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CountsJSON"
+                },
+                "examples": {
+                  "Genesis counts": {
+                    "value": {
+                      "_all": {
+                        "availableTexts": [
+                          [
+                            50,
+                            47,
+                            46,
+                            45,
+                            45,
+                            45,
+                            45,
+                            45,
+                            45,
+                            45,
+                            44,
+                            44,
+                            44,
+                            44,
+                            44,
+                            44,
+                            44,
+                            44,
+                            44,
+                            44,
+                            44,
+                            44,
+                            44,
+                            44,
+                            44,
+                            44,
+                            44,
+                            44,
+                            44,
+                            44,
+                            44
+                          ],
+                          [
+                            38,
+                            38,
+                            38,
+                            38,
+                            38,
+                            38,
+                            38,
+                            38,
+                            38,
+                            38,
+                            38,
+                            38,
+                            38,
+                            38,
+                            38,
+                            38,
+                            38,
+                            38,
+                            38,
+                            38,
+                            38,
+                            38,
+                            38,
+                            38,
+                            38
+                          ],
+                          [
+                            39,
+                            38,
+                            38,
+                            38,
+                            38,
+                            38,
+                            38,
+                            38,
+                            38,
+                            38,
+                            38,
+                            38,
+                            38,
+                            38,
+                            38,
+                            38,
+                            38,
+                            38,
+                            38,
+                            38,
+                            38,
+                            38,
+                            38,
+                            38
+                          ],
+                          [
+                            37,
+                            37,
+                            36,
+                            36,
+                            36,
+                            36,
+                            36,
+                            36,
+                            36,
+                            36,
+                            36,
+                            36,
+                            36,
+                            36,
+                            36,
+                            36,
+                            36,
+                            36,
+                            36,
+                            36,
+                            36,
+                            36,
+                            36,
+                            36,
+                            36,
+                            36
+                          ],
+                          [
+                            37,
+                            37,
+                            37,
+                            37,
+                            37,
+                            37,
+                            37,
+                            37,
+                            37,
+                            37,
+                            36,
+                            36,
+                            36,
+                            36,
+                            36,
+                            36,
+                            36,
+                            36,
+                            36,
+                            36,
+                            36,
+                            36,
+                            36,
+                            36,
+                            36,
+                            36,
+                            36,
+                            36,
+                            36,
+                            36,
+                            36,
+                            36
+                          ],
+                          [
+                            35,
+                            35,
+                            35,
+                            35,
+                            35,
+                            35,
+                            35,
+                            35,
+                            34,
+                            34,
+                            34,
+                            34,
+                            34,
+                            34,
+                            34,
+                            34,
+                            34,
+                            34,
+                            34,
+                            34,
+                            34,
+                            34
+                          ],
+                          [
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32
+                          ],
+                          [
+                            33,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32
+                          ],
+                          [
+                            33,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31
+                          ],
+                          [
+                            31,
+                            31,
+                            31,
+                            30,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31
+                          ],
+                          [
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31
+                          ],
+                          [
+                            32,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31
+                          ],
+                          [
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31
+                          ],
+                          [
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            32,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31
+                          ],
+                          [
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31
+                          ],
+                          [
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            32,
+                            31
+                          ],
+                          [
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31
+                          ],
+                          [
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31
+                          ],
+                          [
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32,
+                            32
+                          ],
+                          [
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31
+                          ],
+                          [
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            29,
+                            30,
+                            30
+                          ],
+                          [
+                            30,
+                            31,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            31,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30
+                          ],
+                          [
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            29,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30
+                          ],
+                          [
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30
+                          ],
+                          [
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            31,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30
+                          ],
+                          [
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30
+                          ],
+                          [
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30
+                          ],
+                          [
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            31,
+                            31,
+                            30,
+                            30,
+                            29,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30
+                          ],
+                          [
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30
+                          ],
+                          [
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30
+                          ],
+                          [
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31
+                          ],
+                          [
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            32,
+                            31,
+                            31,
+                            31
+                          ],
+                          [
+                            31,
+                            30,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31
+                          ],
+                          [
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31
+                          ],
+                          [
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            30,
+                            31
+                          ],
+                          [
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30
+                          ],
+                          [
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31
+                          ],
+                          [
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30
+                          ],
+                          [
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30
+                          ],
+                          [
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30
+                          ],
+                          [
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30
+                          ],
+                          [
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30
+                          ],
+                          [
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30
+                          ],
+                          [
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30
+                          ],
+                          [
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30
+                          ],
+                          [
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30
+                          ],
+                          [
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30
+                          ],
+                          [
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30
+                          ],
+                          [
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            29,
+                            30,
+                            30,
+                            31,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30
+                          ],
+                          [
+                            31,
+                            31,
+                            31,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30
+                          ]
+                        ],
+                        "shape": [
+                          31,
+                          25,
+                          24,
+                          26,
+                          32,
+                          22,
+                          24,
+                          22,
+                          29,
+                          32,
+                          32,
+                          20,
+                          18,
+                          24,
+                          21,
+                          16,
+                          27,
+                          33,
+                          38,
+                          18,
+                          34,
+                          24,
+                          20,
+                          67,
+                          34,
+                          35,
+                          46,
+                          22,
+                          35,
+                          43,
+                          54,
+                          33,
+                          20,
+                          31,
+                          29,
+                          43,
+                          36,
+                          30,
+                          23,
+                          23,
+                          57,
+                          38,
+                          34,
+                          34,
+                          28,
+                          34,
+                          31,
+                          22,
+                          33,
+                          26
+                        ]
+                      },
+                      "_he": {
+                        "percentAvailableInvalid": false,
+                        "sparseness": 4,
+                        "textComplete": true,
+                        "percentAvailable": 100.0,
+                        "completenessPercent": 100.0,
+                        "availableTexts": [
+                          [
+                            10,
+                            8,
+                            8,
+                            8,
+                            8,
+                            8,
+                            8,
+                            8,
+                            8,
+                            8,
+                            8,
+                            8,
+                            8,
+                            8,
+                            8,
+                            8,
+                            8,
+                            8,
+                            8,
+                            8,
+                            8,
+                            8,
+                            8,
+                            8,
+                            8,
+                            8,
+                            8,
+                            8,
+                            8,
+                            8,
+                            8
+                          ],
+                          [
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7
+                          ],
+                          [
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7
+                          ],
+                          [
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7
+                          ],
+                          [
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7
+                          ],
+                          [
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7
+                          ],
+                          [
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7
+                          ],
+                          [
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7
+                          ],
+                          [
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7
+                          ],
+                          [
+                            7,
+                            7,
+                            7,
+                            6,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7
+                          ],
+                          [
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7
+                          ],
+                          [
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7
+                          ],
+                          [
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7
+                          ],
+                          [
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7
+                          ],
+                          [
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7
+                          ],
+                          [
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7
+                          ],
+                          [
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7
+                          ],
+                          [
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7
+                          ],
+                          [
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7
+                          ],
+                          [
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7
+                          ],
+                          [
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            6,
+                            7,
+                            7
+                          ],
+                          [
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7
+                          ],
+                          [
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7
+                          ],
+                          [
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7
+                          ],
+                          [
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7
+                          ],
+                          [
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7
+                          ],
+                          [
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7
+                          ],
+                          [
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7
+                          ],
+                          [
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7
+                          ],
+                          [
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7
+                          ],
+                          [
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7
+                          ],
+                          [
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7
+                          ],
+                          [
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7
+                          ],
+                          [
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7
+                          ],
+                          [
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7
+                          ],
+                          [
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7
+                          ],
+                          [
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7
+                          ],
+                          [
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7
+                          ],
+                          [
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7
+                          ],
+                          [
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7
+                          ],
+                          [
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7
+                          ],
+                          [
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7
+                          ],
+                          [
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7
+                          ],
+                          [
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7
+                          ],
+                          [
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7
+                          ],
+                          [
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7
+                          ],
+                          [
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7
+                          ],
+                          [
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7
+                          ],
+                          [
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            6,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7
+                          ],
+                          [
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7,
+                            7
+                          ]
+                        ],
+                        "availableCounts": [
+                          50,
+                          1533
+                        ]
+                      },
+                      "_en": {
+                        "percentAvailableInvalid": false,
+                        "sparseness": 4,
+                        "textComplete": true,
+                        "percentAvailable": 100.0,
+                        "completenessPercent": 100.0,
+                        "availableTexts": [
+                          [
+                            40,
+                            39,
+                            38,
+                            37,
+                            37,
+                            37,
+                            37,
+                            37,
+                            37,
+                            37,
+                            36,
+                            36,
+                            36,
+                            36,
+                            36,
+                            36,
+                            36,
+                            36,
+                            36,
+                            36,
+                            36,
+                            36,
+                            36,
+                            36,
+                            36,
+                            36,
+                            36,
+                            36,
+                            36,
+                            36,
+                            36
+                          ],
+                          [
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31
+                          ],
+                          [
+                            32,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31,
+                            31
+                          ],
+                          [
+                            30,
+                            30,
+                            29,
+                            29,
+                            29,
+                            29,
+                            29,
+                            29,
+                            29,
+                            29,
+                            29,
+                            29,
+                            29,
+                            29,
+                            29,
+                            29,
+                            29,
+                            29,
+                            29,
+                            29,
+                            29,
+                            29,
+                            29,
+                            29,
+                            29,
+                            29
+                          ],
+                          [
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            30,
+                            29,
+                            29,
+                            29,
+                            29,
+                            29,
+                            29,
+                            29,
+                            29,
+                            29,
+                            29,
+                            29,
+                            29,
+                            29,
+                            29,
+                            29,
+                            29,
+                            29,
+                            29,
+                            29,
+                            29,
+                            29,
+                            29
+                          ],
+                          [
+                            28,
+                            28,
+                            28,
+                            28,
+                            28,
+                            28,
+                            28,
+                            28,
+                            27,
+                            27,
+                            27,
+                            27,
+                            27,
+                            27,
+                            27,
+                            27,
+                            27,
+                            27,
+                            27,
+                            27,
+                            27,
+                            27
+                          ],
+                          [
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25
+                          ],
+                          [
+                            26,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25
+                          ],
+                          [
+                            26,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24
+                          ],
+                          [
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24
+                          ],
+                          [
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24
+                          ],
+                          [
+                            25,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24
+                          ],
+                          [
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24
+                          ],
+                          [
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            25,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24
+                          ],
+                          [
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24
+                          ],
+                          [
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            25,
+                            24
+                          ],
+                          [
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24
+                          ],
+                          [
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24
+                          ],
+                          [
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25,
+                            25
+                          ],
+                          [
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24
+                          ],
+                          [
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23
+                          ],
+                          [
+                            23,
+                            24,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            24,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23
+                          ],
+                          [
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            22,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23
+                          ],
+                          [
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23
+                          ],
+                          [
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            24,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23
+                          ],
+                          [
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23
+                          ],
+                          [
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23
+                          ],
+                          [
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            24,
+                            24,
+                            23,
+                            23,
+                            22,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23
+                          ],
+                          [
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23
+                          ],
+                          [
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23
+                          ],
+                          [
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24
+                          ],
+                          [
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            25,
+                            24,
+                            24,
+                            24
+                          ],
+                          [
+                            24,
+                            23,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24
+                          ],
+                          [
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24
+                          ],
+                          [
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            23,
+                            24
+                          ],
+                          [
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23
+                          ],
+                          [
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24,
+                            24
+                          ],
+                          [
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23
+                          ],
+                          [
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23
+                          ],
+                          [
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23
+                          ],
+                          [
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23
+                          ],
+                          [
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23
+                          ],
+                          [
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23
+                          ],
+                          [
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23
+                          ],
+                          [
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23
+                          ],
+                          [
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23
+                          ],
+                          [
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23
+                          ],
+                          [
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23
+                          ],
+                          [
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            24,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23
+                          ],
+                          [
+                            24,
+                            24,
+                            24,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23,
+                            23
+                          ]
+                        ],
+                        "availableCounts": [
+                          50,
+                          1533
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        }
+      }
+    },
+    "/api/counts/links/{cat1}/{cat2}": {
+      "summary": "Link Counts Between Categories",
+      "description": "Returns the number of links between every book in `cat1` and every book in `cat2`. Returns an error response if no links exist between the requested category pair.",
+      "get": {
+        "operationId": "get-counts-links",
+        "tags": [
+          "Index"
+        ],
+        "parameters": [
+          {
+            "name": "cat1",
+            "description": "First Sefaria category, e.g. `Tanakh`.",
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "cat2",
+            "description": "Second Sefaria category, e.g. `Bavli`.",
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "required": true
+          }
+        ],
+        "description": "Returns the number of links between every book in `cat1` and every book in `cat2`. Returns an error response if no links exist between the requested category pair.",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CountsLinksItemJSON"
+                  }
+                },
+                "examples": {
+                  "First 10 Tanakh↔Bavli pairs": {
+                    "value": [
+                      {
+                        "book1": "Amos",
+                        "book2": "Avodah Zarah",
+                        "count": 1
+                      },
+                      {
+                        "book1": "Amos",
+                        "book2": "Bava Batra",
+                        "count": 5
+                      },
+                      {
+                        "book1": "Amos",
+                        "book2": "Bava Kamma",
+                        "count": 1
+                      },
+                      {
+                        "book1": "Amos",
+                        "book2": "Bava Metzia",
+                        "count": 2
+                      },
+                      {
+                        "book1": "Amos",
+                        "book2": "Bekhorot",
+                        "count": 1
+                      },
+                      {
+                        "book1": "Amos",
+                        "book2": "Berakhot",
+                        "count": 10
+                      },
+                      {
+                        "book1": "Amos",
+                        "book2": "Chagigah",
+                        "count": 6
+                      },
+                      {
+                        "book1": "Amos",
+                        "book2": "Chullin",
+                        "count": 3
+                      },
+                      {
+                        "book1": "Amos",
+                        "book2": "Keritot",
+                        "count": 1
+                      },
+                      {
+                        "book1": "Amos",
+                        "book2": "Ketubot",
+                        "count": 2
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        }
+      }
+    },
+    "/api/counts/words/{title}/{version}/{language}": {
+      "summary": "Word Count for Version",
+      "description": "Returns the word count for a specific text version.",
+      "get": {
+        "operationId": "get-counts-words",
+        "tags": [
+          "Index"
+        ],
+        "parameters": [
+          {
+            "name": "title",
+            "description": "The index title, e.g. `Genesis`.",
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "version",
+            "description": "The version title. URL-encode any special characters.",
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "language",
+            "description": "The version language code, e.g. `en` or `he`.",
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "required": true
+          }
+        ],
+        "description": "Returns the word count for a specific text version.",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CountsWordsJSON"
+                },
+                "examples": {
+                  "JPS 1917 Genesis (en)": {
+                    "value": {
+                      "wordCount": 38340
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        }
+      }
+    },
+    "/api/link-summary/{ref}": {
+      "summary": "Link Summary",
+      "description": "Returns a summary of all links targeting a ref, grouped by category, with per-book breakdowns.",
+      "get": {
+        "operationId": "get-link-summary",
+        "tags": [
+          "Related"
+        ],
+        "parameters": [
+          {
+            "name": "ref",
+            "description": "Sefaria ref, e.g. `Genesis.1.1`.",
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "required": true
+          }
+        ],
+        "description": "Returns a summary of all links targeting a ref, grouped by category, with per-book breakdowns.",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/LinkSummaryJSON"
+                  }
+                },
+                "examples": {
+                  "Genesis 1:1 link summary": {
+                    "value": [
+                      {
+                        "name": "Commentary",
+                        "count": 1431,
+                        "books": {
+                          "Rashbam on Genesis": 1,
+                          "Ramban on Genesis": 4,
+                          "Sforno on Genesis": 6,
+                          "Kli Yakar on Genesis": 10,
+                          "Ibn Ezra on Genesis": 10,
+                          "Shadal on Genesis": 3,
+                          "Kitzur Ba'al HaTurim on Genesis": 1,
+                          "Or HaChaim on Genesis": 64,
+                          "Radak on Genesis": 6,
+                          "Haamek Davar on Genesis": 2,
+                          "Meshekh Chokhmah, Bereshit": 1,
+                          "Penei David, Genesis, Bereshit": 5,
+                          "Tur HaArokh, Genesis": 1,
+                          "Minchat Shai on Torah, Genesis": 3,
+                          "Mizrachi, Genesis": 25,
+                          "Rabbeinu Bahya, Bereshit": 7,
+                          "Malbim on Genesis": 2,
+                          "HaKtav VeHaKabalah, Genesis": 5,
+                          "Torah Temimah on Torah, Genesis": 9,
+                          "Riva on Torah, Genesis": 2,
+                          "Siftei Chakhamim, Genesis": 20,
+                          "Ralbag Beur HaMilot on Torah, Genesis": 1,
+                          "Tzror HaMor on Torah, Genesis": 4,
+                          "Ralbag on Torah, Genesis": 8,
+                          "Recanati on the Torah, Bereshit": 1,
+                          "Rosh on Torah, Genesis": 3,
+                          "Nachal Kedumim on Torah, Genesis": 6,
+                          "Yeriot Shlomo on Torah, Genesis": 6,
+                          "Toledot Yitzchak on Torah, Genesis": 3,
+                          "Minei Targuma on Torah, Genesis": 1,
+                          "Paaneach Raza, Bereshit": 31,
+                          "Gur Aryeh on Bereishit": 19,
+                          "Rav Hirsch on Torah, Genesis": 6,
+                          "Maskil LeDavid, Genesis": 5,
+                          "Tzror HaMor on Torah, Exodus": 1,
+                          "The Five Books of Moses, by Everett Fox, Genesis, Part I; The Primeval History": 3,
+                          "The Five Books of Moses, by Everett Fox, Genesis, Part I; The Primeval History, God as Creator": 2,
+                          "The Five Books of Moses, by Everett Fox, Genesis, On the Book of Genesis and Its Structure": 2,
+                          "Magen Avraham": 1,
+                          "Saadia Gaon on Genesis": 3,
+                          "Hadar Zekenim on Torah, Genesis": 7,
+                          "Reggio on Torah, Genesis": 3,
+                          "Netinah LaGer, Genesis": 2,
+                          "Levush HaOrah, Genesis": 6,
+                          "Rashi on Genesis": 3,
+                          "Steinsaltz on Genesis": 1,
+                          "Tze'enah Ure'enah, Bereshit": 1,
+                          "Pardes Yosef, Genesis": 12,
+                          "Nachalat Ya'akov, Genesis": 4,
+                          "Mechokekei Yehudah; Karnei Ohr, Genesis": 40,
+                          "Mechokekei Yehudah; Yahel Ohr, Genesis": 115,
+                          "The Torah; A Women's Commentary, Genesis": 9,
+                          "The Kehot Chumash; A Chasidic Commentary, Genesis": 13,
+                          "Siftei Kohen on Torah, Genesis": 14,
+                          "Ramban on Leviticus": 3,
+                          "Metzudat Zion on Isaiah": 5,
+                          "Malbim Beur Hamilot on Isaiah": 1,
+                          "Metzudat Zion on Jeremiah": 2,
+                          "Metzudat David on Psalms": 1,
+                          "Rabbeinu Bahya, Devarim": 6,
+                          "Rashi on Bava Kamma": 1,
+                          "Rashi on Berakhot": 1,
+                          "Rash MiShantz on Mishnah Kelim": 1,
+                          "Steinsaltz on Megillah": 3,
+                          "Steinsaltz on Taanit": 1,
+                          "Minchat Ani on Pesach Haggadah, Nirtzah, Chad Gadya": 1,
+                          "Or HaChaim on Numbers": 3,
+                          "Rashba on Megillah": 4,
+                          "Rereading the Rabbis; A Woman's Voice, 6 Procreation": 2,
+                          "Ran on Kiddushin": 1,
+                          "Rif Chullin": 1,
+                          "The Five Books of Moses, by Everett Fox, Exodus, Part I; The Deliverance Narrative": 1,
+                          "The Five Books of Moses, by Everett Fox, Exodus, Part III; The Meeting and Covenant At Sinai, The Meeting and the Covenant": 1,
+                          "The Five Books of Moses, by Everett Fox, Leviticus, On the Book of Leviticus and Its Structure": 2,
+                          "The Five Books of Moses, by Everett Fox, Leviticus, Part II; Ritual Pollution and Purification": 1,
+                          "Ohr LaYesharim on Jerusalem Talmud Chagigah": 3,
+                          "Ohr LaYesharim on Jerusalem Talmud Megillah": 3,
+                          "Ohr LaYesharim on Jerusalem Talmud Rosh Hashanah": 1,
+                          "Karati Bekhol Lev, Shmini": 1,
+                          "Reggio on Torah, Leviticus": 2,
+                          "Judaism's Life Changing Ideas; A Weekly Reading of the Jewish Bible, Noah; The Trace of God": 4,
+                          "I Believe; A Weekly Reading of the Jewish Bible, Bereshit; The Genesis of Love": 5,
+                          "I Believe; A Weekly Reading of the Jewish Bible, Kedoshim; Made with Love": 2,
+                          "I Believe; A Weekly Reading of the Jewish Bible, Naso; The Ethic of Love": 1,
+                          "Megalleh Amukkot on Torah, Vayechi": 1,
+                          "Megalleh Amukkot on Torah, Vayigash": 1,
+                          "Lessons in Leadership; A Weekly Reading of the Jewish Bible, Metzora; How to Praise": 1,
+                          "Sulam on Zohar, Introduction": 19,
+                          "Megalleh Amukkot on Torah, Lech Lecha": 1,
+                          "Megalleh Amukkot on Torah, Vayishlach": 2,
+                          "Megalleh Amukkot on Torah, Vayetzei": 2,
+                          "Megalleh Amukkot on Torah, Vayeshev": 3,
+                          "The Torah; A Women's Commentary, Leviticus": 2,
+                          "The Torah; A Women's Commentary, Contemporary Reflection, Bereshit": 5,
+                          "The Torah; A Women's Commentary, Contemporary Reflection, Noach": 3,
+                          "The Torah; A Women's Commentary, Contemporary Reflection, Tazria": 1,
+                          "The Torah; A Women's Commentary, Numbers": 2,
+                          "The Torah; A Women's Commentary, Deuteronomy": 1,
+                          "The Torah; A Women's Commentary, Parashah Introductions, Bamidbar": 1,
+                          "The Torah; A Women's Commentary, Parashah Introductions, Bereshit": 7,
+                          "The Torah; A Women's Commentary, Exodus": 4,
+                          "The Torah; A Women's Commentary, Parashah Introductions, Kedoshim": 1,
+                          "The Torah; A Women's Commentary, Parashah Introductions, Noach": 1,
+                          "The Torah; A Women's Commentary, Parashah Introductions, Pekudei": 1,
+                          "The Torah; A Women's Commentary, Parashah Introductions, Vayikra": 2,
+                          "The Torah; A Women's Commentary, Postbiblical Interpretations, Bereshit": 1,
+                          "The Torah; A Women's Commentary, Postbiblical Interpretations, Tetzaveh": 1,
+                          "The Torah; A Women's Commentary, Women and Interpretation of the Torah": 1,
+                          "Rashi on Taanit": 2,
+                          "Ikar Tosafot Yom Tov on Mishnah Pesachim": 1,
+                          "Ikar Tosafot Yom Tov on Mishnah Taanit": 1,
+                          "Sforno on Exodus": 1,
+                          "Kitzur Ba'al HaTurim on Exodus": 1,
+                          "Ibn Ezra on Exodus": 8,
+                          "Kli Yakar on Leviticus": 1,
+                          "Metzudat Zion on Psalms": 1,
+                          "Ralbag on Proverbs": 2,
+                          "Ibn Ezra on Psalms": 3,
+                          "Mishnah Berurah": 1,
+                          "Tosafot on Taanit": 2,
+                          "Haamek Davar on Genesis, Kidmat Ha'Emek": 1,
+                          "Haamek Davar on Exodus": 2,
+                          "Haamek Davar on Leviticus": 1,
+                          "Rashi on Shabbat": 1,
+                          "Kli Yakar on Deuteronomy": 1,
+                          "Haamek Davar on Deuteronomy": 2,
+                          "Rashba on Berakhot": 1,
+                          "Kinaat Sofrim on Sefer HaMitzvot, Shorashim": 1,
+                          "Rabbeinu Yonah on Pirkei Avot": 1,
+                          "Tosafot Yom Tov on Mishnah Pesachim": 1,
+                          "Tosafot Yom Tov on Mishnah Shabbat": 1,
+                          "Rabbeinu Bahya, Shemot": 12,
+                          "Rabbeinu Bahya, Vayikra": 3,
+                          "Rabbeinu Bahya, Bamidbar": 5,
+                          "Ralbag Esther, Benefits": 1,
+                          "Yachin on Pirkei Avot": 1,
+                          "Ra'avad on Sefer Yetzirah, Introduction, The Fifty Gates of Understanding": 2,
+                          "Ra'avad on Sefer Yetzirah": 1,
+                          "Ritva on Taanit": 2,
+                          "Minchat Shai on Judges": 1,
+                          "Minchat Shai on Jeremiah": 1,
+                          "Minchat Shai on Ezekiel": 2,
+                          "Minchat Shai on Hosea": 1,
+                          "Minchat Shai on Psalms": 1,
+                          "Minchat Shai on Job": 1,
+                          "Minchat Shai on Daniel": 1,
+                          "Minchat Shai on I Chronicles": 1,
+                          "Minchat Shai on Torah, Exodus": 2,
+                          "Minchat Shai on Torah, Leviticus": 1,
+                          "Minchat Shai on Torah, Numbers": 3,
+                          "Minchat Shai on Torah, Deuteronomy": 2,
+                          "Ibn Ezra on Deuteronomy": 3,
+                          "Tosafot Rid on Megillah Second Recension": 1,
+                          "Melekhet Shelomoh on Mishnah Taanit": 1,
+                          "Mizrachi, Numbers": 2,
+                          "Mizrachi, Deuteronomy": 3,
+                          "Ibn Ezra on Isaiah": 5,
+                          "Mizrachi, Exodus": 6,
+                          "Mizrachi, Leviticus": 1,
+                          "HaKtav VeHaKabalah, Leviticus": 1,
+                          "Steinsaltz on Sukkah": 1,
+                          "Steinsaltz on Rosh Hashanah": 1,
+                          "Steinsaltz on Chagigah": 3,
+                          "Steinsaltz on Bava Kamma": 1,
+                          "Redeeming Relevance; Genesis": 1,
+                          "Masat Moshe on Esther": 1,
+                          "Riva on Torah, Numbers": 1,
+                          "Siftei Chakhamim, Exodus": 2,
+                          "Siftei Chakhamim, Leviticus": 1,
+                          "Tevat Gome, Sh'lach": 1,
+                          "Malbim on Job": 1,
+                          "Ralbag Beur HaMilot on Torah, Exodus": 1,
+                          "Ralbag Beur HaMilot on Torah, Leviticus": 5,
+                          "Ralbag Beur HaMilot on Torah, Deuteronomy": 1,
+                          "Kaf HaChayim on Shulchan Arukh, Orach Chayim": 1,
+                          "Radak on Psalms": 1,
+                          "Or HaChaim on Deuteronomy": 1,
+                          "Mekhir Yayin on Esther": 1,
+                          "Petach Einayim on Shabbat": 1,
+                          "Ralbag on Torah, Exodus": 3,
+                          "Ralbag on Torah, Leviticus": 3,
+                          "Machatzit HaShekel on Orach Chayim": 1,
+                          "Haflaah on Ketubot": 1,
+                          "Naftali Seva Ratzon on Pesach Haggadah, Karpas": 1,
+                          "Recanati on the Torah, Vayera": 2,
+                          "Recanati on the Torah, Toldot": 2,
+                          "Recanati on the Torah, Vayigash": 1,
+                          "Recanati on the Torah, Shemot": 2,
+                          "Recanati on the Torah, Beshalach": 2,
+                          "Recanati on the Torah, Ki Tisa": 1,
+                          "Recanati on the Torah, Achrei Mot": 1,
+                          "Recanati on the Torah, Emor": 1,
+                          "Recanati on the Torah, Eikev": 2,
+                          "Recanati on the Torah, Ki Teitzei": 2,
+                          "Recanati on the Torah, Index, Bereshit": 1,
+                          "Steinsaltz on Arakhin": 1,
+                          "Steinsaltz on Tamid": 1,
+                          "Notes and Corrections on Midrash Lekach Tov, Exodus": 1,
+                          "Rosh David, Bereshit": 1,
+                          "Haamek Sheilah on Sheiltot d'Rav Achai Gaon, Kidmat HaEmek, Part II": 1,
+                          "Haamek Sheilah on Sheiltot d'Rav Achai Gaon, Kidmat HaEmek, Part III": 1,
+                          "Kisse Rahamim on Tractate Soferim": 1,
+                          "Rosh David, Emor": 1,
+                          "Tzror HaMor on Torah, Leviticus": 2,
+                          "Tzror HaMor on Torah, Numbers": 3,
+                          "Tzror HaMor on Torah, Deuteronomy": 1,
+                          "Romemot El on Psalms": 1,
+                          "Yein Levanon on Avot": 2,
+                          "Haamek Davar on Exodus, Introduction to Exodus": 1,
+                          "Nachalat Avot on Avot": 5,
+                          "Machzor Vitry, Laws of Sefer Torah": 1,
+                          "Reshimot Shiurim on Berakhot": 1,
+                          "Peirush Hafla'ah on Pesach Haggadah, Magid, Rabban Gamliel's Three Things": 1,
+                          "Ramban on Exodus": 2,
+                          "Malbim on Psalms": 1,
+                          "Malbim on Jeremiah": 1,
+                          "Notes by Rabbi Yehoshua Hartman on Derekh Chayim, Kol Yisrael; The Opening Mishna": 2,
+                          "Notes by Rabbi Yehoshua Hartman on Derekh Chayim": 44,
+                          "Rashi on Bereshit Rabbah": 1,
+                          "Matnot Kehunah on Bereshit Rabbah": 1,
+                          "Perush Maharzu on Bamidbar Rabbah": 1,
+                          "Matnot Kehunah on Vayikra Rabbah": 1,
+                          "Matnot Kehunah on Devarim Rabbah": 1,
+                          "Matnot Kehunah on Bamidbar Rabbah": 1,
+                          "Notes by Rabbi Yehoshua Hartman on Be'er HaGolah, Well 4": 12,
+                          "Notes by Rabbi Yehoshua Hartman on Be'er HaGolah, Well 5": 3,
+                          "Notes by Rabbi Yehoshua Hartman on Be'er HaGolah, Well 6": 4,
+                          "Notes by Rabbi Yehoshua Hartman on Be'er HaGolah, Well 7": 1,
+                          "Ohr Chadash": 3,
+                          "Notes by Rabbi Yehoshua Hartman on Ohr Chadash, Introduction": 1,
+                          "Notes by Rabbi Yehoshua Hartman on Ohr Chadash": 14,
+                          "Notes by Rabbi Yehoshua Hartman on Ner Mitzvah, Volume I": 1,
+                          "Reshimot Shiurim on Sukkah": 1,
+                          "Notes by Rabbi Yehoshua Hartman on Gevurot Hashem, Introduction to Gevurot Hashem": 2,
+                          "Notes by Rabbi Yehoshua Hartman on Gevurot Hashem, Second Introduction to Gevurot Hashem": 1,
+                          "Notes by Rabbi Yehoshua Hartman on Gevurot Hashem, Third Introduction to Gevurot Hashem": 3,
+                          "Notes by Rabbi Yehoshua Hartman on Gevurot Hashem": 90,
+                          "Notes by Rabbi Yehoshua Hartman on Netivot Olam, Netiv Hatorah": 11,
+                          "Ohev Ger, Part II, Introduction": 1,
+                          "Ohev Ger, Additions, Variants According to Bologna 1482 Edition": 1,
+                          "Rereading the Rabbis; A Woman's Voice, Introduction": 1,
+                          "Meiri on Taanit": 1,
+                          "Rav Hirsch on Torah, Exodus": 1,
+                          "Ibn Ezra on Genesis, Introduction": 1,
+                          "Shiltei HaGiborim on Megillah": 1,
+                          "Mishnat Eretz Yisrael on Mishnah Chagigah": 1,
+                          "Mishnat Eretz Yisrael on Mishnah Megillah": 1,
+                          "Mishnat Eretz Yisrael on Mishnah Taanit": 1,
+                          "Notes by Rabbi Yehoshua Hartman on Tiferet Yisrael": 12,
+                          "Korban HaEdah on Jerusalem Talmud Taanit": 2,
+                          "Korban HaEdah on Jerusalem Talmud Megillah": 1,
+                          "Penei Moshe on Jerusalem Talmud Taanit": 3,
+                          "Gur Aryeh on Shemot": 2,
+                          "Gur Aryeh on Bamidbar": 1,
+                          "Gur Aryeh on Devarim": 1,
+                          "Ohr LaYesharim on Jerusalem Talmud Berakhot": 3,
+                          "Ohr LaYesharim on Jerusalem Talmud Taanit": 1,
+                          "Notes by Rabbi Yehoshua Hartman on Netzach Yisrael": 8,
+                          "Karati Bekhol Lev, Bereshit": 2,
+                          "Karati Bekhol Lev, Bo": 1,
+                          "Hadar Zekenim on Torah, Numbers": 1,
+                          "Sources and References on Torah Ohr, Bereshit": 1,
+                          "Sources and References on Torah Ohr, Miketz": 1,
+                          "Sources and References on Torah Ohr, Mishpatim": 1,
+                          "Sources and References on Torah Ohr, Vayigash": 1,
+                          "Sulam on Zohar, Noach": 1,
+                          "Mikdash Melekh on Zohar": 9,
+                          "Mikdash Melekh, RaMaZ Commentary on Zohar": 8,
+                          "Reggio on Torah, Deuteronomy": 1,
+                          "Mishnat Eretz Yisrael on Mishnah Keritot": 1,
+                          "Mishnat Eretz Yisrael on Mishnah Sanhedrin": 1,
+                          "Ketem Paz on Zohar": 6,
+                          "Ohr HaChammah on Zohar, Preface": 1,
+                          "Ohr HaChammah on Zohar": 30,
+                          "Mishnat Eretz Yisrael on Pirkei Avot": 1,
+                          "Levush HaOrah, Introduction": 1,
+                          "Ohel Ya'akov on Torah, Yitro": 1,
+                          "Ohel Ya'akov on Torah, Tazria": 1,
+                          "Ohel Ya'akov on Torah, Kedoshim": 1,
+                          "Ohel Ya'akov on Torah, Chukat": 1,
+                          "Ohel Ya'akov on Torah, Emor": 1,
+                          "Ohel Ya'akov on Torah, Shoftim": 1,
+                          "Ohel Ya'akov on Torah, Vaetchanan": 1,
+                          "Notes by Rabbi Yehoshua Hartman on Derush al HaTorah, Introduction": 2,
+                          "Notes by Rabbi Yehoshua Hartman on Derush al HaTorah": 8,
+                          "Notes by Rabbi Yehoshua Hartman on Derashat Shabbat HaGadol": 12,
+                          "Pirkei Moshe on Avot": 1,
+                          "Yahel Ohr on Zohar": 72,
+                          "Yahel Ohr on Zohar, Addenda": 3,
+                          "Steinsaltz on Isaiah": 1,
+                          "Steinsaltz on Mishneh Torah, Prayer and the Priestly Blessing": 1,
+                          "Judaism's Life Changing Ideas; A Weekly Reading of the Jewish Bible, Shemini; When Weakness Becomes Strength": 1,
+                          "Studies in Spirituality; A Weekly Reading of the Jewish Bible, Tazria Metzora; The Power of Shame": 1,
+                          "Studies in Spirituality; A Weekly Reading of the Jewish Bible, Bemidbar; The Sound of Silence": 1,
+                          "Studies in Spirituality; A Weekly Reading of the Jewish Bible, Ekev; The Spirituality of Listening": 1,
+                          "Tze'enah Ure'enah, Ki Tavo": 1,
+                          "Megalleh Amukkot on Torah, Shemot": 1,
+                          "Megalleh Amukkot on Torah, Vaera": 2,
+                          "Megalleh Amukkot on Torah, Bo": 2,
+                          "Megalleh Amukkot on Torah, Shmini": 3,
+                          "Megalleh Amukkot on Torah, Kedoshim": 1,
+                          "Megalleh Amukkot on Torah, Korach": 2,
+                          "Megalleh Amukkot on Torah, Bechukotai": 1,
+                          "Megalleh Amukkot on Torah, Sh'lach": 2,
+                          "Megalleh Amukkot on Torah, Balak": 1,
+                          "Megalleh Amukkot on Torah, Shoftim": 1,
+                          "Megalleh Amukkot on Torah, Nitzavim": 1,
+                          "Sirilio on Jerusalem Talmud Kilayim": 1,
+                          "Mechokekei Yehudah; Karnei Ohr, Exodus": 1,
+                          "Mechokekei Yehudah; Yahel Ohr, Introduction": 3,
+                          "Mechokekei Yehudah; Yahel Ohr, Exodus": 10,
+                          "The Torah; A Women's Commentary, Parashah Introductions, Shemot": 1,
+                          "Judaism's Life Changing Ideas; A Weekly Reading of the Jewish Bible, Pekudei; Making Space": 1,
+                          "I Believe; A Weekly Reading of the Jewish Bible, Haazinu; The Arc of the Moral Universe": 1,
+                          "Or HaChaim on Exodus": 1,
+                          "Peri Megadim on Orach Chayim, Eshel Avraham": 1,
+                          "Rashi on Proverbs": 2,
+                          "Od Yosef Chai; Derashot, Bereshit": 1,
+                          "Od Yosef Chai; Derashot, Tetzaveh": 1,
+                          "Od Yosef Chai; Derashot, Ki Tisa": 1,
+                          "The Kehot Chumash; A Chasidic Commentary, Parashah Overviews, Bereshit": 1,
+                          "The Kehot Chumash; A Chasidic Commentary, Parashah Overviews, Bamidbar": 1,
+                          "The Kehot Chumash; A Chasidic Commentary, Exodus": 1,
+                          "Keli Chemdah on Torah, Author's Introduction to Genesis and Exodus": 1,
+                          "Marot HaTzoveot on Joshua": 1,
+                          "Siftei Kohen on Torah, Exodus": 6,
+                          "Siftei Kohen on Torah, Numbers": 1,
+                          "Siftei Kohen on Torah, Deuteronomy": 4,
+                          "Kli Yakar on Exodus": 1,
+                          "Minchat Ani on Torah, Bereshit": 1,
+                          "Sulam on Zohar, Bereshit II": 1,
+                          "Ba'al HaTurim on Genesis": 3,
+                          "Da'at Zekenim on Genesis": 2,
+                          "Abarbanel on Torah, Genesis": 2,
+                          "Bekhor Shor, Genesis": 1,
+                          "Chizkuni, Genesis": 6,
+                          "Avi Ezer, Genesis": 3,
+                          "Chomat Anakh on Torah, Genesis": 1,
+                          "Bartenura on Torah, Genesis": 4,
+                          "Aderet Eliyahu, Genesis": 15,
+                          "Birkat Asher on Torah, Genesis": 6,
+                          "Aderet Eliyahu (Rabbi Yosef Chaim), Bereshit": 1,
+                          "Chanukat HaTorah": 1,
+                          "Chatam Sofer on Torah, Bereshit": 2,
+                          "Em LaMikra, Genesis": 10,
+                          "Alshekh on Torah, Genesis": 1,
+                          "Cassuto on Genesis, From Adam to Noah": 3,
+                          "Divrei David on Rashi, Genesis": 7,
+                          "Buber footnotes on Midrash Mishlei": 1,
+                          "Daf Shevui to Megillah": 1,
+                          "Chizkuni, Exodus": 1,
+                          "Bartenura on Torah, Deuteronomy": 1,
+                          "Birkat Asher on Torah, Exodus": 1,
+                          "Ben Yehoyada on Shabbat": 2,
+                          "Ben Yehoyada on Eruvin": 1,
+                          "Ben Yehoyada on Yoma": 1,
+                          "Ben Yehoyada on Sukkah": 3,
+                          "Ben Yehoyada on Megillah": 1,
+                          "Ben Yehoyada on Taanit": 1,
+                          "Benayahu on Eruvin": 1,
+                          "Benayahu on Yoma": 1,
+                          "Benayahu on Megillah": 1,
+                          "Ben Yehoyada on Kiddushin": 1,
+                          "Ben Yehoyada on Sanhedrin": 2,
+                          "Ben Yehoyada on Chullin": 1,
+                          "Ben Yehoyada on Avodah Zarah": 1,
+                          "Ben Yehoyada on Menachot": 1,
+                          "Derekh Chayyim": 12,
+                          "Commentary on Selected Paragraphs of Arpilei Tohar": 1,
+                          "Birkat Asher on Torah, Deuteronomy": 1,
+                          "Ezra ben Solomon on Song of Songs": 1,
+                          "Eretz Chemdah, Bereshit": 1,
+                          "Cassuto on Genesis, From Noah to Abraham": 1,
+                          "Covenant and Conversation; Genesis; The Book of the Beginnings, Bereshit, The Book of Teaching": 1,
+                          "Covenant and Conversation; Genesis; The Book of the Beginnings, Noach, Drama in Four Acts": 1
+                        }
+                      },
+                      {
+                        "name": "Midrash",
+                        "count": 172,
+                        "books": {
+                          "Legends of the Jews": 2,
+                          "Midrash Aggadah, Genesis": 13,
+                          "Midrash Lekach Tov, Genesis": 36,
+                          "Midrash Lekach Tov, Numbers": 1,
+                          "Midrash Lekach Tov, Deuteronomy": 2,
+                          "Yalkut Shimoni on Torah": 8,
+                          "Otzar Midrashim, Midrash Lekach Tov": 1,
+                          "Ruth Rabbah": 1,
+                          "Sifrei Devarim": 1,
+                          "Shemot Rabbah": 10,
+                          "Vayikra Rabbah": 11,
+                          "Tanna DeBei Eliyahu Rabbah": 2,
+                          "Mekhilta DeRabbi Shimon Ben Yochai": 1,
+                          "Pirkei DeRabbi Eliezer": 3,
+                          "Tanna DeBei Eliyahu Zuta, Additions to Seder Eliyahu Zuta, Pirkei DeRabbi Eliezer": 1,
+                          "Yalkut Shimoni on Nach": 1,
+                          "Midrash Tehillim": 4,
+                          "Otzar Midrashim, Midrash Hagadol": 1,
+                          "Otzar Midrashim, R' Nechunya Ben HaKanah": 1,
+                          "Otzar Midrashim, Sefer Tagin ('Crowns')": 3,
+                          "Otzar Midrashim, Seventy Names of Metatron": 1,
+                          "Otzar Midrashim, Midrash on the Ten Commandments": 1,
+                          "Midrash Tanchuma, Chayei Sara": 1,
+                          "Midrash Tanchuma, Shemot": 1,
+                          "Midrash Tanchuma, Vaera": 1,
+                          "Midrash Tanchuma, Bereshit": 3,
+                          "Midrash Tanchuma, Tetzaveh": 1,
+                          "Midrash Tanchuma, Pekudei": 1,
+                          "Midrash Tanchuma, Nasso": 1,
+                          "Shir HaShirim Rabbah": 1,
+                          "Kohelet Rabbah": 1,
+                          "Ruth Rabbah, Petichta": 1,
+                          "Midrash Tanchuma Buber, Bereshit": 12,
+                          "Midrash Tanchuma Buber, Shemot": 1,
+                          "Midrash Tanchuma Buber, Vaera": 1,
+                          "Midrash Tanchuma Buber, Yitro": 1,
+                          "Midrash Lekach Tov, Exodus": 1,
+                          "Pesikta DeRav Kahana": 2,
+                          "Midrash Yelamdenu, Selections from Yalkut Talmud Torah": 1,
+                          "Mekhilta DeRabbi Yishmael, Tractate Pischa": 2,
+                          "Mekhilta DeRabbi Yishmael, Tractate Shirah": 1,
+                          "Bereshit Rabbah": 21,
+                          "Eikhah Rabbah, Petichta": 1,
+                          "Ein Yaakov, Khagigah": 2,
+                          "Ein Yaakov (Glick Edition), Sukkah": 1,
+                          "Ein Yaakov (Glick Edition), Khagigah": 2,
+                          "Ein Yaakov (Glick Edition), Megillah": 1,
+                          "Bamidbar Rabbah": 2,
+                          "Devarim Rabbah": 1,
+                          "Bereshit Rabbati, Parashat Bereshit": 2
+                        }
+                      },
+                      {
+                        "name": "Tanakh",
+                        "count": 256,
+                        "books": {
+                          "Psalms": 2,
+                          "Genesis": 248,
+                          "Proverbs": 1,
+                          "Jeremiah": 1,
+                          "Lessons in Leadership; Hebrew Edition, Kedoshim; From Priest to People": 2,
+                          "Lessons in Leadership; Hebrew Edition, Naso; Pursuing Peace": 1,
+                          "Deuteronomy": 1
+                        }
+                      },
+                      {
+                        "name": "Mishnah",
+                        "count": 6,
+                        "books": {
+                          "Mishnah Chagigah": 1,
+                          "Mishnah Ta'anit": 2,
+                          "Mishnah Megillah": 3
+                        }
+                      },
+                      {
+                        "name": "Targum",
+                        "count": 5,
+                        "books": {
+                          "Targum Jonathan on Genesis": 1,
+                          "Targum Neofiti": 1,
+                          "Onkelos Genesis": 1,
+                          "Targum Jerusalem, Genesis": 1,
+                          "Tafsir Rasag, Genesis": 1
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        }
+      }
+    },
+    "/api/calendars/topics/parasha": {
+      "summary": "Parasha Topic",
+      "description": "Returns topic metadata for the current week's parasha — title, ref, category ordering, and bilingual display values.",
+      "get": {
+        "operationId": "get-calendar-parasha-topic",
+        "tags": [
+          "Calendars"
+        ],
+        "description": "Returns topic metadata for the current week's parasha — title, ref, category ordering, and bilingual display values.",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CalendarParashaTopicJSON"
+                },
+                "examples": {
+                  "This week's parasha": {
+                    "value": {
+                      "title": {
+                        "en": "Parashat Hashavua",
+                        "he": "פרשת השבוע"
+                      },
+                      "displayValue": {
+                        "en": "Behar-Bechukotai",
+                        "he": "בהר-בחוקתי"
+                      },
+                      "url": "Leviticus.25.1-27.34",
+                      "ref": "Leviticus 25:1-27:34",
+                      "heRef": "ויקרא כ״ה:א׳-כ״ז:ל״ד",
+                      "order": 1,
+                      "category": "Tanakh",
+                      "extraDetails": {
+                        "aliyot": [
+                          "Leviticus 25:1-25:18",
+                          "Leviticus 25:19-25:28",
+                          "Leviticus 25:29-25:38",
+                          "Leviticus 25:39-26:9",
+                          "Leviticus 26:10-26:46",
+                          "Leviticus 27:1-27:15",
+                          "Leviticus 27:16-27:34",
+                          "Leviticus 27:32-27:34"
+                        ]
+                      },
+                      "description": {
+                        "en": "Behar-Bechukoatai (“On The Mountain”-”In My Laws”), a double Torah portion and the final one in the Book of Leviticus, details the laws of the Sabbatical and Jubilee years, vows, and consecration of people and property. It also describes blessings for following God’s law and curses for desecrating them.",
+                        "he": "בפרשה הכפולה בהר-בחוקותי, המסיימת את ספר ויקרא, מובאים דיני שבת הארץ (שמיטה) ודיני היובל. לבני ישראל מובטחים שגשוג כלכלי וחקלאי, שלום והצלחה צבאית והשראת שכינה, אם ישמרו את חוקי התורה. אם יפרו את הברית, יבואו עליהם עונשים וקללות: שפל כלכלי, רעב, מחלות, תבוסה במלחמות וגלות. אלוהים מבטיח שיזכור את בריתו עם האבות והארץ, והפרשה מסתיימת בדיני ערכין באדם ובקרקעות."
+                      },
+                      "topic": "behar-bechukotai"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        }
+      }
+    },
+    "/api/calendars/topics/holiday": {
+      "summary": "Holiday Topic",
+      "description": "Returns topic metadata for the active holiday on the requested date. Returns 404 when no holiday is in season for the given day. Use the `year`, `month`, `day` query params (all three required together) to query a specific date; otherwise the current date is used.",
+      "get": {
+        "operationId": "get-calendar-holiday-topic",
+        "tags": [
+          "Calendars"
+        ],
+        "parameters": [
+          {
+            "name": "year",
+            "description": "Year. Must be combined with `month` and `day`.",
+            "schema": {
+              "type": "integer"
+            },
+            "in": "query",
+            "required": false
+          },
+          {
+            "name": "month",
+            "description": "Month (1–12). Must be combined with `year` and `day`.",
+            "schema": {
+              "type": "integer"
+            },
+            "in": "query",
+            "required": false
+          },
+          {
+            "name": "day",
+            "description": "Day of month. Must be combined with `year` and `month`.",
+            "schema": {
+              "type": "integer"
+            },
+            "in": "query",
+            "required": false
+          },
+          {
+            "name": "lang",
+            "description": "Interface language. Defaults to `en`.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "en",
+                "he"
+              ]
+            },
+            "in": "query",
+            "required": false
+          }
+        ],
+        "description": "Returns topic metadata for the active holiday on the requested date. Returns 404 when no holiday is in season for the given day. Use the `year`, `month`, `day` query params (all three required together) to query a specific date; otherwise the current date is used.",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CalendarHolidayTopicJSON"
+                },
+                "examples": {
+                  "Pesach 2026 (April 3)": {
+                    "value": {
+                      "topic": {
+                        "primaryTitle": {
+                          "en": "Lag BaOmer",
+                          "he": "ל\"ג בעומר"
+                        },
+                        "en": "Lag BaOmer",
+                        "he": "ל\"ג בעומר",
+                        "slug": "lag-baomer",
+                        "titles": [
+                          {
+                            "text": "Lag BaOmer",
+                            "lang": "en",
+                            "primary": true
+                          },
+                          {
+                            "text": "Lag Beomer",
+                            "lang": "en"
+                          },
+                          {
+                            "text": "The 33rd Day of the Omer",
+                            "lang": "en"
+                          },
+                          {
+                            "text": "Lag B'Omer",
+                            "lang": "en"
+                          },
+                          {
+                            "text": "Lag B'omer",
+                            "lang": "en"
+                          },
+                          {
+                            "text": "Lag Ba'omer",
+                            "lang": "en"
+                          },
+                          {
+                            "text": "Lag Baomer",
+                            "lang": "en"
+                          },
+                          {
+                            "text": "Lag Ba'Omer",
+                            "lang": "en"
+                          },
+                          {
+                            "text": "LagBaOmer",
+                            "lang": "en"
+                          },
+                          {
+                            "text": "ל\"ג בעומר",
+                            "lang": "he",
+                            "primary": true
+                          },
+                          {
+                            "text": "לג בעומר",
+                            "lang": "he"
+                          }
+                        ],
+                        "alt_ids": {
+                          "_temp_id": "לג בעומר"
+                        },
+                        "description": {
+                          "en": "Lag BaOmer (\"the 33rd day of the Omer\") is a day of celebration during the otherwise solemn period of the 49 days between the holidays of Passover and Shavuot. Many mark this day with outdoor parties and bonfires.",
+                          "he": "ל״ג בעומר, היום ה-33 לעומר (י״ח באייר), נקבע כיום חג שחל במהלך ספירת העומר, 49 הימים שבין פסח לשבועות המתאפיינים לרוב במנהגי אבלות. בליל ל״ג בעומר נהוג להדליק מדורות בטבע. "
+                        },
+                        "categoryDescription": {},
+                        "displayOrder": 120,
+                        "numSources": 82,
+                        "good_to_promote": true,
+                        "description_published": true,
+                        "data_source": "sefaria",
+                        "image": {
+                          "image_uri": "https://storage.googleapis.com/img.sefaria.org/topics/166904-a5000bf0-16ac-11ef-a28f-3ec606919e2d.gif",
+                          "image_caption": {
+                            "en": "The earliest known documentation of the custom of haircutting on Lag BaOmer. From: Sefer HaMinhagim, 1601, the National Library of Israel collections",
+                            "he": "התיעוד הקדום ביותר של מנהג התספורת בל\"ג בעומר. מתוך: ספר המנהגים, 1601, אוספי הספריה הלאומית"
+                          }
+                        }
+                      },
+                      "secondary_topic": {
+                        "primaryTitle": {
+                          "en": "Lag BaOmer",
+                          "he": "ל\"ג בעומר"
+                        },
+                        "en": "Lag BaOmer",
+                        "he": "ל\"ג בעומר",
+                        "slug": "lag-baomer",
+                        "titles": [
+                          {
+                            "text": "Lag BaOmer",
+                            "lang": "en",
+                            "primary": true
+                          },
+                          {
+                            "text": "Lag Beomer",
+                            "lang": "en"
+                          },
+                          {
+                            "text": "The 33rd Day of the Omer",
+                            "lang": "en"
+                          },
+                          {
+                            "text": "Lag B'Omer",
+                            "lang": "en"
+                          },
+                          {
+                            "text": "Lag B'omer",
+                            "lang": "en"
+                          },
+                          {
+                            "text": "Lag Ba'omer",
+                            "lang": "en"
+                          },
+                          {
+                            "text": "Lag Baomer",
+                            "lang": "en"
+                          },
+                          {
+                            "text": "Lag Ba'Omer",
+                            "lang": "en"
+                          },
+                          {
+                            "text": "LagBaOmer",
+                            "lang": "en"
+                          },
+                          {
+                            "text": "ל\"ג בעומר",
+                            "lang": "he",
+                            "primary": true
+                          },
+                          {
+                            "text": "לג בעומר",
+                            "lang": "he"
+                          }
+                        ],
+                        "alt_ids": {
+                          "_temp_id": "לג בעומר"
+                        },
+                        "description": {
+                          "en": "Lag BaOmer (\"the 33rd day of the Omer\") is a day of celebration during the otherwise solemn period of the 49 days between the holidays of Passover and Shavuot. Many mark this day with outdoor parties and bonfires.",
+                          "he": "ל״ג בעומר, היום ה-33 לעומר (י״ח באייר), נקבע כיום חג שחל במהלך ספירת העומר, 49 הימים שבין פסח לשבועות המתאפיינים לרוב במנהגי אבלות. בליל ל״ג בעומר נהוג להדליק מדורות בטבע. "
+                        },
+                        "categoryDescription": {},
+                        "displayOrder": 120,
+                        "numSources": 82,
+                        "good_to_promote": true,
+                        "description_published": true,
+                        "data_source": "sefaria",
+                        "image": {
+                          "image_uri": "https://storage.googleapis.com/img.sefaria.org/topics/166904-a5000bf0-16ac-11ef-a28f-3ec606919e2d.gif",
+                          "image_caption": {
+                            "en": "The earliest known documentation of the custom of haircutting on Lag BaOmer. From: Sefer HaMinhagim, 1601, the National Library of Israel collections",
+                            "he": "התיעוד הקדום ביותר של מנהג התספורת בל\"ג בעומר. מתוך: ספר המנהגים, 1601, אוספי הספריה הלאומית"
+                          }
+                        }
+                      },
+                      "display_start_date": "2026-05-04",
+                      "display_end_date": "2026-05-04",
+                      "display_date_prefix": null,
+                      "display_date_suffix": "this year begins on the evening of:"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        }
+      }
+    },
+    "/api/profile/{slug}": {
+      "summary": "Public Profile",
+      "description": "Returns the public profile for a Sefaria user.",
+      "get": {
+        "operationId": "get-profile",
+        "tags": [
+          "Misc"
+        ],
+        "parameters": [
+          {
+            "name": "slug",
+            "description": "Profile URL slug, e.g. `sefaria`. Found in the user's profile URL on Sefaria.",
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "required": true
+          }
+        ],
+        "description": "Returns the public profile for a Sefaria user.",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProfileJSON"
+                },
+                "examples": {
+                  "sefaria profile": {
+                    "value": {
+                      "id": 123198,
+                      "slug": "sefaria",
+                      "profile_pic_url": "",
+                      "full_name": " ",
+                      "followers": [],
+                      "followees": [],
+                      "jewish_education": [],
+                      "bio": "",
+                      "website": "",
+                      "location": "",
+                      "public_email": "",
+                      "facebook": "",
+                      "twitter": "",
+                      "linkedin": "",
+                      "youtube": "",
+                      "position": "",
+                      "organization": ""
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        }
+      }
     }
   },
   "components": {
@@ -5831,7 +19739,13 @@
             "type": "string"
           },
           "type": {
-            "description": "By default the Name API returns `Ref`s, book titles, authors, topics, and collections. If `type` is set, the response will only contain items of that type.",
+            "enum": [
+              "ref",
+              "Topic",
+              "AuthorTopic",
+              "PersonTopic",
+              "User"
+            ],
             "type": "string"
           },
           "completions": {
@@ -5867,46 +19781,46 @@
             },
             "example": [
               {
-                "title": "Ruth", 
-                "key": "Ruth", 
-                "type": "ref", 
-                "is_primary": true, 
+                "title": "Ruth",
+                "key": "Ruth",
+                "type": "ref",
+                "is_primary": true,
                 "order": 1000000
-              }, 
+              },
               {
-                "title": "Ruth Rabbah", 
-                "key": "Ruth Rabbah", 
-                "type": "ref", 
-                "is_primary": true,   
+                "title": "Ruth Rabbah",
+                "key": "Ruth Rabbah",
+                "type": "ref",
+                "is_primary": true,
                 "order": 1000000
-              }, 
+              },
               {
-                "title": "Ruth", 
-                "type": "PersonTopic", 
-                "key": "ruth", 
-                "is_primary": true, 
+                "title": "Ruth",
+                "type": "PersonTopic",
+                "key": "ruth",
+                "is_primary": true,
                 "order": 4999550
-              }, 
+              },
               {
-                "title": "Ruach Hakodesh", 
-                "type": "Topic", 
-                "key": "ruach-hakodesh1", 
-                "is_primary": true, 
+                "title": "Ruach Hakodesh",
+                "type": "Topic",
+                "key": "ruach-hakodesh1",
+                "is_primary": true,
                 "order": 4999902
-              }, 
-              { 
-                "title": "Ruach", 
-                "type": "Topic", 
-                "key": "ruach1", 
-                "is_primary": true, 
-                "order": 4999949 
-              }, 
-              { 
-                "title": "Rubissa Sharona Hassan", 
-                "type": "User", 
-                "key":"sharona-hassan", 
-                "pic": "https://storage.googleapis.com/sefaria-profile-pictures/sharona-hassan-1622999139-small.png", 
-                "order": 6999998, 
+              },
+              {
+                "title": "Ruach",
+                "type": "Topic",
+                "key": "ruach1",
+                "is_primary": true,
+                "order": 4999949
+              },
+              {
+                "title": "Rubissa Sharona Hassan",
+                "type": "User",
+                "key": "sharona-hassan",
+                "pic": "https://storage.googleapis.com/sefaria-profile-pictures/sharona-hassan-1622999139-small.png",
+                "order": 6999998,
                 "is_primary": true
               }
             ]
@@ -5930,16 +19844,6 @@
           "is_range": {
             "description": "Returns `true` if the submitted text is a a ranged `Ref` (one that spans multiple sections or segments.) e.g. `Genesis 4-5`",
             "type": "boolean"
-          },
-          "type": {
-            "enum": [
-              "ref",
-              "Topic",
-              "AuthorTopic",
-              "PersonTopic",
-              "User"
-            ],
-            "type": "string"
           },
           "ref": {
             "description": "If `type=ref`, this returns the canonical ref for the submitted text.",
@@ -6115,7 +20019,6 @@
           "is_section": false,
           "is_segment": true,
           "is_range": false,
-          "type": "ref",
           "ref": "Rashi on Job 1:3:3",
           "url": "Rashi_on_Job.1.3.3",
           "index": "Rashi on Job",
@@ -6765,26 +20668,26 @@
           "digitizedBySefaria": {
             "description": "Was the `text` response initially digitized by Sefaria",
             "anyOf": [
-                      {
-                        "type": "boolean"
-                      },
-                      {
-                        "type": "string"
-                      }
-                    ]
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "string"
+              }
+            ]
           },
           "license": {
             "type": "string"
           },
           "formatEnAsPoetry": {
             "oneOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "string"
-                }
-              ]
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "string"
+              }
+            ]
           },
           "heVersionTitle": {
             "type": "string"
@@ -6819,26 +20722,26 @@
           "heDigitizedBySefaria": {
             "description": "Was the `he` response initially digitized by Sefaria `1` or was it initially generated by another digital publisher `0`",
             "oneOf": [
-                      {
-                        "type": "boolean"
-                      },
-                      {
-                        "type": "string"
-                      }
-                    ]
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "string"
+              }
+            ]
           },
           "heLicense": {
             "type": "string"
           },
           "formatHeAsPoetry": {
             "oneOf": [
-                      {
-                        "type": "boolean"
-                      },
-                      {
-                        "type": "string"
-                      }
-                    ]
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "string"
+              }
+            ]
           },
           "alts": {
             "type": "array",
@@ -7394,7 +21297,10 @@
             "items": {
               "type": "string"
             },
-            "example": ["Esther 4:14", "Esther 4:15"]
+            "example": [
+              "Esther 4:14",
+              "Esther 4:15"
+            ]
           },
           "manuscript": {
             "$ref": "#/components/schemas/ManuscriptVersionMetaData"
@@ -7478,9 +21384,9 @@
           "type": "string"
         },
         "example": [
-            "אב",
-            "אַב"
-          ]
+          "אב",
+          "אַב"
+        ]
       },
       "VersionJSON": {
         "title": "Root Type for VersionJSON",
@@ -7523,25 +21429,25 @@
           "digitizedBySefaria": {
             "description": "Whether or not the text was digitized by Sefaria. We have some texts we've been able to add to our database from digital sources, and other texts that we've transfered from print to a digital medium ourselves. This field indicates if Sefaria did the digitization. ",
             "oneOf": [
-                      {
-                        "type": "boolean"
-                      },
-                      {
-                        "type": "string"
-                      }
-                    ]
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "string"
+              }
+            ]
           },
           "priority": {
             "description": "The priority field is a number which indicates the priority of a version relative to all other existing versions of the same text. A value of `1` indicates the lowest priority, while the highest value among all versions of the text indicate the highest priority. \n\nPriority values can also be floating point numbers. The priority field determines how the various available versions of a text will be displayed on the Sefaria website. The texts are displayed to the user in a highest-to-lowest priority order, in many cases offering more complete or higher quality versions of the text before ones of inferior quality. ",
             "oneOf": [
-                  {
-                    "type": "number",
-                    "example": 7
-                  },
-                  {
-                    "type": "string"
-                  }
-                ]
+              {
+                "type": "number",
+                "example": 7
+              },
+              {
+                "type": "string"
+              }
+            ]
           },
           "versionTitleInHebrew": {
             "description": "The title of the version in Hebrew",
@@ -8128,57 +22034,57 @@
             },
             "example": [
               {
-                "text": "Tabernacles", 
-                "lang": "en"
-              }, 
-              {
-                "text": "Succot", 
+                "text": "Tabernacles",
                 "lang": "en"
               },
               {
-                "text": "Sukkos", 
+                "text": "Succot",
                 "lang": "en"
-              }, 
+              },
               {
-                "text": "Succos", 
+                "text": "Sukkos",
                 "lang": "en"
-              }, 
+              },
               {
-                "text": "Booths", 
+                "text": "Succos",
                 "lang": "en"
-              }, 
+              },
               {
-                "text": "sukkot", 
+                "text": "Booths",
                 "lang": "en"
-              }, 
+              },
               {
-                "text": "succot", 
+                "text": "sukkot",
                 "lang": "en"
-              }, 
+              },
               {
-                "text": "Succoth", 
+                "text": "succot",
                 "lang": "en"
-              }, 
+              },
               {
-                "text": "Sukkoth", 
-                "lang": "en" 
-              }, 
+                "text": "Succoth",
+                "lang": "en"
+              },
               {
-                "text": "חג הסוכות", 
+                "text": "Sukkoth",
+                "lang": "en"
+              },
+              {
+                "text": "חג הסוכות",
                 "lang": "he"
-              }, 
+              },
               {
-                "text": "סכות", 
+                "text": "סכות",
                 "lang": "he"
-              }, 
+              },
               {
-                "text": "Sukkot", 
-                "lang": "en", 
-                "primary": true 
-              }, 
+                "text": "Sukkot",
+                "lang": "en",
+                "primary": true
+              },
               {
-                "text": "סוכות", 
-                "lang": "he", 
+                "text": "סוכות",
+                "lang": "he",
                 "primary": true
               }
             ]
@@ -8191,7 +22097,11 @@
                 "type": "string"
               }
             },
-            "example": {"_temp_id": "משה", "wikidata": "Q9077", "_old_slug": "-75"}
+            "example": {
+              "_temp_id": "משה",
+              "wikidata": "Q9077",
+              "_old_slug": "-75"
+            }
           },
           "properties": {
             "$ref": "#/components/schemas/TopicPropertyJson"
@@ -8369,13 +22279,13 @@
           "en": {
             "description": "The English field for a JSON object representing billingual text. ",
             "oneOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "boolean"
-                      }
-                    ],
+              {
+                "type": "string"
+              },
+              {
+                "type": "boolean"
+              }
+            ],
             "example": "Detail of a painting of a sukkah. Image taken from f. 316v of Forli Siddur. 1383, Italian rite. The British Library"
           },
           "he": {
@@ -9296,7 +23206,11 @@
                 "language": "he",
                 "versionSource": "https://he.wikisource.org/wiki/%D7%9E%D7%A9%D7%AA%D7%9E%D7%A9:Dovi/%D7%9E%D7%A7%D7%A8%D7%90_%D7%A2%D7%9C_%D7%A4%D7%99_%D7%94%D7%9E%D7%A1%D7%95%D7%A8%D7%94",
                 "versionTitle": "Miqra according to the Masorah",
-                "text": [["חֲז֖וֹן עֹֽבַדְיָ֑ה כֹּֽה־אָמַר֩ אֲדֹנָ֨י יֱהֹוִ֜ה לֶאֱד֗וֹם שְׁמוּעָ֨ה שָׁמַ֜עְנוּ מֵאֵ֤ת יְהֹוָה֙ וְצִיר֙ בַּגּוֹיִ֣ם שֻׁלָּ֔ח ק֛וּמוּ וְנָק֥וּמָה עָלֶ֖יהָ לַמִּלְחָמָֽה׃\",\n\"הִנֵּ֥ה קָטֹ֛ן נְתַתִּ֖יךָ בַּגּוֹיִ֑ם בָּז֥וּי אַתָּ֖ה מְאֹֽד׃\",\n\"זְד֤וֹן לִבְּךָ֙ הִשִּׁיאֶ֔ךָ שֹׁכְנִ֥י בְחַגְוֵי־סֶ֖לַע מְר֣וֹם שִׁבְתּ֑וֹ אֹמֵ֣ר בְּלִבּ֔וֹ מִ֥י יוֹרִדֵ֖נִי אָֽרֶץ׃\",\n\"אִם־תַּגְבִּ֣יהַּ כַּנֶּ֔שֶׁר וְאִם־בֵּ֥ין כּֽוֹכָבִ֖ים שִׂ֣ים קִנֶּ֑ךָ מִשָּׁ֥ם אוֹרִֽידְךָ֖ נְאֻם־יְהֹוָֽה׃\",\n\"אִם־גַּנָּבִ֤ים בָּאֽוּ־לְךָ֙ אִם־שׁ֣וֹדְדֵי לַ֔יְלָה אֵ֣יךְ נִדְמֵ֔יתָה הֲל֥וֹא יִגְנְב֖וּ דַּיָּ֑ם אִם־בֹּֽצְרִים֙ בָּ֣אוּ לָ֔ךְ הֲל֖וֹא יַשְׁאִ֥ירוּ עֹלֵלֽוֹת׃\",\n\"אֵ֚יךְ נֶחְפְּשׂ֣וּ עֵשָׂ֔ו נִבְע֖וּ מַצְפֻּנָֽיו׃\",\n\"עַֽד־הַגְּב֣וּל שִׁלְּח֗וּךָ כֹּ֚ל אַנְשֵׁ֣י בְרִיתֶ֔ךָ הִשִּׁיא֛וּךָ יָכְל֥וּ לְךָ֖ אַנְשֵׁ֣י שְׁלֹמֶ֑ךָ לַחְמְךָ֗ יָשִׂ֤ימוּ מָזוֹר֙ תַּחְתֶּ֔יךָ אֵ֥ין תְּבוּנָ֖ה בּֽוֹ׃\",\n\"הֲל֛וֹא בַּיּ֥וֹם הַה֖וּא נְאֻם־יְהֹוָ֑ה וְהַאֲבַדְתִּ֤י חֲכָמִים֙ מֵֽאֱד֔וֹם וּתְבוּנָ֖ה מֵהַ֥ר עֵשָֽׂו׃\",\n\"וְחַתּ֥וּ גִבּוֹרֶ֖יךָ תֵּימָ֑ן לְמַ֧עַן יִכָּֽרֶת־אִ֛ישׁ מֵהַ֥ר עֵשָׂ֖ו מִקָּֽטֶל׃\",\n\"מֵחֲמַ֛ס אָחִ֥יךָ יַעֲקֹ֖ב תְּכַסְּךָ֣ בוּשָׁ֑ה וְנִכְרַ֖תָּ לְעוֹלָֽם׃\",\n\"בְּיוֹם֙ עֲמׇֽדְךָ֣ מִנֶּ֔גֶד בְּי֛וֹם שְׁב֥וֹת זָרִ֖ים חֵיל֑וֹ וְנׇכְרִ֞ים בָּ֣אוּ <span class=\\\"mam-kq-trivial\\\">שְׁעָרָ֗ו</span> וְעַל־יְרוּשָׁלַ֙͏ִם֙ יַדּ֣וּ גוֹרָ֔ל גַּם־אַתָּ֖ה כְּאַחַ֥ד מֵהֶֽם׃\",\n\"וְאַל־תֵּ֤רֶא בְיוֹם־אָחִ֙יךָ֙ בְּי֣וֹם נׇכְר֔וֹ וְאַל־תִּשְׂמַ֥ח לִבְנֵֽי־יְהוּדָ֖ה בְּי֣וֹם אׇבְדָ֑ם וְאַל־תַּגְדֵּ֥ל פִּ֖יךָ בְּי֥וֹם צָרָֽה׃\",\n\"אַל־תָּב֤וֹא בְשַֽׁעַר־עַמִּי֙ בְּי֣וֹם אֵידָ֔ם אַל־תֵּ֧רֶא גַם־אַתָּ֛ה בְּרָעָת֖וֹ בְּי֣וֹם אֵיד֑וֹ וְאַל־תִּשְׁלַ֥חְנָה בְחֵיל֖וֹ בְּי֥וֹם אֵידֽוֹ׃\",\n\"וְאַֽל־תַּעֲמֹד֙ עַל־הַפֶּ֔רֶק לְהַכְרִ֖ית אֶת־פְּלִיטָ֑יו וְאַל־תַּסְגֵּ֥ר שְׂרִידָ֖יו בְּי֥וֹם צָרָֽה׃\",\n\"כִּֽי־קָר֥וֹב יוֹם־יְהֹוָ֖ה עַל־כׇּל־הַגּוֹיִ֑ם כַּאֲשֶׁ֤ר עָשִׂ֙יתָ֙ יֵעָ֣שֶׂה לָּ֔ךְ גְּמֻלְךָ֖ יָשׁ֥וּב בְּרֹאשֶֽׁךָ׃\",\n\"כִּ֗י כַּֽאֲשֶׁ֤ר שְׁתִיתֶם֙ עַל־הַ֣ר קׇדְשִׁ֔י יִשְׁתּ֥וּ כׇֽל־הַגּוֹיִ֖ם תָּמִ֑יד וְשָׁת֣וּ וְלָע֔וּ וְהָי֖וּ כְּל֥וֹא הָיֽוּ׃\",\n\"וּבְהַ֥ר צִיּ֛וֹן תִּהְיֶ֥ה פְלֵיטָ֖ה וְהָ֣יָה קֹ֑דֶשׁ וְיָֽרְשׁוּ֙ בֵּ֣ית יַֽעֲקֹ֔ב אֵ֖ת מוֹרָֽשֵׁיהֶֽם׃\",\n\"וְהָיָה֩ בֵית־יַעֲקֹ֨ב אֵ֜שׁ וּבֵ֧ית יוֹסֵ֣ף לֶהָבָ֗ה וּבֵ֤ית עֵשָׂו֙ לְקַ֔שׁ וְדָלְק֥וּ בָהֶ֖ם וַאֲכָל֑וּם וְלֹֽא־יִֽהְיֶ֤ה שָׂרִיד֙ לְבֵ֣ית עֵשָׂ֔ו כִּ֥י יְהֹוָ֖ה דִּבֵּֽר׃\",\n\"וְיָרְשׁ֨וּ הַנֶּ֜גֶב אֶת־הַ֣ר עֵשָׂ֗ו וְהַשְּׁפֵלָה֙ אֶת־פְּלִשְׁתִּ֔ים וְיָרְשׁוּ֙ אֶת־שְׂדֵ֣ה אֶפְרַ֔יִם וְאֵ֖ת שְׂדֵ֣ה שֹׁמְר֑וֹן וּבִנְיָמִ֖ן אֶת־הַגִּלְעָֽד׃\",\n\"וְגָלֻ֣ת הַֽחֵל־הַ֠זֶּ֠ה לִבְנֵ֨י יִשְׂרָאֵ֤ל אֲשֶֽׁר־כְּנַעֲנִים֙ עַד־צָ֣רְפַ֔ת וְגָלֻ֥ת יְרוּשָׁלַ֖͏ִם אֲשֶׁ֣ר בִּסְפָרַ֑ד יִֽרְשׁ֕וּ אֵ֖ת עָרֵ֥י הַנֶּֽגֶב׃\",\n\"וְעָל֤וּ מֽוֹשִׁעִים֙ בְּהַ֣ר צִיּ֔וֹן לִשְׁפֹּ֖ט אֶת־הַ֣ר עֵשָׂ֑ו וְהָיְתָ֥ה לַֽיהֹוָ֖ה הַמְּלוּכָֽה׃"]],
+                "text": [
+                  [
+                    "חֲז֖וֹן עֹֽבַדְיָ֑ה כֹּֽה־אָמַר֩ אֲדֹנָ֨י יֱהֹוִ֜ה לֶאֱד֗וֹם שְׁמוּעָ֨ה שָׁמַ֜עְנוּ מֵאֵ֤ת יְהֹוָה֙ וְצִיר֙ בַּגּוֹיִ֣ם שֻׁלָּ֔ח ק֛וּמוּ וְנָק֥וּמָה עָלֶ֖יהָ לַמִּלְחָמָֽה׃\",\n\"הִנֵּ֥ה קָטֹ֛ן נְתַתִּ֖יךָ בַּגּוֹיִ֑ם בָּז֥וּי אַתָּ֖ה מְאֹֽד׃\",\n\"זְד֤וֹן לִבְּךָ֙ הִשִּׁיאֶ֔ךָ שֹׁכְנִ֥י בְחַגְוֵי־סֶ֖לַע מְר֣וֹם שִׁבְתּ֑וֹ אֹמֵ֣ר בְּלִבּ֔וֹ מִ֥י יוֹרִדֵ֖נִי אָֽרֶץ׃\",\n\"אִם־תַּגְבִּ֣יהַּ כַּנֶּ֔שֶׁר וְאִם־בֵּ֥ין כּֽוֹכָבִ֖ים שִׂ֣ים קִנֶּ֑ךָ מִשָּׁ֥ם אוֹרִֽידְךָ֖ נְאֻם־יְהֹוָֽה׃\",\n\"אִם־גַּנָּבִ֤ים בָּאֽוּ־לְךָ֙ אִם־שׁ֣וֹדְדֵי לַ֔יְלָה אֵ֣יךְ נִדְמֵ֔יתָה הֲל֥וֹא יִגְנְב֖וּ דַּיָּ֑ם אִם־בֹּֽצְרִים֙ בָּ֣אוּ לָ֔ךְ הֲל֖וֹא יַשְׁאִ֥ירוּ עֹלֵלֽוֹת׃\",\n\"אֵ֚יךְ נֶחְפְּשׂ֣וּ עֵשָׂ֔ו נִבְע֖וּ מַצְפֻּנָֽיו׃\",\n\"עַֽד־הַגְּב֣וּל שִׁלְּח֗וּךָ כֹּ֚ל אַנְשֵׁ֣י בְרִיתֶ֔ךָ הִשִּׁיא֛וּךָ יָכְל֥וּ לְךָ֖ אַנְשֵׁ֣י שְׁלֹמֶ֑ךָ לַחְמְךָ֗ יָשִׂ֤ימוּ מָזוֹר֙ תַּחְתֶּ֔יךָ אֵ֥ין תְּבוּנָ֖ה בּֽוֹ׃\",\n\"הֲל֛וֹא בַּיּ֥וֹם הַה֖וּא נְאֻם־יְהֹוָ֑ה וְהַאֲבַדְתִּ֤י חֲכָמִים֙ מֵֽאֱד֔וֹם וּתְבוּנָ֖ה מֵהַ֥ר עֵשָֽׂו׃\",\n\"וְחַתּ֥וּ גִבּוֹרֶ֖יךָ תֵּימָ֑ן לְמַ֧עַן יִכָּֽרֶת־אִ֛ישׁ מֵהַ֥ר עֵשָׂ֖ו מִקָּֽטֶל׃\",\n\"מֵחֲמַ֛ס אָחִ֥יךָ יַעֲקֹ֖ב תְּכַסְּךָ֣ בוּשָׁ֑ה וְנִכְרַ֖תָּ לְעוֹלָֽם׃\",\n\"בְּיוֹם֙ עֲמׇֽדְךָ֣ מִנֶּ֔גֶד בְּי֛וֹם שְׁב֥וֹת זָרִ֖ים חֵיל֑וֹ וְנׇכְרִ֞ים בָּ֣אוּ <span class=\\\"mam-kq-trivial\\\">שְׁעָרָ֗ו</span> וְעַל־יְרוּשָׁלַ֙͏ִם֙ יַדּ֣וּ גוֹרָ֔ל גַּם־אַתָּ֖ה כְּאַחַ֥ד מֵהֶֽם׃\",\n\"וְאַל־תֵּ֤רֶא בְיוֹם־אָחִ֙יךָ֙ בְּי֣וֹם נׇכְר֔וֹ וְאַל־תִּשְׂמַ֥ח לִבְנֵֽי־יְהוּדָ֖ה בְּי֣וֹם אׇבְדָ֑ם וְאַל־תַּגְדֵּ֥ל פִּ֖יךָ בְּי֥וֹם צָרָֽה׃\",\n\"אַל־תָּב֤וֹא בְשַֽׁעַר־עַמִּי֙ בְּי֣וֹם אֵידָ֔ם אַל־תֵּ֧רֶא גַם־אַתָּ֛ה בְּרָעָת֖וֹ בְּי֣וֹם אֵיד֑וֹ וְאַל־תִּשְׁלַ֥חְנָה בְחֵיל֖וֹ בְּי֥וֹם אֵידֽוֹ׃\",\n\"וְאַֽל־תַּעֲמֹד֙ עַל־הַפֶּ֔רֶק לְהַכְרִ֖ית אֶת־פְּלִיטָ֑יו וְאַל־תַּסְגֵּ֥ר שְׂרִידָ֖יו בְּי֥וֹם צָרָֽה׃\",\n\"כִּֽי־קָר֥וֹב יוֹם־יְהֹוָ֖ה עַל־כׇּל־הַגּוֹיִ֑ם כַּאֲשֶׁ֤ר עָשִׂ֙יתָ֙ יֵעָ֣שֶׂה לָּ֔ךְ גְּמֻלְךָ֖ יָשׁ֥וּב בְּרֹאשֶֽׁךָ׃\",\n\"כִּ֗י כַּֽאֲשֶׁ֤ר שְׁתִיתֶם֙ עַל־הַ֣ר קׇדְשִׁ֔י יִשְׁתּ֥וּ כׇֽל־הַגּוֹיִ֖ם תָּמִ֑יד וְשָׁת֣וּ וְלָע֔וּ וְהָי֖וּ כְּל֥וֹא הָיֽוּ׃\",\n\"וּבְהַ֥ר צִיּ֛וֹן תִּהְיֶ֥ה פְלֵיטָ֖ה וְהָ֣יָה קֹ֑דֶשׁ וְיָֽרְשׁוּ֙ בֵּ֣ית יַֽעֲקֹ֔ב אֵ֖ת מוֹרָֽשֵׁיהֶֽם׃\",\n\"וְהָיָה֩ בֵית־יַעֲקֹ֨ב אֵ֜שׁ וּבֵ֧ית יוֹסֵ֣ף לֶהָבָ֗ה וּבֵ֤ית עֵשָׂו֙ לְקַ֔שׁ וְדָלְק֥וּ בָהֶ֖ם וַאֲכָל֑וּם וְלֹֽא־יִֽהְיֶ֤ה שָׂרִיד֙ לְבֵ֣ית עֵשָׂ֔ו כִּ֥י יְהֹוָ֖ה דִּבֵּֽר׃\",\n\"וְיָרְשׁ֨וּ הַנֶּ֜גֶב אֶת־הַ֣ר עֵשָׂ֗ו וְהַשְּׁפֵלָה֙ אֶת־פְּלִשְׁתִּ֔ים וְיָרְשׁוּ֙ אֶת־שְׂדֵ֣ה אֶפְרַ֔יִם וְאֵ֖ת שְׂדֵ֣ה שֹׁמְר֑וֹן וּבִנְיָמִ֖ן אֶת־הַגִּלְעָֽד׃\",\n\"וְגָלֻ֣ת הַֽחֵל־הַ֠זֶּ֠ה לִבְנֵ֨י יִשְׂרָאֵ֤ל אֲשֶֽׁר־כְּנַעֲנִים֙ עַד־צָ֣רְפַ֔ת וְגָלֻ֥ת יְרוּשָׁלַ֖͏ִם אֲשֶׁ֣ר בִּסְפָרַ֑ד יִֽרְשׁ֕וּ אֵ֖ת עָרֵ֥י הַנֶּֽגֶב׃\",\n\"וְעָל֤וּ מֽוֹשִׁעִים֙ בְּהַ֣ר צִיּ֔וֹן לִשְׁפֹּ֖ט אֶת־הַ֣ר עֵשָׂ֑ו וְהָיְתָ֥ה לַֽיהֹוָ֖ה הַמְּלוּכָֽה׃"
+                  ]
+                ],
                 "firstSectionRef": "Obadiah 1"
               }
             ]
@@ -9375,7 +23289,10 @@
             "items": {
               "type": "string"
             },
-            "example": ["Tanakh", "Writings"]
+            "example": [
+              "Tanakh",
+              "Writings"
+            ]
           },
           "heIndexTitle": {
             "type": "string"
@@ -9435,7 +23352,10 @@
             "items": {
               "type": "string"
             },
-            "example": ["Perek", "Pasuk"]
+            "example": [
+              "Perek",
+              "Pasuk"
+            ]
           },
           "titleVariants": {
             "description": "Various alternative titles used for the text. ",
@@ -9443,7 +23363,14 @@
             "items": {
               "type": "string"
             },
-            "example": ["Est.", "Est", "Ester", "Esth.", "Esth", "Esther"]
+            "example": [
+              "Est.",
+              "Est",
+              "Ester",
+              "Esth.",
+              "Esth",
+              "Esther"
+            ]
           },
           "heTitleVariants": {
             "type": "array",
@@ -9462,12 +23389,11 @@
               {
                 "finnish": {
                   "warning_code": 102,
-                  "message": "We do not have the language you asked for Esther 1:1. Available languages are ['english', 'esperanto', 'french', 'german', 'hebrew', 'italian', 'persian', 'polish', 'spanish', 'yiddish']" 
+                  "message": "We do not have the language you asked for Esther 1:1. Available languages are ['english', 'esperanto', 'french', 'german', 'hebrew', 'italian', 'persian', 'polish', 'spanish', 'yiddish']"
                 }
               },
               {
-                "dutch": 
-                {
+                "dutch": {
                   "warning_code": 102,
                   "message": "We do not have the language you asked for Esther 1:1. Available languages are ['english', 'esperanto', 'french', 'german', 'hebrew', 'italian', 'persian', 'polish', 'spanish', 'yiddish']"
                 }
@@ -9586,11 +23512,11 @@
               "priority": {
                 "oneOf": [
                   {
-                  "type": "string"
-                  }, 
+                    "type": "string"
+                  },
                   {
-                  "format": "int32",
-                  "type": "integer"
+                    "format": "int32",
+                    "type": "integer"
                   }
                 ]
               },
@@ -9731,7 +23657,7 @@
                 "type": "string"
               },
               {
-                "type": "number", 
+                "type": "number",
                 "format": "float"
               }
             ]
@@ -9968,7 +23894,10 @@
             "items": {
               "type": "string"
             },
-            "example": ["Esther 4:14", "Esther 4:15"]
+            "example": [
+              "Esther 4:14",
+              "Esther 4:15"
+            ]
           },
           "sourceRef": {
             "$ref": "#/components/schemas/ref"
@@ -10337,7 +24266,7 @@
           },
           "topic": {
             "$ref": "#/components/schemas/RandomByTopicTopicJSON"
-            },
+          },
           "url": {
             "description": "The `Ref` in a format appropriate for a URL, with spaces replaced with `.` etc. ",
             "type": "string",
@@ -10492,7 +24421,7 @@
           },
           "dataSource": {
             "$ref": "#/components/schemas/DataSourceJSON"
-            },
+          },
           "is_sheet": {
             "description": "Is this ref-to-topic link one that was generated by a user-created source sheet?",
             "type": "boolean",
@@ -10500,7 +24429,7 @@
           },
           "order": {
             "$ref": "#/components/schemas/OrderTopicLinkJSON"
-            },
+          },
           "descriptions": {
             "description": "JSON containing descriptions for a given topic in various languages. Each language contains a `title` for the topic description, as well as a `prompt` which previews the source and asks questions to help the user engage with the text. ",
             "type": "object",
@@ -10518,10 +24447,9 @@
               }
             },
             "example": {
-                          "title": "A New Grain Offering",
-                          "prompt": "The central ritual of Shavuot as described in the Torah is a special bread offering that was brought to the Temple. This sacrifice marked the beginning of sacrifices that were brought using grain from that year, as opposed to grains from the previous year, as explained in the Book of Numbers."
-                        }
-                        
+              "title": "A New Grain Offering",
+              "prompt": "The central ritual of Shavuot as described in the Torah is a special bread offering that was brought to the Temple. This sacrifice marked the beginning of sacrifices that were brought using grain from that year, as opposed to grains from the previous year, as explained in the Book of Numbers."
+            }
           },
           "topic": {
             "description": "The title of the topic. ",
@@ -10539,7 +24467,17 @@
             "items": {
               "type": "string"
             },
-            "example": ["Numbers 28:16", "Numbers 28:17", "Numbers 28:18", "Numbers 28:19", "Numbers 28:20", "Numbers 28:21", "Numbers 28:22", "Numbers 28:23", "Numbers 28:24"]
+            "example": [
+              "Numbers 28:16",
+              "Numbers 28:17",
+              "Numbers 28:18",
+              "Numbers 28:19",
+              "Numbers 28:20",
+              "Numbers 28:21",
+              "Numbers 28:22",
+              "Numbers 28:23",
+              "Numbers 28:24"
+            ]
           }
         },
         "example": {
@@ -10629,7 +24567,10 @@
             "items": {
               "type": "string"
             },
-            "example": ["en", "he"]
+            "example": [
+              "en",
+              "he"
+            ]
           },
           "comp_date": {
             "format": "int32",
@@ -10661,7 +24602,10 @@
                 "type": "integer"
               }
             },
-            "example": {"en": 100, "he": 0}
+            "example": {
+              "en": 100,
+              "he": 0
+            }
           }
         },
         "example": {
@@ -10699,7 +24643,7 @@
             "items": {
               "$ref": "#/components/schemas/TitlesJSON"
             },
-            "example": [ 
+            "example": [
               {
                 "primary": true,
                 "text": "Noach",
@@ -10830,14 +24774,22 @@
                 "type": "",
                 "ref": "Psalms 51",
                 "anchorRef": "Or HaChaim on Deuteronomy 1:1:1",
-                "anchorRefExpanded": ["Or HaChaim on Deuteronomy 1:1:1"],
+                "anchorRefExpanded": [
+                  "Or HaChaim on Deuteronomy 1:1:1"
+                ],
                 "sourceRef": "Psalms 51",
                 "sourceHeRef": "תהילים נ״א",
                 "anchorVerse": 1,
                 "sourceHasEn": true,
-                "compDate": [-1000, 0],
+                "compDate": [
+                  -1000,
+                  0
+                ],
                 "commentaryNum": 51,
-                "collectiveTitle": {"en": "Psalms", "he": "תהילים"},
+                "collectiveTitle": {
+                  "en": "Psalms",
+                  "he": "תהילים"
+                },
                 "heTitle": "תהילים"
               },
               {
@@ -10847,14 +24799,22 @@
                 "type": "",
                 "ref": "Pirkei Avot 3",
                 "anchorRef": "Or HaChaim on Deuteronomy 1:1:1",
-                "anchorRefExpanded": ["Or HaChaim on Deuteronomy 1:1:1"],
+                "anchorRefExpanded": [
+                  "Or HaChaim on Deuteronomy 1:1:1"
+                ],
                 "sourceRef": "Pirkei Avot 3",
                 "sourceHeRef": "משנה אבות ג׳",
                 "anchorVerse": 1,
                 "sourceHasEn": true,
-                "compDate": [190, 230],
+                "compDate": [
+                  190,
+                  230
+                ],
                 "commentaryNum": 3,
-                "collectiveTitle": {"en": "Pirkei Avot", "he": "משנה אבות"},
+                "collectiveTitle": {
+                  "en": "Pirkei Avot",
+                  "he": "משנה אבות"
+                },
                 "heTitle": "משנה אבות"
               },
               {
@@ -10864,18 +24824,26 @@
                 "type": "",
                 "ref": "Pirkei Avot 4",
                 "anchorRef": "Or HaChaim on Deuteronomy 1:1:1",
-                "anchorRefExpanded": ["Or HaChaim on Deuteronomy 1:1:1"],
+                "anchorRefExpanded": [
+                  "Or HaChaim on Deuteronomy 1:1:1"
+                ],
                 "sourceRef": "Pirkei Avot 4",
                 "sourceHeRef": "משנה אבות ד׳",
                 "anchorVerse": 1,
                 "sourceHasEn": true,
-                "compDate": [190, 230],
+                "compDate": [
+                  190,
+                  230
+                ],
                 "commentaryNum": 4,
-                "collectiveTitle": {"en": "Pirkei Avot", "he": "משנה אבות"},
+                "collectiveTitle": {
+                  "en": "Pirkei Avot",
+                  "he": "משנה אבות"
+                },
                 "heTitle": "משנה אבות"
-                }
+              }
             ]
-            },
+          },
           "sheets": {
             "description": "All public source sheets linked to a given `Ref` or containing that `Ref` on the sheet. ",
             "type": "array",
@@ -10883,46 +24851,49 @@
               "$ref": "#/components/schemas/SheetsJSON"
             },
             "example": [
-              {"owner": 65000,
-              "_id": "5ec3a6f7c73d4d278311782e",
-              "id": "238181",
-              "public": true,
-              "title": "סדר תיקון ליל שבועות",
-              "sheetUrl": "/sheets/238181",
-              "anchorRef": "Deuteronomy 1",
-              "anchorRefExpanded": ["Deuteronomy 1:2"],
-              "options": {
-                "numbered": 0,
-                "boxed": 0,
-                "assignable": 0,
-                "bsd": 1,
-                "language": "hebrew",
-                "layout": "stacked",
-                "langLayout": "heRight",
-                "divineNames": "ykvk",
-                "highlightMode": 0,
-                "collaboration": "none"
-              },
-              "collectionTOC": "",
-              "ownerName": "יותם גונן",
-              "via": "",
-              "viaOwnerName": "",
-              "assignerName": "",
-              "viaOwnerProfileUrl": "",
-              "assignerProfileUrl": "",
-              "ownerProfileUrl": "/profile/-2977",
-              "ownerImageUrl": "https://storage.googleapis.com/sefaria-profile-pictures/-2977-1626800304-small.png",
-              "status": "public",
-              "views": 8509,
-              "topics": [],
-              "likes": [],
-              "summary": "",
-              "attribution": "",
-              "is_featured": false,
-              "category": "Sheets",
-              "type": "sheet"
-            }
-          ]
+              {
+                "owner": 65000,
+                "_id": "5ec3a6f7c73d4d278311782e",
+                "id": "238181",
+                "public": true,
+                "title": "סדר תיקון ליל שבועות",
+                "sheetUrl": "/sheets/238181",
+                "anchorRef": "Deuteronomy 1",
+                "anchorRefExpanded": [
+                  "Deuteronomy 1:2"
+                ],
+                "options": {
+                  "numbered": 0,
+                  "boxed": 0,
+                  "assignable": 0,
+                  "bsd": 1,
+                  "language": "hebrew",
+                  "layout": "stacked",
+                  "langLayout": "heRight",
+                  "divineNames": "ykvk",
+                  "highlightMode": 0,
+                  "collaboration": "none"
+                },
+                "collectionTOC": "",
+                "ownerName": "יותם גונן",
+                "via": "",
+                "viaOwnerName": "",
+                "assignerName": "",
+                "viaOwnerProfileUrl": "",
+                "assignerProfileUrl": "",
+                "ownerProfileUrl": "/profile/-2977",
+                "ownerImageUrl": "https://storage.googleapis.com/sefaria-profile-pictures/-2977-1626800304-small.png",
+                "status": "public",
+                "views": 8509,
+                "topics": [],
+                "likes": [],
+                "summary": "",
+                "attribution": "",
+                "is_featured": false,
+                "category": "Sheets",
+                "type": "sheet"
+              }
+            ]
           },
           "notes": {
             "description": "Any notes a user has on a given `Ref`. **Note:** This data is only available for logged-in users to view their own notes on a text. This field will always present as an empty array for third party developers. ",
@@ -10940,8 +24911,8 @@
                 "linkType": "about",
                 "class": "refTopic",
                 "dataSource": {
-                  "en": "Sheets by Sefaria users", 
-                  "he": "דפי מקורות ממשתמשי ספריא", 
+                  "en": "Sheets by Sefaria users",
+                  "he": "דפי מקורות ממשתמשי ספריא",
                   "slug": "sefaria-users"
                 },
                 "is_sheet": false,
@@ -10950,21 +24921,42 @@
                   "user_votes": 14,
                   "tfidf": 10.783834565585545,
                   "numDatasource": 1,
-                  "availableLangs": ["en", "he"],
+                  "availableLangs": [
+                    "en",
+                    "he"
+                  ],
                   "comp_date": -1400,
                   "order_id": "A00000000400010001-00010011",
                   "pr": 8.083013483888324,
                   "numSources": 143
                 },
                 "topic": "parashat-devarim",
-                "title": {"en": "Parashat Devarim", "he": "פרשת דברים"},
-                "titleIsTransliteration": {"en": false, "he": false },
+                "title": {
+                  "en": "Parashat Devarim",
+                  "he": "פרשת דברים"
+                },
+                "titleIsTransliteration": {
+                  "en": false,
+                  "he": false
+                },
                 "description": {
                   "en": "Devarim (“Words”) is the first Torah portion in the Book of Deuteronomy, the final book of the Torah. In it, Moses recounts events from the Israelites’ travels in the desert, like the appointment of judges, the sin of the spies, and the wars with the Emorite kings Sihon and Og.",
                   "he": "דברים היא הפרשה הראשונה בספר דברים, החומש החמישי והאחרון בתורה. בספר מובאים נאומי משה, שבהם הוא מזכיר אירועים מהעבר, סוקר מצוות שכבר ניתנו ומצווה מצוות חדשות. בפרשה משה מספר על הצורך במינוי שופטים להנהגת העם. הוא גם מזכיר את חטא המרגלים, שבו התלונן העם על הכניסה העתידית לארץ כנען, את העונש שהוטל על העם לנדוד במדבר ארבעים שנה ואת מלחמות ישראל במדבר."
                 },
                 "anchorRef": "Deuteronomy 1:1-11",
-                "anchorRefExpanded": ["Deuteronomy 1:1", "Deuteronomy 1:2", "Deuteronomy 1:3", "Deuteronomy 1:4", "Deuteronomy 1:5", "Deuteronomy 1:6", "Deuteronomy 1:7", "Deuteronomy 1:8", "Deuteronomy 1:9", "Deuteronomy 1:10", "Deuteronomy 1:11"]
+                "anchorRefExpanded": [
+                  "Deuteronomy 1:1",
+                  "Deuteronomy 1:2",
+                  "Deuteronomy 1:3",
+                  "Deuteronomy 1:4",
+                  "Deuteronomy 1:5",
+                  "Deuteronomy 1:6",
+                  "Deuteronomy 1:7",
+                  "Deuteronomy 1:8",
+                  "Deuteronomy 1:9",
+                  "Deuteronomy 1:10",
+                  "Deuteronomy 1:11"
+                ]
               }
             ]
           },
@@ -10980,8 +24972,10 @@
                 "page_id": "LC_Folio_98v",
                 "image_url": "https://manuscripts.sefaria.org/leningrad-color/BIB_LENCDX_F098B.jpg",
                 "thumbnail_url": "https://manuscripts.sefaria.org/leningrad-color/BIB_LENCDX_F098B_thumbnail.jpg",
-                "anchorRef": "Deuteronomy 1:1-21", 
-                "anchorRefExpanded": ["Deuteronomy 1:2"],
+                "anchorRef": "Deuteronomy 1:1-21",
+                "anchorRefExpanded": [
+                  "Deuteronomy 1:2"
+                ],
                 "manuscript": {
                   "slug": "leningrad-codex-(1008-ce)",
                   "title": "Leningrad Codex (1008 CE)",
@@ -11614,7 +25608,31 @@
             "items": {
               "$ref": "#/components/schemas/ref"
             },
-            "example": ["Joshua 2:2-3", "I Samuel 26:9", "Deuteronomy 32:51", "Numbers 34:16-29", "Numbers 26:52-56", "Joshua 14", "Numbers 13", "Numbers 20:12", "Numbers 32:9", "Deuteronomy 9:1-2", "Numbers 13:20", "Genesis 13:17", "Numbers 13:21", "Numbers 13:22", "Deuteronomy 1:37", "Joshua 2:1", "Deuteronomy 1:22", "Deuteronomy 1", "Numbers 34", "Deuteronomy 1:21", "Numbers 32", "Deuteronomy 1:24", "Joshua 18:3-9"]
+            "example": [
+              "Joshua 2:2-3",
+              "I Samuel 26:9",
+              "Deuteronomy 32:51",
+              "Numbers 34:16-29",
+              "Numbers 26:52-56",
+              "Joshua 14",
+              "Numbers 13",
+              "Numbers 20:12",
+              "Numbers 32:9",
+              "Deuteronomy 9:1-2",
+              "Numbers 13:20",
+              "Genesis 13:17",
+              "Numbers 13:21",
+              "Numbers 13:22",
+              "Deuteronomy 1:37",
+              "Joshua 2:1",
+              "Deuteronomy 1:22",
+              "Deuteronomy 1",
+              "Numbers 34",
+              "Deuteronomy 1:21",
+              "Numbers 32",
+              "Deuteronomy 1:24",
+              "Joshua 18:3-9"
+            ]
           },
           "description": {
             "description": "Description of the article. ",
@@ -11643,12 +25661,12 @@
           },
           "authors": {
             "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "object"
-                      }
+              {
+                "type": "string"
+              },
+              {
+                "type": "object"
+              }
             ]
           },
           "articleSource": {
@@ -11663,7 +25681,10 @@
             "items": {
               "$ref": "#/components/schemas/ref"
             },
-            "example": ["Genesis 1.1", "Genesis 1.2"]
+            "example": [
+              "Genesis 1.1",
+              "Genesis 1.2"
+            ]
           }
         },
         "example": {
@@ -11717,7 +25738,8 @@
           },
           "_id": {
             "description": "The unique `id` for the source sheet.",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           "id": {
             "description": "The `id` of the sheet. This is used in the URL to retrieve sheets, for example, a sheet with an `id` of 1, would be accessible on [Sefaria](sefaria.org) at [sefaria.org/sheets/1](sefaria.org/sheets/1).",
@@ -11736,7 +25758,8 @@
           "sheetUrl": {
             "description": "URL to this source sheet.",
             "type": "string",
-            "example": "/sheets/1"
+            "example": "/sheets/1",
+            "nullable": true
           },
           "anchorRef": {
             "$ref": "#/components/schemas/ref"
@@ -11746,7 +25769,8 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ref"
-            }
+            },
+            "nullable": true
           },
           "options": {
             "description": "A JSON object containing document level options related to how this source sheet should be displayed in Sefaria's Source Sheet editor.",
@@ -11770,13 +25794,13 @@
               "assignable": {
                 "description": "Is this source sheet an assignment for students in the Sefaria editor view",
                 "oneOf": [
-                            {
-                              "type": "boolean"
-                            },
-                            {
-                              "type": "number"
-                            }
-                          ]
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
               },
               "bsd": {
                 "description": "Should the source sheet include בס\"ד at the top of the page in the Sefaria editor view",
@@ -11828,49 +25852,52 @@
               "langLayout": "enLeft",
               "numbered": 0,
               "divineNames": "noSub"
-            }
+            },
+            "nullable": true
           },
           "collectionTOC": {
-            "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "object"
-                      }
-                    ]
+            "nullable": true,
+            "type": "object"
           },
           "ownerName": {
             "description": "Name of the owner of the sheet.",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           "via": {
             "description": "Some source sheets are made by copying another users. If this is one of them, the original owner's user ID will be listed here.",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           "viaOwnerName": {
             "description": "Some source sheets are made by copying another users. If this is one of them, the original owner's display name will be listed here.",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           "assignerName": {
             "description": "Some source sheets are created as assignments by a teacher to be completed by students. If this is one of those sheets the name of the assigner will be found here.",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           "viaOwnerProfileUrl": {
             "description": "Some source sheets are made by copying another users. If this is one of them, the path to the original owner's profile page will be listed here.",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           "assignerProfileUrl": {
             "description": "Some source sheets are created as assignments by a teacher to be completed by students. If this is one of those sheets this will be the URL path to their profile.",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           "ownerProfileUrl": {
             "description": "The URL Path that will link to a user's profile on the Sefaria site.",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           "ownerImageUrl": {
             "description": "Sheet owner image.",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           "status": {
             "description": "a string indicating whether the sheet is `public` or `unlisted`",
@@ -11960,32 +25987,39 @@
                 "he": "מדינה",
                 "en": "State"
               }
-            ]
+            ],
+            "nullable": true
           },
           "likes": {
             "description": "An array of user IDs who have favorited or liked this source sheet.",
             "type": "array",
-            "items": {}
+            "items": {},
+            "nullable": true
           },
           "summary": {
             "description": "A user generated description of the source sheet",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           "attribution": {
             "description": "Some source sheets are made by copying another users. If so, an attribution field will be created and displayed here.",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           "is_featured": {
             "deprecated": true,
             "description": "Previously a source sheet flagged with `is_featured` would be promoted throughout the site in various places. This behavior was removed in 2022 but some of the data remains. ",
-            "type": "boolean"
+            "type": "boolean",
+            "nullable": true
           },
           "category": {
             "description": "This will always return `Sheets`",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           "type": {
-            "type": "string"
+            "type": "string",
+            "nullable": true
           }
         },
         "example": {
@@ -12090,7 +26124,9 @@
             "items": {
               "$ref": "#/components/schemas/ref"
             },
-            "example": ["Deuteronomy 1:11"]
+            "example": [
+              "Deuteronomy 1:11"
+            ]
           },
           "sourceRef": {
             "type": "string"
@@ -12116,7 +26152,10 @@
               "format": "int32",
               "type": "integer"
             },
-            "example": [1075, 1105]
+            "example": [
+              1075,
+              1105
+            ]
           },
           "commentaryNum": {
             "format": "double",
@@ -12185,7 +26224,7 @@
           },
           "dataSource": {
             "$ref": "#/components/schemas/DataSourceJSON"
-           },
+          },
           "is_sheet": {
             "description": "Is this ref-to-topic link one that was generated by a user-created source sheet?",
             "type": "boolean",
@@ -12218,7 +26257,7 @@
             "example": {
               "en": false,
               "he": false
-              }
+            }
           },
           "description": {
             "description": "JSON containing descriptions for a given topic in various languages. Each language contains a title for the topic description, as well as a prompt which previews the source and asks questions to help the user engage with the text.",
@@ -12282,7 +26321,11 @@
             "items": {
               "type": "string"
             },
-            "example": ["Talmud", "Bavli", "Seder Moed"]
+            "example": [
+              "Talmud",
+              "Bavli",
+              "Seder Moed"
+            ]
           },
           "schema": {
             "$ref": "#/components/schemas/RawIndexSchemaJSON"
@@ -12372,7 +26415,9 @@
             "items": {
               "type": "string"
             },
-            "example": ["Bavli"]
+            "example": [
+              "Bavli"
+            ]
           }
         },
         "example": {
@@ -13049,7 +27094,10 @@
             "items": {
               "type": "string"
             },
-            "example": ["Talmud", "Integer"]
+            "example": [
+              "Talmud",
+              "Integer"
+            ]
           },
           "sectionNames": {
             "description": "An array containing the type names of the sections of this text. The length of `sectionNames` gives the depth of the structure of this text. For example, Kohelet (`[\"Chapter\", \"Verse\"]`) has depth 2, while Mishneh Torah (`[\"Book\", \"Topic\", \"Section\", \"Law\"]`) has depth 4. Comparing this depth to the depth of sections will show if the request was for the lowest level, or a higher level, of the text.",
@@ -13057,7 +27105,12 @@
             "items": {
               "type": "string"
             },
-            "example": ["Book", "Topic", "Section", "Law"]
+            "example": [
+              "Book",
+              "Topic",
+              "Section",
+              "Law"
+            ]
           },
           "match_templates": {
             "description": "This data is used for the linker.",
@@ -13071,7 +27124,10 @@
               "format": "int32",
               "type": "integer"
             },
-            "example": [50, 1533]
+            "example": [
+              50,
+              1533
+            ]
           },
           "referenceableSections": {
             "type": "array",
@@ -13201,37 +27257,42 @@
           }
         },
         "example": {
-            "Chapters": {
-              "nodes": [
-                {
-                  "nodeType": "ArrayMapNode",
-                  "depth": 0,
-                  "wholeRef": "Pesachim 2a:1-21a:7",
-                  "includeSections": true,
-                  "match_templates": [
-                    {
-                      "term_slugs": [
-                        "perek",
-                        "chapter-129"
-                      ],
-                      "scope": "any"
-                    },
-                    {
-                      "term_slugs": [
-                        "perek",
-                        "first"]
-                    },
-                    {
-                      "term_slugs": [
-                        "chapter-129"
-                      ],
-                      "scope": "any"},
-                    {
-                      "term_slugs": ["first"]
-                    }
-                  ],
-                  "numeric_equivalent": 1,
-                  "titles": [{
+          "Chapters": {
+            "nodes": [
+              {
+                "nodeType": "ArrayMapNode",
+                "depth": 0,
+                "wholeRef": "Pesachim 2a:1-21a:7",
+                "includeSections": true,
+                "match_templates": [
+                  {
+                    "term_slugs": [
+                      "perek",
+                      "chapter-129"
+                    ],
+                    "scope": "any"
+                  },
+                  {
+                    "term_slugs": [
+                      "perek",
+                      "first"
+                    ]
+                  },
+                  {
+                    "term_slugs": [
+                      "chapter-129"
+                    ],
+                    "scope": "any"
+                  },
+                  {
+                    "term_slugs": [
+                      "first"
+                    ]
+                  }
+                ],
+                "numeric_equivalent": 1,
+                "titles": [
+                  {
                     "primary": true,
                     "text": "Chapter 1",
                     "lang": "en"
@@ -13250,18 +27311,28 @@
                 "includeSections": true,
                 "match_templates": [
                   {
-                    "term_slugs": ["perek", "chapter-224"],
+                    "term_slugs": [
+                      "perek",
+                      "chapter-224"
+                    ],
                     "scope": "any"
                   },
                   {
-                    "term_slugs": ["perek","second"]
+                    "term_slugs": [
+                      "perek",
+                      "second"
+                    ]
                   },
                   {
-                    "term_slugs": ["chapter-224"],
+                    "term_slugs": [
+                      "chapter-224"
+                    ],
                     "scope": "any"
                   },
                   {
-                    "term_slugs": ["second"]
+                    "term_slugs": [
+                      "second"
+                    ]
                   }
                 ],
                 "numeric_equivalent": 2,
@@ -13285,18 +27356,28 @@
                 "includeSections": true,
                 "match_templates": [
                   {
-                    "term_slugs": ["perek", "chapter-324"],
+                    "term_slugs": [
+                      "perek",
+                      "chapter-324"
+                    ],
                     "scope": "any"
                   },
                   {
-                    "term_slugs": ["perek", "third"]
+                    "term_slugs": [
+                      "perek",
+                      "third"
+                    ]
                   },
                   {
-                    "term_slugs": ["chapter-324"],
+                    "term_slugs": [
+                      "chapter-324"
+                    ],
                     "scope": "any"
                   },
                   {
-                    "term_slugs": ["third"]
+                    "term_slugs": [
+                      "third"
+                    ]
                   }
                 ],
                 "numeric_equivalent": 3,
@@ -13320,21 +27401,28 @@
                 "includeSections": true,
                 "match_templates": [
                   {
-                    "term_slugs": ["perek", "chapter-420"],
+                    "term_slugs": [
+                      "perek",
+                      "chapter-420"
+                    ],
                     "scope": "any"
                   },
                   {
                     "term_slugs": [
                       "perek",
                       "fourth"
-                      ]
+                    ]
                   },
                   {
-                    "term_slugs": ["chapter-420"],
+                    "term_slugs": [
+                      "chapter-420"
+                    ],
                     "scope": "any"
                   },
                   {
-                    "term_slugs": ["fourth"]
+                    "term_slugs": [
+                      "fourth"
+                    ]
                   }
                 ],
                 "numeric_equivalen": 4,
@@ -13358,18 +27446,28 @@
                 "includeSections": true,
                 "match_templates": [
                   {
-                    "term_slugs": ["perek", "chapter-518"],
+                    "term_slugs": [
+                      "perek",
+                      "chapter-518"
+                    ],
                     "scope": "any"
                   },
                   {
-                    "term_slugs": ["perek", "fifth"]
+                    "term_slugs": [
+                      "perek",
+                      "fifth"
+                    ]
                   },
                   {
-                    "term_slugs": ["chapter-518"],
+                    "term_slugs": [
+                      "chapter-518"
+                    ],
                     "scope": "any"
                   },
                   {
-                    "term_slugs": ["fifth"]
+                    "term_slugs": [
+                      "fifth"
+                    ]
                   }
                 ],
                 "numeric_equivalent": 5,
@@ -13393,18 +27491,28 @@
                 "includeSections": true,
                 "match_templates": [
                   {
-                    "term_slugs": ["perek", "chapter-616"],
+                    "term_slugs": [
+                      "perek",
+                      "chapter-616"
+                    ],
                     "scope": "any"
                   },
                   {
-                    "term_slugs": ["perek", "sixth"]
+                    "term_slugs": [
+                      "perek",
+                      "sixth"
+                    ]
                   },
                   {
-                    "term_slugs": ["chapter-616"],
+                    "term_slugs": [
+                      "chapter-616"
+                    ],
                     "scope": "any"
                   },
                   {
-                    "term_slugs": ["sixth"]
+                    "term_slugs": [
+                      "sixth"
+                    ]
                   }
                 ],
                 "numeric_equivalent": 6,
@@ -13428,18 +27536,28 @@
                 "includeSections": true,
                 "match_templates": [
                   {
-                    "term_slugs": ["perek", "chapter-714"],
+                    "term_slugs": [
+                      "perek",
+                      "chapter-714"
+                    ],
                     "scope": "any"
                   },
                   {
-                    "term_slugs": ["perek", "seventh"]
+                    "term_slugs": [
+                      "perek",
+                      "seventh"
+                    ]
                   },
                   {
-                    "term_slugs": ["chapter-714"],
+                    "term_slugs": [
+                      "chapter-714"
+                    ],
                     "scope": "any"
                   },
                   {
-                    "term_slugs": ["seventh"]
+                    "term_slugs": [
+                      "seventh"
+                    ]
                   }
                 ],
                 "numeric_equivalent": 7,
@@ -13463,18 +27581,28 @@
                 "includeSections": true,
                 "match_templates": [
                   {
-                    "term_slugs": ["perek", "chapter-814"],
+                    "term_slugs": [
+                      "perek",
+                      "chapter-814"
+                    ],
                     "scope": "any"
                   },
                   {
-                    "term_slugs": ["perek", "eighth"]
+                    "term_slugs": [
+                      "perek",
+                      "eighth"
+                    ]
                   },
                   {
-                    "term_slugs": ["chapter-814"],
+                    "term_slugs": [
+                      "chapter-814"
+                    ],
                     "scope": "any"
                   },
                   {
-                    "term_slugs": ["eighth"]
+                    "term_slugs": [
+                      "eighth"
+                    ]
                   }
                 ],
                 "numeric_equivalent": 8,
@@ -13498,18 +27626,28 @@
                 "includeSections": true,
                 "match_templates": [
                   {
-                    "term_slugs": ["perek", "chapter-914"],
+                    "term_slugs": [
+                      "perek",
+                      "chapter-914"
+                    ],
                     "scope": "any"
                   },
                   {
-                    "term_slugs": ["perek","ninth"]
+                    "term_slugs": [
+                      "perek",
+                      "ninth"
+                    ]
                   },
                   {
-                    "term_slugs": ["chapter-914"],
+                    "term_slugs": [
+                      "chapter-914"
+                    ],
                     "scope": "any"
                   },
                   {
-                    "term_slugs": ["ninth"]
+                    "term_slugs": [
+                      "ninth"
+                    ]
                   }
                 ],
                 "numeric_equivalent": 9,
@@ -13533,32 +27671,46 @@
                 "includeSections": true,
                 "match_templates": [
                   {
-                    "term_slugs": ["perek", "chapter-109"],
+                    "term_slugs": [
+                      "perek",
+                      "chapter-109"
+                    ],
                     "scope": "any"
                   },
                   {
-                    "term_slugs": ["perek", "tenth"]
+                    "term_slugs": [
+                      "perek",
+                      "tenth"
+                    ]
                   },
                   {
-                    "term_slugs": ["chapter-109"],
+                    "term_slugs": [
+                      "chapter-109"
+                    ],
                     "scope": "any"
                   },
                   {
-                    "term_slugs": ["tenth"]
+                    "term_slugs": [
+                      "tenth"
+                    ]
                   },
                   {
-                    "term_slugs": ["perek","last"]
+                    "term_slugs": [
+                      "perek",
+                      "last"
+                    ]
                   },
                   {
-                    "term_slugs": ["last"]
+                    "term_slugs": [
+                      "last"
+                    ]
                   }
                 ],
                 "numeric_equivalent": 10,
                 "titles": [
                   {
                     "primary": true,
-                    "text": 
-                    "Chapter 10",
+                    "text": "Chapter 10",
                     "lang": "en"
                   },
                   {
@@ -13622,15 +27774,15 @@
             "items": {
               "$ref": "#/components/schemas/TitlesJSON"
             },
-            "example": [ 
+            "example": [
               {
                 "primary": true,
                 "text": "Chapter 1",
                 "lang": "en"
               },
               {
-                "primary": true, 
-                "text": "אור לארבעה עשר", 
+                "primary": true,
+                "text": "אור לארבעה עשר",
                 "lang": "he"
               }
             ]
@@ -13787,7 +27939,9 @@
             "items": {
               "type": "string"
             },
-            "default": ["pagesheetrank"]
+            "default": [
+              "pagesheetrank"
+            ]
           },
           "sort_method": {
             "description": "How to sort results. If sort, the values are sorted according to `sort_fields`. If `score`, the value in `sort_fields` is multiplied with the default ElasticSearch score.",
@@ -13844,42 +27998,47 @@
       "ShapeJSON": {
         "description": "The shape API allows one to retrieve information about the shape of an Index on Sefaria. The shape refers some basic statistics about the Index, mostly the number of chapters, and the number of segments per chapter.",
         "required": [
-            "book",
-            "heBook",
-            "chapters"
+          "book",
+          "heBook",
+          "chapters"
         ],
         "type": "object",
         "properties": {
-            "Section": {
-                "description": "The parent section for this `Index`. (So for example, the `section` for `Jonah` is `Prophets`. The `section` for `Pesachim` is `Seder Moed`)",
-                "type": "string",
-                "example": "Prophets"
+          "Section": {
+            "description": "The parent section for this `Index`. (So for example, the `section` for `Jonah` is `Prophets`. The `section` for `Pesachim` is `Seder Moed`)",
+            "type": "string",
+            "example": "Prophets"
+          },
+          "isComplex": {
+            "description": "A boolean representing whether or not this is a complex text. ",
+            "type": "boolean"
+          },
+          "Length": {
+            "description": "The number of chapters or top-level sections in the `Index`. "
+          },
+          "Book": {
+            "description": "Title of the `Index` in English",
+            "type": "string"
+          },
+          "heBook": {
+            "description": "Title of the `Index` in Hebrew. ",
+            "type": "string"
+          },
+          "Chapters": {
+            "description": "For simple texts, this is a list of chapter lengths. For complex texts or categories, the Shape API will return a list of dicts for each text within that category or text. ",
+            "type": "array",
+            "items": {
+              "type": "integer"
             },
-            "isComplex": {
-                "description": "A boolean representing whether or not this is a complex text. ",
-                "type": "boolean"
-            },
-            "Length": {
-                "description": "The number of chapters or top-level sections in the `Index`. "
-            },
-            "Book": {
-                "description": "Title of the `Index` in English",
-                "type": "string"
-            },
-            "heBook": {
-                "description": "Title of the `Index` in Hebrew. ",
-                "type": "string"
-            },
-            "Chapters": {
-                "description": "For simple texts, this is a list of chapter lengths. For complex texts or categories, the Shape API will return a list of dicts for each text within that category or text. ",
-                "type": "array",
-                "items": {
-                    "type": "integer"
-                },
-                "example": [16, 11, 10, 11]
-            }
+            "example": [
+              16,
+              11,
+              10,
+              11
+            ]
+          }
         }
-    },
+      },
       "CatJSON": {
         "title": "Root Type for CatJSON",
         "description": "JSON response for a Category GET request",
@@ -13922,6 +28081,880 @@
             }
           ],
           "lastPath": "Torah"
+        }
+      },
+      "SheetDetailJSON": {
+        "title": "Root Type for SheetDetailJSON",
+        "description": "JSON containing the full content and metadata of a single Sefaria source sheet, including all of its sources.",
+        "type": "object",
+        "properties": {
+          "id": {
+            "description": "Numeric `id` of the sheet — the same value that appears in the sheet's URL on `voices.sefaria.org`.",
+            "type": "integer"
+          },
+          "_id": {
+            "description": "Internal MongoDB identifier for the sheet.",
+            "type": "string"
+          },
+          "title": {
+            "description": "Title of the source sheet.",
+            "type": "string"
+          },
+          "summary": {
+            "description": "A short, plain-text description of the sheet's contents.",
+            "type": "string"
+          },
+          "owner": {
+            "description": "Numeric Sefaria user ID of the sheet's owner.",
+            "type": "integer"
+          },
+          "ownerName": {
+            "description": "Display name of the sheet's owner.",
+            "type": "string"
+          },
+          "ownerProfileUrl": {
+            "description": "Path to the owner's public profile on Sefaria.",
+            "type": "string"
+          },
+          "ownerImageUrl": {
+            "description": "URL of the owner's profile image.",
+            "type": "string"
+          },
+          "status": {
+            "description": "Visibility of the sheet — `public` for sheets that are publicly listed, `unlisted` for sheets accessible by direct link only.",
+            "type": "string",
+            "enum": [
+              "public",
+              "unlisted"
+            ]
+          },
+          "sheetLanguage": {
+            "description": "Default display language for the sheet.",
+            "type": "string"
+          },
+          "dateCreated": {
+            "description": "Timestamp the sheet was first created. May be ISO-8601 or a Unix timestamp string depending on the sheet's age.",
+            "type": "string"
+          },
+          "dateModified": {
+            "description": "Timestamp of the most recent modification to the sheet.",
+            "type": "string"
+          },
+          "datePublished": {
+            "description": "Timestamp the sheet was first made public. Empty if the sheet has never been published.",
+            "type": "string"
+          },
+          "views": {
+            "description": "Number of times the sheet has been viewed.",
+            "type": "integer"
+          },
+          "likes": {
+            "description": "Array of user IDs who have liked the sheet.",
+            "type": "array",
+            "items": {
+              "type": "integer"
+            }
+          },
+          "options": {
+            "description": "Sheet-level display options used by the Sefaria source sheet editor.",
+            "type": "object"
+          },
+          "tags": {
+            "description": "Free-text tags applied to the sheet. Often empty in favor of `topics`.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "topics": {
+            "description": "Sefaria topics associated with the sheet. Each entry contains the topic `slug`, the typed display value (`asTyped`), and bilingual labels.",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "slug": {
+                  "type": "string"
+                },
+                "asTyped": {
+                  "type": "string"
+                },
+                "en": {
+                  "type": "string"
+                },
+                "he": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "collections": {
+            "description": "Collections that include this sheet.",
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          },
+          "displayedCollection": {
+            "description": "Slug of the collection currently displayed alongside this sheet, if any.",
+            "type": "string"
+          },
+          "collectionName": {
+            "description": "Display name of the collection in `displayedCollection`, if set.",
+            "type": "string"
+          },
+          "collectionImage": {
+            "description": "URL of the collection's image, if set.",
+            "type": "string"
+          },
+          "includedRefs": {
+            "description": "All Sefaria refs cited anywhere on the sheet.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ref"
+            }
+          },
+          "expandedRefs": {
+            "description": "Each entry in `includedRefs` expanded out to its constituent segment refs.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ref"
+            }
+          },
+          "nextNode": {
+            "description": "The next available `node` ID — used by the editor when appending a new source.",
+            "type": "integer"
+          },
+          "sources": {
+            "description": "Ordered list of sources that make up the sheet body. Each source has a unique `node` ID and one of several shapes — a Sefaria reference (`ref` + `text`), a free-text comment (`comment`), an arbitrary HTML block (`outsideText`), or a media item (`media`).",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "node": {
+                  "description": "Unique numeric ID for the source within the sheet.",
+                  "type": "integer"
+                },
+                "ref": {
+                  "description": "Sefaria ref, present on text-source nodes.",
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/ref"
+                    }
+                  ]
+                },
+                "heRef": {
+                  "description": "Hebrew rendering of `ref`.",
+                  "type": "string"
+                },
+                "text": {
+                  "description": "Bilingual text for a `ref` source.",
+                  "type": "object",
+                  "properties": {
+                    "en": {
+                      "type": "string"
+                    },
+                    "he": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "outsideText": {
+                  "description": "HTML block authored directly on the sheet (not tied to a Sefaria text).",
+                  "type": "string"
+                },
+                "comment": {
+                  "description": "Free-text comment authored on the sheet.",
+                  "type": "string"
+                },
+                "media": {
+                  "description": "URL of an embedded image or media item.",
+                  "type": "string"
+                },
+                "options": {
+                  "description": "Per-source display options.",
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "sheetNotice": {
+            "description": "Optional moderator notice attached to the sheet. `null` when no notice is set.",
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "AuthorIndexesJSON": {
+        "title": "Root Type for AuthorIndexesJSON",
+        "description": "List of indexes (works) attributed to a given Sefaria author.",
+        "type": "object",
+        "properties": {
+          "author": {
+            "description": "Identifying information for the author.",
+            "type": "object",
+            "properties": {
+              "slug": {
+                "description": "The author's topic slug.",
+                "type": "string"
+              },
+              "title": {
+                "description": "Bilingual display title for the author.",
+                "type": "object",
+                "properties": {
+                  "en": {
+                    "type": "string"
+                  },
+                  "he": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "total": {
+            "description": "Total number of indexes attributed to this author.",
+            "type": "integer"
+          },
+          "indexes": {
+            "description": "List of indexes (works) attributed to the author.",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "title": {
+                  "description": "English title of the index.",
+                  "type": "string"
+                },
+                "heTitle": {
+                  "description": "Hebrew title of the index.",
+                  "type": "string"
+                },
+                "categories": {
+                  "description": "Sefaria category path for the index.",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "url": {
+                  "description": "Path to the index page on Sefaria.",
+                  "type": "string"
+                },
+                "dependence": {
+                  "description": "Whether this index is a base text or a commentary on another text. Empty for base texts.",
+                  "type": "string",
+                  "nullable": true
+                }
+              }
+            }
+          }
+        }
+      },
+      "TrendingSheetTagJSON": {
+        "title": "Root Type for TrendingSheetTagJSON",
+        "description": "A single trending sheet tag, including bilingual labels and recent usage counts.",
+        "type": "object",
+        "properties": {
+          "slug": {
+            "description": "URL-safe slug for the tag's underlying topic.",
+            "type": "string"
+          },
+          "tag": {
+            "description": "English display label for the tag.",
+            "type": "string"
+          },
+          "he_tag": {
+            "description": "Hebrew display label for the tag.",
+            "type": "string"
+          },
+          "count": {
+            "description": "Number of recent sheets using this tag.",
+            "type": "integer"
+          },
+          "author_count": {
+            "description": "Number of distinct authors who have used this tag recently.",
+            "type": "integer"
+          },
+          "primaryTitle": {
+            "description": "Bilingual primary title for the tag.",
+            "type": "object",
+            "properties": {
+              "en": {
+                "type": "string"
+              },
+              "he": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "CollectionSummaryJSON": {
+        "title": "Root Type for CollectionSummaryJSON",
+        "description": "Summary of a Sefaria collection as it appears in collection lists.",
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "Display name of the collection.",
+            "type": "string"
+          },
+          "slug": {
+            "description": "URL slug for the collection.",
+            "type": "string"
+          },
+          "description": {
+            "description": "Free-text description of the collection.",
+            "type": "string",
+            "nullable": true
+          },
+          "imageUrl": {
+            "description": "URL of the collection's image.",
+            "type": "string",
+            "nullable": true
+          },
+          "headerUrl": {
+            "description": "URL of the collection's header image, if set.",
+            "type": "string",
+            "nullable": true
+          },
+          "memberCount": {
+            "description": "Number of members in the collection.",
+            "type": "integer"
+          },
+          "sheetCount": {
+            "description": "Number of sheets in the collection.",
+            "type": "integer"
+          },
+          "lastModified": {
+            "description": "Timestamp of the most recent change.",
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "CollectionsListJSON": {
+        "title": "Root Type for CollectionsListJSON",
+        "description": "Lists of Sefaria collections separated by visibility. For unauthenticated callers, `private` is empty and `public` contains all publicly-listed collections.",
+        "type": "object",
+        "properties": {
+          "private": {
+            "description": "Private collections visible to the caller. Empty for unauthenticated requests.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CollectionSummaryJSON"
+            }
+          },
+          "public": {
+            "description": "Publicly-listed collections.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CollectionSummaryJSON"
+            }
+          }
+        }
+      },
+      "CollectionDetailJSON": {
+        "title": "Root Type for CollectionDetailJSON",
+        "description": "Full content of a single Sefaria collection, including its member sheets.",
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "Display name of the collection.",
+            "type": "string"
+          },
+          "slug": {
+            "description": "URL slug for the collection.",
+            "type": "string"
+          },
+          "privateSlug": {
+            "description": "Private slug used for collaborator-only access.",
+            "type": "string"
+          },
+          "description": {
+            "description": "Free-text description of the collection.",
+            "type": "string",
+            "nullable": true
+          },
+          "lastModified": {
+            "description": "Timestamp of the most recent change.",
+            "type": "string",
+            "nullable": true
+          },
+          "admins": {
+            "description": "Admin members of the collection.",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "uid": {
+                  "type": "integer"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "profileUrl": {
+                  "type": "string"
+                },
+                "imageUrl": {
+                  "type": "string"
+                },
+                "position": {
+                  "type": "string"
+                },
+                "organization": {
+                  "type": "string"
+                },
+                "isStaff": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "members": {
+            "description": "Members of the collection.",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "uid": {
+                  "type": "integer"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "profileUrl": {
+                  "type": "string"
+                },
+                "imageUrl": {
+                  "type": "string"
+                },
+                "position": {
+                  "type": "string"
+                },
+                "organization": {
+                  "type": "string"
+                },
+                "isStaff": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "sheets": {
+            "description": "Sheets contained in the collection.",
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          }
+        }
+      },
+      "UserSheetsJSON": {
+        "title": "Root Type for UserSheetsJSON",
+        "description": "List of public sheets owned by a user.",
+        "type": "object",
+        "properties": {
+          "sheets": {
+            "description": "Sheets owned by the user. For anonymous requests this contains only public sheets; an authenticated user requesting their own user_id additionally sees their private sheets.",
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          }
+        }
+      },
+      "AllSheetsJSON": {
+        "title": "Root Type for AllSheetsJSON",
+        "description": "Paginated list of public sheets.",
+        "type": "object",
+        "properties": {
+          "sheets": {
+            "description": "Page of public sheets, each as a summary object.",
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          }
+        }
+      },
+      "SheetLikersJSON": {
+        "title": "Root Type for SheetLikersJSON",
+        "description": "List of users who have liked a sheet.",
+        "type": "object",
+        "properties": {
+          "likers": {
+            "description": "List of users who liked the sheet.",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "BulkSheetEntryJSON": {
+        "title": "Root Type for BulkSheetEntryJSON",
+        "description": "Lightweight summary of a single sheet returned by the bulk endpoint.",
+        "type": "object",
+        "properties": {
+          "sheet_id": {
+            "type": "integer"
+          },
+          "sheet_title": {
+            "type": "string"
+          },
+          "sheet_summary": {
+            "type": "string"
+          },
+          "sheet_via": {
+            "type": "integer",
+            "nullable": true
+          },
+          "publisher_id": {
+            "type": "integer"
+          },
+          "publisher_name": {
+            "type": "string"
+          },
+          "publisher_url": {
+            "type": "string"
+          },
+          "publisher_image": {
+            "type": "string"
+          },
+          "publisher_position": {
+            "type": "string"
+          },
+          "publisher_organization": {
+            "type": "string"
+          }
+        }
+      },
+      "AliyotJSON": {
+        "title": "Root Type for AliyotJSON",
+        "description": "Aliyot ranges for a parasha.",
+        "type": "object",
+        "properties": {
+          "ref": {
+            "description": "Ordered list of refs, one per aliyah.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ref"
+            }
+          }
+        }
+      },
+      "SheetTagCountJSON": {
+        "title": "Root Type for SheetTagCountJSON",
+        "description": "A sheet tag and its usage count.",
+        "type": "object",
+        "properties": {
+          "tag": {
+            "description": "Display label for the tag.",
+            "type": "string"
+          },
+          "count": {
+            "description": "Number of sheets using this tag.",
+            "type": "integer"
+          }
+        }
+      },
+      "UserSheetTagJSON": {
+        "title": "Root Type for UserSheetTagJSON",
+        "description": "A topic tag used by a specific user, with bilingual labels.",
+        "type": "object",
+        "properties": {
+          "slug": {
+            "type": "string"
+          },
+          "asTyped": {
+            "type": "string"
+          },
+          "en": {
+            "type": "string"
+          },
+          "he": {
+            "type": "string"
+          },
+          "count": {
+            "type": "integer"
+          }
+        }
+      },
+      "BulktextJSON": {
+        "title": "Root Type for BulktextJSON",
+        "description": "A map keyed by Sefaria ref. Each entry contains the ref's English and Hebrew text plus version metadata. The exact key set matches the requested refs.",
+        "type": "object",
+        "additionalProperties": {
+          "type": "object"
+        }
+      },
+      "PassagesJSON": {
+        "title": "Root Type for PassagesJSON",
+        "description": "A map keyed by the requested Sefaria ref. Each value is the canonical passage ref containing it (e.g. a verse mapped to its three-verse passage).",
+        "type": "object",
+        "additionalProperties": {
+          "$ref": "#/components/schemas/ref"
+        }
+      },
+      "IndexTitlesJSON": {
+        "title": "Root Type for IndexTitlesJSON",
+        "description": "The complete list of recognized title strings on Sefaria, including alternate titles and abbreviations across languages. Useful for client-side autocomplete or ref recognition.",
+        "type": "object",
+        "properties": {
+          "books": {
+            "description": "All recognized title strings.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "IndexJSON": {
+        "title": "Root Type for IndexJSON",
+        "description": "Index (work) metadata: title, categories, schema (text structure), order, authors, and descriptive copy.",
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "heTitle": {
+            "type": "string"
+          },
+          "categories": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "schema": {
+            "description": "Structural schema describing how the text is divided.",
+            "type": "object"
+          },
+          "order": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            }
+          },
+          "authors": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          },
+          "enDesc": {
+            "type": "string"
+          },
+          "heDesc": {
+            "type": "string"
+          },
+          "enShortDesc": {
+            "type": "string"
+          },
+          "heShortDesc": {
+            "type": "string"
+          },
+          "pubDate": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            }
+          },
+          "compDate": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            }
+          },
+          "compPlace": {
+            "type": "string"
+          },
+          "pubPlace": {
+            "type": "string"
+          }
+        }
+      },
+      "CountsJSON": {
+        "title": "Root Type for CountsJSON",
+        "description": "Word and segment counts for a text, broken down by language.",
+        "type": "object",
+        "properties": {
+          "_all": {
+            "type": "object"
+          },
+          "_he": {
+            "type": "object"
+          },
+          "_en": {
+            "type": "object"
+          }
+        }
+      },
+      "CountsLinksItemJSON": {
+        "title": "Root Type for CountsLinksItemJSON",
+        "description": "Link count between two specific books.",
+        "type": "object",
+        "properties": {
+          "book1": {
+            "type": "string"
+          },
+          "book2": {
+            "type": "string"
+          },
+          "count": {
+            "type": "integer"
+          }
+        }
+      },
+      "CountsWordsJSON": {
+        "title": "Root Type for CountsWordsJSON",
+        "description": "Word count for a specific text version.",
+        "type": "object",
+        "properties": {
+          "wordCount": {
+            "type": "integer"
+          }
+        }
+      },
+      "LinkSummaryJSON": {
+        "title": "Root Type for LinkSummaryJSON",
+        "description": "Single category bucket from a link summary.",
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "Category name.",
+            "type": "string"
+          },
+          "count": {
+            "description": "Total links in this category.",
+            "type": "integer"
+          },
+          "books": {
+            "description": "Per-book breakdown within the category, keyed by book title. Each value is the number of links from that book.",
+            "type": "object",
+            "additionalProperties": {
+              "type": "integer"
+            }
+          }
+        }
+      },
+      "CalendarParashaTopicJSON": {
+        "title": "Root Type for CalendarParashaTopicJSON",
+        "description": "Topic metadata for the current week's parasha.",
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "object",
+            "description": "Bilingual title of the parasha topic."
+          },
+          "displayValue": {
+            "type": "object",
+            "description": "Bilingual display value."
+          },
+          "url": {
+            "type": "string"
+          },
+          "ref": {
+            "$ref": "#/components/schemas/ref"
+          },
+          "heRef": {
+            "type": "string"
+          },
+          "order": {
+            "type": "integer"
+          },
+          "category": {
+            "type": "string"
+          },
+          "extraDetails": {
+            "type": "object"
+          }
+        }
+      },
+      "CalendarHolidayTopicJSON": {
+        "title": "Root Type for CalendarHolidayTopicJSON",
+        "description": "Topic metadata for an active holiday. Returns 404 when no holiday is in season for the requested date.",
+        "type": "object",
+        "properties": {
+          "topic": {
+            "type": "object"
+          },
+          "secondary_topic": {
+            "type": "object",
+            "nullable": true
+          },
+          "display_start_date": {
+            "type": "string",
+            "nullable": true
+          },
+          "display_end_date": {
+            "type": "string",
+            "nullable": true
+          },
+          "display_date_prefix": {
+            "type": "string",
+            "nullable": true
+          },
+          "display_date_suffix": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "ProfileJSON": {
+        "title": "Root Type for ProfileJSON",
+        "description": "Public profile data for a Sefaria user.",
+        "type": "object",
+        "properties": {
+          "id": {
+            "description": "Numeric user ID.",
+            "type": "integer"
+          },
+          "slug": {
+            "description": "URL slug used in the profile path.",
+            "type": "string"
+          },
+          "full_name": {
+            "type": "string"
+          },
+          "profile_pic_url": {
+            "type": "string"
+          },
+          "followers": {
+            "description": "Counts of followers/follow ids; the API returns an empty array on the public endpoint.",
+            "type": "array",
+            "items": {
+              "type": "integer"
+            }
+          },
+          "followees": {
+            "description": "Counts of followees; empty array on the public endpoint.",
+            "type": "array",
+            "items": {
+              "type": "integer"
+            }
+          },
+          "bio": {
+            "type": "string"
+          },
+          "jewish_education": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
## Description
This PR adds AI-assisted documentation to the OpenAPI.json file for 29 additional endpoints which may be helpful for public-facing users, organized by tags. 

**Note:**
Validation: `npx rdme openapi:validate docs/openAPI.json` passes (the same command CI runs). 

## Code Changes
1. New endpoints in `OpenAPI.json`
2. Decisions and classifications around which endpoints to document, and which are less useful for external developers in `docs/decisions`. 

## Notes

- [ ] Was tested in a ReadMe test env and looks good
- I highly recommend a slightly different code review in this instance, due to the nature of this PR. See the shortcut card for a specific path forward. 