### PR TITLE
fix: remove punctuation when matching dibur hamatchil

### DIFF
--- a/sefaria/model/linker/tests/linker_test.py
+++ b/sefaria/model/linker/tests/linker_test.py
@@ -95,6 +95,7 @@ def test_multiple_ambiguities():
 
 
 @pytest.mark.parametrize(('resolver_data', 'expected_trefs'), [
+    [crrd(["@תוספות", "@ברכות", '#י"ג ע"א', '''*ד"ה 'עד כאן\'''']), ("Tosafot on Berakhot 13a:36:1",)],
     # Numbered JAs
     [crrd(["@ירושלמי", "@ברכות", "#יג ע״א"]), ("Jerusalem Talmud Berakhot 9:1:11-19", "Jerusalem Talmud Berakhot 2:1:14-19")],  # ambig venice or vilna yerushalmi daf
     [crrd(["@ירושלמי", "@ברכות", "#יג ע״ג"]), ("Jerusalem Talmud Berakhot 9:1:31-2:9",)],  # venice yerushalmi daf

--- a/sefaria/utils/hebrew.py
+++ b/sefaria/utils/hebrew.py
@@ -584,9 +584,9 @@ class Abbrev:
 
 
 def is_abbr(word):
-	if re.search(r'[^"]["][^"]', word):
+	if re.search(r'\w"\w', word):
 		return True
-	if re.search(r"[א-ת]'$", word):
+	if re.search(r"\w'$", word):
 		return True
 	return False
 
@@ -608,6 +608,8 @@ def get_all_abbrs(abbr_words, unabbr_words) -> List[Abbrev]:
 
 _unidecode = NormalizerFactory.get("unidecode")
 
+_INWORD_HYPHENS = '[-—–־]'  # ASCII hyphen, em dash, en dash, Hebrew maqaf
+
 
 def _strip_word_edges(w):
 	"""
@@ -615,15 +617,12 @@ def _strip_word_edges(w):
 	:param w: 
 	:return: 
 	"""
-	return re.sub(r'^\W+|[^\w\']+$', '', w)
+	return re.sub(r"^\W+|[^\w']+$", '', w)
 
 
 def _normalize_hebrew_punctuation(s):
-	s = _unidecode.normalize(s.strip())
-	s = re.sub(r'(?<=\S)[\-\u2014\u2013\u05be](?=\S)', ' ', s)
-	# strip matching quotes on the edge of the string
-	if len(s) >= 2 and s[0] == s[-1] and s[0] in ('"', "'"):
-		s = s[1:-1]
+	s = _unidecode.normalize(s)
+	s = re.sub(r'(?<=\w)' + _INWORD_HYPHENS + r'(?=\w)', ' ', s)
 	words = [_strip_word_edges(w) for w in s.split()]
 	return ' '.join(w for w in words if w)
 

--- a/sefaria/utils/hebrew.py
+++ b/sefaria/utils/hebrew.py
@@ -622,8 +622,8 @@ def hebrew_starts_with(he: str, other_he: str) -> False:
 	he = _normalize_hebrew_punctuation(he)
 	other_he = _normalize_hebrew_punctuation(other_he)
 
-	he_words = he.strip().split()
-	other_words = other_he.strip().split()
+	he_words = he.split()
+	other_words = other_he.split()
 	he_abbrs = get_all_abbrs(he_words, other_words)
 	other_abbrs = get_all_abbrs(other_words, he_words)
 

--- a/sefaria/utils/hebrew.py
+++ b/sefaria/utils/hebrew.py
@@ -601,8 +601,16 @@ def get_all_abbrs(abbr_words, unabbr_words) -> List[Abbrev]:
 	return abbrevs
 
 
-def _strip_hebrew_punctuation(s: str) -> str:
-	return regex.sub(r'\p{P}', '', s)
+_INWORD_HYPHENS = r'[-—–־]'  # ASCII hyphen, em dash, en dash, maqaf
+
+
+def _normalize_hebrew_punctuation(s: str) -> str:
+	# Hyphens between two non-space chars split a compound word into parts
+	s = regex.sub(r'(?<=\S)' + _INWORD_HYPHENS + r'(?=\S)', ' ', s)
+	# Strip leading/trailing punctuation from each whitespace-delimited token,
+	# leaving internal punctuation (e.g. gershayim in abbreviations) intact
+	words = [regex.sub(r'^\p{P}+|\p{P}+$', '', w) for w in s.split()]
+	return ' '.join(w for w in words if w)
 
 
 def hebrew_starts_with(he: str, other_he: str) -> False:
@@ -611,8 +619,8 @@ def hebrew_starts_with(he: str, other_he: str) -> False:
 	includes possible abbreviation expansion
 	TODO. in future may include fuzzy matching
 	"""
-	he = _strip_hebrew_punctuation(he)
-	other_he = _strip_hebrew_punctuation(other_he)
+	he = _normalize_hebrew_punctuation(he)
+	other_he = _normalize_hebrew_punctuation(other_he)
 
 	he_words = he.strip().split()
 	other_words = other_he.strip().split()

--- a/sefaria/utils/hebrew.py
+++ b/sefaria/utils/hebrew.py
@@ -601,14 +601,21 @@ def get_all_abbrs(abbr_words, unabbr_words) -> List[Abbrev]:
 	return abbrevs
 
 
+def _strip_hebrew_punctuation(s: str) -> str:
+	return regex.sub(r'\p{P}', '', s)
+
+
 def hebrew_starts_with(he: str, other_he: str) -> False:
 	"""
 	does `he` start with `other_he`?
 	includes possible abbreviation expansion
 	TODO. in future may include fuzzy matching
 	"""
-	he_words = he.split()
-	other_words = other_he.split()
+	he = _strip_hebrew_punctuation(he)
+	other_he = _strip_hebrew_punctuation(other_he)
+
+	he_words = he.strip().split()
+	other_words = other_he.strip().split()
 	he_abbrs = get_all_abbrs(he_words, other_words)
 	other_abbrs = get_all_abbrs(other_words, he_words)
 

--- a/sefaria/utils/hebrew.py
+++ b/sefaria/utils/hebrew.py
@@ -14,6 +14,7 @@ import math
 from typing import List, Callable
 import itertools
 from sefaria.system.decorators import memoized
+from sefaria.helper.normalization import NormalizerFactory
 import structlog
 logger = structlog.get_logger(__name__)
 
@@ -583,7 +584,11 @@ class Abbrev:
 
 
 def is_abbr(word):
-	return re.search(r'[^"״]["״][^"״]', word) is not None
+	if re.search(r'[^"]["][^"]', word):
+		return True
+	if re.search(r"[א-ת]'$", word):
+		return True
+	return False
 
 
 def get_all_abbrs(abbr_words, unabbr_words) -> List[Abbrev]:
@@ -601,15 +606,25 @@ def get_all_abbrs(abbr_words, unabbr_words) -> List[Abbrev]:
 	return abbrevs
 
 
-_INWORD_HYPHENS = r'[-—–־]'  # ASCII hyphen, em dash, en dash, maqaf
+_unidecode = NormalizerFactory.get("unidecode")
 
 
-def _normalize_hebrew_punctuation(s: str) -> str:
-	# Hyphens between two non-space chars split a compound word into parts
-	s = regex.sub(r'(?<=\S)' + _INWORD_HYPHENS + r'(?=\S)', ' ', s)
-	# Strip leading/trailing punctuation from each whitespace-delimited token,
-	# leaving internal punctuation (e.g. gershayim in abbreviations) intact
-	words = [regex.sub(r'^\p{P}+|\p{P}+$', '', w) for w in s.split()]
+def _strip_word_edges(w):
+	"""
+	Strip all non-word chars at the start and end of `w` excluding single quote which can indicate an abbreviation at the end of a word.
+	:param w: 
+	:return: 
+	"""
+	return re.sub(r'^\W+|[^\w\']+$', '', w)
+
+
+def _normalize_hebrew_punctuation(s):
+	s = _unidecode.normalize(s.strip())
+	s = re.sub(r'(?<=\S)[\-\u2014\u2013\u05be](?=\S)', ' ', s)
+	# strip matching quotes on the edge of the string
+	if len(s) >= 2 and s[0] == s[-1] and s[0] in ('"', "'"):
+		s = s[1:-1]
+	words = [_strip_word_edges(w) for w in s.split()]
 	return ' '.join(w for w in words if w)
 
 

--- a/sefaria/utils/tests/hebrew_test.py
+++ b/sefaria/utils/tests/hebrew_test.py
@@ -120,6 +120,8 @@ class TestGematria():
     ("הבית כנסת פתוח", "הביכ״נ פתוח רק", False),  # same other longer abbrev
     ("אע״ג שרבי שמעול בן גמליאל שמר שבית שאשרעש לגכשג", "אף על גב שרשב״ג שמר שבשאש״ל", True),    # multiple abbrevs
     ("אע״ג שרבי שמעול בן גמליאל שמר שבית שארעש לגכשג", "אף על גב שרשב״ג שמר שבשאש״ל", False),    # diff multiple abbrevs
+    ("אפילו כך", "אפ׳ כך", True),     # trailing geresh abbreviation
+    ("אפילו כך", "אפ' כך", True),     # trailing ASCII apostrophe abbreviation
 ])
 def test_hebrew_starts_with(hebrew, other_hebrew, should_match):
     assert h.hebrew_starts_with(hebrew, other_hebrew) == should_match


### PR DESCRIPTION
This pull request enhances Hebrew text processing in the `sefaria` codebase, focusing on improving abbreviation handling and test coverage for ambiguous references. The main updates include adding punctuation-stripping to Hebrew string comparisons and expanding test cases for ambiguity resolution.

Improvements to Hebrew string comparison:

* Added a new helper function `_strip_hebrew_punctuation` in `sefaria/utils/hebrew.py` to remove punctuation from Hebrew strings before processing. This ensures more accurate comparisons, especially for abbreviation expansion and matching.
* Updated the `hebrew_starts_with` function to use `_strip_hebrew_punctuation` on both input strings, improving its robustness against punctuation differences.

Test coverage enhancements:

* Added a new test case to `test_multiple_ambiguities` in `sefaria/model/linker/tests/linker_test.py` to cover ambiguity resolution involving Tosafot on Berakhot 13a.