### PR TITLE
fix: only use ref instantiation if the raw_ref has only NAMED and NUMBERED parts

### DIFF
--- a/sefaria/model/linker/ref_resolver.py
+++ b/sefaria/model/linker/ref_resolver.py
@@ -462,6 +462,9 @@ class RefResolver:
 
     @staticmethod
     def resolve_raw_ref_using_ref_instantiation(raw_ref: RawRef) -> Optional[ResolvedRef]:
+        allowed_types = {RefPartType.NAMED, RefPartType.NUMBERED}
+        if any(part.type not in allowed_types for part in raw_ref.parts_to_match):
+            return None
         try:
             ref = text.Ref(raw_ref.text)
             part_and_node_matches = [RefPartAndNodeMatch((part,), None, True) for part in raw_ref.parts_to_match]

--- a/sefaria/model/linker/tests/linker_test.py
+++ b/sefaria/model/linker/tests/linker_test.py
@@ -95,7 +95,6 @@ def test_multiple_ambiguities():
 
 
 @pytest.mark.parametrize(('resolver_data', 'expected_trefs'), [
-    [crrd(["@תוספות", "@ברכות", '#י"ג ע"א', '''*ד"ה 'עד כאן\'''']), ("Tosafot on Berakhot 13a:36:1",)],
     # Numbered JAs
     [crrd(["@ירושלמי", "@ברכות", "#יג ע״א"]), ("Jerusalem Talmud Berakhot 9:1:11-19", "Jerusalem Talmud Berakhot 2:1:14-19")],  # ambig venice or vilna yerushalmi daf
     [crrd(["@ירושלמי", "@ברכות", "#יג ע״ג"]), ("Jerusalem Talmud Berakhot 9:1:31-2:9",)],  # venice yerushalmi daf
@@ -173,6 +172,7 @@ def test_multiple_ambiguities():
     [crrd(['@שבועות', '#דף כה ע"א', '@תוד"ה', '*חומר']), ("Tosafot on Shevuot 25a:11:1",)],
     [crrd(["@רש\"י", "#דף ב עמוד א", "@בסוכה", "*ד\"ה סוכה ורבי"]), ("Rashi on Sukkah 2a:1:1",)], # rashi dibur hamatchil
     [crrd(["@רש\"י", "@בראשית", "#פרק א", "#פסוק א", "*ד\"ה בראשית"]), ("Rashi on Genesis 1:1:1", "Rashi on Genesis 1:1:2")],
+    [crrd(["@תוספות", "@ברכות", '#י"ג ע"א', '''*ד"ה 'עד כאן\'''']), ("Tosafot on Berakhot 13a:36:1",)],
 
     # Ranged refs
     [crrd(['@ספר בראשית', '#פרק יג', '#פסוק א', '^עד', '#פרק יד', '#פסוק ד']), ("Genesis 13:1-14:4",)],
@@ -224,6 +224,7 @@ def test_multiple_ambiguities():
     [crrd(["@Yoma", "&ibid"], lang="en", prev_trefs=["Yoma 86"]), ("Yoma 86",)],  # respect the amud-less ibid
     [crrd(['@והשולחן ערוך', '#סימן א', '#סעיף ב'], context_tref='Arukh HaShulchan, Orach Chaim 75:11'), ("Shulchan Arukh, Orach Chayim 1:2",)],  # pull context from lower node to use to resolve book title
     [crrd(["#verse 2"], lang='en', context_tref="Rashi on Genesis 1:1:1"), ("Rashi on Genesis 1:2", "Genesis 1:2")],  # ibid that can refer to either commentary or base text
+    [crrd(["@משנה ברורה", "&שם", "#א"]), tuple()],  # no ibid context, shouldn't match MB 340
 
     # Relative (e.g. Lekaman)
     [crrd(["@תוס'", "<לקמן", "#ד ע\"ב", "*ד\"ה דאר\"י"], "Gilyon HaShas on Berakhot 2a:2"), ("Tosafot on Berakhot 4b:6:1",)],  # likaman + abbrev in DH


### PR DESCRIPTION
This pull request introduces an important validation step in the `resolve_raw_ref_using_ref_instantiation` method to ensure only certain types of reference parts are processed, and updates the associated tests to reflect this logic. The main changes are grouped as follows:

Ref resolution logic improvements:

* Added a type check in `resolve_raw_ref_using_ref_instantiation` (`ref_resolver.py`) so that only `NAMED` and `NUMBERED` reference part types are allowed; if any part is of a different type, the method returns `None`.

Test suite adjustments:

* Moved a test case for Tosafot on Berakhot 13a:36:1 to a later position in the parameterized list in `test_multiple_ambiguities` to match the new type checking logic. [[1]](diffhunk://#diff-5451a242992e95ae2562ee9874d6984060222bcda58611f15489b7023063b7f9L98) [[2]](diffhunk://#diff-5451a242992e95ae2562ee9874d6984060222bcda58611f15489b7023063b7f9R175)
* Added a new test case to ensure that when there is no ibid context, the reference does not incorrectly match `Mishnah Berurah 340`.