### PR TITLE
chore(helm): add staging, preprod, and sefaria.org.il to CSRF_TRUSTED_ORIGINS

### DIFF
--- a/helm-chart/sefaria/templates/configmap/local-settings-file.yaml
+++ b/helm-chart/sefaria/templates/configmap/local-settings-file.yaml
@@ -39,9 +39,13 @@ data:
         "https://*.sefaria.org",
         "https://*.sefaria.org.il",
         "https://www.sefariastaging.org",
+        "http://www.sefariastaging.org",
         "https://www.sefariastaging-il.org",
+        "http://www.sefariastaging-il.org",
         "https://www.sefariapreprod.org",
+        "http://www.sefariapreprod.org",
         "https://www.sefariapreprod-il.org",
+        "http://www.sefariapreprod-il.org",
     ]
 
     DEBUG = os.getenv("DEBUG").lower() == "true"

--- a/helm-chart/sefaria/templates/configmap/local-settings-file.yaml
+++ b/helm-chart/sefaria/templates/configmap/local-settings-file.yaml
@@ -38,14 +38,18 @@ data:
     CSRF_TRUSTED_ORIGINS = [
         "https://*.sefaria.org",
         "https://*.sefaria.org.il",
-        "https://www.sefariastaging.org",
-        "http://www.sefariastaging.org",
-        "https://www.sefariastaging-il.org",
-        "http://www.sefariastaging-il.org",
-        "https://www.sefariapreprod.org",
-        "http://www.sefariapreprod.org",
-        "https://www.sefariapreprod-il.org",
-        "http://www.sefariapreprod-il.org",
+        "https://sefariastaging.org",
+        "https://*.sefariastaging.org",
+        "http://sefariastaging.org",
+        "http://*.sefariastaging.org",
+        "https://sefariastaging-il.org",
+        "https://*.sefariastaging-il.org",
+        "http://sefariastaging-il.org",
+        "http://*.sefariastaging-il.org",
+        "https://sefariapreprod.org",
+        "https://*.sefariapreprod.org",
+        "https://sefariapreprod-il.org",
+        "https://*.sefariapreprod-il.org",
     ]
 
     DEBUG = os.getenv("DEBUG").lower() == "true"

--- a/helm-chart/sefaria/templates/configmap/local-settings-file.yaml
+++ b/helm-chart/sefaria/templates/configmap/local-settings-file.yaml
@@ -35,7 +35,14 @@ data:
     varnishHost = os.getenv("VARNISH_HOST")
 
     ALLOWED_HOSTS = ["*"]
-    CSRF_TRUSTED_ORIGINS = ["https://*.sefaria.org"]
+    CSRF_TRUSTED_ORIGINS = [
+        "https://*.sefaria.org",
+        "https://*.sefaria.org.il",
+        "https://www.sefariastaging.org",
+        "https://www.sefariastaging-il.org",
+        "https://www.sefariapreprod.org",
+        "https://www.sefariapreprod-il.org",
+    ]
 
     DEBUG = os.getenv("DEBUG").lower() == "true"
     OFFLINE = os.getenv("OFFLINE").lower() == "true"


### PR DESCRIPTION
## Summary
- Adds `https://*.sefaria.org.il` (wildcard, covers www and subdomains) to `CSRF_TRUSTED_ORIGINS`
- Adds explicit entries for `sefariastaging.org`, `sefariastaging-il.org`, `sefariapreprod.org`, and `sefariapreprod-il.org`
- These domains are different TLDs from `sefaria.org` so the existing `*.sefaria.org` wildcard does not cover them

## Test plan
- [ ] Verify CSRF-protected POST requests succeed on sefariastaging.org
- [ ] Verify CSRF-protected POST requests succeed on sefariapreprod.org
- [ ] Verify CSRF-protected POST requests succeed on www.sefaria.org.il

🤖 Generated with [Claude Code](https://claude.com/claude-code)