### PR TITLE
feat(preprod): point postgres at postgres-18

### DIFF
--- a/envs/preprod/helmrelease.yaml
+++ b/envs/preprod/helmrelease.yaml
@@ -20,6 +20,8 @@ spec:
     deployEnv: preprod
     previousServicesCount: "3"
     deploymentMessage: true
+    postgres:
+      host: "postgres-18.default.svc.cluster.local"
     restore:
       enabled: false
       dynamicName: false


### PR DESCRIPTION
## Summary
- Adds `postgres.host: "postgres-18.default.svc.cluster.local"` to the preprod helmrelease values
- Preprod runs in the `preprod` namespace, so it needs the FQDN to reach the postgres-18 Service in `default`
- The Helm chart template (`local-settings-file.yaml`) already supports this override via `{{ if .Values.postgres.host }}`

## Context
The postgres-18 StatefulSet and Service were provisioned in the infrastructure repo (`prod/cluster-1/spec/postgres-18/`, namespace `default`). Without this override, preprod falls back to `DATABASES_HOST` from the shared `local-settings-secrets-production` secret, which uses a short service name that only resolves within the `default` namespace.

## Test plan
- [ ] Verify preprod pods start and can connect to postgres-18
- [ ] Confirm Django migrations run successfully
- [ ] Check that user auth flows (login, signup) work on sefariapreprod.org

🤖 Generated with [Claude Code](https://claude.com/claude-code)