### PR TITLE
fix: serve linker bundle map file

### DIFF
--- a/helm-chart/sefaria/templates/configmap/varnish-config.yaml
+++ b/helm-chart/sefaria/templates/configmap/varnish-config.yaml
@@ -58,6 +58,7 @@ data:
             || req.url ~"^/api/regexs/"
             || req.url ~"^/api/bulktext/"
             || req.url ~"^/linker.js"
+            || req.url ~"^/linker\.v3\.js"
             || req.url ~"^/api/stats/"
             || req.url ~"^/api/find-refs/cache-lookup"
             || req.url ~"^/api/websites/"

--- a/sefaria/client/util.py
+++ b/sefaria/client/util.py
@@ -53,7 +53,7 @@ def send_email(subject, message_html, from_email, to_email):
     return True
 
 
-def read_webpack_bundle(config_name):
+def _webpack_bundle_path(config_name):
     webpack_files = webpack_utils.get_files('main', config=config_name)
     url = webpack_files[0]["url"]
     # Handle both relative paths and full URLs
@@ -61,6 +61,14 @@ def read_webpack_bundle(config_name):
     # which makes webpack_files return full URLs instead of relative paths
     parsed = urlparse(url)
     path = parsed.path if parsed.scheme else url
-    bundle_path = relative_to_abs_path('..' + path)
-    with open(bundle_path, 'r') as file:
+    return relative_to_abs_path('..' + path)
+
+
+def read_webpack_bundle(config_name):
+    with open(_webpack_bundle_path(config_name), 'r') as file:
+        return file.read()
+
+
+def read_webpack_bundle_map(config_name):
+    with open(_webpack_bundle_path(config_name) + '.map', 'r') as file:
         return file.read()

--- a/sefaria/urls_shared.py
+++ b/sefaria/urls_shared.py
@@ -226,6 +226,7 @@ shared_patterns = [
     path('sefaria.js', sefaria_views.sefaria_js),
 
     re_path(r'^linker\.?v?([0-9]+)?\.js$', sefaria_views.linker_js),
+    path('linker.v3.js.map', sefaria_views.linker_js_map),
     re_path(r'^api/find-refs/report/?$', sefaria_views.find_refs_report_api),
     re_path(r'^api/find-refs/?$', sefaria_views.find_refs_api),
     re_path(r'^api/regexs/(?P<titles>.+)$', sefaria_views.title_regex_api),

--- a/sefaria/views.py
+++ b/sefaria/views.py
@@ -46,7 +46,7 @@ import sefaria.system.cache as scache
 from sefaria.helper.crm.crm_mediator import CrmMediator
 from sefaria.helper.crm.salesforce import SalesforceNewsletterListRetrievalError
 from sefaria.system.cache import get_shared_cache_elem, in_memory_cache, set_shared_cache_elem, get_cache_elem, set_cache_elem, get_cache_factory, invalidate_cache_by_pattern
-from sefaria.client.util import jsonResponse, send_email, read_webpack_bundle
+from sefaria.client.util import jsonResponse, send_email, read_webpack_bundle, read_webpack_bundle_map
 from sefaria.forms import SefariaNewUserForm, SefariaNewUserFormAPI, SefariaDeleteUserForm, SefariaDeleteSheet
 from sefaria.settings import MAINTENANCE_MESSAGE, USE_VARNISH, MULTISERVER_ENABLED
 from sefaria.celery_setup.config import CeleryQueue
@@ -419,6 +419,10 @@ def linker_js(request, linker_version=None):
     }
 
     return render(request, linker_link, attrs, content_type = "text/javascript; charset=utf-8")
+
+
+def linker_js_map(request):
+    return HttpResponse(read_webpack_bundle_map("LINKER"), content_type="application/json")
 
 
 @api_view(["POST"])


### PR DESCRIPTION
This pull request introduces support for serving the source map for the `linker.v3.js` JavaScript bundle, which will aid in debugging and development. It does so by adding a view to serve the source map, updating the URL routing, and refactoring utility functions for webpack bundle file access.

**Support for serving JavaScript source maps:**

* Added a new view function `linker_js_map` in `sefaria/views.py` to serve the `linker.v3.js.map` source map file using the new `read_webpack_bundle_map` utility.
* Registered a new URL route in `sefaria/urls_shared.py` for `linker.v3.js.map` to map requests to the new view.

**Webpack bundle file utilities refactor:**

* Refactored the bundle file reading logic in `sefaria/client/util.py` by extracting a shared `_webpack_bundle_path` helper and adding a new `read_webpack_bundle_map` function for reading the source map file.
* Updated imports in `sefaria/views.py` to include the new `read_webpack_bundle_map` utility.