### PR TITLE
feat(sc-44228): add Sentry User Feedback widget to Sefaria web app

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@floating-ui/react-dom": "^2.1.6",
         "@playwright/test": "^1.52.0",
-        "@sentry/react": "^7.57.0",
+        "@sentry/react": "^7.85.0",
         "body-parser": "^1.15.1",
         "buffer": "^6.0.3",
         "cheerio": "^0.22.0",
@@ -3541,59 +3541,107 @@
       ],
       "peer": true
     },
-    "node_modules/@sentry-internal/tracing": {
-      "version": "7.61.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.61.0.tgz",
-      "integrity": "sha512-zTr+MXEG4SxNxif42LIgm2RQn+JRXL2NuGhRaKSD2i4lXKFqHVGlVdoWqY5UfqnnJPokiTWIj9ejR8I5HV8Ogw==",
+    "node_modules/@sentry-internal/feedback": {
+      "version": "7.120.4",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.120.4.tgz",
+      "integrity": "sha512-eSwgvTdrh03zYYaI6UVOjI9p4VmKg6+c2+CBQfRZX++6wwnCVsNv7XF7WUIpVGBAkJ0N2oapjQmCzJKGKBRWQg==",
+      "license": "MIT",
       "dependencies": {
-        "@sentry/core": "7.61.0",
-        "@sentry/types": "7.61.0",
-        "@sentry/utils": "7.61.0",
-        "tslib": "^2.4.1 || ^1.9.3"
+        "@sentry/core": "7.120.4",
+        "@sentry/types": "7.120.4",
+        "@sentry/utils": "7.120.4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "7.120.4",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.120.4.tgz",
+      "integrity": "sha512-2+W4CgUL1VzrPjArbTid4WhKh7HH21vREVilZdvffQPVwOEpgNTPAb69loQuTlhJVveh9hWTj2nE5UXLbLP+AA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "7.120.4",
+        "@sentry/replay": "7.120.4",
+        "@sentry/types": "7.120.4",
+        "@sentry/utils": "7.120.4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sentry-internal/tracing": {
+      "version": "7.120.4",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.120.4.tgz",
+      "integrity": "sha512-Fz5+4XCg3akeoFK+K7g+d7HqGMjmnLoY2eJlpONJmaeT9pXY7yfUyXKZMmMajdE2LxxKJgQ2YKvSCaGVamTjHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "7.120.4",
+        "@sentry/types": "7.120.4",
+        "@sentry/utils": "7.120.4"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "7.61.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.61.0.tgz",
-      "integrity": "sha512-IGEkJZRP16Oe5CkXkmhU3QdV5RugW6Vds16yJFFYsgp87NprWtRZgqzldFDYkINStfBHVdctj/Rh/ZrLf8QlkQ==",
+      "version": "7.120.4",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.120.4.tgz",
+      "integrity": "sha512-ymlNtIPG6HAKzM/JXpWVGCzCNufZNADfy+O/olZuVJW5Be1DtOFyRnBvz0LeKbmxJbXb2lX/XMhuen6PXPdoQw==",
+      "license": "MIT",
       "dependencies": {
-        "@sentry-internal/tracing": "7.61.0",
-        "@sentry/core": "7.61.0",
-        "@sentry/replay": "7.61.0",
-        "@sentry/types": "7.61.0",
-        "@sentry/utils": "7.61.0",
-        "tslib": "^2.4.1 || ^1.9.3"
+        "@sentry-internal/feedback": "7.120.4",
+        "@sentry-internal/replay-canvas": "7.120.4",
+        "@sentry-internal/tracing": "7.120.4",
+        "@sentry/core": "7.120.4",
+        "@sentry/integrations": "7.120.4",
+        "@sentry/replay": "7.120.4",
+        "@sentry/types": "7.120.4",
+        "@sentry/utils": "7.120.4"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/core": {
-      "version": "7.61.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.61.0.tgz",
-      "integrity": "sha512-zl0ZKRjIoYJQWYTd3K/U6zZfS4GDY9yGd2EH4vuYO4kfYtEp/nJ8A+tfAeDo0c9FGxZ0Q+5t5F4/SfwbgyyQzg==",
+      "version": "7.120.4",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.120.4.tgz",
+      "integrity": "sha512-TXu3Q5kKiq8db9OXGkWyXUbIxMMuttB5vJ031yolOl5T/B69JRyAoKuojLBjRv1XX583gS1rSSoX8YXX7ATFGA==",
+      "license": "MIT",
       "dependencies": {
-        "@sentry/types": "7.61.0",
-        "@sentry/utils": "7.61.0",
-        "tslib": "^2.4.1 || ^1.9.3"
+        "@sentry/types": "7.120.4",
+        "@sentry/utils": "7.120.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/integrations": {
+      "version": "7.120.4",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.120.4.tgz",
+      "integrity": "sha512-kkBTLk053XlhDCg7OkBQTIMF4puqFibeRO3E3YiVc4PGLnocXMaVpOSCkMqAc1k1kZ09UgGi8DxfQhnFEjUkpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "7.120.4",
+        "@sentry/types": "7.120.4",
+        "@sentry/utils": "7.120.4",
+        "localforage": "^1.8.1"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/react": {
-      "version": "7.61.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-7.61.0.tgz",
-      "integrity": "sha512-17ZPDdzx3hzJSHsVFAiw4hUT701LUVIcm568q38sPlSUmnOmNmPeHx/xcQkuxMoVsw/xgf/82B/BKKnIP5/diA==",
+      "version": "7.120.4",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-7.120.4.tgz",
+      "integrity": "sha512-Pj1MSezEncE+5riuwsk8peMncuz5HR72Yr1/RdZhMZvUxoxAR/tkwD3aPcK6ddQJTagd2TGwhdr9SHuDLtONew==",
+      "license": "MIT",
       "dependencies": {
-        "@sentry/browser": "7.61.0",
-        "@sentry/types": "7.61.0",
-        "@sentry/utils": "7.61.0",
-        "hoist-non-react-statics": "^3.3.2",
-        "tslib": "^2.4.1 || ^1.9.3"
+        "@sentry/browser": "7.120.4",
+        "@sentry/core": "7.120.4",
+        "@sentry/types": "7.120.4",
+        "@sentry/utils": "7.120.4",
+        "hoist-non-react-statics": "^3.3.2"
       },
       "engines": {
         "node": ">=8"
@@ -3603,33 +3651,36 @@
       }
     },
     "node_modules/@sentry/replay": {
-      "version": "7.61.0",
-      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.61.0.tgz",
-      "integrity": "sha512-1ugk0yZssOPkSg6uTVcysjxlBydycXiOgV0PCU7DsXCFOV1ua5YpyPZFReTz9iFTtwD0LwGFM1LW9wJeQ67Fzg==",
+      "version": "7.120.4",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.120.4.tgz",
+      "integrity": "sha512-FW8sPenNFfnO/K7sncsSTX4rIVak9j7VUiLIagJrcqZIC7d1dInFNjy8CdVJUlyz3Y3TOgIl3L3+ZpjfyMnaZg==",
+      "license": "MIT",
       "dependencies": {
-        "@sentry/core": "7.61.0",
-        "@sentry/types": "7.61.0",
-        "@sentry/utils": "7.61.0"
+        "@sentry-internal/tracing": "7.120.4",
+        "@sentry/core": "7.120.4",
+        "@sentry/types": "7.120.4",
+        "@sentry/utils": "7.120.4"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@sentry/types": {
-      "version": "7.61.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.61.0.tgz",
-      "integrity": "sha512-/GLlIBNR35NKPE/SfWi9W10dK9hE8qTShzsuPVn5wAJxpT3Lb4+dkwmKCTLUYxdkmvRDEudkfOxgalsfQGTAWA==",
+      "version": "7.120.4",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.120.4.tgz",
+      "integrity": "sha512-cUq2hSSe6/qrU6oZsEP4InMI5VVdD86aypE+ENrQ6eZEVLTCYm1w6XhW1NvIu3UuWh7gZec4a9J7AFpYxki88Q==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "7.61.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.61.0.tgz",
-      "integrity": "sha512-jfj14d0XBFiCU0G6dZZ12SizATiF5Mt4stBGzkM5iS9nXFj8rh1oTT7/p+aZoYzP2JTF+sDzkNjWxyKZkcTo0Q==",
+      "version": "7.120.4",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.120.4.tgz",
+      "integrity": "sha512-zCKpyDIWKHwtervNK2ZlaK8mMV7gVUijAgFeJStH+CU/imcdquizV3pFLlSQYRswG+Lbyd6CT/LGRh3IbtkCFw==",
+      "license": "MIT",
       "dependencies": {
-        "@sentry/types": "7.61.0",
-        "tslib": "^2.4.1 || ^1.9.3"
+        "@sentry/types": "7.120.4"
       },
       "engines": {
         "node": ">=8"
@@ -9419,6 +9470,12 @@
       "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
       "dev": true
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/immer": {
       "version": "9.0.21",
       "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.21.tgz",
@@ -11095,6 +11152,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
     "node_modules/load-json-file": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
@@ -11140,6 +11206,15 @@
       },
       "engines": {
         "node": ">=8.9.0"
+      }
+    },
+    "node_modules/localforage": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
+      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lie": "3.1.1"
       }
     },
     "node_modules/locate-path": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "dependencies": {
     "@floating-ui/react-dom": "^2.1.6",
     "@playwright/test": "^1.52.0",
-    "@sentry/react": "^7.57.0",
+    "@sentry/react": "^7.85.0",
     "body-parser": "^1.15.1",
     "buffer": "^6.0.3",
     "cheerio": "^0.22.0",

--- a/static/js/client.jsx
+++ b/static/js/client.jsx
@@ -12,17 +12,32 @@ $(function() {
   const remoteConfig = DJANGO_VARS.props?.remoteConfig || {};
   // Initialize Sentry, sentryDSN is defined in base.html
   if (sentryDSN) {
+    const integrations = [
+      new Sentry.BrowserTracing(),
+      new Sentry.Replay(),
+    ];
+    if (remoteConfig?.sentry?.feedbackEnabled) {
+      // `useSentryUser` keys come from the Sentry user set via Sentry.setUser below.
+      integrations.push(Sentry.feedbackIntegration({
+        colorScheme: "system",
+        useSentryUser: { name: "fullName", email: "email" },
+      }));
+    }
     Sentry.init({
       dsn: sentryDSN,
-      integrations: [
-        new Sentry.BrowserTracing(),
-        new Sentry.Replay(),
-      ],
+      integrations,
       tracesSampleRate: remoteConfig?.sentry?.tracesSampleRate || 0.0,
       sampleRate: remoteConfig?.sentry?.sampleRate || 0.0,
       replaysSessionSampleRate: remoteConfig?.sentry?.replaysSessionSampleRate || 0.0,
       replaysOnErrorSampleRate: remoteConfig?.sentry?.replaysOnErrorSampleRate || 0.0,
     });
+    if (typeof Sefaria !== "undefined" && Sefaria._uid) {
+      Sentry.setUser({
+        id: String(Sefaria._uid),
+        email: Sefaria._email,
+        fullName: Sefaria.full_name,
+      });
+    }
   }
 
   let container = document.getElementById('s2');


### PR DESCRIPTION
## Summary

Adds Sentry's [User Feedback widget](https://docs.sentry.io/platforms/javascript/guides/react/user-feedback/) to Sefaria's web app so users can submit reports any time — not only on error. Each submission carries rich debugging context (session replay, URL, user, breadcrumbs).

This is the **code-side** of the pipeline. The Sentry-side config (Shortcut integration install + Alert rule that auto-creates Shortcut stories from Feedback issues) is checklist work in [sc-44228](https://app.shortcut.com/sefaria/story/44228) and happens in Sentry's UI after this lands.

## Changes

- **`package.json` / `package-lock.json`** — bump `@sentry/react` from `^7.57.0` → `^7.85.0` (resolved 7.120.4). 7.85.0 is the minimum version that ships `feedbackIntegration`. No v7→v8 migration needed.
- **`static/js/client.jsx`**:
  - New remote-config gate: `remoteConfig.sentry.feedbackEnabled`. When truthy, `Sentry.feedbackIntegration({ colorScheme: "system", useSentryUser: { name: "fullName", email: "email" } })` is pushed onto the `integrations` array passed to `Sentry.init`.
  - When `Sefaria._uid` is set, call `Sentry.setUser({ id, email, fullName })` after init so the widget can pre-fill name/email for logged-in users via `useSentryUser`.

## Rollout (ship dark)

Default the new `sentry.feedbackEnabled` remote-config key to **false**. After merge:

1. Deploy to cauldron.
2. Flip `feedbackEnabled = true` in cauldron remote-config and run the [cauldron verification checklist on the story](https://app.shortcut.com/sefaria/story/44228).
3. Install Sentry ↔ Shortcut integration and the Feedback → Create Shortcut Story alert rule (Sentry-side, see story checklist).
4. Flip `feedbackEnabled = true` in prod remote-config.
5. Kill-switch is the same flag — flippable without a redeploy.

## Test plan

- [ ] Local build runs and page loads without console errors when `feedbackEnabled` is undefined/false (no widget).
- [ ] Local build with `feedbackEnabled: true` injected into `remoteConfig`: widget renders bottom-right, opens, submits.
- [ ] Logged-in user: name + email pre-filled in the widget form.
- [ ] Logged-out user: widget still opens; name + email fields editable and empty.
- [ ] Mobile viewport + Hebrew/RTL pages: widget renders without layout regressions.
- [ ] After deploy to cauldron, a real submission lands in Sentry → User Feedback with replay + URL context attached.

## References

- Story: [sc-44228](https://app.shortcut.com/sefaria/story/44228) (has full checklist incl. cauldron + Sentry-side config)
- Sentry docs: https://docs.sentry.io/platforms/javascript/guides/react/user-feedback/
- Sentry docs: https://docs.sentry.io/product/user-feedback/setup/

🤖 Generated with [Claude Code](https://claude.com/claude-code)