### PR TITLE
helm(datadog): add DD_ENTITY_ID for DogStatsD origin detection

### DIFF
--- a/helm-chart/sefaria/templates/rollout/task.yaml
+++ b/helm-chart/sefaria/templates/rollout/task.yaml
@@ -98,6 +98,10 @@ spec:
           {{- if .Values.datadog.enabled }}
           - name: DD_LOGS_INJECTION
             value: "true"
+          - name: DD_ENTITY_ID
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.uid
           {{- end }}
           {{- with .Values.gpuServer }}
           - name: GPU_SERVER_HOST

--- a/helm-chart/sefaria/templates/rollout/web.yaml
+++ b/helm-chart/sefaria/templates/rollout/web.yaml
@@ -109,6 +109,10 @@ spec:
             value: "true"
           - name: DD_RUNTIME_METRICS_ENABLED
             value: "true"
+          - name: DD_ENTITY_ID
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.uid
           {{- end }}
           - name: REDIS_HOST
             value: "redis-{{ .Values.deployEnv }}"


### PR DESCRIPTION
## Summary
- Adds `DD_ENTITY_ID` env var (Kubernetes downward API → `metadata.uid`) to **web** and **tasks** rollout templates
- Gated behind existing `datadog.enabled` flag — no values.yaml changes needed
- Enables DogStatsD origin detection over UDP per [Datadog docs](https://docs.datadoghq.com/extend/dogstatsd/?tab=udp#origin-detection-over-udp)

## Context
Datadog's python profiling engineer is investigating memory leak data in our account and requested this env var to correlate DogStatsD metrics to specific pods.

Companion PR in infrastructure repo: enables `dogstatsd.originDetectionEnabled` on the prod DatadogAgent CR.

## Test plan
- [ ] Verify `helm template` renders DD_ENTITY_ID correctly when `datadog.enabled=true`
- [ ] Verify DD_ENTITY_ID is absent when `datadog.enabled=false`
- [ ] After deploy, confirm pods have `DD_ENTITY_ID` set to their UID via `kubectl exec`
- [ ] Confirm Datadog shows origin-tagged DogStatsD metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)