### PR TITLE
helm(datadog): add DD_ENTITY_ID for DogStatsD origin detection

### DIFF
--- a/helm-chart/sefaria/templates/rollout/task.yaml
+++ b/helm-chart/sefaria/templates/rollout/task.yaml
@@ -98,6 +98,10 @@ spec:
           {{- if .Values.datadog.enabled }}
           - name: DD_LOGS_INJECTION
             value: "true"
+          - name: DD_ENTITY_ID
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.uid
           {{- end }}
           {{- with .Values.gpuServer }}
           - name: GPU_SERVER_HOST

--- a/helm-chart/sefaria/templates/rollout/web.yaml
+++ b/helm-chart/sefaria/templates/rollout/web.yaml
@@ -109,6 +109,10 @@ spec:
             value: "true"
           - name: DD_RUNTIME_METRICS_ENABLED
             value: "true"
+          - name: DD_ENTITY_ID
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.uid
           {{- end }}
           - name: REDIS_HOST
             value: "redis-{{ .Values.deployEnv }}"


### PR DESCRIPTION
Hotfix: adds `DD_ENTITY_ID` environment variable to the Helm chart for DogStatsD origin detection over UDP.

Replaces #3299 (closed due to branch rename from `feature/` → `hotfix/`).