### PR TITLE
fix(ci): merge duplicate env blocks in manual-promotion workflow

### DIFF
--- a/.github/workflows/manual-promotion.yaml
+++ b/.github/workflows/manual-promotion.yaml
@@ -60,7 +60,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-        env:
           SOURCE: ${{ github.event.inputs.source }}
           TARGET: ${{ github.event.inputs.target }}
         run: ./build/ci/generate-promotion-pr.sh "$SOURCE" "$TARGET"


### PR DESCRIPTION
## Summary
- Fixes a YAML parse error that prevented the `manual-promotion` workflow from being queued
- The `Generate changelog and create PR` step had two separate `env:` keys at the same mapping level, which GitHub Actions rejects as invalid YAML
- Merged the two `env:` blocks into one

## Test plan
- [ ] Trigger the Manual Promotion workflow from the Actions tab and confirm it queues successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)