### PR TITLE
helm(datadog): set DD_PROFILING_MAX_FRAMES=128 for web

### DIFF
--- a/helm-chart/sefaria/templates/rollout/web.yaml
+++ b/helm-chart/sefaria/templates/rollout/web.yaml
@@ -107,6 +107,8 @@ spec:
             value: "true"
           - name: DD_PROFILING_ENABLED
             value: "true"
+          - name: DD_PROFILING_MAX_FRAMES
+            value: "128"
           - name: DD_RUNTIME_METRICS_ENABLED
             value: "true"
           - name: DD_ENTITY_ID


### PR DESCRIPTION
## Summary
- Adds `DD_PROFILING_MAX_FRAMES=128` to the web rollout's Datadog env block
- Increases profiling stack depth from the default (64) to 128 frames
- Ref: [ddtrace configuration docs](https://ddtrace.readthedocs.io/en/stable/configuration.html#DD_PROFILING_MAX_FRAMES)

## Context
Requested by Datadog's python profiling engineer to improve visibility into deep call stacks during the ongoing memory leak investigation.

## Test plan
- [ ] Verify `helm template` renders `DD_PROFILING_MAX_FRAMES` correctly when `datadog.enabled=true`
- [ ] After deploy, confirm the env var is set on web pods via `kubectl exec`

🤖 Generated with [Claude Code](https://claude.com/claude-code)