### PR TITLE
feat(prod): point postgres connection at postgres-18

### DIFF
--- a/envs/prod/helmrelease.yaml
+++ b/envs/prod/helmrelease.yaml
@@ -20,6 +20,8 @@ spec:
     deployEnv: production
     previousServicesCount: "3"
     deploymentMessage: true
+    postgres:
+      host: "postgres-18.default.svc.cluster.local"
     restore:
       enabled: false
       dynamicName: false


### PR DESCRIPTION
## Summary
- Override `postgres.host` in prod helmrelease to use `postgres-18.default.svc.cluster.local`
- Same change as preprod (#3282) — switches production to the postgres-18 service

## Test plan
- [ ] Verify prod pods pick up the new host after Flux reconciles
- [ ] Confirm Django connects successfully to postgres-18

🤖 Generated with [Claude Code](https://claude.com/claude-code)