### PR TITLE
feat: add CLAUDE.md with shared wiki reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,7 +64,6 @@ node_modules
 ##########
 .cursor/
 .claude/
-CLAUDE.md
 
 # pystest cache #
 #####################

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,14 @@
+## Sefaria Wiki (Shared Knowledge Base)
+
+Path: `~/sefaria/sefaria-wiki`
+
+When you need architectural context, deployment patterns, or domain knowledge not captured in this repo's code:
+1. Read `~/sefaria/sefaria-wiki/wiki/hot.md` (recent context)
+2. Read `~/sefaria/sefaria-wiki/wiki/index.md` (full catalog)
+3. Drill into domain pages as needed
+
+When you discover architecture decisions, deployment patterns, or system behaviors worth preserving:
+- Offer to `/save` the insight to the wiki
+- Or use `ingest` for longer documents
+
+The wiki is a shared resource. If you learned it, file it.


### PR DESCRIPTION
## Summary
- Removes `CLAUDE.md` from `.gitignore` so project-level Claude Code config can be shared across the team
- Adds a `CLAUDE.md` that points Claude Code sessions to the `sefaria-wiki` knowledge base
- Developers get automatic wiki context and can `/save` insights mid-session

## Context
The sefaria-wiki is now registered in the sefaria-marketplace as a plugin. This CLAUDE.md tells Claude _when_ to read from and write to the wiki — the plugin provides the _how_ (`/save`, `/wiki`, `ingest`).

## Test plan
- [ ] Verify `CLAUDE.md` loads in a Claude Code session within Sefaria-Project
- [ ] Verify Claude reads `wiki/hot.md` when asked for architectural context
- [ ] Verify `/save` works when the wiki plugin is installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)