### PR TITLE
feat: add חזק חזק ונתחזק easter egg on Torah book completion

### DIFF
--- a/reader/views.py
+++ b/reader/views.py
@@ -4206,6 +4206,42 @@ def _get_anonymous_user_history(request):
     return history
 
 
+@login_required
+def book_completion_api(request):
+    """
+    GET /api/book_completion?book=Genesis
+    Returns whether the logged-in user has viewed at least one verse from every chapter.
+    """
+    if request.method != "GET":
+        return jsonResponse({"error": "Unsupported HTTP method."})
+
+    book = request.GET.get("book")
+    if not book:
+        return jsonResponse({"error": "Must specify 'book' param"})
+
+    try:
+        index = library.get_index(book)
+    except (InputError, BookNameError):
+        return jsonResponse({"error": f"Unknown book: {book}"})
+
+    all_chapter_refs = {r.normal() for r in index.all_top_section_refs()}
+    total_chapters = len(all_chapter_refs)
+
+    pipeline = [
+        {"$match": {"uid": request.user.id, "book": book, "secondary": {"$ne": True}}},
+        {"$unwind": "$context_refs"},
+        {"$group": {"_id": "$context_refs"}},
+    ]
+    viewed_context_refs = {doc["_id"] for doc in db.user_history.aggregate(pipeline)}
+    chapters_read = len(all_chapter_refs & viewed_context_refs)
+
+    return jsonResponse({
+        "complete": chapters_read >= total_chapters,
+        "chapters_read": chapters_read,
+        "total_chapters": total_chapters,
+    })
+
+
 def user_history_api(request):
     """
     GET API for user history for a particular user. optional URL params are

--- a/sefaria/urls_shared.py
+++ b/sefaria/urls_shared.py
@@ -45,6 +45,7 @@ shared_patterns = [
     path('api/profile/<str:slug>', reader_views.profile_api),
     re_path(r'^api/profile/(?P<slug>[^/]+)/(?P<ftype>followers|following)$', reader_views.profile_follow_api),
     path('api/user_history/saved', reader_views.saved_history_for_ref),
+    path('api/book_completion', reader_views.book_completion_api),
 
     re_path(r'^topics/category/(?P<topicCategory>.+)?$', reader_views.topics_category_page),
     re_path(r'^topics/all/(?P<letter>.)$', reader_views.all_topics_page),

--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -15740,3 +15740,118 @@ span.ref-link-color-3 {color: blue}
 }
 
 /* ========== GUIDE OVERLAY COMPONENT STYLES - END ========== */
+
+/* ========== HAZAK CELEBRATION - START ========== */
+
+@keyframes hazakFadeIn {
+  from { opacity: 0; transform: translateY(20px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes hazakShimmer {
+  0%   { background-position: -200% center; }
+  100% { background-position: 200% center; }
+}
+
+@keyframes hazakSparkle {
+  0%, 100% { opacity: 0.3; transform: scale(0.8); }
+  50%      { opacity: 1; transform: scale(1.2); }
+}
+
+.hazakCelebration {
+  text-align: center;
+  padding: 40px 20px;
+  margin: 20px auto;
+  max-width: 500px;
+  animation: hazakFadeIn 0.8s ease-out forwards;
+}
+
+.hazakContent {
+  position: relative;
+  background: #fff;
+  border-radius: 12px;
+  padding: 32px 24px;
+  box-shadow: 0 2px 16px rgba(0, 0, 0, 0.1);
+  border: 2px solid var(--tanakh-teal);
+}
+
+.hazakContent .readerNavMenuCloseButton {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+}
+
+.hazakText {
+  font-family: "Taamey Frank", "Frank Ruehl", serif;
+  font-size: 2.4em;
+  font-weight: bold;
+  margin-bottom: 8px;
+  background: linear-gradient(
+    90deg,
+    var(--tanakh-teal),
+    var(--talmud-gold),
+    var(--tanakh-teal)
+  );
+  background-size: 200% auto;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  animation: hazakShimmer 3s ease-in-out infinite;
+}
+
+.hazakTranslation {
+  font-size: 1.1em;
+  color: #666;
+  margin-bottom: 16px;
+  font-style: italic;
+}
+
+.hazakBookName {
+  font-size: 1em;
+  font-weight: 600;
+  margin-bottom: 16px;
+  color: #333;
+}
+
+.hazakSourceLink {
+  display: inline-block;
+  font-size: 0.9em;
+  color: var(--tanakh-teal);
+  text-decoration: underline;
+}
+
+.hazakSourceLink:hover {
+  opacity: 0.8;
+}
+
+.hazakDecorationTop,
+.hazakDecorationBottom {
+  display: flex;
+  justify-content: center;
+  gap: 16px;
+  padding: 8px 0;
+}
+
+.hazakDecorationTop::before,
+.hazakDecorationTop::after,
+.hazakDecorationBottom::before,
+.hazakDecorationBottom::after {
+  content: "\2726";
+  font-size: 16px;
+  color: var(--talmud-gold);
+  animation: hazakSparkle 1.5s ease-in-out infinite;
+}
+
+.hazakDecorationTop::after {
+  animation-delay: 0.3s;
+}
+
+.hazakDecorationBottom::before {
+  animation-delay: 0.6s;
+}
+
+.hazakDecorationBottom::after {
+  animation-delay: 0.9s;
+}
+
+/* ========== HAZAK CELEBRATION - END ========== */

--- a/static/js/HazakCelebration.jsx
+++ b/static/js/HazakCelebration.jsx
@@ -1,0 +1,61 @@
+import React, { useState, useEffect } from "react";
+import Sefaria from "./sefaria/sefaria";
+import { InterfaceText, CloseButton } from "./Misc";
+import Cookies from "js-cookie";
+
+const HAZAK_HALAKHA_REF = "Shulchan Arukh, Orach Chayim 139.11";
+
+const HazakCelebration = ({ bookTitle, heBookTitle }) => {
+    const cookieName = `hazak_seen_${bookTitle}`;
+    const [show, setShow] = useState(false);
+
+    useEffect(() => {
+        if (Cookies.get(cookieName) || !Sefaria._uid || !Sefaria.titleIsTorah(bookTitle)) {
+            return;
+        }
+        Sefaria.checkBookCompletion(bookTitle).then(data => {
+            if (data.complete) {
+                setShow(true);
+                Cookies.set(cookieName, "1", { path: "/", expires: 20 * 365 });
+                gtag("event", "hazak_celebration", {
+                    book: bookTitle,
+                    feature_name: "Hazak Celebration"
+                });
+            }
+        });
+    }, [bookTitle]);
+
+    if (!show) return null;
+
+    return (
+        <div className="hazakCelebration">
+            <div className="hazakDecorationTop" />
+            <div className="hazakContent">
+                <CloseButton onClick={() => setShow(false)} />
+                <div className="hazakText" dir="rtl">
+                    חזק חזק ונתחזק
+                </div>
+                <div className="hazakTranslation">
+                    Be strong, be strong, and may we be strengthened!
+                </div>
+                <div className="hazakBookName">
+                    <InterfaceText text={{ en: bookTitle, he: heBookTitle }} />
+                </div>
+                <a
+                    className="hazakSourceLink"
+                    href={`/${Sefaria.normRef(HAZAK_HALAKHA_REF)}`}
+                >
+                    <InterfaceText
+                        text={{
+                            en: "Learn about this custom",
+                            he: "למדו על המנהג"
+                        }}
+                    />
+                </a>
+            </div>
+            <div className="hazakDecorationBottom" />
+        </div>
+    );
+};
+
+export default HazakCelebration;

--- a/static/js/TextColumn.jsx
+++ b/static/js/TextColumn.jsx
@@ -10,6 +10,7 @@ import $  from './sefaria/sefariaJquery';
 import Sefaria  from './sefaria/sefaria';
 import Component from 'react-class';
 import {ContentText} from "./ContentText";
+import HazakCelebration from './HazakCelebration';
 
 
 class TextColumn extends Component {
@@ -465,9 +466,16 @@ class TextColumn extends Component {
         (noPrev ? bookTitle :
         <LoadingMessage className="base prev" key={"prev"}/>) : null;
 
+      const isEndOfBook = last && !last.next;
+      const isTorahBook = Sefaria.titleIsTorah(this.props.bookTitle);
+
       post = hasNext && this.state.showScrollPlaceholders ?
         <LoadingMessage className="base next" key={"next"}/> :
-        <LoadingMessage message={" "} heMessage={" "} className="base next final" key={"next"}/>;
+        <React.Fragment key={"next"}>
+          {isEndOfBook && isTorahBook &&
+            <HazakCelebration bookTitle={this.props.bookTitle} heBookTitle={this.props.heBookTitle} />}
+          <LoadingMessage message={" "} heMessage={" "} className="base next final" />
+        </React.Fragment>;
     }
 
     return (<div className={classes} onMouseUp={this.handleTextSelection} onClick={this.handleClick} onMouseDown={this.handleDoubleClick}>

--- a/static/js/sefaria/sefaria.js
+++ b/static/js/sefaria/sefaria.js
@@ -2858,6 +2858,15 @@ _media: {},
     }
     Sefaria.last_place = history_item_array.filter(x=>!x.secondary).concat(Sefaria.last_place);  // while technically we should remove dup. books, this list is only used on client
   },
+  _bookCompletions: {},
+  checkBookCompletion: function(book) {
+    if (!Sefaria._uid) { return Promise.resolve({complete: false}); }
+    return Sefaria._cachedApiPromise({
+      url:   Sefaria.apiHost + "/api/book_completion?book=" + encodeURIComponent(book),
+      key:   book,
+      store: Sefaria._bookCompletions
+    });
+  },
     isNewVisitor: () => {
         return (
             ("isNewVisitor" in sessionStorage &&


### PR DESCRIPTION
## Summary

- Adds an animated celebration when a logged-in user finishes all chapters of a Torah book (Genesis, Exodus, Leviticus, Numbers, Deuteronomy)
- Shows "חזק חזק ונתחזק" with shimmer animation, English translation, book name, and a link to Shulchan Arukh, Orach Chayim 139:11 explaining the custom
- Appears once per book (cookie-persisted), only for logged-in users

## How it works

**Completion check**: A new `GET /api/book_completion?book=Genesis` endpoint runs a MongoDB aggregation on `user_history`, counting distinct chapter-level `context_refs` for the user. Completion = at least one verse viewed from every chapter.

**Display trigger**: `TextColumn.jsx` renders `<HazakCelebration>` inline at the end of a Torah book (when `last.next` is null and `Sefaria.titleIsTorah()` is true). The component checks the cookie, login state, and calls the API before showing.

**Animation**: Pure CSS `@keyframes` — no new libraries. Uses existing `--tanakh-teal` and `--talmud-gold` palette variables.

## Files changed

- `reader/views.py` — new `book_completion_api` view
- `sefaria/urls_shared.py` — URL route for the new endpoint
- `static/js/sefaria/sefaria.js` — `Sefaria.checkBookCompletion()` with session cache
- `static/js/HazakCelebration.jsx` — new celebration component
- `static/js/TextColumn.jsx` — render the component at end of Torah books
- `static/css/s2.css` — animations and styling

## Test plan

- [ ] Navigate to the last chapter of a Torah book as a logged-in user who hasn't viewed all chapters → no celebration
- [ ] Seed history entries for all chapters of a book and revisit the last chapter → celebration appears
- [ ] After seeing it once, refresh and scroll to the end → does **not** reappear (cookie)
- [ ] Close button dismisses the celebration
- [ ] Navigate to the end of a non-Torah book → no celebration
- [ ] Log out and navigate to end of a Torah book → no celebration
- [ ] "Learn about this custom" link opens Shulchan Arukh, Orach Chayim 139:11

🤖 Generated with [Claude Code](https://claude.com/claude-code)