### PR TITLE
Resurrect Social Image Generation

### DIFF
--- a/docs/openAPI.json
+++ b/docs/openAPI.json
@@ -19070,13 +19070,14 @@
         "parameters": [
           {
             "name": "lang",
-            "description": "The language the social image should return, `en` for English language or `he` for Hebrew. ",
+            "description": "The language the social image should return, `en` for English language or `he` for Hebrew. Defaults to `en` if omitted. `bi` is accepted and returns English. ",
             "schema": {
               "enum": [
                 "he",
                 "en"
               ],
-              "type": "string"
+              "type": "string",
+              "default": "en"
             },
             "in": "query"
           },

--- a/docs/openAPI.json
+++ b/docs/openAPI.json
@@ -19083,13 +19083,14 @@
           },
           {
             "name": "platform",
-            "description": "This value determines the size of the image, set to the platform's ideal as specified in its own developer documentation.",
+            "description": "This value determines the size of the image, set to the platform's ideal as specified in its own developer documentation. Defaults to `facebook` if omitted or invalid. Use `twitter` for X/Twitter cards.",
             "schema": {
               "enum": [
                 "facebook",
                 "twitter"
               ],
-              "type": "string"
+              "type": "string",
+              "default": "facebook"
             },
             "in": "query"
           },

--- a/e2e-tests/tests/social-image.spec.ts
+++ b/e2e-tests/tests/social-image.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from '@playwright/test';
+
+const FACEBOOK_IMAGE_SIZE = { width: 1200, height: 630 };
+
+function getPngDimensions(buffer: Buffer) {
+  return {
+    width: buffer.readUInt32BE(16),
+    height: buffer.readUInt32BE(20),
+  };
+}
+
+async function expectGeneratedPng(request, url: string, expectedSize = FACEBOOK_IMAGE_SIZE) {
+  const response = await request.get(url);
+  expect(response.status()).toBe(200);
+  expect(response.headers()['content-type']?.toLowerCase()).toContain('image/png');
+
+  const body = await response.body();
+  expect(body.length).toBeGreaterThan(10_000);
+  expect(getPngDimensions(body)).toEqual(expectedSize);
+}
+
+async function getOgImageUrlFromPageHtml(page, request, path: string) {
+  const response = await request.get(path);
+  expect(response.status()).toBe(200);
+  expect(response.headers()['content-type']?.toLowerCase()).toContain('text/html');
+
+  const html = await response.text();
+  const imageUrl = await page.evaluate((pageHtml) => {
+    const doc = new DOMParser().parseFromString(pageHtml, 'text/html');
+    return doc.querySelector('meta[property="og:image"]')?.getAttribute('content');
+  }, html);
+  expect(imageUrl).toBeTruthy();
+  return new URL(imageUrl!);
+}
+
+test.describe('Social image generation', () => {
+  test('text ref page renders encoded og:image URL and generated PNG', async ({ page, request }) => {
+    const selectedVersion = 'english|The_Contemporary_Torah,_Jewish_Publication_Society,_2006';
+    const pagePath = `/Genesis.1.1?ven=${encodeURIComponent(selectedVersion)}&lang=en&with=Translations&lang2=en`;
+
+    const imageUrl = await getOgImageUrlFromPageHtml(page, request, pagePath);
+    expect(imageUrl.pathname).toBe('/api/img-gen/Genesis.1.1');
+    expect(imageUrl.searchParams.get('platform')).toBe('facebook');
+    expect(imageUrl.searchParams.get('lang')).toBe('en');
+    expect(imageUrl.searchParams.get('ven')).toBe(selectedVersion);
+
+    await expectGeneratedPng(request, `${imageUrl.pathname}${imageUrl.search}`);
+  });
+
+  test('static page renders og:image URL and generated PNG', async ({ page, request }) => {
+    const imageUrl = await getOgImageUrlFromPageHtml(page, request, '/jobs');
+    expect(imageUrl.pathname).toBe('/api/img-gen/jobs');
+    expect(imageUrl.searchParams.get('platform')).toBe('facebook');
+
+    await expectGeneratedPng(request, `${imageUrl.pathname}${imageUrl.search}`);
+  });
+
+  test('direct img-gen endpoint returns generated PNG', async ({ request }) => {
+    await expectGeneratedPng(request, '/api/img-gen/Genesis.1.1?lang=en&platform=facebook');
+  });
+});

--- a/reader/templatetags/sefaria_tags.py
+++ b/reader/templatetags/sefaria_tags.py
@@ -45,6 +45,22 @@ register = template.Library()
 domain = SimpleLazyObject(lambda: Site.objects.get_current().domain)
 
 
+@register.simple_tag
+def social_image_url(request, platform):
+    """
+    Build the social-image endpoint URL with a real query encoder so version
+    titles containing spaces, pipes, ampersands, or punctuation survive when
+    nested inside the meta tag URL.
+    """
+    params = {
+        "lang": request.GET.get("lang", ""),
+        "platform": platform,
+        "ven": request.GET.get("ven", ""),
+        "vhe": request.GET.get("vhe", ""),
+    }
+    return f"https://{request.get_host()}/api/img-gen{request.path}?{urllib.parse.urlencode(params)}"
+
+
 class SyncedMetaTagNode(template.Node):
     """
     Base node that renders content into synchronized regular, OpenGraph, and Twitter meta tags.
@@ -608,5 +624,4 @@ def date_string_to_date(dateString):
 def sheet_via_absolute_link(sheet_id):
     return mark_safe(absolute_link(
 		'<a href="/sheets/{}">a sheet</a>'.format(sheet_id)))
-
 

--- a/reader/templatetags/tests.py
+++ b/reader/templatetags/tests.py
@@ -75,3 +75,24 @@ class TestStaticFileTag(SimpleTestCase):
         rendered = template.render(Context({}))
         self.assertIn(f'?v={new_expected_hash}', rendered)
         self.assertNotIn(f'?v={self.expected_hash}', rendered)
+
+
+class TestSocialImageUrlTag(SimpleTestCase):
+    databases = set()
+
+    def test_social_image_url_tag_url_encodes_version_query_params(self):
+        template = Template('{% load sefaria_tags %}{% social_image_url request "facebook" %}')
+        request = self.client.request().wsgi_request
+        request.path = "/Genesis.1.1"
+        request.GET = {
+            "lang": "en",
+            "ven": "english|The Five Books of Moses, by Everett Fox & Co.",
+            "vhe": "",
+        }
+
+        rendered = template.render(Context({"request": request}))
+
+        self.assertIn("platform=facebook", rendered)
+        self.assertIn("lang=en", rendered)
+        self.assertIn("ven=english%7CThe+Five+Books+of+Moses%2C+by+Everett+Fox+%26+Co.", rendered)
+        self.assertNotIn("Everett Fox & Co.", rendered)

--- a/reader/tests/social_image_api_test.py
+++ b/reader/tests/social_image_api_test.py
@@ -21,8 +21,10 @@ class DummyRef:
 
 
 class DummyTextFamily:
+    captured_kwargs = {}
+
     def __init__(self, *args, **kwargs):
-        pass
+        self.__class__.captured_kwargs = kwargs
 
     def contents(self):
         return {
@@ -38,6 +40,7 @@ def _request(path):
 
 def _capture_social_image_call(monkeypatch, path):
     captured = {}
+    DummyTextFamily.captured_kwargs = {}
 
     def fake_response(text, category, ref_str, lang, platform):
         captured.update(
@@ -49,6 +52,7 @@ def _capture_social_image_call(monkeypatch, path):
                 "platform": platform,
             }
         )
+        captured["text_family_kwargs"] = DummyTextFamily.captured_kwargs
         return captured
 
     monkeypatch.setattr(views, "Ref", lambda tref: DummyRef())
@@ -111,7 +115,37 @@ def test_social_image_api_defaults_invalid_platform_to_facebook(monkeypatch):
     assert result["platform"] == "facebook"
 
 
+def test_social_image_api_preserves_facebook_platform(monkeypatch):
+    result = _capture_social_image_call(monkeypatch, "/api/img-gen/Genesis.1.1?platform=facebook")
+
+    assert result["platform"] == "facebook"
+
+
 def test_social_image_api_preserves_twitter_platform(monkeypatch):
     result = _capture_social_image_call(monkeypatch, "/api/img-gen/Genesis.1.1?platform=twitter")
 
     assert result["platform"] == "twitter"
+
+
+def test_social_image_api_extracts_translation_version_title_from_ven(monkeypatch):
+    path = (
+        "/api/img-gen/Genesis.1.1?"
+        "lang=en&ven=english%7CThe_Contemporary_Torah,_Jewish_Publication_Society,_2006"
+    )
+    result = _capture_social_image_call(monkeypatch, path)
+
+    assert result["text_family_kwargs"]["version"] == "The Contemporary Torah, Jewish Publication Society, 2006"
+
+
+def test_social_image_api_extracts_hebrew_version_title_from_vhe(monkeypatch):
+    path = "/api/img-gen/Genesis.1.1?lang=he&vhe=hebrew%7CTanach_with_Ta%27amei_Hamikra"
+    result = _capture_social_image_call(monkeypatch, path)
+
+    assert result["text_family_kwargs"]["version"] == "Tanach with Ta'amei Hamikra"
+
+
+def test_social_image_api_accepts_legacy_version_title_without_language_prefix(monkeypatch):
+    path = "/api/img-gen/Genesis.1.1?lang=en&ven=The_Contemporary_Torah,_Jewish_Publication_Society,_2006"
+    result = _capture_social_image_call(monkeypatch, path)
+
+    assert result["text_family_kwargs"]["version"] == "The Contemporary Torah, Jewish Publication Society, 2006"

--- a/reader/tests/social_image_api_test.py
+++ b/reader/tests/social_image_api_test.py
@@ -1,3 +1,10 @@
+"""
+Tests for the social_image_api view.
+
+Covers the lang parameter normalization added to fix cases where a missing,
+empty, or unrecognized lang value caused the wrong language to be used when
+generating social share images.
+"""
 from django.test import RequestFactory
 
 from reader import views
@@ -8,12 +15,14 @@ class DummyRef:
         return "Genesis 1:1"
 
     def he_normal(self):
+        # Stub — tests assert against this exact string to verify the view
+        # picks ref.he_normal() when lang="he".
         return "בראשית א׳:א׳"
 
 
 class DummyTextFamily:
     def __init__(self, *args, **kwargs):
-        self.kwargs = kwargs
+        pass
 
     def contents(self):
         return {
@@ -55,6 +64,7 @@ def test_social_image_api_defaults_missing_lang_to_english(monkeypatch):
     assert result["lang"] == "en"
     assert result["text"] == "In the beginning"
     assert result["ref_str"] == "Genesis 1:1"
+    assert result["platform"] == "twitter"
 
 
 def test_social_image_api_defaults_empty_lang_to_english(monkeypatch):

--- a/reader/tests/social_image_api_test.py
+++ b/reader/tests/social_image_api_test.py
@@ -62,9 +62,9 @@ def test_social_image_api_defaults_missing_lang_to_english(monkeypatch):
     result = _capture_social_image_call(monkeypatch, "/api/img-gen/Genesis.1.1")
 
     assert result["lang"] == "en"
+    assert result["platform"] == "facebook"
     assert result["text"] == "In the beginning"
     assert result["ref_str"] == "Genesis 1:1"
-    assert result["platform"] == "twitter"
 
 
 def test_social_image_api_defaults_empty_lang_to_english(monkeypatch):
@@ -97,3 +97,21 @@ def test_social_image_api_preserves_hebrew_lang(monkeypatch):
     assert result["lang"] == "he"
     assert result["text"] == "בראשית"
     assert result["ref_str"] == "בראשית א׳:א׳"
+
+
+def test_social_image_api_defaults_empty_platform_to_facebook(monkeypatch):
+    result = _capture_social_image_call(monkeypatch, "/api/img-gen/Genesis.1.1?platform=")
+
+    assert result["platform"] == "facebook"
+
+
+def test_social_image_api_defaults_invalid_platform_to_facebook(monkeypatch):
+    result = _capture_social_image_call(monkeypatch, "/api/img-gen/Genesis.1.1?platform=linkedin")
+
+    assert result["platform"] == "facebook"
+
+
+def test_social_image_api_preserves_twitter_platform(monkeypatch):
+    result = _capture_social_image_call(monkeypatch, "/api/img-gen/Genesis.1.1?platform=twitter")
+
+    assert result["platform"] == "twitter"

--- a/reader/tests/social_image_api_test.py
+++ b/reader/tests/social_image_api_test.py
@@ -1,0 +1,89 @@
+from django.test import RequestFactory
+
+from reader import views
+
+
+class DummyRef:
+    def normal(self):
+        return "Genesis 1:1"
+
+    def he_normal(self):
+        return "בראשית א׳:א׳"
+
+
+class DummyTextFamily:
+    def __init__(self, *args, **kwargs):
+        self.kwargs = kwargs
+
+    def contents(self):
+        return {
+            "text": "In the beginning",
+            "he": "בראשית",
+            "primary_category": "Tanakh",
+        }
+
+
+def _request(path):
+    return RequestFactory().get(path)
+
+
+def _capture_social_image_call(monkeypatch, path):
+    captured = {}
+
+    def fake_response(text, category, ref_str, lang, platform):
+        captured.update(
+            {
+                "text": text,
+                "category": category,
+                "ref_str": ref_str,
+                "lang": lang,
+                "platform": platform,
+            }
+        )
+        return captured
+
+    monkeypatch.setattr(views, "Ref", lambda tref: DummyRef())
+    monkeypatch.setattr(views, "TextFamily", DummyTextFamily)
+    monkeypatch.setattr(views, "make_img_http_response", fake_response)
+
+    return views.social_image_api(_request(path), "Genesis.1.1")
+
+
+def test_social_image_api_defaults_missing_lang_to_english(monkeypatch):
+    result = _capture_social_image_call(monkeypatch, "/api/img-gen/Genesis.1.1")
+
+    assert result["lang"] == "en"
+    assert result["text"] == "In the beginning"
+    assert result["ref_str"] == "Genesis 1:1"
+
+
+def test_social_image_api_defaults_empty_lang_to_english(monkeypatch):
+    result = _capture_social_image_call(monkeypatch, "/api/img-gen/Genesis.1.1?lang=")
+
+    assert result["lang"] == "en"
+    assert result["text"] == "In the beginning"
+    assert result["ref_str"] == "Genesis 1:1"
+
+
+def test_social_image_api_defaults_invalid_lang_to_english(monkeypatch):
+    result = _capture_social_image_call(monkeypatch, "/api/img-gen/Genesis.1.1?lang=english")
+
+    assert result["lang"] == "en"
+    assert result["text"] == "In the beginning"
+    assert result["ref_str"] == "Genesis 1:1"
+
+
+def test_social_image_api_maps_bilingual_lang_to_english(monkeypatch):
+    result = _capture_social_image_call(monkeypatch, "/api/img-gen/Genesis.1.1?lang=bi")
+
+    assert result["lang"] == "en"
+    assert result["text"] == "In the beginning"
+    assert result["ref_str"] == "Genesis 1:1"
+
+
+def test_social_image_api_preserves_hebrew_lang(monkeypatch):
+    result = _capture_social_image_call(monkeypatch, "/api/img-gen/Genesis.1.1?lang=he")
+
+    assert result["lang"] == "he"
+    assert result["text"] == "בראשית"
+    assert result["ref_str"] == "בראשית א׳:א׳"

--- a/reader/views.py
+++ b/reader/views.py
@@ -1775,7 +1775,9 @@ def social_image_api(request, tref):
     if lang == "bi":
         lang = "en"
     version = request.GET.get("ven", None) if lang == "en" else request.GET.get("vhe", None)
-    platform = request.GET.get("platform", "twitter")
+    platform = request.GET.get("platform") or "facebook"
+    if platform not in {"facebook", "twitter"}:
+        platform = "facebook"
 
     try:
         ref = Ref(tref)

--- a/reader/views.py
+++ b/reader/views.py
@@ -1769,7 +1769,9 @@ def complete_version_api(request):
 @catch_error_as_json
 @csrf_exempt
 def social_image_api(request, tref):
-    lang = request.GET.get("lang", "en")
+    lang = request.GET.get("lang") or "en"
+    if lang not in {"en", "he", "bi"}:
+        lang = "en"
     if lang == "bi":
         lang = "en"
     version = request.GET.get("ven", None) if lang == "en" else request.GET.get("vhe", None)

--- a/reader/views.py
+++ b/reader/views.py
@@ -654,6 +654,22 @@ def _extract_version_params(request, key):
     languageFamilyName, versionTitle = params.split('|')
     return {'languageFamilyName': languageFamilyName, 'versionTitle': versionTitle}
 
+
+def _extract_version_title_param(request, key):
+    """
+    Accept both the current ReaderApp URL shape, languageFamilyName|versionTitle,
+    and older links that pass only the version title.
+    """
+    params = request.GET.get(key)
+    if not params:
+        return None
+    params = params.replace("_", " ")
+    if "|" in params:
+        _, version_title = params.split("|", 1)
+        return version_title or None
+    return params
+
+
 @sanitize_get_params
 def text_panels(request, ref, version=None, lang=None, sheet=None):
     """
@@ -1774,7 +1790,7 @@ def social_image_api(request, tref):
         lang = "en"
     if lang == "bi":
         lang = "en"
-    version = request.GET.get("ven", None) if lang == "en" else request.GET.get("vhe", None)
+    version = _extract_version_title_param(request, "ven") if lang == "en" else _extract_version_title_param(request, "vhe")
     platform = request.GET.get("platform") or "facebook"
     if platform not in {"facebook", "twitter"}:
         platform = "facebook"

--- a/sefaria/image_generator.py
+++ b/sefaria/image_generator.py
@@ -105,6 +105,15 @@ def calc_letters_per_line(text, font, img_width):
     return max(1, max_char_count)
 
 
+def wrap_text_preserving_linebreaks(text, width):
+    # HTML cleanup turns <br> and block boundaries into "\n". Wrap each line
+    # independently so those intentional breaks survive textwrap's whitespace handling.
+    return "\n".join(
+        textwrap.fill(text=line, width=width, replace_whitespace=False)
+        for line in text.split("\n")
+    )
+
+
 def supports_rtl_text_layout():
     return features.check("raqm")
 
@@ -186,7 +195,7 @@ def generate_image(text="", category="System", ref_str="", lang="he", platform="
         cat_border_pos = (img.size[0], 0, img.size[0], img.size[1])
 
     text = cleanup_and_format_text(text, lang)
-    text = textwrap.fill(text=text, width= calc_letters_per_line(text, font, int(img.size[0]-padding_x)))
+    text = wrap_text_preserving_linebreaks(text, calc_letters_per_line(text, font, int(img.size[0]-padding_x)))
     text = prepare_text_for_drawing(text, lang)
     direction = get_text_direction(lang)
 

--- a/sefaria/image_generator.py
+++ b/sefaria/image_generator.py
@@ -20,14 +20,45 @@ palette = { # [(bg), (font)]
     "Chasidut":    [(151, 179, 134), (0, 0, 0)],
     "Musar":    [(124, 65, 111), (255, 255, 255)],
     "Responsa":    [(203, 97, 88), (255, 255, 255)],
+    "Second Temple": [(198, 167, 180), (0, 0, 0)],
     "Quoting Commentary": [(203, 97, 88), (255, 255, 255)],
     "Sheets":    [(24, 52, 93), (255, 255, 255)],
     "Sheet":    [(24, 52, 93), (255, 255, 255)],
     "Targum":    [(59, 88, 73), (255, 255, 255)],
     "Modern Commentary":    [(184, 212, 211), (255, 255, 255)],
     "Reference":    [(212, 137, 108), (255, 255, 255)],
-    "System":    [(24, 52, 93), (255, 255, 255)]
+    "System":    [(24, 52, 93), (255, 255, 255)],
+    "Static":    [(0, 80, 94), (255, 255, 255)]
 }
+
+fallback_palette_colors = [
+    (0, 78, 95),
+    (124, 65, 111),
+    (93, 149, 111),
+    (154, 184, 203),
+    (72, 113, 191),
+    (203, 97, 88),
+    (199, 167, 180),
+    (7, 53, 112),
+    (171, 78, 102),
+    (127, 133, 169),
+    (204, 180, 121),
+    (89, 65, 118),
+    (90, 153, 183),
+    (151, 179, 134),
+    (128, 47, 62),
+    (0, 130, 127),
+    (184, 212, 211),
+    (212, 137, 108),
+]
+
+
+def get_category_colors(category):
+    if category in palette:
+        return palette[category]
+    category = category if isinstance(category, str) else ""
+    index = sum(ord(char) for char in category) % len(fallback_palette_colors)
+    return [fallback_palette_colors[index], (255, 255, 255)]
 
 platforms = {
     "facebook": {
@@ -130,8 +161,7 @@ def cleanup_and_format_text(text, language):
 
 
 def generate_image(text="", category="System", ref_str="", lang="he", platform="twitter"):
-    text_color = palette[category][1]
-    bg_color = palette[category][0]
+    bg_color, text_color = get_category_colors(category)
 
     font = ImageFont.truetype(font='static/fonts/Amiri-Taamey-Frank-merged.ttf', size=platforms[platform]["font_size"])
     width = platforms[platform]["width"]
@@ -166,7 +196,7 @@ def generate_image(text="", category="System", ref_str="", lang="he", platform="
 
 
     #category line
-    draw.line(cat_border_pos, fill=palette[category][0], width=int(width*.02))
+    draw.line(cat_border_pos, fill=bg_color, width=int(width*.02))
 
     #header white
     draw.line((0, int(height*.05), img.size[0], int(height*.05)), fill=(255, 255, 255), width=int(height*.1))

--- a/sefaria/image_generator.py
+++ b/sefaria/image_generator.py
@@ -1,4 +1,4 @@
-from PIL import Image, ImageDraw, ImageFont
+from PIL import Image, ImageDraw, ImageFont, features
 import textwrap
 from bidi.algorithm import get_display
 import re
@@ -55,10 +55,39 @@ def smart_truncate(content, length=180, suffix='...'):
     else:
         return ' '.join(content[:length+1].split(' ')[0:-1]) + suffix
 
+def get_text_width(text, font):
+    if hasattr(font, "getlength"):
+        return font.getlength(text)
+    if hasattr(font, "getbbox"):
+        left, _, right, _ = font.getbbox(text)
+        return right - left
+    return font.getsize(text)[0]
+
+
 def calc_letters_per_line(text, font, img_width):
-    avg_char_width = sum(font.getsize(char)[0] for char in text) / len(text)
-    max_char_count = int(img_width / avg_char_width )
-    return max_char_count
+    if not text:
+        return 1
+    avg_char_width = sum(get_text_width(char, font) for char in text) / len(text)
+    if avg_char_width <= 0:
+        return len(text)
+    max_char_count = int(img_width / avg_char_width)
+    return max(1, max_char_count)
+
+
+def supports_rtl_text_layout():
+    return features.check("raqm")
+
+
+def prepare_text_for_drawing(text, lang):
+    if lang == "en" or supports_rtl_text_layout():
+        return text
+    return get_display(text)
+
+
+def get_text_direction(lang):
+    if lang != "en" and supports_rtl_text_layout():
+        return "rtl"
+    return None
 
 
 def html_to_text_canonical(html):
@@ -94,7 +123,7 @@ def cleanup_and_format_text(text, language):
     text = text.replace("—", "-")
     text = text.replace(u"\u05BE", " ")  #replace hebrew dash with ascii
 
-    strip_cantillation_vowel_regex = re.compile("[^\u05d0-\u05f4\s^\x00-\x7F\x80-\xFF\u0100-\u017F\u0180-\u024F\u1E00-\u1EFF\u2000-\u206f]")
+    strip_cantillation_vowel_regex = re.compile("[^\u05d0-\u05f4\\s^\x00-\x7F\x80-\xFF\u0100-\u017F\u0180-\u024F\u1E00-\u1EFF\u2000-\u206f]")
     text = strip_cantillation_vowel_regex.sub('', text)
     text = smart_truncate(text)
     return text
@@ -128,11 +157,12 @@ def generate_image(text="", category="System", ref_str="", lang="he", platform="
 
     text = cleanup_and_format_text(text, lang)
     text = textwrap.fill(text=text, width= calc_letters_per_line(text, font, int(img.size[0]-padding_x)))
-    text = get_display(text) # Applies BIDI algorithm to text so that letters aren't reversed in PIL.
+    text = prepare_text_for_drawing(text, lang)
+    direction = get_text_direction(lang)
 
     draw = ImageDraw.Draw(im=img)
     draw.text(xy=(img.size[0] / 2, img.size[1] / 2), text=text, font=font, spacing=spacing, align=align,
-              fill=text_color, anchor='mm')
+              fill=text_color, anchor='mm', direction=direction)
 
 
     #category line
@@ -143,7 +173,8 @@ def generate_image(text="", category="System", ref_str="", lang="he", platform="
     draw.line((0, int(height*.1), img.size[0], int(height*.1)), fill="#CCCCCC", width=int(height*.0025))
 
     #write ref
-    draw.text(xy=(img.size[0] / 2, img.size[1]-padding_y/2), text=get_display(ref_str.upper()), font=ref_font, spacing=spacing, align=align, fill=text_color, anchor='mm')
+    ref_text = prepare_text_for_drawing(ref_str.upper(), lang)
+    draw.text(xy=(img.size[0] / 2, img.size[1]-padding_y/2), text=ref_text, font=ref_font, spacing=spacing, align=align, fill=text_color, anchor='mm', direction=direction)
 
 
     #border

--- a/sefaria/tests/image_generator_test.py
+++ b/sefaria/tests/image_generator_test.py
@@ -23,6 +23,13 @@ def _rms_brightness_delta(img, box_a, box_b):
     return diff.rms[0]
 
 
+def _rms_image_delta(img_a, img_b, box):
+    region_a = img_a.crop(box).convert("L")
+    region_b = img_b.crop(box).convert("L")
+    diff = ImageStat.Stat(ImageChops.difference(region_a, region_b))
+    return diff.rms[0]
+
+
 def _text_box(img):
     # Central body area where the main quote should be drawn.
     width, height = img.size
@@ -162,6 +169,58 @@ def test_generate_social_image_renders_unknown_category_with_stable_fallback_col
 def test_unknown_category_color_fallback_is_deterministic():
     assert get_category_colors("New Category") == get_category_colors("New Category")
     assert get_category_colors("New Category") != palette["System"]
+
+
+@pytest.mark.parametrize(
+    ("html_text", "expected_drawn_text"),
+    [
+        ("First line<br>Second line<br />Third line", "First line\nSecond line\nThird line"),
+        ("<p>First paragraph</p><p>Second paragraph</p>", "First paragraph\nSecond paragraph\n"),
+        ("<div>First block</div><div>Second block</div>", "First block\nSecond block\n"),
+    ],
+)
+def test_generate_social_image_preserves_linebreaks_created_from_html(monkeypatch, html_text, expected_drawn_text):
+    drawn_texts = []
+    original_text = image_generator.ImageDraw.ImageDraw.text
+
+    def capture_text(self, *args, **kwargs):
+        drawn_texts.append(kwargs.get("text"))
+        return original_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(image_generator.ImageDraw.ImageDraw, "text", capture_text)
+
+    generate_image(
+        text=html_text,
+        category="Tanakh",
+        ref_str="Genesis 1:1",
+        lang="en",
+        platform="facebook",
+    )
+
+    # Literal source newlines are stripped during HTML cleanup, but HTML layout
+    # tags become real line breaks and should not be flattened by text wrapping.
+    assert drawn_texts[0] == expected_drawn_text
+
+
+def test_generate_social_image_visually_renders_br_linebreaks():
+    image_with_break = generate_image(
+        text="First line<br>Second line",
+        category="Tanakh",
+        ref_str="Genesis 1:1",
+        lang="en",
+        platform="facebook",
+    )
+    image_with_space = generate_image(
+        text="First line Second line",
+        category="Tanakh",
+        ref_str="Genesis 1:1",
+        lang="en",
+        platform="facebook",
+    )
+
+    # If <br> is flattened to a space, these two images are identical in the
+    # quote area. A preserved line break moves text onto a second visual line.
+    assert _rms_image_delta(image_with_break, image_with_space, _text_box(image_with_break)) > 1
 
 
 def test_hebrew_text_keeps_logical_order_when_pillow_supports_rtl(monkeypatch):

--- a/sefaria/tests/image_generator_test.py
+++ b/sefaria/tests/image_generator_test.py
@@ -4,7 +4,7 @@ import pytest
 from bidi.algorithm import get_display
 
 from sefaria import image_generator
-from sefaria.image_generator import generate_image, palette, platforms
+from sefaria.image_generator import generate_image, get_category_colors, palette, platforms
 
 
 def _pixel_variance(img, box):
@@ -100,6 +100,20 @@ def _assert_logo_rendered(img):
             "en",
             "twitter",
         ),
+        (
+            "And the king said to the wise men who knew the times.",
+            "Second Temple",
+            "Esther 1:13",
+            "en",
+            "facebook",
+        ),
+        (
+            "Explore Jewish texts, translations, commentaries, and source sheets.",
+            "Static",
+            "Sefaria",
+            "en",
+            "facebook",
+        ),
     ],
 )
 def test_generate_social_image_smoke(text, category, ref_str, lang, platform):
@@ -127,6 +141,27 @@ def test_generate_social_image_renders_logo_in_header():
     )
 
     _assert_logo_rendered(img)
+
+
+def test_generate_social_image_renders_unknown_category_with_stable_fallback_color():
+    category = "New Category"
+    img = generate_image(
+        text="A new category should still produce a usable social image.",
+        category=category,
+        ref_str="New Category 1",
+        lang="en",
+        platform="facebook",
+    )
+
+    expected_bg, _ = get_category_colors(category)
+    assert img.getpixel((100, 200))[:3] == expected_bg
+    _assert_text_rendered(img)
+    _assert_logo_rendered(img)
+
+
+def test_unknown_category_color_fallback_is_deterministic():
+    assert get_category_colors("New Category") == get_category_colors("New Category")
+    assert get_category_colors("New Category") != palette["System"]
 
 
 def test_hebrew_text_keeps_logical_order_when_pillow_supports_rtl(monkeypatch):

--- a/sefaria/tests/image_generator_test.py
+++ b/sefaria/tests/image_generator_test.py
@@ -1,0 +1,147 @@
+from PIL import ImageChops, ImageStat
+
+import pytest
+from bidi.algorithm import get_display
+
+from sefaria import image_generator
+from sefaria.image_generator import generate_image, palette, platforms
+
+
+def _pixel_variance(img, box):
+    # A blank text area has nearly one color throughout, so brightness variance
+    # stays close to zero. Rendered letters add light/dark pixels and raise it.
+    region = img.crop(box).convert("L")
+    return ImageStat.Stat(region).var[0]
+
+
+def _rms_brightness_delta(img, box_a, box_b):
+    # RMS compares two regions by the size of their pixel differences. Here we
+    # compare the text area to a plain background area to catch blank/no-text renders.
+    region_a = img.crop(box_a).convert("L")
+    region_b = img.crop(box_b).resize(region_a.size).convert("L")
+    diff = ImageStat.Stat(ImageChops.difference(region_a, region_b))
+    return diff.rms[0]
+
+
+def _text_box(img):
+    # Central body area where the main quote should be drawn.
+    width, height = img.size
+    return (
+        int(width * 0.25),
+        int(height * 0.30),
+        int(width * 0.75),
+        int(height * 0.70),
+    )
+
+
+def _background_box(img):
+    # Plain colored area away from text/header/logo, used as a baseline.
+    width, height = img.size
+    return (
+        int(width * 0.05),
+        int(height * 0.25),
+        int(width * 0.20),
+        int(height * 0.40),
+    )
+
+
+def _logo_box(img):
+    # Top-center header area where the Sefaria logo is composited.
+    width, height = img.size
+    return (
+        int(width * 0.43),
+        int(height * 0.02),
+        int(width * 0.57),
+        int(height * 0.085),
+    )
+
+
+def _plain_header_box(img):
+    # Header area away from the logo; should remain close to solid white.
+    width, height = img.size
+    return (
+        int(width * 0.05),
+        int(height * 0.02),
+        int(width * 0.19),
+        int(height * 0.085),
+    )
+
+
+def _assert_text_rendered(img):
+    # Use both local variance and RMS-vs-background so a blank body cannot pass.
+    text_box = _text_box(img)
+    background_box = _background_box(img)
+    assert _pixel_variance(img, text_box) > 1
+    assert _rms_brightness_delta(img, text_box, background_box) > 1
+
+
+def _assert_logo_rendered(img):
+    # Same idea as the text check, but scoped to the logo's header position.
+    logo_box = _logo_box(img)
+    plain_header_box = _plain_header_box(img)
+    assert _pixel_variance(img, logo_box) > 1
+    assert _rms_brightness_delta(img, logo_box, plain_header_box) > 1
+
+
+@pytest.mark.parametrize(
+    ("text", "category", "ref_str", "lang", "platform"),
+    [
+        (
+            "In the beginning God created the heaven and the earth.",
+            "Tanakh",
+            "Genesis 1:1",
+            "en",
+            "facebook",
+        ),
+        (
+            "From what time may one recite Shema in the evening?",
+            "Talmud",
+            "Berakhot 2a",
+            "en",
+            "twitter",
+        ),
+    ],
+)
+def test_generate_social_image_smoke(text, category, ref_str, lang, platform):
+    img = generate_image(
+        text=text,
+        category=category,
+        ref_str=ref_str,
+        lang=lang,
+        platform=platform,
+    )
+
+    expected_size = (platforms[platform]["width"], platforms[platform]["height"])
+    assert img.size == expected_size
+    assert img.getpixel((100, 200))[:3] == palette[category][0]
+    _assert_text_rendered(img)
+
+
+def test_generate_social_image_renders_logo_in_header():
+    img = generate_image(
+        text="In the beginning God created the heaven and the earth.",
+        category="Tanakh",
+        ref_str="Genesis 1:1",
+        lang="en",
+        platform="facebook",
+    )
+
+    _assert_logo_rendered(img)
+
+
+def test_hebrew_text_keeps_logical_order_when_pillow_supports_rtl(monkeypatch):
+    text = "בראשית ברא אלהים"
+
+    monkeypatch.setattr(image_generator, "supports_rtl_text_layout", lambda: True)
+
+    assert image_generator.prepare_text_for_drawing(text, "he") == text
+    assert image_generator.get_text_direction("he") == "rtl"
+
+
+def test_hebrew_text_uses_bidi_fallback_without_pillow_rtl_support(monkeypatch):
+    text = "בראשית ברא אלהים"
+
+    monkeypatch.setattr(image_generator, "supports_rtl_text_layout", lambda: False)
+
+    assert image_generator.prepare_text_for_drawing(text, "he") == get_display(text)
+    assert image_generator.get_text_direction("he") is None

--- a/templates/base.html
+++ b/templates/base.html
@@ -31,7 +31,7 @@
     {% endblock %}
 
     {% block ogimage %}
-        <meta property="og:image" content="https://{{ request.get_host }}/api/img-gen{{ request.path }}?lang={{request.GET.lang}}&platform=facebook&ven={{request.GET.ven}}&vhe={{request.GET.vhe}}" />
+        <meta property="og:image" content="{% social_image_url request 'facebook' %}" />
         <meta property="og:image:type" content="image/png" />
         <meta property="og:image:width" content="1200" />
         <meta property="og:image:height" content="630" />
@@ -42,7 +42,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     {# Sefaria is stopping use of its Twitter account. However, according to Twitter dev docs, an account to reference as an attribute is still necessary for cards usage #}
     <meta name="twitter:site" content="@sefariaproject" />
-    <meta name="twitter:image" content="https://{{ request.get_host }}/api/img-gen{{ request.path }}?lang={{request.GET.lang}}&platform=twitter&ven={{request.GET.ven}}&vhe={{request.GET.vhe}}" />
+    <meta name="twitter:image" content="{% social_image_url request 'twitter' %}" />
 
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-itunes-app" content="app-id=1163273965">


### PR DESCRIPTION
## Summary

 - Fixed social image generation after the Pillow upgrade. The image generator now uses supported Pillow APIs for measuring text, so `/api/img-gen/...` no longer falls back to the generic image because of
  `FreeTypeFont.getsize`. 
- Fixed Hebrew rendering order in generated images. When Pillow has RTL layout support, Hebrew is passed in logical order and rendered with RTL direction instead of being manually reversed first.
- Normalized `lang` and `platform` query parameters for the image endpoint. Missing, empty, or invalid values now fall back safely to English and Facebook-sized images.
- Fixed selected version handling from ReaderApp links. The image endpoint now understands `ven` / `vhe` values like `english|Version_Title` and extracts the actual version title before loading text.
- Fixed URL encoding for social image meta tags. Open Graph and Twitter image URLs are now built with proper query encoding, so version titles with spaces, pipes, commas, or ampersands survive when shared.
- Updated backend category colors to match the frontend palette. Missing categories like `Second Temple` and `Static` now render with the expected colors.
- Added a stable fallback color for unknown categories. If a new category reaches the image generator before backend colors are updated, it still produces a valid image instead of failing.
- Preserved intentional HTML line breaks in generated quote text. Breaks created from `<br>`, `<p>`, and `<div>` are no longer flattened by text wrapping before the image is drawn.
- Added Playwright coverage for social image wiring. The tests fetch server-rendered HTML like a crawler, inspect the `og:image` meta URL, and verify the generated endpoint returns a real PNG.

## Testing

Testing now covers this at several levels:

- Unit tests verify image generation does not produce blank output, renders the Sefaria logo, uses expected category colors, handles fallback colors, and preserves Hebrew text order.
- Unit tests verify `ven` / `vhe`, `lang`, and `platform` are normalized correctly before calling the image generator.
- Unit tests verify HTML cleanup and line-break preservation survive through the text wrapping step.
- Template tag tests verify social image URLs encode query parameters correctly.
- Playwright tests verify real pages expose valid `og:image` URLs and that those URLs return `1200x630` PNG images from the endpoint.
  
 ## Notes

- Updated text measurement to use Pillow-supported APIs. This fixes the `FreeTypeFont.getsize` failure on newer Pillow versions; wrapping may differ slightly because the newer measurement APIs are more precise
- Static pages still use the existing generic fallback image behavior. This PR adds the backend `Static` palette color, but routing non-Ref pages like `/jobs` through the `Static` category image should be
handled in a follow-up PR.
- This PR preserves intentional HTML line breaks, but it does not change the existing vertical fitting behavior. Very long quotes, or quotes with many preserved line breaks, can still overflow and should be
addressed separately.
- Playwright tests validate that generated image URLs return PNGs of the expected size, but they do not do pixel-perfect visual snapshot comparisons. Lower-level pytest checks cover blank-image detection, logo
rendering, colors, and line-break behavior.