### PR TITLE
helm: increase web startupProbe failureThreshold 40→80

### DIFF
--- a/helm-chart/sefaria/templates/rollout/web.yaml
+++ b/helm-chart/sefaria/templates/rollout/web.yaml
@@ -179,7 +179,7 @@ spec:
           httpGet:
             path: /healthz-rollout
             port: 80
-          failureThreshold: 40 # 40 attempts x 15 secs = 10 minutes for the pod to successfully start
+          failureThreshold: 80 # 80 attempts x 15 secs = 20 minutes for the pod to successfully start
           periodSeconds: 15
           timeoutSeconds: 10
         livenessProbe:


### PR DESCRIPTION
## Description
Several cauldrons and sefariastaging are stuck with web pods that never pass their startup probe. Investigation showed the Django app spends 8+ minutes in "Initializing Shared Cache" (MongoDB topics query) — exceeding the current 10-minute window (40 × 15s).

Increasing to 80 attempts × 15s = 20 minutes gives the pod enough time to complete initialization.

## Affected pods (as of 2026-05-24)
- `community-books-web` — stuck, startup probe timeout
- `sefariastaging-web` — 49+ restarts, startup probe timeout

## Code Changes
- `helm-chart/sefaria/templates/rollout/web.yaml`: `failureThreshold: 40 → 80`

## Notes
Same approach as [PR #3262](https://github.com/Sefaria/Sefaria-Project/pull/3262) which increased the tasks pod failureThreshold from 100→200.