### PR TITLE
fix: remove hardcoded postgres.host from prod/preprod helmreleases

### DIFF
--- a/envs/preprod/helmrelease.yaml
+++ b/envs/preprod/helmrelease.yaml
@@ -20,8 +20,6 @@ spec:
     deployEnv: preprod
     previousServicesCount: "3"
     deploymentMessage: true
-    postgres:
-      host: "postgres-18.default.svc.cluster.local"
     restore:
       enabled: false
       dynamicName: false

--- a/envs/prod/helmrelease.yaml
+++ b/envs/prod/helmrelease.yaml
@@ -20,8 +20,6 @@ spec:
     deployEnv: production
     previousServicesCount: "3"
     deploymentMessage: true
-    postgres:
-      host: "postgres-18.default.svc.cluster.local"
     restore:
       enabled: false
       dynamicName: false


### PR DESCRIPTION
## Summary
- Removes hardcoded `postgres.host` from prod and preprod HelmRelease values
- Both environments will now source `DATABASES_HOST` from the `local-settings-secrets-production` secret
- The chart template already has the fallback: `os.getenv("DATABASES_HOST")` when `postgres.host` is unset (`local-settings-file.yaml:90`)

## Prerequisite: infrastructure secret update

> **DO NOT MERGE** until the infrastructure secret is updated and Flux-reconciled.

The current `DATABASES_HOST` in `local-settings-secrets-production` is **stale** — it points to `prod1-pgbouncer.default.svc` (from the pre-migration setup). It must be updated to `postgres-18` before this PR lands.

## How it works

The chart template at `helm-chart/sefaria/templates/configmap/local-settings-file.yaml:90`:
```python
'HOST': {{ if .Values.postgres.host }}'{{ .Values.postgres.host }}'{{ else }}os.getenv("DATABASES_HOST"){{ end }},
```
When `postgres.host` is not set in values, Django reads `DATABASES_HOST` from the environment (injected from the secret via `envFrom`).

## Test plan
- [ ] Infrastructure secret updated: `DATABASES_HOST` → `postgres-18`
- [ ] Flux reconciliation applied the secret to the cluster
- [ ] Verify prod pods start correctly after this PR merges
- [ ] Verify preprod pods start correctly
- [ ] Confirm postgres connection is to `postgres-18` (check Django logs or admin)
- [ ] Verify postgres backup cronjob still works (uses its own hardcoded `DATABASES_HOST: "postgres"`)