### PR TITLE
chore/sc-43838/keyword-search-in-connected-refs

### DIFF
--- a/sefaria/helper/search.py
+++ b/sefaria/helper/search.py
@@ -138,7 +138,7 @@ def get_filter_obj(type, filters, filter_fields):
 
 
 def make_filter(type, agg_type, agg_key):
-    if type == "text":
+    if type == "text" and agg_type == "path":
         # filters with '/' might be leading to books. also, very unlikely they'll match an false positives
         agg_key = agg_key.rstrip('/')
         agg_key = re.escape(agg_key)

--- a/sefaria/helper/search.py
+++ b/sefaria/helper/search.py
@@ -144,7 +144,7 @@ def make_filter(type, agg_type, agg_key):
         agg_key = re.escape(agg_key)
         reg = f"{agg_key}|{agg_key}/.*"
         return Regexp(path=reg)
-    elif type == "sheet":
+    else:
         return Term(**{agg_type: agg_key})
 
 

--- a/sefaria/search.py
+++ b/sefaria/search.py
@@ -400,6 +400,9 @@ def put_text_mapping(index_name):
                         'analyzer': 'exact_english'
                     }
                 }
+            },
+            "linked_refs": {
+                'type': 'keyword'
             }
         }
     }
@@ -891,6 +894,12 @@ class TextIndexer(object):
 
         oref = Ref(tref)
 
+        linked_refs = []
+        for link in LinkSet(oref):
+            linked_refs.extend(link.expandedRefs0)
+            linked_refs.extend(link.expandedRefs1)
+        linked_refs = list({r for r in linked_refs if r != tref})
+
         indexed_categories = get_search_categories(oref, categories)
 
         tp = cls.best_time_period
@@ -916,6 +925,7 @@ class TextIndexer(object):
             'hebrew_version_title': hebrew_version_title,
             "languageFamilyName": language_family_name,
             "isPrimary": is_primary,
+            "linked_refs": linked_refs,
         }
 
 

--- a/sefaria/search.py
+++ b/sefaria/search.py
@@ -349,6 +349,9 @@ def put_text_mapping(index_name):
     Settings mapping for the text document type.
     """
     text_mapping = {
+        '_source': {
+            'excludes': ['linked_refs']
+        },
         'properties' : {
             'categories': {
                 'type': 'keyword',


### PR DESCRIPTION
This pull request introduces enhancements to how linked references are handled in text search indexing, as well as a refinement to the filter creation logic. The most significant update is the addition of a new `linked_refs` field to text documents in the search index, which collects and stores references linked to each text. Additionally, the filter creation logic is simplified for better maintainability.

**Search Index Enhancements:**

* Added a new `linked_refs` field to the text search index mapping, storing all references linked to a given text except itself. This field is excluded from the `_source` by default to optimize search responses. [[1]](diffhunk://#diff-50caef9b129793c3a598628b4d78ab2a4aec68581c6eef5f5c26dcbeb0983e16R352-R354) [[2]](diffhunk://#diff-50caef9b129793c3a598628b4d78ab2a4aec68581c6eef5f5c26dcbeb0983e16R406-R408) [[3]](diffhunk://#diff-50caef9b129793c3a598628b4d78ab2a4aec68581c6eef5f5c26dcbeb0983e16R900-R905) [[4]](diffhunk://#diff-50caef9b129793c3a598628b4d78ab2a4aec68581c6eef5f5c26dcbeb0983e16R931)

**Filter Logic Improvements:**

* Simplified the `make_filter` function to return a `Term` filter for all cases except when `type` is `"text"` and `agg_type` is `"path"`, improving code clarity and maintainability.