### PR TITLE
startup: per-substep timing logs + ensure_indices self-heal

### DIFF
--- a/reader/startup.py
+++ b/reader/startup.py
@@ -1,4 +1,18 @@
+import time
+from contextlib import contextmanager
+
 from django_topics.models import Topic as DjangoTopic
+
+
+@contextmanager
+def _timed_step(logger, name):
+    t0 = time.monotonic()
+    logger.info("startup_step_start", step=name)
+    try:
+        yield
+    finally:
+        logger.info("startup_step_end", step=name, elapsed_sec=round(time.monotonic() - t0, 2))
+
 
 def init_sentry_from_settings():
     import structlog
@@ -28,33 +42,31 @@ def init_library_cache():
     from sefaria.system.multiserver.coordinator import server_coordinator
     from django.conf import settings
 
-    logger.info("Initializing topic pools cache")
-    DjangoTopic.objects.build_slug_to_pools_cache()
+    with _timed_step(logger, "topic_pools_cache"):
+        DjangoTopic.objects.build_slug_to_pools_cache()
 
     logger.info("Initializing library objects.")
-    logger.info("Initializing TOC Tree")
-    library.get_toc_tree()
+    with _timed_step(logger, "toc_tree"):
+        library.get_toc_tree()
 
-    logger.info("Initializing Shared Cache")
-    library.init_shared_cache()
+    with _timed_step(logger, "shared_cache"):
+        library.init_shared_cache()
 
     if not settings.DISABLE_AUTOCOMPLETER:
-        logger.info("Initializing Full Auto Completer")
-        library.build_full_auto_completer()
-
-
-        logger.info("Initializing Lexicon Auto Completers")
-        library.build_lexicon_auto_completers()
-
-        logger.info("Initializing Cross Lexicon Auto Completer")
-        library.build_cross_lexicon_auto_completer()
-
+        with _timed_step(logger, "full_auto_completer"):
+            library.build_full_auto_completer()
+        with _timed_step(logger, "lexicon_auto_completers"):
+            library.build_lexicon_auto_completers()
+        with _timed_step(logger, "cross_lexicon_auto_completer"):
+            library.build_cross_lexicon_auto_completer()
 
     if settings.ENABLE_LINKER:
-        logger.info("Initializing Linker")
-        library.build_linker('he')
-        library.build_linker('en')
+        with _timed_step(logger, "linker_he"):
+            library.build_linker('he')
+        with _timed_step(logger, "linker_en"):
+            library.build_linker('en')
 
     if server_coordinator:
-        server_coordinator.connect()
+        with _timed_step(logger, "server_coordinator_connect"):
+            server_coordinator.connect()
     logger.info("Initialization Complete")

--- a/reader/startup.py
+++ b/reader/startup.py
@@ -40,7 +40,15 @@ def init_library_cache():
 
     from sefaria.model.text import library
     from sefaria.system.multiserver.coordinator import server_coordinator
+    from sefaria.system.database import ensure_indices
     from django.conf import settings
+
+    # Self-heal missing Mongo indexes. mongorestore can silently drop index metadata
+    # for some collections (notably topic_links), which causes init_shared_cache to
+    # collection-scan under contention and stall startup for tens of minutes. createIndex
+    # is idempotent, so this is a fast no-op when the indexes already exist.
+    with _timed_step(logger, "ensure_indices"):
+        ensure_indices()
 
     with _timed_step(logger, "topic_pools_cache"):
         DjangoTopic.objects.build_slug_to_pools_cache()

--- a/sefaria/model/text.py
+++ b/sefaria/model/text.py
@@ -5082,27 +5082,41 @@ class Library(object):
         self._full_title_list_jsons = {}
 
     def init_shared_cache(self, rebuild=False):
+        import time
+        import structlog
         from sefaria.helper.text import get_talmud_perek_ref_set, get_parasha_ref_set
-        
-        self.get_toc(rebuild=rebuild)
-        self.get_toc_with_authors(rebuild=rebuild)
-        self.get_toc_json(rebuild=rebuild)
-        self.get_topic_mapping(rebuild=rebuild)
-        self.get_topic_toc(rebuild=rebuild)
-        self.get_topic_toc_json(rebuild=rebuild)
-        self.get_topic_toc_category_mapping(rebuild=rebuild)
-        self.get_text_titles_json(rebuild=rebuild)
-        self.get_simple_term_mapping(rebuild=rebuild)
-        self.get_simple_term_mapping_json(rebuild=rebuild)
-        self.get_virtual_books(rebuild=rebuild)
-        
+
+        log = structlog.get_logger("reader.startup.shared_cache")
+
+        substeps = [
+            ("toc",                        lambda: self.get_toc(rebuild=rebuild)),
+            ("toc_with_authors",           lambda: self.get_toc_with_authors(rebuild=rebuild)),
+            ("toc_json",                   lambda: self.get_toc_json(rebuild=rebuild)),
+            ("topic_mapping",              lambda: self.get_topic_mapping(rebuild=rebuild)),
+            ("topic_toc",                  lambda: self.get_topic_toc(rebuild=rebuild)),
+            ("topic_toc_json",             lambda: self.get_topic_toc_json(rebuild=rebuild)),
+            ("topic_toc_category_mapping", lambda: self.get_topic_toc_category_mapping(rebuild=rebuild)),
+            ("text_titles_json",           lambda: self.get_text_titles_json(rebuild=rebuild)),
+            ("simple_term_mapping",        lambda: self.get_simple_term_mapping(rebuild=rebuild)),
+            ("simple_term_mapping_json",   lambda: self.get_simple_term_mapping_json(rebuild=rebuild)),
+            ("virtual_books",              lambda: self.get_virtual_books(rebuild=rebuild)),
+        ]
+        for name, fn in substeps:
+            t0 = time.monotonic()
+            fn()
+            log.info("substep", step=name, elapsed_sec=round(time.monotonic() - t0, 2))
+
         # functions backed by lru cache
         if rebuild:
             get_talmud_perek_ref_set.cache_clear()
             get_parasha_ref_set.cache_clear()
+        t0 = time.monotonic()
         get_talmud_perek_ref_set()
+        log.info("substep", step="talmud_perek_ref_set", elapsed_sec=round(time.monotonic() - t0, 2))
+        t0 = time.monotonic()
         get_parasha_ref_set()
-        
+        log.info("substep", step="parasha_ref_set", elapsed_sec=round(time.monotonic() - t0, 2))
+
         if rebuild:
             scache.delete_shared_cache_elem("regenerating")
 


### PR DESCRIPTION
## Summary
Two related changes to make web pod startup observable and self-healing against the cauldron Mongo index problem:

1. **Per-substep timing logs** in `init_library_cache` and `init_shared_cache` — every step now emits start/end logs with `elapsed_sec`, so it's no longer a black box when a pod gets stuck. Previously `init_shared_cache` ran ~13 builders silently and pods that timed out gave no signal which substep was slow.
2. **`ensure_indices()` called on web startup** — self-heals missing Mongo indexes. `mongorestore --drop` (used to seed cauldron and staging DBs from prod backups) has been observed to silently drop index metadata for some collections (notably `topic_links` — Steve's finding). Without indexes on `topic_links.{class,expandedRefs,toTopic,fromTopic}`, `init_shared_cache` collection-scans for tens of minutes under dev-Mongo contention and trips the startup probe. `createIndex` is idempotent, so this is a fast no-op when indexes already exist.

## Motivation
Cauldron web pods routinely fail to come up — `community-books`, `sefariastaging`, others — with the failing pattern being a silent stall at `Initializing Shared Cache` for 10+ minutes (sometimes >120m). Increasing `startupProbe.failureThreshold` only buys time; this PR addresses both the diagnosability and the root data-layer cause.

## Risk
Near-zero.
- Timing logs are INFO-level only.
- `ensure_indices()` already swallows per-index `OperationFailure` (`sefaria/system/database.py:191`); `createIndex` is idempotent in MongoDB.
- On a fully-healthy DB the new step takes well under a second (it just iterates the index list and Mongo ack's each as already-present).

## Validation plan
- Cauldron `startup-timing` is being created off this branch (yaml in `Sefaria/cauldrons` main).
- Pod logs will be checked for:
  - `startup_step_end step=ensure_indices` near-zero on healthy DBs, longer on a freshly restored cauldron that was missing indexes
  - `substep step=topic_mapping`/`topic_toc` timings dropping dramatically once indexes are present
- If `startup-timing` cauldron is itself missing indexes, the `ensure_indices` log line will show non-trivial elapsed_sec and subsequent substeps will be fast — that's the confirmation.

## Refs
- Wiki: `sefaria-wiki/wiki/concepts/Cauldron Startup Probe Fix Pattern.md`
- Slack thread w/ Steve (today): `topic_links` missing all indices except `_id` after cauldron creation
- `sefaria/system/database.py:146-149` — the four indices this self-heal restores

🤖 Generated with [Claude Code](https://claude.com/claude-code)