### PR TITLE
fix(admin): restore Seasonal Topic raw-id picker + PoolFilter/remote-config fixes after Django upgrade

### DIFF
--- a/django_topics/admin.py
+++ b/django_topics/admin.py
@@ -64,10 +64,6 @@ class PoolFilter(admin.SimpleListFilter):
     def value(self):
         value = super().value()
         if value is None:
-            # In a raw_id_fields popup, default to all topics so users can find
-            # any topic regardless of pool membership.
-            if self.request.GET.get('_popup'):
-                return 'all'
             return PoolType.LIBRARY.value
         return value
 

--- a/django_topics/admin.py
+++ b/django_topics/admin.py
@@ -55,7 +55,10 @@ class PoolFilter(admin.SimpleListFilter):
         pool_name = self.value()
         if pool_name == 'all':
             return queryset
-        pool = TopicPool.objects.get(name=pool_name)
+        try:
+            pool = TopicPool.objects.get(name=pool_name)
+        except TopicPool.DoesNotExist:
+            return queryset
         return queryset.filter(pools=pool)
 
     def value(self):
@@ -238,7 +241,7 @@ class SeasonalTopicAdmin(admin.ModelAdmin):
     def formfield_for_foreignkey(self, db_field, request, **kwargs):
         if db_field.name == "topic":
             kwargs["label"] = "Topic slug"
-            kwargs["help_text"] = "Use the magnifying glass button to select a topic."
+            kwargs["help_text"] = "Type to search for a topic by slug or title."
         if db_field.name == "secondary_topic":
             kwargs["label"] = "Secondary topic slug"
         return super().formfield_for_foreignkey(db_field, request, **kwargs)

--- a/django_topics/admin.py
+++ b/django_topics/admin.py
@@ -77,6 +77,7 @@ class TopicAdmin(admin.ModelAdmin):
     list_filter = (PoolFilter,)
     filter_horizontal = ('pools',)
     search_fields = ('slug', 'en_title', 'he_title')
+    ordering = ['slug']
     readonly_fields = ('slug', 'en_title', 'he_title')
     actions = [
         create_add_to_pool_action(PoolType.LIBRARY.value),
@@ -90,6 +91,13 @@ class TopicAdmin(admin.ModelAdmin):
         create_remove_from_pool_action(PoolType.GENERAL_HE.value),
         create_remove_from_pool_action(PoolType.TORAH_TAB.value),
     ]
+    def get_queryset(self, request):
+        # The PoolFilter adds an INNER JOIN on the M2M through table which can
+        # produce duplicate rows if the through table has duplicate entries.
+        # Django admin only auto-deduplicates when search_fields contain __ lookups;
+        # our direct-field searches don't trigger that, so we call distinct() here.
+        return super().get_queryset(request).distinct()
+
     def save_related(self, request, form, formsets, change):
         super().save_related(request, form, formsets, change)
         Topic.objects.build_slug_to_pools_cache(rebuild=True)

--- a/django_topics/admin.py
+++ b/django_topics/admin.py
@@ -64,6 +64,10 @@ class PoolFilter(admin.SimpleListFilter):
     def value(self):
         value = super().value()
         if value is None:
+            # In a raw_id_fields popup, default to all topics so users can find
+            # any topic regardless of pool membership.
+            if self.request.GET.get('_popup'):
+                return 'all'
             return PoolType.LIBRARY.value
         return value
 
@@ -201,7 +205,7 @@ class SeasonalTopicAdmin(admin.ModelAdmin):
     )
     ordering = ['-start_date']
     search_fields = ('topic__slug', 'topic__en_title', 'topic__he_title', 'secondary_topic__slug')
-    autocomplete_fields = ('topic', 'secondary_topic')
+    raw_id_fields = ('topic', 'secondary_topic')
     date_hierarchy = 'start_date'
     fieldsets = (
         (None, {
@@ -242,7 +246,7 @@ class SeasonalTopicAdmin(admin.ModelAdmin):
     def formfield_for_foreignkey(self, db_field, request, **kwargs):
         if db_field.name == "topic":
             kwargs["label"] = "Topic slug"
-            kwargs["help_text"] = "Type to search for a topic by slug or title."
+            kwargs["help_text"] = "Use the magnifying glass button to select a topic."
         if db_field.name == "secondary_topic":
             kwargs["label"] = "Secondary topic slug"
         return super().formfield_for_foreignkey(db_field, request, **kwargs)

--- a/django_topics/admin.py
+++ b/django_topics/admin.py
@@ -64,7 +64,7 @@ class PoolFilter(admin.SimpleListFilter):
     def value(self):
         value = super().value()
         if value is None:
-            return PoolType.LIBRARY.value
+            return 'all'
         return value
 
 

--- a/django_topics/admin.py
+++ b/django_topics/admin.py
@@ -64,14 +64,13 @@ class PoolFilter(admin.SimpleListFilter):
     def value(self):
         value = super().value()
         if value is None:
-            # When a search query is active, search across all topics so results
-            # aren't silently restricted to one pool. Otherwise default to Library.
-            return 'all' if self.request.GET.get('q') else PoolType.LIBRARY.value
+            return PoolType.LIBRARY.value
         return value
 
 
 @admin.register(Topic)
 class TopicAdmin(admin.ModelAdmin):
+    search_help_text = "Searching within the active pool filter. Select 'All Topics' in the filter panel to search all topics."
     list_display = ['slug', 'en_title', 'he_title', 'sefaria_link']
     for pool_type in PoolType:
         list_display.append(f'is_in_pool_{pool_type.value}')

--- a/django_topics/admin.py
+++ b/django_topics/admin.py
@@ -64,7 +64,9 @@ class PoolFilter(admin.SimpleListFilter):
     def value(self):
         value = super().value()
         if value is None:
-            return 'all'
+            # When a search query is active, search across all topics so results
+            # aren't silently restricted to one pool. Otherwise default to Library.
+            return 'all' if self.request.GET.get('q') else PoolType.LIBRARY.value
         return value
 
 

--- a/django_topics/admin.py
+++ b/django_topics/admin.py
@@ -190,7 +190,6 @@ class SeasonalTopicAdmin(admin.ModelAdmin):
         'display_start_date_diaspora',
         'display_end_date_diaspora'
     )
-    raw_id_fields = ('topic', 'secondary_topic')
     list_filter = (
         'start_date',
         'display_start_date_israel',

--- a/helm-chart/sefaria/Chart.yaml
+++ b/helm-chart/sefaria/Chart.yaml
@@ -10,4 +10,5 @@ maintainers:
   - name: Sefaria
 sources:
   - https://github.com/Sefaria/Sefaria-Project
+# sc-44504
 ...

--- a/helm-chart/sefaria/Chart.yaml
+++ b/helm-chart/sefaria/Chart.yaml
@@ -10,5 +10,4 @@ maintainers:
   - name: Sefaria
 sources:
   - https://github.com/Sefaria/Sefaria-Project
-# sc-44504
 ...

--- a/remote_config/cache.py
+++ b/remote_config/cache.py
@@ -4,8 +4,11 @@ Process-local cache for remote configuration values.
 from __future__ import annotations
 
 from typing import Any, Optional
+import logging
 import threading
 from django.db.utils import OperationalError, ProgrammingError
+
+logger = logging.getLogger(__name__)
 
 
 class RemoteConfigCache:
@@ -44,7 +47,8 @@ class RemoteConfigCache:
                 if self._cache is None:  # double-checked locking for minimal contention
                     try:
                         self._cache = self._build_cache()
-                    except (OperationalError, ProgrammingError, RuntimeError):
+                    except (OperationalError, ProgrammingError, RuntimeError) as e:
+                        logger.warning("RemoteConfigCache: could not load from DB, using empty cache (%s: %s)", type(e).__name__, e)
                         self._cache = {}
         return self._cache
 

--- a/remote_config/cache.py
+++ b/remote_config/cache.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from typing import Any, Optional
 import threading
-from django.db.utils import OperationalError
+from django.db.utils import OperationalError, ProgrammingError
 
 
 class RemoteConfigCache:
@@ -44,7 +44,7 @@ class RemoteConfigCache:
                 if self._cache is None:  # double-checked locking for minimal contention
                     try:
                         self._cache = self._build_cache()
-                    except (OperationalError, RuntimeError):
+                    except (OperationalError, ProgrammingError, RuntimeError):
                         self._cache = {}
         return self._cache
 

--- a/remote_config/tests/remote_config_test.py
+++ b/remote_config/tests/remote_config_test.py
@@ -1,8 +1,10 @@
 from django.core.exceptions import ValidationError
+from django.db.utils import ProgrammingError
 from django.test import TestCase
 from django.urls import reverse
 
 from remote_config import remoteConfigCache
+from remote_config.cache import RemoteConfigCache
 from remote_config.models import RemoteConfigEntry, ValueType
 
 
@@ -70,6 +72,22 @@ class RemoteConfigCacheTest(TestCase):
         )
         self.assertEqual(remoteConfigCache.get("timeout"), 10)
         self.assertEqual(remoteConfigCache.get("missing_key", default="fallback"), "fallback")
+
+    def test_get_cache_returns_empty_on_programming_error(self):
+        # When the underlying table doesn't exist yet (e.g. management commands
+        # running before migrations are applied), _build_cache raises
+        # ProgrammingError. get_cache should swallow it and return an empty
+        # cache rather than crash. Use a fresh instance so we don't pollute the
+        # module-level singleton.
+        cache = RemoteConfigCache()
+
+        def raise_programming_error():
+            raise ProgrammingError("relation \"remote_config_remoteconfigentry\" does not exist")
+
+        cache._build_cache = raise_programming_error
+
+        self.assertEqual(cache.get_cache(), {})
+        self.assertEqual(cache.get("any_key", default="fallback"), "fallback")
 
 
 class RemoteConfigAPITest(TestCase):


### PR DESCRIPTION
## Summary

Fixes a cluster of Django-admin regressions in the Seasonal Topic / Topic Pool screens that surfaced after the Django 1.11 → 6 upgrade, plus a startup-resilience fix for the remote-config cache.

### `django_topics/admin.py`
- **Seasonal Topic picker — keep `raw_id_fields`, drop `autocomplete_fields`.** Under Django 1.11 `autocomplete_fields` was silently ignored, so the raw-id magnifying-glass popup was actually in use. Django 2.0+ honours `autocomplete_fields`, which swapped in the Select2 widget — but that widget doesn't show which **pool** a topic belongs to, so content editors could no longer tell whether a topic was in the library pool. We intentionally keep the `raw_id_fields` popup picker (which exposes the pool/whitelist columns) and remove `autocomplete_fields`.
- **`PoolFilter` crash fix.** `TopicPool.objects.get(name=...)` now catches `DoesNotExist` and falls back to the unfiltered queryset instead of 500-ing when the selected pool no longer exists.
- **De-duplicated Topic results.** The `PoolFilter` adds an INNER JOIN on the M2M through table that can yield duplicate rows; `get_queryset()` now calls `.distinct()`. Results are also ordered by `slug`, and a `search_help_text` explains that search is scoped to the active pool filter.

### `remote_config/cache.py`
- **Resilient cache startup.** `get_cache()` now also catches `ProgrammingError` (table doesn't exist yet) so management commands run on a fresh DB don't crash before migrations are applied. The swallowed exception is logged at WARNING level so genuinely unexpected `ProgrammingError`s aren't lost silently.
- Added a unit test asserting `get_cache()` returns `{}` (and doesn't re-raise) when `_build_cache()` raises `ProgrammingError`.

### `helm-chart/sefaria/Chart.yaml`
- Marker comment to trigger a chart bump for `sc-44504`.

Fixes: [sc-44504](https://app.shortcut.com/sefaria/story/44504)

## Test plan

- [ ] Open a Seasonal Topic EN/HE add or change page in Django admin — the `topic` / `secondary_topic` fields show the raw-id magnifying-glass popup, and the popup lists pool membership columns.
- [ ] In Topic Pool Management, select a pool in the filter — no duplicate rows, results sorted by slug, no 500 if a pool is missing.
- [ ] Run `./venv/bin/python manage.py migrate` on a fresh DB (no tables) — should not crash; a WARNING is logged for the empty remote-config cache.
- [ ] `pytest remote_config/tests/remote_config_test.py` passes, including the new `ProgrammingError` test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
