### PR TITLE
Bug fix - Bound texts (like Steinsaltz on X) caused a massive throwaway querying of related texts

### DIFF
--- a/sefaria/client/wrapper.py
+++ b/sefaria/client/wrapper.py
@@ -305,7 +305,7 @@ def get_links(tref, with_text=True, with_sheet_links=False, categories=None):
     for prefix in bound_texts:
         if nRef.startswith(prefix):
             base_ref = nRef[len(prefix):]
-            base_links = get_links(base_ref)
+            base_links = get_links(base_ref, with_text=with_text, with_sheet_links=with_sheet_links, categories=categories)
             def add_prefix(link):
                 link["anchorRef"] = prefix + link["anchorRef"]
                 link["anchorRefExpanded"] = [prefix + l for l in link["anchorRefExpanded"]]


### PR DESCRIPTION
Testing: /api/related/Steinsaltz_on_Genesis.20?prof=1

Baseline (initial / reload):
7,766,016 function calls (7311110 primitive calls) in 17.660 seconds
2,162,099 function calls (2068793 primitive calls) in 5.285 seconds

After Fix (initial / reload):
4,838,272 function calls (4657227 primitive calls) in 1.657 seconds
220,269 function calls (220112 primitive calls) in 0.205 seconds