### PR TITLE
docs: document find-refs api as an async api

### DIFF
--- a/docs/openAPI.json
+++ b/docs/openAPI.json
@@ -18999,6 +18999,23 @@
           "Misc"
         ],
         "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AsyncTaskEnqueued"
+                },
+                "examples": {
+                  "Example": {
+                    "value": {
+                      "task_id": "b3d9e1a2-4f7c-4e2b-9a1d-6c8e2f0d5b3a"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Task enqueued. Poll `GET /api/async/{task_id}` to retrieve results. When the task completes successfully, the result will have the shape described by `FindRefsAPIResponse`."
+          },
           "200": {
             "content": {
               "application/json": {
@@ -19007,11 +19024,11 @@
                 }
               }
             },
-            "description": "Successful Response"
+            "description": "Shape of the `result` field returned by `GET /api/async/{task_id}` on successful completion."
           }
         },
         "summary": "Find Refs",
-        "description": "Initially designed to find links on websites using [Sefaria's Linker](https://www.sefaria.org/linker), the Find Refs API can identify textual refernces in any arbitrary text that gets sent to it via a structured POST request and returns a response object identifying each located reference including its start and end position within the submitted text."
+        "description": "Initially designed to find links on websites using [Sefaria's Linker](https://www.sefaria.org/linker), the Find Refs API can identify textual references in any arbitrary text that gets sent to it via a structured POST request.\n\n**This is an asynchronous API.** The endpoint immediately returns a `task_id` with HTTP 202. You must poll `GET /api/async/{task_id}` to retrieve the task status. When the task completes successfully, the `/api/async/{task_id}` response will include a `result` field containing the same `FindRefsAPIResponse` object described in the 200 response schema below."
       }
     },
     "/api/search-wrapper": {
@@ -19277,6 +19294,114 @@
               }
             },
             "description": "Successful Response"
+          }
+        }
+      }
+    },
+    "/api/async/{task_id}": {
+      "get": {
+        "operationId": "get-async-task-status",
+        "summary": "Get Async Task Status",
+        "description": "Poll the status of an asynchronous task. Returns the current state of the task and, when complete, the result or error. This endpoint is generic — it works for any task enqueued by an asynchronous Sefaria API (e.g. `POST /api/find-refs`).\n\n**States:**\n- `PENDING` — The task has not yet started (or the task ID is unknown).\n- `STARTED` — The task is currently being executed.\n- `RETRY` — The task failed and is being retried.\n- `SUCCESS` — The task completed successfully. The `result` field contains the task output; its shape depends on which API enqueued the task.\n- `FAILURE` — The task failed permanently. The `error` field contains the error message.\n\n**HTTP status codes:**\n- `202` — Task is still running (state is `PENDING`, `STARTED`, or `RETRY`).\n- `200` — Task completed successfully.\n- `500` — Task failed permanently.",
+        "tags": [
+          "Misc"
+        ],
+        "parameters": [
+          {
+            "name": "task_id",
+            "in": "path",
+            "required": true,
+            "description": "The task ID returned by an asynchronous API endpoint (e.g. `POST /api/find-refs`).",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Task is still in progress (`PENDING`, `STARTED`, or `RETRY`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AsyncTaskPending"
+                },
+                "examples": {
+                  "Pending": {
+                    "value": {
+                      "task_id": "b3d9e1a2-4f7c-4e2b-9a1d-6c8e2f0d5b3a",
+                      "state": "PENDING",
+                      "ready": false
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "Task completed successfully. The shape of the `result` field depends on which API enqueued the task. For tasks started by `POST /api/find-refs`, `result` is a `FindRefsAPIResponse` object.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AsyncTaskSuccess"
+                },
+                "examples": {
+                  "find-refs task (success)": {
+                    "summary": "Result for a task enqueued by POST /api/find-refs",
+                    "value": {
+                      "task_id": "b3d9e1a2-4f7c-4e2b-9a1d-6c8e2f0d5b3a",
+                      "state": "SUCCESS",
+                      "ready": true,
+                      "result": {
+                        "title": {
+                          "results": [],
+                          "refData": {}
+                        },
+                        "body": {
+                          "results": [
+                            {
+                              "startChar": 0,
+                              "endChar": 11,
+                              "text": "Genesis 1:1",
+                              "linkFailed": false,
+                              "refs": [
+                                "Genesis 1:1"
+                              ]
+                            }
+                          ],
+                          "refData": {
+                            "Genesis 1:1": {
+                              "heRef": "בראשית א׳:א׳",
+                              "url": "Genesis.1.1",
+                              "primaryCategory": "Tanakh"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Task failed permanently. The `error` field contains the error message.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AsyncTaskFailure"
+                },
+                "examples": {
+                  "Failure": {
+                    "value": {
+                      "task_id": "b3d9e1a2-4f7c-4e2b-9a1d-6c8e2f0d5b3a",
+                      "state": "FAILURE",
+                      "ready": true,
+                      "error": "An unexpected error occurred while processing the request."
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -28782,6 +28907,123 @@
           "percentAvailableInvalid": {
             "description": "True when the percentAvailable figure could not be calculated.",
             "type": "boolean"
+          }
+        }
+      },
+      "AsyncTaskEnqueued": {
+        "title": "Async Task Enqueued",
+        "description": "Response returned when an asynchronous task has been successfully enqueued.",
+        "type": "object",
+        "required": [
+          "task_id"
+        ],
+        "properties": {
+          "task_id": {
+            "type": "string",
+            "description": "Unique identifier for the enqueued task. Pass this to `GET /api/async/{task_id}` to poll for results."
+          }
+        },
+        "example": {
+          "task_id": "b3d9e1a2-4f7c-4e2b-9a1d-6c8e2f0d5b3a"
+        }
+      },
+      "AsyncTaskPending": {
+        "title": "Async Task Pending",
+        "description": "Response returned while a task is still in progress.",
+        "type": "object",
+        "required": [
+          "task_id",
+          "state",
+          "ready"
+        ],
+        "properties": {
+          "task_id": {
+            "type": "string",
+            "description": "The task identifier."
+          },
+          "state": {
+            "type": "string",
+            "enum": [
+              "PENDING",
+              "STARTED",
+              "RETRY"
+            ],
+            "description": "Current state of the task. `PENDING` means not yet started; `STARTED` means actively running; `RETRY` means the task failed and is being retried."
+          },
+          "ready": {
+            "type": "boolean",
+            "description": "Always `false` while the task is in progress.",
+            "example": false
+          },
+          "meta": {
+            "type": "object",
+            "description": "Optional progress or metadata reported by the task while it is running."
+          }
+        }
+      },
+      "AsyncTaskSuccess": {
+        "title": "Async Task Success",
+        "description": "Response returned when a task has completed successfully. The shape of `result` depends on which API enqueued the task.",
+        "type": "object",
+        "required": [
+          "task_id",
+          "state",
+          "ready",
+          "result"
+        ],
+        "properties": {
+          "task_id": {
+            "type": "string",
+            "description": "The task identifier."
+          },
+          "state": {
+            "type": "string",
+            "enum": [
+              "SUCCESS"
+            ],
+            "description": "Always `SUCCESS` for this response."
+          },
+          "ready": {
+            "type": "boolean",
+            "description": "Always `true` when the task has completed.",
+            "example": true
+          },
+          "result": {
+            "description": "The task output. Its shape depends on which API enqueued the task. For `POST /api/find-refs` tasks, this is a `FindRefsAPIResponse` object.",
+            "type": "object"
+          }
+        }
+      },
+      "AsyncTaskFailure": {
+        "title": "Async Task Failure",
+        "description": "Response returned when a task has failed permanently.",
+        "type": "object",
+        "required": [
+          "task_id",
+          "state",
+          "ready",
+          "error"
+        ],
+        "properties": {
+          "task_id": {
+            "type": "string",
+            "description": "The task identifier."
+          },
+          "state": {
+            "type": "string",
+            "enum": [
+              "FAILURE"
+            ],
+            "description": "Always `FAILURE` for this response."
+          },
+          "ready": {
+            "type": "boolean",
+            "description": "Always `true` when the task has failed permanently.",
+            "example": true
+          },
+          "error": {
+            "type": "string",
+            "description": "Human-readable description of the error that caused the task to fail."
           }
         }
       }


### PR DESCRIPTION
This pull request updates the OpenAPI specification to document new asynchronous API behavior, including a generic endpoint for polling the status of async tasks and standardized response schemas for async operations. These changes clarify how clients should interact with endpoints that return results asynchronously, such as the Find Refs API.

Key changes:

**Async API Documentation & Endpoints**
- Added documentation for the new generic `GET /api/async/{task_id}` endpoint, which allows clients to poll the status of any asynchronous task. The documentation details the possible task states, expected HTTP status codes, and includes example responses for pending, successful, and failed tasks.
- Updated the `POST /api/find-refs` endpoint documentation to specify that it is now asynchronous: it returns a `task_id` with HTTP 202, and clients must poll the async endpoint to retrieve results. The description and response documentation were revised to reflect this new workflow. [[1]](diffhunk://#diff-4026be2299c445e0daf82542a7931c27e075362acda4605de26d496adbdf4cafR19002-R19018) [[2]](diffhunk://#diff-4026be2299c445e0daf82542a7931c27e075362acda4605de26d496adbdf4cafL19010-R19031)

**Standardized Async Response Schemas**
- Defined new components/schemas for async task responses: `AsyncTaskEnqueued`, `AsyncTaskPending`, `AsyncTaskSuccess`, and `AsyncTaskFailure`. Each schema describes the structure of the response for different task states, including required fields and example payloads.