### PR TITLE
Change loading screens to be module specific

### DIFF
--- a/reader/views.py
+++ b/reader/views.py
@@ -217,7 +217,7 @@ def render_template(request, template_name='base.html', app_props=None, template
     return render(request, template_name=template_name, context=template_context, content_type=content_type, status=status, using=using)
 
 
-def render_react_component(component, props, request=None):
+def render_react_component(component, props, request):
     """
     Asks the Node Server to render `component` with `props`.
     `props` may either be JSON (to save reencoding) or a dictionary.

--- a/reader/views.py
+++ b/reader/views.py
@@ -210,21 +210,21 @@ def render_template(request, template_name='base.html', app_props=None, template
     propsJSON = json.dumps(props, ensure_ascii=False)
     template_context["propsJSON"] = propsJSON
     if app_props: # We are rendering the ReaderApp in Node, otherwise its jsut a Django template view with ReaderApp set to headerMode
-        html = render_react_component("ReaderApp", propsJSON)
+        html = render_react_component("ReaderApp", propsJSON, request=request)
         template_context["html"] = html
     else:
         template_context["renderStatic"] = True
     return render(request, template_name=template_name, context=template_context, content_type=content_type, status=status, using=using)
 
 
-def render_react_component(component, props):
+def render_react_component(component, props, request=None):
     """
     Asks the Node Server to render `component` with `props`.
     `props` may either be JSON (to save reencoding) or a dictionary.
     Returns HTML.
     """
     if not USE_NODE:
-        return render_to_string("elements/loading.html", context={"SITE_SETTINGS": SITE_SETTINGS})
+        return render_to_string("elements/loading.html", request=request)
 
     propsJSON = json.dumps(props, ensure_ascii=False) if isinstance(props, dict) else props
     cache_key = "todo" # zlib.compress(propsJSON)
@@ -262,11 +262,11 @@ def render_react_component(component, props):
                     "Logged In" if props.get("loggedIn", False) else "Logged Out",
                     props.get("interfaceLang")
             ))
-            return render_to_string("elements/loading.html", context={"SITE_SETTINGS": SITE_SETTINGS})
+            return render_to_string("elements/loading.html", request=request)
         else:
             # If anything else goes wrong with Node, just fall back to client-side rendering
             logger.warning("Node error: Fell back to client-side rendering.")
-            return render_to_string("elements/loading.html", context={"SITE_SETTINGS": SITE_SETTINGS})
+            return render_to_string("elements/loading.html", request=request)
 
 
 def base_props(request):

--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -8385,16 +8385,6 @@ But not to use a display block directive that might break continuous mode for ot
   left: 50%;
   transform: translate(-50%, -50%);
 }
-#appLoading img.int-en {
-  width: 150px;
-  height: 42px;
-  margin-bottom: 6px;
-}
-#appLoading img.int-he {
-  width: 150px;
-  height: 49px;
-  margin-bottom: 6px;
-}
 .emptyDesktop {
   margin-top: 200px;
   text-align: center;

--- a/templates/elements/loading.html
+++ b/templates/elements/loading.html
@@ -1,15 +1,19 @@
 {% load static %}
-{% load sefaria_tags %}
 
+<style>
+  #appLoading .loading-logo-english { height: 42px; width: auto; margin-bottom: 6px; }
+  #appLoading .loading-logo-hebrew  { height: 49px; width: auto; margin-bottom: 6px; }
+</style>
 <div id="appLoading">
     <div class='loadingMessage'>
       {% if SITE_SETTINGS.TORAH_SPECIFIC %}
-      <img class="int-en" src="{% static 'img/logo.svg' %}" alt="Sefaria Loading Icon" />
-      <img class="int-he" src="{% static 'img/logo-hebrew.png' %}" alt="Sefaria Loading Icon" />
+      {% with logo_path="img/"|add:active_module|add:"-logo-"|add:request.interfaceLang|add:".svg" %}
+      <img src="{% static logo_path %}" alt="Sefaria Loading Icon" class="loading-logo-{{ request.interfaceLang }}" />
+      {% endwith %}
       <br>
       {% endif %}
       <div class="smallText">
-      	<span class="int-he">...טעינה</span>
+      	<span class="int-he">טעינה...</span>
       	<span class="int-en">Loading...</span>
         </div>
     </div>


### PR DESCRIPTION
## Description
Changes the loading screens to the use right logo depending on the `active_module` and `interfaceLang` for consistent branding.

## Notes
*  I switched the code to use `RequestContext` so that it could use the context processors pipeline with additional properties instead of a bare `Context`.
* When a RequestContext is used, Django runs all processors: `global_settings()` supplies `SITE_SETTINGS`, and `module_context()` supplies `active_module`. `SITE_SETTINGS` doesn't need to be directly passed to the template
* CSS was included inline to keep the code self-contained and avoid depending on external CSS files, which is better suited for a loading screen.
