### PR TITLE
fix: restore re_path in sites/sefaria/urls.py (url() breaks Django 6)

### DIFF
--- a/sites/sefaria/urls.py
+++ b/sites/sefaria/urls.py
@@ -63,19 +63,19 @@ static_pages_by_lang = [
 
 # Static and Semi Static Content
 site_urlpatterns = [
-    url(r'^metrics/?$', reader_views.metrics),
-    url(r'^digitized-by-sefaria/?$', reader_views.digitized_by_sefaria),
-    url(r'^(favicon\.ico|apple-touch-icon\.png|favicon\.svg)/?$', reader_views.module_favicon),
-    url(r'^(?P<filename>site\.webmanifest|manifest\.json)/?$', reader_views.dynamic_manifest),
-    url(r'^apple-app-site-association/?$', reader_views.apple_app_site_association),
-    url(r'^\.well-known/apple-app-site-association/?$', reader_views.apple_app_site_association),
-    url(r'^\.well-known/assetlinks.json/?$', reader_views.android_asset_links_json),
-    url(r'^llms\.txt/?$', reader_views.serve_llms_txt),
-    url(r'^(%s)/?$' % "|".join(static_pages), reader_views.serve_static),
-    url(r'^(%s)/?$' % "|".join(static_pages_by_lang), reader_views.serve_static_by_lang),
-    url(r'^healthz/?$', reader_views.application_health_api),  # this oddly is returning 'alive' when it's not.  is k8s jumping in the way?
-    url(r'^health-check/?$', reader_views.application_health_api),
-    url(r'^healthz-rollout/?$', reader_views.rollout_health_api),
+    re_path(r'^metrics/?$', reader_views.metrics),
+    re_path(r'^digitized-by-sefaria/?$', reader_views.digitized_by_sefaria),
+    re_path(r'^(favicon\.ico|apple-touch-icon\.png|favicon\.svg)/?$', reader_views.module_favicon),
+    re_path(r'^(?P<filename>site\.webmanifest|manifest\.json)/?$', reader_views.dynamic_manifest),
+    re_path(r'^apple-app-site-association/?$', reader_views.apple_app_site_association),
+    re_path(r'^\.well-known/apple-app-site-association/?$', reader_views.apple_app_site_association),
+    re_path(r'^\.well-known/assetlinks.json/?$', reader_views.android_asset_links_json),
+    re_path(r'^llms\.txt/?$', reader_views.serve_llms_txt),
+    re_path(r'^(%s)/?$' % "|".join(static_pages), reader_views.serve_static),
+    re_path(r'^(%s)/?$' % "|".join(static_pages_by_lang), reader_views.serve_static_by_lang),
+    re_path(r'^healthz/?$', reader_views.application_health_api),  # this oddly is returning 'alive' when it's not.  is k8s jumping in the way?
+    re_path(r'^health-check/?$', reader_views.application_health_api),
+    re_path(r'^healthz-rollout/?$', reader_views.rollout_health_api),
 ]
 
 


### PR DESCRIPTION
## Problem
`sites/sefaria/urls.py` calls `url(...)` for the `metrics → healthz-rollout` route block (lines 66–78), but **`django.conf.urls.url` was removed in Django 4.0** and the file only imports `re_path`. On Django 6.0.4 (this repo's version) the URLConf module raises **`NameError: name 'url' is not defined`** at import → Django fails to load URLs → **every request returns HTTP 500**, including the `/healthz-rollout` startup probe.

### Impact
Because the rollout health probe 500s, web pods never pass startup and CrashLoop — **all new deploys and cauldrons built from `master` fail to come up** (observed on a fresh cauldron: web pod `0/1`, nginx serving 503 with `NameError: name 'url' is not defined`).

### Cause
Introduced by #3045 (LLMs.txt), which converted that route block from `re_path()` to `url()`.

## Fix
Revert the 13 affected routes from `url(` back to `re_path(` (anchored to line-leading calls; commented examples and `STATIC_URL` untouched). `python -m py_compile sites/sefaria/urls.py` passes.

## Test plan
- [x] `py_compile` clean
- [ ] URLConf loads without NameError (CI / app boot)
- [ ] `/healthz-rollout` returns 200 once `library.is_initialized()`
- [ ] New cauldron/deploy web pod reaches Ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)