### PR TITLE
fix(django6): convert remaining url() to re_path() in sites/sefaria/urls.py

### DIFF
--- a/sites/sefaria/urls.py
+++ b/sites/sefaria/urls.py
@@ -63,19 +63,19 @@ static_pages_by_lang = [
 
 # Static and Semi Static Content
 site_urlpatterns = [
-    url(r'^metrics/?$', reader_views.metrics),
-    url(r'^digitized-by-sefaria/?$', reader_views.digitized_by_sefaria),
-    url(r'^(favicon\.ico|apple-touch-icon\.png|favicon\.svg)/?$', reader_views.module_favicon),
-    url(r'^(?P<filename>site\.webmanifest|manifest\.json)/?$', reader_views.dynamic_manifest),
-    url(r'^apple-app-site-association/?$', reader_views.apple_app_site_association),
-    url(r'^\.well-known/apple-app-site-association/?$', reader_views.apple_app_site_association),
-    url(r'^\.well-known/assetlinks.json/?$', reader_views.android_asset_links_json),
-    url(r'^llms\.txt/?$', reader_views.serve_llms_txt),
-    url(r'^(%s)/?$' % "|".join(static_pages), reader_views.serve_static),
-    url(r'^(%s)/?$' % "|".join(static_pages_by_lang), reader_views.serve_static_by_lang),
-    url(r'^healthz/?$', reader_views.application_health_api),  # this oddly is returning 'alive' when it's not.  is k8s jumping in the way?
-    url(r'^health-check/?$', reader_views.application_health_api),
-    url(r'^healthz-rollout/?$', reader_views.rollout_health_api),
+    re_path(r'^metrics/?$', reader_views.metrics),
+    re_path(r'^digitized-by-sefaria/?$', reader_views.digitized_by_sefaria),
+    re_path(r'^(favicon\.ico|apple-touch-icon\.png|favicon\.svg)/?$', reader_views.module_favicon),
+    re_path(r'^(?P<filename>site\.webmanifest|manifest\.json)/?$', reader_views.dynamic_manifest),
+    re_path(r'^apple-app-site-association/?$', reader_views.apple_app_site_association),
+    re_path(r'^\.well-known/apple-app-site-association/?$', reader_views.apple_app_site_association),
+    re_path(r'^\.well-known/assetlinks.json/?$', reader_views.android_asset_links_json),
+    re_path(r'^llms\.txt/?$', reader_views.serve_llms_txt),
+    re_path(r'^(%s)/?$' % "|".join(static_pages), reader_views.serve_static),
+    re_path(r'^(%s)/?$' % "|".join(static_pages_by_lang), reader_views.serve_static_by_lang),
+    re_path(r'^healthz/?$', reader_views.application_health_api),  # this oddly is returning 'alive' when it's not.  is k8s jumping in the way?
+    re_path(r'^health-check/?$', reader_views.application_health_api),
+    re_path(r'^healthz-rollout/?$', reader_views.rollout_health_api),
 ]
 
 


### PR DESCRIPTION
## Problem

`master`'s `sites/sefaria/urls.py` currently contains **13 bare `url(...)` calls** (lines 66+) but only imports `re_path`:

```python
from django.urls import re_path   # line 3 — no `url` imported
...
url(r'^metrics/?$', reader_views.metrics),   # line 66 — url is undefined
```

`django.conf.urls.url` was **removed in Django 4.0**. Since this is the root urlconf, Django loads it lazily on the first request and raises:

```
NameError: name 'url' is not defined   (sites/sefaria/urls.py, line 66)
```

→ **HTTP 500 on every request** for any image built off current master. (Currently-running prod/staging pods predate this and are unaffected; the break only surfaces on the next image build.)

## Root cause

PR #3045 (`feature/sc-41060/produce-an-llms-txt-for-sefaria-org-to-enhance`) was branched **before** the Django 1.11 → 6.0 migration (#3251) and still used `url()`. When it was merged up to master (merge `8697d0a26`, "Merge branch 'master' of …"), it reintroduced the 13 `url()` calls that the migration had converted to `re_path()`.

## Fix

Convert the 13 `url(` → `re_path(`, matching the Django-6 style already used by the other 25 patterns in this file. `re_path` is already imported (line 3); these regex routes map 1:1 to `re_path`.

```
sites/sefaria/urls.py | 26 +++++++++++++-------------
1 file changed, 13 insertions(+), 13 deletions(-)
```

After: `grep -cE '^\s*url\(' sites/sefaria/urls.py` → `0`; file compiles (`python -m py_compile`).

## How it was found

A freshly built image (a cauldron) crash-looped with this exact `NameError` at `sites/sefaria/urls.py:66`. Verified via the running pod's DEBUG traceback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)