### PR TITLE
Fix showing notes

### DIFF
--- a/static/js/sefaria/sefaria.js
+++ b/static/js/sefaria/sefaria.js
@@ -2042,10 +2042,11 @@ Sefaria = extend(Sefaria, {
     return true;
   },
   addPrivateNote: function(note) {
-    // Add a single private note to the cache of private notes.
+    // Add a single private note to the caches of private notes.
     var notes = this.privateNotes(note["anchorRef"]) || [];
     notes = [note].concat(notes);
     this._saveItemsByRef(notes, this._privateNotes);
+    Sefaria._allPrivateNotes = null; // The note format in _allPrivateNotes is different from in _privateNotes. Clearing it ensures we'll get a fresh data from API next time.
   },
   clearPrivateNotes: function() {
     this._privateNotes = {};

--- a/static/js/sefaria/sefaria.js
+++ b/static/js/sefaria/sefaria.js
@@ -2046,7 +2046,7 @@ Sefaria = extend(Sefaria, {
     var notes = this.privateNotes(note["anchorRef"]) || [];
     notes = [note].concat(notes);
     this._saveItemsByRef(notes, this._privateNotes);
-    Sefaria._allPrivateNotes = null; // The note format in _allPrivateNotes is different from in _privateNotes. Clearing it ensures we'll get a fresh data from API next time.
+    this._allPrivateNotes = null; // Note format in _allPrivateNotes differs from _privateNotes; clearing it ensures we'll fetch fresh data from the API next time.
   },
   clearPrivateNotes: function() {
     this._privateNotes = {};


### PR DESCRIPTION
## The bug
After visiting once on notes page, when adding notes and going again to notes page, one won't see the new notes.

## Key reason
`Sefaria._allPrivateNotes` is populated on the first time visiting notes page, and not affected by saving a new note.

## Fix
Clear `_allPrivateNotes` when saving, so the user will get fresh data next time arriving at notes page.
Note - we save the note on `Sefaria._privateNotes`, but the format of note in `_privateNotes` is different from the one in `_privateNotes`. We can modify it, but it seems better to do an API call when visiting notes page than maintaing a code for modifying note formant.