### PR TITLE
hot-fix-search-filters

### DIFF
--- a/sefaria/helper/search.py
+++ b/sefaria/helper/search.py
@@ -138,7 +138,7 @@ def get_filter_obj(type, filters, filter_fields):
 
 
 def make_filter(type, agg_type, agg_key):
-    if type == "text" and agg_type == "path":
+    if type == "text" and agg_type in (None, "path"):
         # filters with '/' might be leading to books. also, very unlikely they'll match an false positives
         agg_key = agg_key.rstrip('/')
         agg_key = re.escape(agg_key)

--- a/sefaria/tests/search_test.py
+++ b/sefaria/tests/search_test.py
@@ -2,8 +2,28 @@
 instead of aborting the entire multi-hour run."""
 import pytest
 from elastic_transport import ApiError, ConnectionTimeout
+from elasticsearch_dsl.query import Bool, Regexp, Term
 
 from sefaria.search import TextIndexer
+from sefaria.helper.search import get_filter_obj, make_filter
+
+
+@pytest.mark.parametrize("type,agg_type,agg_key,expected", [
+    ("text", None,          "Mishnah",             Regexp),  # regression: null agg_type must not reach Term(**{None: ...})
+    ("text", "path",        "Mishnah",             Regexp),
+    ("text", "linked_refs", "Mishnah Berakhot 1:1", Term),
+    ("sheet", "group",      "some-group",           Term),
+])
+def test_make_filter(type, agg_type, agg_key, expected):
+    assert isinstance(make_filter(type, agg_type, agg_key), expected)
+
+
+@pytest.mark.parametrize("filter_fields", [
+    [None, None],  # regression: explicit JSON nulls from client raised TypeError
+    [],
+])
+def test_get_filter_obj(filter_fields):
+    assert isinstance(get_filter_obj("text", ["Mishnah", "Talmud"], filter_fields), Bool)
 
 
 class _FakeIndex:


### PR DESCRIPTION
This pull request addresses a regression in the `make_filter` function and adds tests to ensure correct filter construction for search queries. The main focus is on handling cases where `agg_type` is `None`, preventing errors that previously occurred when this value was passed.

**Bug fix and test improvements:**

* Updated `make_filter` in `sefaria/helper/search.py` to handle cases where `agg_type` is `None` as well as `"path"`, ensuring that a `Regexp` filter is created instead of causing an error.
* Added parameterized tests in `sefaria/tests/search_test.py` to verify that `make_filter` and `get_filter_obj` handle various input scenarios, including regression cases with `None` values and explicit JSON nulls from the client.