### PR TITLE
hotfix(search): restore default 'path' field for text filters (sc-44603)

### DIFF
--- a/e2e-tests/Sanity/search-filter-sanity.spec.ts
+++ b/e2e-tests/Sanity/search-filter-sanity.spec.ts
@@ -1,0 +1,115 @@
+/**
+ * SEARCH FILTER SANITY TESTS
+ *
+ * Regression coverage for sc-44603: applying a path (category/book) filter on a
+ * text search must return results.
+ *
+ * The bug: the search page sends text filters with filter_fields=[null] (it relies
+ * on the backend supplying the default "path" field). make_filter() did not honor
+ * that None default, so it fell through to Term(**{None: ...}) and raised
+ * TypeError -> HTTP 500 on /api/search-wrapper. Filtered text searches returned
+ * nothing. This broke both the URL-applied filter path and the in-app click path.
+ *
+ * PRIORITY: Critical - Run before every release
+ */
+
+import { test, expect } from '@playwright/test';
+import { goToPageWithLang, hideAllModalsAndPopups } from '../utils';
+import { LANGUAGES, t } from '../globals';
+import { MODULE_URLS } from '../constants';
+
+test.describe('Search Filter Sanity Tests', () => {
+
+  // =================================================================
+  // TEST 1: URL-applied path filter returns results (exact sc-44603 repro)
+  // =================================================================
+  test('Library - URL-applied path filter on text search returns results', async ({ context }) => {
+    // The exact problematic URL from the bug report: query "מעל" filtered to Psalms.
+    const query = 'מעל';
+    const url = `${MODULE_URLS.EN.LIBRARY}/search?q=${encodeURIComponent(query)}`
+      + `&tab=text&tpathFilters=${encodeURIComponent('Tanakh/Writings/Psalms')}`
+      + `&tvar=1&tsort=relevance`;
+
+    const page = await goToPageWithLang(context, url, LANGUAGES.EN);
+    await hideAllModalsAndPopups(page);
+
+    // The result count only renders text when there are > 0 results (was empty / 500 before).
+    const resultCount = page.locator('.searchResultCount');
+    await expect(resultCount).toContainText(/\d/, { timeout: t(20000) });
+
+    // Actual result rows render (the filtered query returns hits).
+    const results = page.locator('.result.textResult');
+    await expect(results.first()).toBeVisible({ timeout: t(20000) });
+
+    // The filter sidebar only renders when totalResults > 0, so its presence
+    // is an extra guarantee the filtered search succeeded.
+    await expect(page.locator('.searchFilters').first()).toBeVisible({ timeout: t(20000) });
+  });
+
+  // =================================================================
+  // TEST 2: Applying a path filter via the UI returns results (click path)
+  // =================================================================
+  test('Library - Clicking a category filter keeps results (no 500)', async ({ context }) => {
+    const page = await goToPageWithLang(
+      context,
+      `${MODULE_URLS.EN.LIBRARY}/search?q=shabbat&tab=text&tsort=relevance`,
+      LANGUAGES.EN
+    );
+    await hideAllModalsAndPopups(page);
+
+    // Unfiltered search has results and the filter sidebar is shown.
+    await expect(page.locator('.result.textResult').first()).toBeVisible({ timeout: t(20000) });
+
+    // The checkbox input is visually hidden (custom styled control); the clickable
+    // element is the label. Top-level categories are expandable, so the title span
+    // expands the tree — the label is what toggles selection.
+    const tanakhFilterLabel = page.locator('label#label-for-Tanakh').first();
+    await expect(tanakhFilterLabel).toBeVisible({ timeout: t(20000) });
+
+    // Apply the Tanakh category filter.
+    await tanakhFilterLabel.click();
+
+    // The applied filter is reflected in the URL...
+    await expect(page).toHaveURL(/tpathFilters=Tanakh/, { timeout: t(20000) });
+
+    // ...and results are still returned (before the fix this 500'd / returned 0).
+    await expect(page.locator('.searchResultCount')).toContainText(/\d/, { timeout: t(20000) });
+    await expect(page.locator('.result.textResult').first()).toBeVisible({ timeout: t(20000) });
+  });
+
+  // =================================================================
+  // TEST 3: An applied filter shows its real count, not "(0)" (sc-44603)
+  // =================================================================
+  test('Library - Applied filter shows its real count, not (0)', async ({ context }) => {
+    const url = `${MODULE_URLS.EN.LIBRARY}/search?q=${encodeURIComponent('מעל')}`
+      + `&tab=text&tpathFilters=${encodeURIComponent('Tanakh/Writings/Psalms')}`
+      + `&tvar=1&tsort=relevance`;
+    const page = await goToPageWithLang(context, url, LANGUAGES.EN);
+    await hideAllModalsAndPopups(page);
+
+    await expect(page.locator('.result.textResult').first()).toBeVisible({ timeout: t(20000) });
+
+    // Expand Tanakh -> Writings to reveal the selected Psalms filter.
+    await page.locator('.searchFilterTitle', { hasText: /^\s*Tanakh\b/ }).first().click();
+    await page.locator('.searchFilterTitle', { hasText: /^\s*Writings\b/ }).first().click();
+
+    // The selected Psalms filter must show a real count, not "(0)".
+    const psalms = page.locator('.searchFilterTitle', { hasText: /Psalms/ }).first();
+    await expect(psalms).toBeVisible({ timeout: t(20000) });
+    await expect(psalms).not.toContainText('(0)');
+    await expect(psalms).toContainText(/\([1-9]\d*\)/);
+  });
+});
+
+/**
+ * TEST SUMMARY:
+ *
+ * 2 search-filter regression tests (sc-44603):
+ *  1. URL-applied path filter: loads the exact reported URL (q=מעל filtered to
+ *     Tanakh/Writings/Psalms) and asserts results render.
+ *  2. UI click path: searches, clicks the Tanakh category filter, and asserts the
+ *     filter is applied (URL) and results still render.
+ *
+ * Both exercise text path filters, which send filter_fields=[null] to
+ * /api/search-wrapper and previously crashed the backend with a 500.
+ */

--- a/reader/views.py
+++ b/reader/views.py
@@ -998,7 +998,7 @@ def get_search_params(get_dict, i=None):
     if get_dict.get('tab') == 'text':
         filters = get_filters("t", "path")
         sort = get_dict.get(get_param("tsort", i), None)
-        agg_types = [None for _ in filters] # currently unused. just needs to be equal len as filters
+        agg_types = ["path" for _ in filters]  # text search always filters on the "path" field
         field = ("naive_lemmatizer" if get_dict.get(get_param("tvar", i)) == "1" else "exact") if get_dict.get(get_param("tvar", i)) else ""
     else:
         for filter_type in sheet_filters_types:

--- a/sefaria/helper/search.py
+++ b/sefaria/helper/search.py
@@ -138,8 +138,11 @@ def get_filter_obj(type, filters, filter_fields):
 
 
 def make_filter(type, agg_type, agg_key):
-    if type == "text" and agg_type == "path":
-        # filters with '/' might be leading to books. also, very unlikely they'll match an false positives
+    if type == "text" and agg_type in (None, "path"):
+        # "path" is the standard text filter field (regexp over category path).
+        # None is accepted as a defensive fallback for callers that pass an empty filter_fields list,
+        # which get_filter_obj normalises to [None] (see line 129).
+        # filters with '/' might be leading to books. also, very unlikely they'll match any false positives
         agg_key = agg_key.rstrip('/')
         agg_key = re.escape(agg_key)
         reg = f"{agg_key}|{agg_key}/.*"

--- a/sefaria/helper/tests/search_test.py
+++ b/sefaria/helper/tests/search_test.py
@@ -30,6 +30,25 @@ def test_query_obj():
     assert ordered(t) == ordered(s.to_dict())
 
 
+def test_text_filter_default_agg_type():
+    # Regression test for sc-44603: a text path filter applied from a URL (or via the
+    # documented `filter_fields = [None]` "use the default field" contract) must produce a
+    # `path` regexp filter, not crash with `Term(**{None: ...})` -> TypeError -> HTTP 500.
+    expected = get_query_obj("moshe", "text", "naive_lemmatizer", False, 10, 0, 10,
+                             ["Tanakh/Writings/Psalms"], ["path"], [], "score",
+                             ['pagesheetrank'], sort_score_missing=0.04)
+    # explicit None agg_type (what the search page sends for URL-applied text filters)
+    none_agg = get_query_obj("moshe", "text", "naive_lemmatizer", False, 10, 0, 10,
+                             ["Tanakh/Writings/Psalms"], [None], [], "score",
+                             ['pagesheetrank'], sort_score_missing=0.04)
+    # empty filter_fields, which get_filter_obj fills with [None] * len(filters)
+    empty_agg = get_query_obj("moshe", "text", "naive_lemmatizer", False, 10, 0, 10,
+                              ["Tanakh/Writings/Psalms"], [], [], "score",
+                              ['pagesheetrank'], sort_score_missing=0.04)
+    assert ordered(none_agg.to_dict()) == ordered(expected.to_dict())
+    assert ordered(empty_agg.to_dict()) == ordered(expected.to_dict())
+
+
 def ordered(obj):
     if isinstance(obj, dict):
         return sorted((str(k), ordered(v)) for k, v in list(obj.items()))

--- a/static/js/sefaria/search.js
+++ b/static/js/sefaria/search.js
@@ -457,10 +457,17 @@ class Search {
         const registry = {};        // Mappings of "/" separated category path strings to FilterNode objects
 
         // create combined list of filters with {aggKey, docCount, path}
+        // Applied filters are included so they always appear in the tree, even when the
+        // aggregation has no bucket for them. Seed their docCount from the aggregation
+        // bucket (when present) so an applied filter shows its real count rather than 0
+        // (sc-44603: a selected filter like Psalms otherwise renders as "(0)" because the
+        // placeholder shadowed the matching bucket).
+        const bucketDocCounts = {};
+        aggregation_buckets.forEach(f => { bucketDocCounts[f["key"]] = f["doc_count"]; });
         let filters = [
             ...appliedFilters.map(fkey => ({
                 aggKey: fkey,
-                docCount: 0,
+                docCount: bucketDocCounts[fkey] || 0,
                 path: fkey.split("/")
             })),
             ...aggregation_buckets.map(f => ({


### PR DESCRIPTION
**Hotfix to `prod`** replicating the same code as #3368 (which targets `master`).

## Problem

[sc-44603](https://app.shortcut.com/sefaria/story/44603) — Selecting a path filter on a **text** search returns no results. Repro: search `מעל`, filter to תהילים (Psalms). The facet shows results in Psalms, but applying the filter shows nothing and `/api/search-wrapper/es8` returns **HTTP 500**.

## Root cause

Commit `125265597` tightened `make_filter`'s text branch to only match `agg_type == "path"`, which excluded the `agg_type=None` default that URL-bootstrapped text filters rely on. `None` then fell through to `Term(**{None: agg_key})` → `TypeError: keywords must be strings` → 500.

## Fix

- **Backend** — `reader/views.py` now passes `"path"` explicitly for URL text filters; `make_filter` keeps a documented `agg_type in (None, "path")` defensive fallback.
- **Frontend** — pre-index aggregation bucket counts in `buildFilterTree` so a selected path filter shows its real count instead of always `(0)`.

## Tests

- `test_text_filter_default_agg_type` (`sefaria/helper/tests/search_test.py`).
- e2e regression tests (`e2e-tests/Sanity/search-filter-sanity.spec.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)