### PR TITLE
feat(ci): reverse back-merge promotion (prod→preprod→master)

### DIFF
--- a/.github/workflows/manual-promotion.yaml
+++ b/.github/workflows/manual-promotion.yaml
@@ -3,11 +3,21 @@ name: "Manual Promotion"
 # Trigger manually from the Actions tab when you want to promote between environments.
 # Creates a promotion PR with changelog (and AI summary for prod).
 #
-# Promotion paths:
+# Forward promotion paths:
 #   master  → preprod  (staging → pre-production)
 #   preprod → prod     (pre-production → production)
 #
-# After the PR is created and reviewed, merge it normally.
+# Reverse back-merge paths (propagate a hotfix that landed directly on prod):
+#   prod    → preprod
+#   preprod → master
+#
+# Reverse chaining: when a prod → preprod PR is merged, the chain-backmerge
+# job below automatically opens the follow-up preprod → master PR — so a
+# single prod → preprod trigger walks the hotfix all the way back to master.
+# The chained PR is created with BYPASS_BRANCH_PROTECTION_TOKEN so its
+# required checks (PyTest / Playwright / Sandbox Deploy) actually run.
+#
+# After a PR is created and reviewed, merge it normally.
 # The promotion-gate.yaml check enforces that only valid source branches can merge.
 
 on:
@@ -20,6 +30,7 @@ on:
         options:
           - master
           - preprod
+          - prod
       target:
         description: "Target branch"
         required: true
@@ -27,10 +38,17 @@ on:
         options:
           - preprod
           - prod
+          - master
+  # Reverse-chain trigger: fires when a prod → preprod back-merge PR is merged,
+  # to auto-open the follow-up preprod → master PR.
+  pull_request:
+    types: [closed]
+    branches: [preprod]
 
 jobs:
   promote:
     name: "Promote: ${{ github.event.inputs.source }} → ${{ github.event.inputs.target }}"
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -45,15 +63,17 @@ jobs:
           SOURCE: ${{ github.event.inputs.source }}
           TARGET: ${{ github.event.inputs.target }}
         run: |
-          if [[ "$SOURCE" == "master" && "$TARGET" == "preprod" ]]; then
-            echo "✅ Valid: master → preprod"
-          elif [[ "$SOURCE" == "preprod" && "$TARGET" == "prod" ]]; then
-            echo "✅ Valid: preprod → prod"
-          else
-            echo "❌ Invalid path: $SOURCE → $TARGET"
-            echo "Allowed: master→preprod, preprod→prod"
-            exit 1
-          fi
+          case "${SOURCE} -> ${TARGET}" in
+            "master -> preprod"|"preprod -> prod")
+              echo "✅ Valid forward promotion: ${SOURCE} → ${TARGET}" ;;
+            "prod -> preprod"|"preprod -> master")
+              echo "✅ Valid reverse back-merge: ${SOURCE} → ${TARGET}" ;;
+            *)
+              echo "❌ Invalid path: ${SOURCE} → ${TARGET}"
+              echo "Allowed forward:  master→preprod, preprod→prod"
+              echo "Allowed reverse:  prod→preprod, preprod→master"
+              exit 1 ;;
+          esac
 
       - name: Generate changelog and create PR
         id: create_pr
@@ -118,3 +138,34 @@ jobs:
       - name: No changes
         if: steps.create_pr.outputs.pr_url == 'no-changes'
         run: echo "⚠️ No commits between ${{ github.event.inputs.source }} and ${{ github.event.inputs.target }} — nothing to promote."
+
+  # Reverse-chain leg: when a prod → preprod back-merge PR is merged, auto-open
+  # the follow-up preprod → master PR so the hotfix propagates all the way back.
+  # Fires on ANY merged prod → preprod PR (action-created or hand-made), which is
+  # the correct invariant: commits on prod that preprod lacked must reach master.
+  chain-backmerge-to-master:
+    name: "Chain back-merge: preprod → master"
+    if: >
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.head.ref == 'prod' &&
+      github.event.pull_request.base.ref == 'preprod'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # SOURCE/TARGET are hardcoded literals (not derived from event payload),
+      # so there is no injection surface from the triggering PR.
+      # BYPASS_BRANCH_PROTECTION_TOKEN (a PAT) is used so the created PR triggers
+      # master's required checks — GITHUB_TOKEN-created PRs do not.
+      - name: Open preprod → master back-merge PR
+        env:
+          GH_TOKEN: ${{ secrets.BYPASS_BRANCH_PROTECTION_TOKEN }}
+          SOURCE: preprod
+          TARGET: master
+        run: ./build/ci/generate-promotion-pr.sh "$SOURCE" "$TARGET"

--- a/.github/workflows/manual-promotion.yaml
+++ b/.github/workflows/manual-promotion.yaml
@@ -143,11 +143,14 @@ jobs:
   # the follow-up preprod → master PR so the hotfix propagates all the way back.
   # Fires on ANY merged prod → preprod PR (action-created or hand-made), which is
   # the correct invariant: commits on prod that preprod lacked must reach master.
+  # The same-repo guard prevents a fork PR opened from a branch coincidentally
+  # named `prod` from triggering the privileged (PAT-backed) chain leg.
   chain-backmerge-to-master:
     name: "Chain back-merge: preprod → master"
     if: >
       github.event_name == 'pull_request' &&
       github.event.pull_request.merged == true &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.head.ref == 'prod' &&
       github.event.pull_request.base.ref == 'preprod'
     runs-on: ubuntu-latest
@@ -163,6 +166,9 @@ jobs:
       # so there is no injection surface from the triggering PR.
       # BYPASS_BRANCH_PROTECTION_TOKEN (a PAT) is used so the created PR triggers
       # master's required checks — GITHUB_TOKEN-created PRs do not.
+      # Required scope: a fine-grained PAT limited to THIS repo with
+      # Contents: Read + Pull requests: Write (it only reads git history and
+      # opens a PR — it does not need, and should not have, push/admin scope).
       - name: Open preprod → master back-merge PR
         env:
           GH_TOKEN: ${{ secrets.BYPASS_BRANCH_PROTECTION_TOKEN }}

--- a/.github/workflows/manual-promotion.yaml
+++ b/.github/workflows/manual-promotion.yaml
@@ -89,8 +89,10 @@ jobs:
           github.event.inputs.target == 'prod' &&
           steps.create_pr.outputs.pr_url != 'already exists' &&
           steps.create_pr.outputs.pr_url != 'no-changes'
-        uses: slackapi/slack-github-action@v1.27.0
+        uses: slackapi/slack-github-action@v3.0.3
         with:
+          webhook: ${{ secrets.SLACK_DEPLOY_WEBHOOK }}
+          webhook-type: incoming-webhook
           payload: |
             {
               "blocks": [
@@ -124,8 +126,6 @@ jobs:
                 }
               ]
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_DEPLOY_WEBHOOK }}
 
       - name: Summary
         if: steps.create_pr.outputs.pr_url != 'no-changes'

--- a/.github/workflows/promotion-gate.yaml
+++ b/.github/workflows/promotion-gate.yaml
@@ -6,8 +6,13 @@ name: "Promotion Gate"
 # settings for preprod and prod — PRs cannot merge without this passing.
 #
 # Allowed paths:
-#   preprod ← master, hotfix/*
+#   preprod ← master, hotfix/*, prod (reverse back-merge after a prod hotfix)
 #   prod    ← preprod, hotfix/*
+#
+# The reverse back-merge prod → preprod propagates a hotfix that landed
+# directly on prod back down the chain. preprod → master is not gated here
+# (master is not in the branch list below, and gating it would block every
+# feature → master PR), so the second back-merge hop needs no gate change.
 #
 # Who can approve merges is controlled by GitHub environment reviewers
 # on the "promote-preprod" and "promote-prod" environments, not here.
@@ -46,11 +51,13 @@ jobs:
           if [[ "$TARGET" == "preprod" ]]; then
             if [[ "$SOURCE" == "master" ]]; then
               echo "✅ preprod ← master: allowed"
+            elif [[ "$SOURCE" == "prod" ]]; then
+              echo "✅ preprod ← prod: reverse back-merge allowed"
             else
-              echo "❌ BLOCKED: preprod only accepts PRs from master or hotfix/*"
+              echo "❌ BLOCKED: preprod only accepts PRs from master, prod, or hotfix/*"
               echo ""
               echo "  Got: $SOURCE → preprod"
-              echo "  Expected: master → preprod (or hotfix/* → preprod)"
+              echo "  Expected: master → preprod, prod → preprod (back-merge), or hotfix/* → preprod"
               exit 1
             fi
 

--- a/.github/workflows/promotion-gate.yaml
+++ b/.github/workflows/promotion-gate.yaml
@@ -6,8 +6,13 @@ name: "Promotion Gate"
 # settings for preprod and prod — PRs cannot merge without this passing.
 #
 # Allowed paths:
-#   preprod ← master, hotfix/*, prod (reverse back-merge after a prod hotfix)
-#   prod    ← preprod, hotfix/*
+#   preprod ← master, hotfix/* (preferred hotfix path), prod (reverse back-merge)
+#   prod    ← preprod, hotfix/* (BREAK-GLASS — emergencies only)
+#
+# Hotfix policy: ship hotfixes via hotfix/* → preprod → prod, the same gate as
+# everything else. hotfix/* → prod stays allowed as a break-glass path for true
+# emergencies (and is the case the reverse back-merge below cleans up), but it
+# is not the default — the gate warns when it is used.
 #
 # The reverse back-merge prod → preprod propagates a hotfix that landed
 # directly on prod back down the chain. preprod → master is not gated here
@@ -42,9 +47,15 @@ jobs:
             exit 1
           fi
 
-          # hotfix/* branches are allowed into both preprod and prod
+          # hotfix/* branches: preprod is the preferred path; prod is break-glass.
           if [[ "$SOURCE" == hotfix/* ]]; then
-            echo "✅ $TARGET ← $SOURCE: hotfix branch allowed"
+            if [[ "$TARGET" == "prod" ]]; then
+              echo "⚠️ $TARGET ← $SOURCE: hotfix → prod is a BREAK-GLASS path (emergencies only)."
+              echo "   Prefer hotfix/* → preprod → prod. After a direct prod hotfix, run the"
+              echo "   reverse back-merge (prod → preprod → master) so environments don't diverge."
+            else
+              echo "✅ $TARGET ← $SOURCE: hotfix → preprod (preferred hotfix path)"
+            fi
             exit 0
           fi
 


### PR DESCRIPTION
## Why

After a hotfix lands directly on `prod` (via `hotfix/* → prod`, outside the normal twice-weekly `master → preprod → prod` cadence), that fix must propagate back **down** the chain so the environments don't diverge. There was no first-class way to do `prod → preprod` then `preprod → master`, and the promotion gate falsely failed the `prod → preprod` PRs that are already being merged by hand.

## What

- **`promotion-gate.yaml`** — `preprod` now accepts `prod` (reverse back-merge), alongside `master` / `hotfix/*`. `preprod → master` stays ungated (master isn't in the gate's branch list; gating it would block every `feature → master` PR).
- **`manual-promotion.yaml`** — adds `prod` source + `master` target; validation is now a 4-pair allowlist (`master→preprod`, `preprod→prod`, `prod→preprod`, `preprod→master`); new `chain-backmerge-to-master` job auto-opens the `preprod → master` PR when a `prod → preprod` PR merges. The chained PR is created with `BYPASS_BRANCH_PROTECTION_TOKEN` so its required checks (PyTest / Playwright / Sandbox Deploy) actually run — a `GITHUB_TOKEN`-created PR would not trigger them.
- **`generate-promotion-pr.sh`** — maps `master → staging` env for the rollback-ref lookup so reverse PRs don't warn "unknown".

## Rollback-reference fix (`app=unknown, chart=unknown`)

This branch also fixes the long-standing bug where the auto-generated **Rollback Reference** table rendered `app=unknown, chart=unknown` (e.g. promotion PR #3447). **Supersedes #3446**, which targeted the same bug.

**Root cause:** the version extraction used `python3 -c "..."` double-quoted *inside* `$(...)`, so bash collapsed the `[\"\'']` quote class to `["\'']` within the program text. Python then raised `SyntaxError: closing parenthesis ']' does not match` — which `2>&1` swallowed and `|| ="unknown"` turned into `unknown`. Both fields failed identically, hence both showed `unknown`. (Reproduced against the exact prod helmrelease that was live when #3447 was generated.)

**Fix:** the Python is now written via a **single-quoted heredoc** (`'PYEOF'`) so bash performs no substitution on the regex, and the YAML is passed through an **env var** rather than the command line. Verified: it now extracts the real values (`app=v6.101.14-prod.3, chart=0.85.12-prod.1` for the #3447 snapshot).

Additional hardening folded in:
- Fetch promotion refs with **explicit forced refspecs** (`refs/heads/<b>:refs/remotes/origin/<b>`) so `origin/<target>` is reliably the true remote tip for both the changelog and the rollback lookup.
- **Randomize the `GITHUB_OUTPUT` heredoc delimiter** for `ai_summary` so a model-generated summary containing a bare `EOF` line can't inject extra output keys (Actions output injection).
- Resolve the "already exists" PR URL by `SOURCE→TARGET` pair via `gh pr list --base --head --jq '.[0].url // empty'` instead of a bare `gh pr view` that returned the runner's current-branch PR.
- **Same-repo guard** on `chain-backmerge-to-master` (`head.repo.full_name == github.repository`) so a fork PR from a branch coincidentally named `prod` can't trigger the PAT-backed leg.
- Documented the required **fine-grained PAT scope** for `BYPASS_BRANCH_PROTECTION_TOKEN` (Contents: Read + Pull requests: Write, this repo only).

## Flow

Trigger `prod → preprod` from the Actions tab → review/merge → the `preprod → master` PR opens automatically with checks running → review/merge → environments back in sync.

## Reviewer notes / caveats

- **Token scope:** the chain leg needs `BYPASS_BRANCH_PROTECTION_TOKEN` to be able to *create PRs* (fine-grained PAT with `pull-requests: write`, `contents: read`). It's currently proven only for `git push` in `deploy-static.yaml`. Please confirm scope.
- **Inert until on preprod:** GitHub evaluates `pull_request` triggers from the base branch's copy of the workflow, so the chain job is dormant until this is promoted to `preprod` normally. Recommend one deliberate dry-run after it reaches preprod.
- The chain fires on **any** merged `prod → preprod` PR (action-created or hand-made) — the correct invariant: prod commits preprod lacked must reach master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
