### PR TITLE
hotfix: disable BuildKit cache on asset image build (fixes static JS 404 outage)

### DIFF
--- a/scripts/release-prepare.sh
+++ b/scripts/release-prepare.sh
@@ -57,8 +57,6 @@ fi
 # Asset image depends on web image
 docker buildx build --push \
   --build-arg "SRC_IMG=${IMAGE_REGISTRY}/${IMAGE_NAME}-web:${TAG}" \
-  --cache-from "type=registry,ref=${IMAGE_REGISTRY}/${IMAGE_NAME}-asset:cache" \
-  --cache-to "type=registry,ref=${IMAGE_REGISTRY}/${IMAGE_NAME}-asset:cache,mode=max" \
   -t "${IMAGE_REGISTRY}/${IMAGE_NAME}-asset:${TAG}" \
   -f build/asset/Dockerfile \
   .


### PR DESCRIPTION
## Incident
Production site down — pages 404'd on `/static/bundles/client/client-b547ebcbfc9f5e3ac142.js`. nginx (`sefaria-asset`) was serving a stale JS bundle (`client-701e9ff…`) that no longer matched what the rendered pages referenced (`client-b547…`).

## Root cause
The `sefaria-asset` (nginx) image bakes a **copy** of the static bundles from the web image at build time (`build/asset/Dockerfile`: `COPY --from=static_source /app/static-collected /app/static/`). The asset build used a BuildKit **registry cache** (`--cache-from/--cache-to …-asset:cache`), and the `COPY --from` layer was served from cache (`#11 CACHED`) instead of re-copying. So nginx froze on an old bundle while the web pods moved to the new one → every JS asset request 404'd.

(Compounded by a debug build — `26729be65 "install patched ddtrace for debugging"` on `prod` — whose web image became the stale `SRC_IMG`.)

## Fix
Cherry-picked from `stop-static-caching` (Brendan Galloway, `512cc083f`): remove `--cache-from`/`--cache-to` from the **asset** image build in `scripts/release-prepare.sh` so the static `COPY` is always fresh.

Branched off `prod`; this is the **only** change (2-line deletion) — isolated from the unrelated work on `stop-static-caching` (slack-webhook removal, llms.txt, etc.).

## Deploy note
Merging to `prod` triggers a fresh build; the asset image will now copy current static. Verify post-deploy: nginx pod `/app/static/bundles/client/` contains the bundle the live HTML references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)