### PR TITLE
fix(chart): force rollout to re-pull corrected asset image (static 404 hotfix)

### DIFF
--- a/helm-chart/sefaria/templates/rollout/nginx.yaml
+++ b/helm-chart/sefaria/templates/rollout/nginx.yaml
@@ -1,5 +1,9 @@
 # apiVersion: apps/v1
 # kind: Deployment
+# The nginx (asset) image bakes a copy of the static bundles from the web image at
+# build time. That copy is now built cache-free (see scripts/release-prepare.sh) so it
+# always matches the web build. Bumping the chart forces a rollout, which re-pulls the
+# corrected v*-prod.* asset image and keeps served static in sync with the served HTML.
 apiVersion: argoproj.io/v1alpha1
 kind: Rollout
 metadata:


### PR DESCRIPTION
## Context
Follow-up to #3386. That PR merged the build-side fix (cache-free asset image) and its deploy run **already built and pushed corrected `v6.101.2-prod.1` images** (web `c25fc9c2`, asset `937e761b`, built 21:23 cache-free). But:
1. The deploy's `release-app` job then **failed** on a pre-existing semantic-release collision (`v6.101.2-prod.1` tag already exists — prod's version lineage is behind staging).
2. The running pods **never re-pulled** the corrected images, because the image tag string was unchanged → nothing triggered a rollout. So nginx still serves the stale bundle and the site stays 404'd.

## What this does
A **chart-only** change (`app_changed=false`), so it:
- **Skips `release-app`** → avoids the `v6.101.2-prod.1` collision entirely.
- Routes through `release-chart` (separate `helm-chart-*` lineage, next ≈ `0.85.10-prod.1`, no collision).
- Bumps the chart → Flux upgrade → `.Release.Revision`++ → revision-tagged `NODEJS_HOST`/`VARNISH_HOST` env vars change → **Argo rolls all rollouts** → pods re-pull `v6.101.2-prod.1` (the corrected build) via `imagePullPolicy: Always`.

Net: gets the already-built fix **live** via GitOps, without manual pod restarts and without the app-tag collision.

## Diff
A single comment in `helm-chart/sefaria/templates/rollout/nginx.yaml` — no rendered-manifest change; the roll is driven by the chart-version / release-revision bump.

## After merge — verify
- nginx pods on digest `937e761b`, web on `c25fc9c2`
- `ls /app/static/bundles/client/` in an nginx pod contains the bundle the live HTML references → site loads.

## Follow-up (not this PR)
Fix prod's version lineage (back-merge the missing `v6.101.2` / `v6.101.3-6` release tags, or clear the orphaned `v6.101.2-prod.1`) so `release-app` deploys stop colliding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)