### PR TITLE
Fix linker: allow llm_resolved_ref_but_rejected in LinkerOutput span schema

### DIFF
--- a/sefaria/model/marked_up_text_chunk.py
+++ b/sefaria/model/marked_up_text_chunk.py
@@ -242,6 +242,7 @@ class LinkerOutput(MarkedUpTextChunk):
                     "llm_resolved_method_non_segment": {"type": "string", "required": False, "nullable": True},
                     "llm_resolved_phrase_non_segment": {"type": "string", "required": False, "nullable": True},
                     "llm_ambiguous_option_valid": {"type": "boolean", "required": False, "nullable": True},
+                    "llm_resolved_ref_but_rejected": {"type": "string", "required": False, "nullable": True},
                     "failed": {"type": "boolean", "required": True},
                     "ambiguous": {"type": "boolean", "required": True},
                     **{k: {"type": "list", "schema": {"type": "string"}, "required": False, "nullable": True} for k in optional_list_str_schema_keys}


### PR DESCRIPTION
## Problem

When the linker disambiguator's LLM **rejects the sole candidate** for a non-segment citation, `_update_linker_output_resolution_fields` records it by setting `span["llm_resolved_ref_but_rejected"]` (`sefaria/helper/linker/tasks.py`) and then calls `linker_output.save()`.

But `LinkerOutput`'s `spans` schema never declared that field. Cerberus rejects unknown fields, so the save raised:

```
InputError({'spans': [{N: [{'llm_resolved_ref_but_rejected': ['unknown field']}]}]})
```

crashing the `linker.link_segment_with_worker` task on that path. It reproduces for any text where the disambiguator rejects a non-segment candidate (surfaced while bulk-linking Encyclopedia Talmudit, which is dense with non-segment citations).

## Fix

Declare `llm_resolved_ref_but_rejected` in the `LinkerOutput` span schema, alongside its sibling `llm_*` diagnostic fields, as an optional nullable string — matching `disambiguator.NonSegmentResolutionResult.rejected_ref` (`Optional[str]`).

This is an additive schema widening; it only permits a field the code already writes and cannot invalidate existing records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)