### PR TITLE
fix(helm): template reindex ES cronjob SEARCH_HOST instead of hardcoding prod host [sc-44754]

### DIFF
--- a/helm-chart/sefaria/templates/cronjob/reindex-elasticsearch.yaml
+++ b/helm-chart/sefaria/templates/cronjob/reindex-elasticsearch.yaml
@@ -33,7 +33,7 @@ spec:
                 memory: 15Gi
             env:
             - name: SEARCH_HOST
-              value: "elasticsearch-1b-es-http.elasticsearch.svc"
+              value: "{{ .Values.nginx.SEARCH_HOST }}"
             - name: SEARCH_PORT
               value: "9200"
             - name: SEARCH_PATH


### PR DESCRIPTION
## Problem

The `reindex-elastic-search` CronJob template hardcodes the **production** Elasticsearch hostname, so the job cannot run in the dev cluster / cauldrons.

`helm-chart/sefaria/templates/cronjob/reindex-elasticsearch.yaml`:
```yaml
- name: SEARCH_HOST
  value: "elasticsearch-1b-es-http.elasticsearch.svc"   # prod-only name
```

That name doesn't resolve in dev. ES is healthy there — the services that actually exist in the dev `elasticsearch` namespace are:
```
elasticsearch-es-default   ClusterIP None         9200/TCP   (headless)
elasticsearch-es-http      ClusterIP 10.11.250.34 9200/TCP   (HTTP svc)
```
Reported by Steve while trying to run a reindex job for the `sk-squad-feature` cauldron (had to `sed` the host to work around it).

## Root cause

This was the **only** cronjob template hardcoding `SEARCH_HOST`. The sibling `index-from-queue.yaml` already templates it from `.Values.nginx.SEARCH_HOST`.

## Fix

Template `SEARCH_HOST` from `.Values.nginx.SEARCH_HOST`, matching `index-from-queue.yaml`.

- **prod** (`envs/prod/helmrelease.yaml`) and **preprod** (`build/ci/preprod-values.yaml`) override `nginx.SEARCH_HOST` to `elasticsearch-1b-es-http.elasticsearch.svc` → **behavior unchanged**.
- **dev / cauldrons** don't override it → inherit the chart default `elasticsearch-es-default.elasticsearch`, which resolves in dev.

Verified with `helm template`:
| values | rendered SEARCH_HOST |
|--------|----------------------|
| default (dev/cauldron) | `elasticsearch-es-default.elasticsearch` |
| prod/preprod override  | `elasticsearch-1b-es-http.elasticsearch.svc` |

Chart-level fix, not a per-cauldron patch.

## Notes
- `cronJobs.reindexElasticSearch.SEARCH_HOST_ES6/ES8` in `values.yaml` are dead config (referenced nowhere) — left for a follow-up cleanup.

Story: [sc-44754](https://app.shortcut.com/sefaria/story/44754)

🤖 Generated with [Claude Code](https://claude.com/claude-code)