### PR TITLE
fix: update ddtrace install script

### DIFF
--- a/build/web/Dockerfile
+++ b/build/web/Dockerfile
@@ -7,7 +7,7 @@ COPY requirements.txt /app/requirements.txt
 RUN pip install --trusted-host pypi.python.org -r requirements.txt
 
 # temp debugging binary for datadog investigation
-RUN curl https://dd-trace-py-builds.s3.amazonaws.com/116310691/install-manylinux2014_x86_64.sh | bash
+RUN curl https://dd-trace-py-builds.s3.amazonaws.com/117803795/install-manylinux2014_x86_64.sh | bash
 
 COPY package*.json /app/
 RUN npm install --unsafe-perm


### PR DESCRIPTION
Cherry-picks the ddtrace install script fix from #3398 onto a branch off `preprod` (the original PR targets `master`).

Single commit: `b0083792` — fix: update ddtrace install script (@BrendanGalloway).

🤖 Generated with [Claude Code](https://claude.com/claude-code)