### PR TITLE
chore: csrf first pass

### DIFF
--- a/static/js/BookPage.jsx
+++ b/static/js/BookPage.jsx
@@ -33,7 +33,7 @@ import Hebrew from './sefaria/hebrew.js';
 import ReactTags from 'react-tag-autocomplete';
 import ReaderDisplayOptionsMenu from "./ReaderDisplayOptionsMenu";
 import {DropdownMenu} from "./common/DropdownMenu";
-import Cookies from "js-cookie";
+import { getCsrfToken } from "./sefaria/csrf";
 
 
 
@@ -1295,7 +1295,7 @@ const EditTextInfo = function({initTitle, close}) {
     try {
       const request = new Request(
         `/api/terms/${collectiveTitle}`,
-        {headers: {'X-CSRFToken': Cookies.get('csrftoken')}}
+        {headers: {'X-CSRFToken': getCsrfToken()}}
       );
       const response = await fetch(request, {
         method: 'POST',

--- a/static/js/StaticPages.jsx
+++ b/static/js/StaticPages.jsx
@@ -13,7 +13,7 @@ import {
 import {NewsletterSignUpForm} from "./NewsletterSignUpForm";
 import palette from './sefaria/palette';
 import classNames from 'classnames';
-import Cookies from 'js-cookie';
+import { getCsrfToken } from './sefaria/csrf';
 import ReactMarkdown from 'react-markdown';
 import Sefaria from './sefaria/sefaria';
 import { OnInView, handleAnalyticsOnMarkdown } from './Misc';
@@ -2020,7 +2020,7 @@ const SubscribeButton = ({enAction, heAction, heLists, enLists, redirectURL}) =>
 
           const request = new Request(
               "/api/subscribe/" + email,
-              {headers: {'X-CSRFToken': Cookies.get('csrftoken')}}
+              {headers: {'X-CSRFToken': getCsrfToken()}}
           );
           fetch(request, {
               method: 'POST',

--- a/static/js/TopicEditor.jsx
+++ b/static/js/TopicEditor.jsx
@@ -4,7 +4,7 @@ import $ from "./sefaria/sefariaJquery";
 import {AdminEditor} from "./AdminEditor";
 import {Reorder} from "./CategoryEditor";
 import {ImageCropper} from "./ImageCropper";
-import Cookies from "js-cookie";
+import { getCsrfToken } from "./sefaria/csrf";
 import React, {useState, useRef} from "react";
 import Button from "./common/Button";
 
@@ -17,7 +17,7 @@ const uploadTopicImage = function(imageBlob, old_filename, topic_image_api) {
     }
     const request = new Request(
         `${Sefaria.apiHost}/${topic_image_api}`,
-        {headers: {'X-CSRFToken': Cookies.get('csrftoken')}}
+        {headers: {'X-CSRFToken': getCsrfToken()}}
     );
     return fetch(request, {
         method: 'POST',

--- a/static/js/lib/django-csrf.js
+++ b/static/js/lib/django-csrf.js
@@ -33,8 +33,18 @@ function init() {
             return (/^(GET|HEAD|OPTIONS|TRACE)$/.test(method));
         }
 
+        function getCsrfToken() {
+            // Prefer the server-rendered token over the cookie. A cauldron host
+            // inherits the parent-domain (.sefaria.org) csrftoken cookie alongside
+            // its own, and getCookie returns the first match while Django validates
+            // against the last — the meta tag always matches what Django validates.
+            var meta = document.querySelector('meta[name="csrf-token"]');
+            if (meta && meta.content) { return meta.content; }
+            return getCookie('csrftoken');
+        }
+
         if (!safeMethod(settings.type) && sameOrigin(settings.url)) {
-            xhr.setRequestHeader("X-CSRFToken", getCookie('csrftoken'));
+            xhr.setRequestHeader("X-CSRFToken", getCsrfToken());
         }
     });
 }

--- a/static/js/lib/django-csrf.js
+++ b/static/js/lib/django-csrf.js
@@ -1,22 +1,10 @@
 var $  = require('jquery');
+// Canonical CSRF token reader (meta tag first, cookie fallback). Shared with the
+// fetch()-based call sites so the dual-cookie fix lives in exactly one place.
+var getCsrfToken = require('../sefaria/csrf').getCsrfToken;
 
 function init() {
     $(document).ajaxSend(function(event, xhr, settings) {
-        function getCookie(name) {
-            var cookieValue = null;
-            if (document.cookie && document.cookie != '') {
-                var cookies = document.cookie.split(';');
-                for (var i = 0; i < cookies.length; i++) {
-                    var cookie = $.trim(cookies[i]);
-                    // Does this cookie string begin with the name we want?
-                    if (cookie.substring(0, name.length + 1) == (name + '=')) {
-                        cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
-                        break;
-                    }
-                }
-            }
-            return cookieValue;
-        }
         function sameOrigin(url) {
             // url could be relative or scheme relative or absolute
             var host = document.location.host; // host + port
@@ -31,16 +19,6 @@ function init() {
         }
         function safeMethod(method) {
             return (/^(GET|HEAD|OPTIONS|TRACE)$/.test(method));
-        }
-
-        function getCsrfToken() {
-            // Prefer the server-rendered token over the cookie. A cauldron host
-            // inherits the parent-domain (.sefaria.org) csrftoken cookie alongside
-            // its own, and getCookie returns the first match while Django validates
-            // against the last — the meta tag always matches what Django validates.
-            var meta = document.querySelector('meta[name="csrf-token"]');
-            if (meta && meta.content) { return meta.content; }
-            return getCookie('csrftoken');
         }
 
         if (!safeMethod(settings.type) && sameOrigin(settings.url)) {

--- a/static/js/lib/django-csrf.js
+++ b/static/js/lib/django-csrf.js
@@ -1,5 +1,5 @@
-var $  = require('jquery');
-var getCsrfToken = require('../sefaria/csrf').getCsrfToken;
+const $  = require('jquery');
+const getCsrfToken = require('../sefaria/csrf').getCsrfToken;
 
 function init() {
     $(document).ajaxSend(function(event, xhr, settings) {

--- a/static/js/lib/django-csrf.js
+++ b/static/js/lib/django-csrf.js
@@ -1,6 +1,4 @@
 var $  = require('jquery');
-// Canonical CSRF token reader (meta tag first, cookie fallback). Shared with the
-// fetch()-based call sites so the dual-cookie fix lives in exactly one place.
 var getCsrfToken = require('../sefaria/csrf').getCsrfToken;
 
 function init() {

--- a/static/js/modtools/components/BulkUploadCSV.jsx
+++ b/static/js/modtools/components/BulkUploadCSV.jsx
@@ -12,7 +12,7 @@
  * Backend endpoint: POST /api/text-upload
  */
 import React, { useState, useRef } from 'react';
-import Cookies from 'js-cookie';
+import { getCsrfToken } from '../../sefaria/csrf';
 import ModToolsSection from './shared/ModToolsSection';
 import { splitCsvByIndex } from '../utils';
 
@@ -121,7 +121,7 @@ const postJob = async (job) => {
 
   const response = await fetch('/api/text-upload', {
     method: 'POST',
-    headers: { 'X-CSRFToken': Cookies.get('csrftoken') },
+    headers: { 'X-CSRFToken': getCsrfToken() },
     credentials: 'same-origin',
     body: formData,
   });

--- a/static/js/modtools/components/RemoveLinksFromCsv.jsx
+++ b/static/js/modtools/components/RemoveLinksFromCsv.jsx
@@ -7,7 +7,7 @@
  * Backend endpoint: POST /modtools/links (with action=DELETE)
  */
 import React, { useState } from 'react';
-import Cookies from 'js-cookie';
+import { getCsrfToken } from '../../sefaria/csrf';
 import { saveAs } from 'file-saver';
 import ModToolsSection from './shared/ModToolsSection';
 import { stripHtmlTags } from '../utils';
@@ -105,7 +105,7 @@ const RemoveLinksFromCsv = () => {
     data.append('action', 'DELETE');
     const request = new Request(
       '/modtools/links',
-      { headers: { 'X-CSRFToken': Cookies.get('csrftoken') } }
+      { headers: { 'X-CSRFToken': getCsrfToken() } }
     );
     fetch(request, {
       method: 'POST',

--- a/static/js/modtools/components/UploadLinksFromCSV.jsx
+++ b/static/js/modtools/components/UploadLinksFromCSV.jsx
@@ -8,7 +8,7 @@
  */
 import React from 'react';
 import Component from 'react-class';
-import Cookies from 'js-cookie';
+import { getCsrfToken } from '../../sefaria/csrf';
 import { saveAs } from 'file-saver';
 import ModToolsSection from './shared/ModToolsSection';
 import { stripHtmlTags } from '../utils';
@@ -161,7 +161,7 @@ class UploadLinksFromCSV extends Component {
     const data = new FormData(event.target);
     const request = new Request(
       '/modtools/links',
-      { headers: { 'X-CSRFToken': Cookies.get('csrftoken') } }
+      { headers: { 'X-CSRFToken': getCsrfToken() } }
     );
     fetch(request, {
       method: 'POST',

--- a/static/js/modtools/components/WorkflowyModeratorTool.jsx
+++ b/static/js/modtools/components/WorkflowyModeratorTool.jsx
@@ -12,7 +12,7 @@
  */
 import React from 'react';
 import Component from 'react-class';
-import Cookies from 'js-cookie';
+import { getCsrfToken } from '../../sefaria/csrf';
 import { InterfaceText, EnglishText, HebrewText } from '../../Misc';
 import ModToolsSection from './shared/ModToolsSection';
 import { stripHtmlTags } from '../utils';
@@ -160,7 +160,7 @@ class WorkflowyModeratorTool extends Component {
     const data = new FormData(event.target);
     const request = new Request(
       '/modtools/upload_text',
-      { headers: { 'X-CSRFToken': Cookies.get('csrftoken') } }
+      { headers: { 'X-CSRFToken': getCsrfToken() } }
     );
 
     fetch(request, {

--- a/static/js/sefaria/csrf.js
+++ b/static/js/sefaria/csrf.js
@@ -1,20 +1,24 @@
-import Cookies from 'js-cookie';
-
 /**
  * Returns the CSRF token to send in the X-CSRFToken header.
  *
- * Prefers the server-rendered `<meta name="csrf-token">` value (see base.html)
- * over the `csrftoken` cookie. Reading the cookie directly is unreliable when
- * more than one `csrftoken` cookie reaches the browser. That happens on a
- * cauldron (`*.cauldron.sefaria.org`): it inherits the parent-domain
- * `.sefaria.org` cookie set by production in addition to its own host-scoped
- * cookie. js-cookie (and hand-rolled cookie parsers) return the *first* match,
- * while Django's parse_cookie() keeps the *last* — so the header and the token
- * Django validates against disagree, yielding a 403.
+ * Reads the server-rendered `<meta name="csrf-token">` value (see base.html;
+ * standalone pages such as edit_text.html render their own copy). We do NOT
+ * read the `csrftoken` cookie: it is unreliable when more than one `csrftoken`
+ * cookie reaches the browser. That happens on a cauldron
+ * (`*.cauldron.sefaria.org`): it inherits the parent-domain `.sefaria.org`
+ * cookie set by production in addition to its own host-scoped cookie. js-cookie
+ * (and hand-rolled cookie parsers) return the *first* match, while Django's
+ * parse_cookie() keeps the *last* — so the header and the token Django
+ * validates against disagree, yielding a 403.
  *
  * The meta tag is rendered from Django's own `{{ csrf_token }}`, which derives
  * from the same parsed value Django validates against, so the two always agree
  * regardless of how many duplicate cookies are present.
+ *
+ * There is intentionally no cookie fallback: every page that submits a token
+ * renders the meta tag, and falling back to the cookie would silently
+ * reintroduce the exact dual-cookie 403 this fix exists to prevent, on the
+ * pages hardest to diagnose. A missing meta tag fails loudly instead.
  */
 export function getCsrfToken() {
   if (typeof document !== 'undefined') {
@@ -23,6 +27,6 @@ export function getCsrfToken() {
       return meta.content;
     }
   }
-  // Fallback for any page that doesn't render the meta tag.
-  return Cookies.get('csrftoken');
+  console.warn('csrf-token meta tag missing — POST will likely 403. Add <meta name="csrf-token"> to this page.');
+  return '';
 }

--- a/static/js/sefaria/csrf.js
+++ b/static/js/sefaria/csrf.js
@@ -1,0 +1,28 @@
+import Cookies from 'js-cookie';
+
+/**
+ * Returns the CSRF token to send in the X-CSRFToken header.
+ *
+ * Prefers the server-rendered `<meta name="csrf-token">` value (see base.html)
+ * over the `csrftoken` cookie. Reading the cookie directly is unreliable when
+ * more than one `csrftoken` cookie reaches the browser. That happens on a
+ * cauldron (`*.cauldron.sefaria.org`): it inherits the parent-domain
+ * `.sefaria.org` cookie set by production in addition to its own host-scoped
+ * cookie. js-cookie (and hand-rolled cookie parsers) return the *first* match,
+ * while Django's parse_cookie() keeps the *last* — so the header and the token
+ * Django validates against disagree, yielding a 403.
+ *
+ * The meta tag is rendered from Django's own `{{ csrf_token }}`, which derives
+ * from the same parsed value Django validates against, so the two always agree
+ * regardless of how many duplicate cookies are present.
+ */
+export function getCsrfToken() {
+  if (typeof document !== 'undefined') {
+    const meta = document.querySelector('meta[name="csrf-token"]');
+    if (meta && meta.content) {
+      return meta.content;
+    }
+  }
+  // Fallback for any page that doesn't render the meta tag.
+  return Cookies.get('csrftoken');
+}

--- a/static/js/sefaria/sefaria.js
+++ b/static/js/sefaria/sefaria.js
@@ -9,7 +9,7 @@ import Track from './track';
 import Hebrew from './hebrew';
 import Util from './util';
 import $ from './sefariaJquery';
-import Cookies from 'js-cookie';
+import { getCsrfToken } from './csrf';
 import FilterNode from "./FilterNode";
 import { VOICES_MODULE, LIBRARY_MODULE } from '../constants';
 
@@ -956,7 +956,7 @@ Sefaria = extend(Sefaria, {
         method,
         mode: 'same-origin',
         headers: {
-            'X-CSRFToken': Cookies.get('csrftoken'),
+            'X-CSRFToken': getCsrfToken(),
             'Content-Type': 'application/json'
         },
         credentials: 'same-origin',

--- a/static/js/sefaria/tests/csrf.test.js
+++ b/static/js/sefaria/tests/csrf.test.js
@@ -1,6 +1,5 @@
 /* Testing done using Jest */
 import { getCsrfToken } from '../csrf';
-import Cookies from 'js-cookie';
 
 const META_SELECTOR = 'meta[name="csrf-token"]';
 
@@ -22,7 +21,7 @@ function removeMetaToken() {
 describe('getCsrfToken', () => {
   afterEach(() => {
     removeMetaToken();
-    Cookies.remove('csrftoken');
+    jest.restoreAllMocks();
   });
 
   it('returns the meta-tag token when present', () => {
@@ -30,23 +29,28 @@ describe('getCsrfToken', () => {
     expect(getCsrfToken()).toBe('META_TOKEN');
   });
 
-  it('prefers the meta-tag token over a conflicting cookie (the dual-cookie fix)', () => {
+  it('reads only the meta tag, never a conflicting cookie (the dual-cookie fix)', () => {
     // This is the core guarantee: when production's .sefaria.org csrftoken and a
     // cauldron's host-scoped csrftoken both reach the browser, we must NOT trust
     // the cookie. The meta tag (rendered from Django's {{ csrf_token }}) wins.
+    document.cookie = 'csrftoken=COOKIE_TOKEN';
     setMetaToken('META_TOKEN');
-    Cookies.set('csrftoken', 'COOKIE_TOKEN');
     expect(getCsrfToken()).toBe('META_TOKEN');
   });
 
-  it('falls back to the cookie when no meta tag is present', () => {
-    Cookies.set('csrftoken', 'COOKIE_TOKEN');
-    expect(getCsrfToken()).toBe('COOKIE_TOKEN');
+  it('returns "" and warns when no meta tag is present (no cookie fallback)', () => {
+    // A cookie fallback would silently reintroduce the dual-cookie 403, so a
+    // missing meta tag must fail loudly rather than read the cookie.
+    document.cookie = 'csrftoken=COOKIE_TOKEN';
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(getCsrfToken()).toBe('');
+    expect(warn).toHaveBeenCalled();
   });
 
-  it('falls back to the cookie when the meta tag is empty', () => {
+  it('returns "" and warns when the meta tag is empty', () => {
     setMetaToken('');
-    Cookies.set('csrftoken', 'COOKIE_TOKEN');
-    expect(getCsrfToken()).toBe('COOKIE_TOKEN');
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(getCsrfToken()).toBe('');
+    expect(warn).toHaveBeenCalled();
   });
 });

--- a/static/js/sefaria/tests/csrf.test.js
+++ b/static/js/sefaria/tests/csrf.test.js
@@ -1,0 +1,52 @@
+/* Testing done using Jest */
+import { getCsrfToken } from '../csrf';
+import Cookies from 'js-cookie';
+
+const META_SELECTOR = 'meta[name="csrf-token"]';
+
+function setMetaToken(value) {
+  let meta = document.querySelector(META_SELECTOR);
+  if (!meta) {
+    meta = document.createElement('meta');
+    meta.setAttribute('name', 'csrf-token');
+    document.head.appendChild(meta);
+  }
+  meta.setAttribute('content', value);
+}
+
+function removeMetaToken() {
+  const meta = document.querySelector(META_SELECTOR);
+  if (meta) { meta.remove(); }
+}
+
+describe('getCsrfToken', () => {
+  afterEach(() => {
+    removeMetaToken();
+    Cookies.remove('csrftoken');
+  });
+
+  it('returns the meta-tag token when present', () => {
+    setMetaToken('META_TOKEN');
+    expect(getCsrfToken()).toBe('META_TOKEN');
+  });
+
+  it('prefers the meta-tag token over a conflicting cookie (the dual-cookie fix)', () => {
+    // This is the core guarantee: when production's .sefaria.org csrftoken and a
+    // cauldron's host-scoped csrftoken both reach the browser, we must NOT trust
+    // the cookie. The meta tag (rendered from Django's {{ csrf_token }}) wins.
+    setMetaToken('META_TOKEN');
+    Cookies.set('csrftoken', 'COOKIE_TOKEN');
+    expect(getCsrfToken()).toBe('META_TOKEN');
+  });
+
+  it('falls back to the cookie when no meta tag is present', () => {
+    Cookies.set('csrftoken', 'COOKIE_TOKEN');
+    expect(getCsrfToken()).toBe('COOKIE_TOKEN');
+  });
+
+  it('falls back to the cookie when the meta tag is empty', () => {
+    setMetaToken('');
+    Cookies.set('csrftoken', 'COOKIE_TOKEN');
+    expect(getCsrfToken()).toBe('COOKIE_TOKEN');
+  });
+});

--- a/templates/base.html
+++ b/templates/base.html
@@ -9,10 +9,6 @@
 <head>
     {% block meta_title %}{% meta_title %}{{ title|striptags }}{% endmeta_title %}{% endblock %}
     <meta charset="utf-8"/>
-    {# Server-rendered CSRF token. Read this in JS rather than the csrftoken cookie: #}
-    {# when a parent-domain (.sefaria.org) cookie coexists with a host-scoped one (e.g. on #}
-    {# cauldrons), the cookie readers and Django can disagree on which token is valid → 403. #}
-    {# This value is exactly the token Django validates against. See sefaria/csrf.js. #}
     <meta name="csrf-token" content="{{ csrf_token }}"/>
     {% block meta_description %}{% meta_desc %}{{ desc|striptags }}{% endmeta_desc %}{% endblock %}
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -9,6 +9,11 @@
 <head>
     {% block meta_title %}{% meta_title %}{{ title|striptags }}{% endmeta_title %}{% endblock %}
     <meta charset="utf-8"/>
+    {# Server-rendered CSRF token. Read this in JS rather than the csrftoken cookie: #}
+    {# when a parent-domain (.sefaria.org) cookie coexists with a host-scoped one (e.g. on #}
+    {# cauldrons), the cookie readers and Django can disagree on which token is valid → 403. #}
+    {# This value is exactly the token Django validates against. See sefaria/csrf.js. #}
+    <meta name="csrf-token" content="{{ csrf_token }}"/>
     {% block meta_description %}{% meta_desc %}{{ desc|striptags }}{% endmeta_desc %}{% endblock %}
 
     {% if noindex or DEBUG %}

--- a/templates/edit_profile.html
+++ b/templates/edit_profile.html
@@ -149,7 +149,7 @@
 {% block js %}
 	<script src="{% static 'ckeditor/ckeditor.js' %}"></script>
 	<script src="{% static 'ckeditor/adapters/jquery.js' %}"></script>
-	<script src="{% static 'js/django-csrf.js' %}"></script>
+	<script>{% include "js/django-csrf.js" %}</script>
     <script>
 
 		CKEDITOR.config.font_names =

--- a/templates/edit_text.html
+++ b/templates/edit_text.html
@@ -7,6 +7,11 @@
 
 <head>
 
+	{# Server-rendered CSRF token — this page is standalone (does not extend base.html), #}
+	{# so it needs its own copy. Read in JS via sefaria/csrf.js / django-csrf.js rather than #}
+	{# the csrftoken cookie, which can be ambiguous when a parent-domain (.sefaria.org) #}
+	{# cookie coexists with a host-scoped one (e.g. on cauldrons). See base.html. #}
+	<meta name="csrf-token" content="{{ csrf_token }}"/>
 	<title>{{ page_title }} | Sefaria</title>
 	<meta name="description" content="{{ description_text }}... [{{ page_title }} {{ title_variants }}]">
 	<meta name="apple-mobile-web-app-capable" content="yes">

--- a/templates/edit_text.html
+++ b/templates/edit_text.html
@@ -8,9 +8,11 @@
 <head>
 
 	{# Server-rendered CSRF token — this page is standalone (does not extend base.html), #}
-	{# so it needs its own copy. Read in JS via sefaria/csrf.js / django-csrf.js rather than #}
-	{# the csrftoken cookie, which can be ambiguous when a parent-domain (.sefaria.org) #}
-	{# cookie coexists with a host-scoped one (e.g. on cauldrons). See base.html. #}
+	{# so it needs its own copy. The 'main' React bundle reads it at runtime via #}
+	{# sefaria/csrf.js rather than the csrftoken cookie, which can be ambiguous when a #}
+	{# parent-domain (.sefaria.org) cookie coexists with a host-scoped one (e.g. on #}
+	{# cauldrons). The inline jQuery AJAX hook (js/django-csrf.js) instead inlines #}
+	{# {{ csrf_token }} directly, since it is itself server-rendered. See base.html. #}
 	<meta name="csrf-token" content="{{ csrf_token }}"/>
 	<title>{{ page_title }} | Sefaria</title>
 	<meta name="description" content="{{ description_text }}... [{{ page_title }} {{ title_variants }}]">

--- a/templates/js/django-csrf.js
+++ b/templates/js/django-csrf.js
@@ -32,7 +32,17 @@ jQuery(document).ajaxSend(function(event, xhr, settings) {
         return (/^(GET|HEAD|OPTIONS|TRACE)$/.test(method));
     }
 
+    function getCsrfToken() {
+        // Prefer the server-rendered token over the cookie. A cauldron host
+        // inherits the parent-domain (.sefaria.org) csrftoken cookie alongside
+        // its own, and getCookie returns the first match while Django validates
+        // against the last — the meta tag always matches what Django validates.
+        var meta = document.querySelector('meta[name="csrf-token"]');
+        if (meta && meta.content) { return meta.content; }
+        return getCookie('csrftoken');
+    }
+
     if (!safeMethod(settings.type) && sameOrigin(settings.url)) {
-        xhr.setRequestHeader("X-CSRFToken", getCookie('csrftoken'));
+        xhr.setRequestHeader("X-CSRFToken", getCsrfToken());
     }
 });

--- a/templates/js/django-csrf.js
+++ b/templates/js/django-csrf.js
@@ -1,4 +1,11 @@
 // --- Django CSRF support for AJAX -----------
+//
+// NOTE: getCsrfToken() below is intentionally a standalone copy of
+// static/js/sefaria/csrf.js. This file is {% include %}'d inline into legacy
+// server-rendered pages that do NOT load the webpack bundle, so it cannot
+// import the shared helper. Keep the meta-tag-first logic here in sync with
+// sefaria/csrf.js. The bundled twin (static/js/lib/django-csrf.js) imports the
+// shared helper instead of duplicating it.
 
 jQuery(document).ajaxSend(function(event, xhr, settings) {
     function getCookie(name) {

--- a/templates/js/django-csrf.js
+++ b/templates/js/django-csrf.js
@@ -8,21 +8,6 @@
 // the shared helper instead of duplicating it.
 
 jQuery(document).ajaxSend(function(event, xhr, settings) {
-    function getCookie(name) {
-        var cookieValue = null;
-        if (document.cookie && document.cookie != '') {
-            var cookies = document.cookie.split(';');
-            for (var i = 0; i < cookies.length; i++) {
-                var cookie = jQuery.trim(cookies[i]);
-                // Does this cookie string begin with the name we want?
-                if (cookie.substring(0, name.length + 1) == (name + '=')) {
-                    cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
-                    break;
-                }
-            }
-        }
-        return cookieValue;
-    }
     function sameOrigin(url) {
         // url could be relative or scheme relative or absolute
         var host = document.location.host; // host + port
@@ -40,13 +25,16 @@ jQuery(document).ajaxSend(function(event, xhr, settings) {
     }
 
     function getCsrfToken() {
-        // Prefer the server-rendered token over the cookie. A cauldron host
+        // Read the server-rendered token, never the cookie. A cauldron host
         // inherits the parent-domain (.sefaria.org) csrftoken cookie alongside
-        // its own, and getCookie returns the first match while Django validates
-        // against the last — the meta tag always matches what Django validates.
+        // its own; a cookie read returns the first match while Django validates
+        // against the last, so the cookie can disagree with what Django expects
+        // (a 403). The meta tag always matches what Django validates. There is
+        // no cookie fallback by design — see static/js/sefaria/csrf.js.
         var meta = document.querySelector('meta[name="csrf-token"]');
         if (meta && meta.content) { return meta.content; }
-        return getCookie('csrftoken');
+        console.warn('csrf-token meta tag missing — POST will likely 403. Add <meta name="csrf-token"> to this page.');
+        return '';
     }
 
     if (!safeMethod(settings.type) && sameOrigin(settings.url)) {

--- a/templates/js/django-csrf.js
+++ b/templates/js/django-csrf.js
@@ -1,11 +1,11 @@
 // --- Django CSRF support for AJAX -----------
 //
 // NOTE: getCsrfToken() below is intentionally a standalone copy of
-// static/js/sefaria/csrf.js. This file is {% include %}'d inline into legacy
-// server-rendered pages that do NOT load the webpack bundle, so it cannot
-// import the shared helper. Keep the meta-tag-first logic here in sync with
-// sefaria/csrf.js. The bundled twin (static/js/lib/django-csrf.js) imports the
-// shared helper instead of duplicating it.
+// static/js/sefaria/csrf.js. This file is included inline (via Django's include
+// tag) into legacy server-rendered pages that do NOT load the webpack bundle, so
+// it cannot import the shared helper. Keep the meta-tag-first logic here in sync
+// with sefaria/csrf.js. The bundled twin (static/js/lib/django-csrf.js) imports
+// the shared helper instead of duplicating it.
 
 jQuery(document).ajaxSend(function(event, xhr, settings) {
     function getCookie(name) {

--- a/templates/js/django-csrf.js
+++ b/templates/js/django-csrf.js
@@ -1,11 +1,10 @@
 // --- Django CSRF support for AJAX -----------
 //
-// NOTE: getCsrfToken() below is intentionally a standalone copy of
-// static/js/sefaria/csrf.js. This file is included inline (via Django's include
-// tag) into legacy server-rendered pages that do NOT load the webpack bundle, so
-// it cannot import the shared helper. Keep the meta-tag-first logic here in sync
-// with sefaria/csrf.js. The bundled twin (static/js/lib/django-csrf.js) imports
-// the shared helper instead of duplicating it.
+// Included into server-rendered pages via `include`, so Django inlines
+// {{ csrf_token }} directly below. We use that value, never the csrftoken
+// cookie: on a cauldron the inherited .sefaria.org cookie can disagree with
+// what Django validates against, yielding a 403. Bundled React pages instead
+// use the runtime reader in static/js/sefaria/csrf.js.
 
 jQuery(document).ajaxSend(function(event, xhr, settings) {
     function sameOrigin(url) {
@@ -24,20 +23,7 @@ jQuery(document).ajaxSend(function(event, xhr, settings) {
         return (/^(GET|HEAD|OPTIONS|TRACE)$/.test(method));
     }
 
-    function getCsrfToken() {
-        // Read the server-rendered token, never the cookie. A cauldron host
-        // inherits the parent-domain (.sefaria.org) csrftoken cookie alongside
-        // its own; a cookie read returns the first match while Django validates
-        // against the last, so the cookie can disagree with what Django expects
-        // (a 403). The meta tag always matches what Django validates. There is
-        // no cookie fallback by design — see static/js/sefaria/csrf.js.
-        var meta = document.querySelector('meta[name="csrf-token"]');
-        if (meta && meta.content) { return meta.content; }
-        console.warn('csrf-token meta tag missing — POST will likely 403. Add <meta name="csrf-token"> to this page.');
-        return '';
-    }
-
     if (!safeMethod(settings.type) && sameOrigin(settings.url)) {
-        xhr.setRequestHeader("X-CSRFToken", getCsrfToken());
+        xhr.setRequestHeader("X-CSRFToken", "{{ csrf_token }}");
     }
 });


### PR DESCRIPTION
## Description
This fixes dual-csrftoken-cookie 403s on cauldrons.  When someone has visited both sefaria.org and a cauldron, their browser ends up holding two cookies both named `csrftoken`: one scoped to the parent .sefaria.org (from production) and one scoped to the cauldron host. Both get sent on every request. The bug is that our JavaScript and Django disagree on which one to use: js-cookie/our getCookie return the first match (the cauldron token), while Django's cookie parser keeps the last (the production token). So the X-CSRFToken header we send never matches the token Django validates against, producing a 403.

## Code Changes

This PR stops reading the token from the cookie and instead reads it from a value Django stamps into the page itself: a new <meta name="csrf-token" content="{{ csrf_token }}"> tag in base.html. That value is derived from the exact token Django will validate against, so the two can never disagree no matter how many duplicate cookies exist. A single new helper, getCsrfToken() (static/js/sefaria/csrf.js), reads the meta tag with a cookie fallback, and all ~8 previous direct cookie reads now route through it (sefaria.js, BookPage, TopicEditor, StaticPages, and the four modtools components). 

## Code Changes
- **`static/js/sefaria/csrf.js`** (new) — single `getCsrfToken()` helper that reads
  the meta tag. The ~8 previous scattered cookie reads (sefaria.js, BookPage,
  TopicEditor, StaticPages, and the four modtools components) now route through it.
- **`static/js/lib/django-csrf.js`** — the bundled jQuery `ajaxSend` hook. Kept (it
  auto-attaches the header to legacy jQuery POSTs) but no longer duplicates logic —
  it imports `getCsrfToken` from the shared helper.
- **`templates/js/django-csrf.js`** — the inline hook for server-rendered pages that
  don't load the webpack bundle. Because this file is itself a Django template
  (pulled in via `{% include %}`), it now inlines `{{ csrf_token }}` directly instead
  of carrying a hand-maintained copy of `getCsrfToken()`. This removes the last
  duplicate, leaving a single source of truth.
- **`templates/base.html`** / **`templates/edit_text.html`** — render the meta tag
  (edit_text.html is standalone and needs its own copy for the React bundle).
- **`templates/edit_profile.html`** — switched from `<script src="{% static
  'js/django-csrf.js' %}">` to `{% include %}`. This also fixes a pre-existing 404:
  the `static` path no longer exists (the file was moved to `lib/`), so the hook
  hadn't been loading on that page.
- **`static/js/sefaria/tests/csrf.test.js`** (new) — covers the meta-tag read and the
  no-cookie-fallback guarantee.

## Notes
This was only tested on two APIs, but in both cases, this PR works perfectly: the presence of the meta tag that holds the `csrf_token` was necessary for the APIs to work.