### PR TITLE
fix(ci): refresh GKE creds via auth provider so long pytest runs don't 401

### DIFF
--- a/.github/workflows/continuous.yaml
+++ b/.github/workflows/continuous.yaml
@@ -248,6 +248,7 @@ jobs:
           cluster_name: ${{secrets.DEV_GKE_CLUSTER}}
           location: ${{secrets.DEV_GKE_REGION}}
           project_id: ${{secrets.DEV_GCP_PROJECT}}
+          use_auth_provider: true
       - name: Deploy Sandbox
         run: ./build/ci/sandbox-helm-deploy.sh build/ci/sandbox-values.yaml
         env:
@@ -307,6 +308,7 @@ jobs:
           cluster_name: ${{secrets.DEV_GKE_CLUSTER}}
           location: ${{secrets.DEV_GKE_REGION}}
           project_id: ${{secrets.DEV_GCP_PROJECT}}
+          use_auth_provider: true
       - name: Set outputs
         id: get-sha
         run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
@@ -387,6 +389,7 @@ jobs:
           cluster_name: ${{secrets.DEV_GKE_CLUSTER}}
           location: ${{secrets.DEV_GKE_REGION}}
           project_id: ${{secrets.DEV_GCP_PROJECT}}
+          use_auth_provider: true
       - name: Set outputs
         id: get-sha
         run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Problem
The `Cleanup pyTest Pod` (and sometimes `Get Logs From Cluster`) step in the Continuous workflow intermittently fails with `couldn't get current server API group list: the server has asked for the client to provide credentials` → `You must be logged in to the server (Unauthorized)`.

## Root cause
`google-github-actions/auth@v2` mints a GCP access token with a default 1-hour lifetime. `get-gke-credentials` (without `use_auth_provider`) embeds that static token in the kubeconfig. The `Wait For Job To Finish` step allows up to 60 minutes, so on long runs the token expires before the trailing kubectl steps execute.

## Fix
Add `use_auth_provider: true` to the `get-gke-credentials` steps so the kubeconfig uses the `gke-gcloud-auth-plugin` exec provider and re-mints credentials per call instead of relying on a frozen token. Applied to `pytest-job` (the affected job) plus `sandbox-deploy` and `sandbox-cleanup` for consistency.

Story: sc-44850

🤖 Generated with [Claude Code](https://claude.com/claude-code)