### PR TITLE
Fix English header on Sheets-with-Ref view in Chiburim

### DIFF
--- a/static/js/ReaderPanel.jsx
+++ b/static/js/ReaderPanel.jsx
@@ -890,7 +890,7 @@ class ReaderPanel extends Component {
                     initialWidth={this.state.width}
                     toggleSignUpModal={this.props.toggleSignUpModal} />);
     } else if (this.state.menuOpen === "sheetsWithRef") {
-      menu = (<SheetsWithRefPage srefs={this.state.sheetsWithRef.en}
+      menu = (<SheetsWithRefPage srefs={this.state.sheetsWithRef}
                                  searchState={this.state['searchState']}
                                  updateSearchState={this.props.updateSearchState}
                                  updateAppliedFilter={this.props.updateSearchFilter}

--- a/static/js/sefaria/strings.js
+++ b/static/js/sefaria/strings.js
@@ -27,6 +27,7 @@ const Strings = {
     "Texts & Source Sheets from Torah, Talmud and Sefaria's library of Jewish sources.": "טקסטים ודפי מקורות מן התורה, התלמוד וספריית המקורות של ספריא.",
     "Moderator Tools": "כלי מנהלים",
     " with " : " עם ",
+    "Sheets With": "דפי מקורות עם",
     "Connections" : "קשרים",
     " & ": " | ",
     "My Source Sheets" : "דפי המקורות שלי",

--- a/static/js/sheets/SheetsWithRefPage.jsx
+++ b/static/js/sheets/SheetsWithRefPage.jsx
@@ -16,7 +16,9 @@ const SheetsWithRefPage = ({srefs, searchState, updateSearchState, updateApplied
     // we can return the searchState's available filters to the original list.  Once origAvailableFilters are loaded,
     // they are never changed.
 
-    const [refs, setRefs] = useState(srefs);
+    const [refs, setRefs] = useState(srefs.en);
+    const shortLang = Sefaria._getShortInterfaceLang();
+    const displayRef = srefs[shortLang] || srefs.en;
     const sortTypeArray = SearchState.metadataByType['sheet'].sortTypeArray;
 
     const cloneFilters = (availableFilters, resetDocCounts = true) => {
@@ -195,7 +197,7 @@ const SheetsWithRefPage = ({srefs, searchState, updateSearchState, updateApplied
           sortTypeArray={sortTypeArray}
           searchTopMsg="Sheets With"
           hits={sortedSheets}
-          query={refs}
+          query={displayRef}
           type={'sheet'}
           totalResults={new SearchTotal({value: sortedSheets.length})}
           compare={false}

--- a/static/js/sheets/SheetsWithRefPage.jsx
+++ b/static/js/sheets/SheetsWithRefPage.jsx
@@ -16,7 +16,7 @@ const SheetsWithRefPage = ({srefs, searchState, updateSearchState, updateApplied
     // we can return the searchState's available filters to the original list.  Once origAvailableFilters are loaded,
     // they are never changed.
 
-    const [refs, setRefs] = useState(srefs.en);
+    const enRefs = srefs.en;
     const shortLang = Sefaria._getShortInterfaceLang();
     const displayRef = srefs[shortLang] || srefs.en;
     const sortTypeArray = SearchState.metadataByType['sheet'].sortTypeArray;
@@ -173,8 +173,8 @@ const SheetsWithRefPage = ({srefs, searchState, updateSearchState, updateApplied
     }
 
     useEffect(() => {
-      Sefaria.sheets.getSheetsByRef(refs, makeSheetsUnique).then(sheets => {handleSheetsLoad(sheets);})
-    }, [refs]);
+      Sefaria.sheets.getSheetsByRef(enRefs, makeSheetsUnique).then(sheets => {handleSheetsLoad(sheets);})
+    }, [enRefs]);
 
     useEffect(() => { // when component unmounts, reset searchState
         return () => resetSearchFilters();
@@ -187,7 +187,7 @@ const SheetsWithRefPage = ({srefs, searchState, updateSearchState, updateApplied
     sortedSheets = normalizeSheetsMetaData(sortedSheets);
     const handleSheetResultClick = (sheetRef) => {
         const sheetId = parseInt(sheetRef.replace("Sheet ", ""), 10);
-        onResultClick(sheetId, null, refs);
+        onResultClick(sheetId, null, enRefs);
     };
     const aiBadgeText = searchState?.sortType?.toLowerCase?.() === 'relevance'
         ? 'These sheet results are ranked by AI relevance.' : undefined;

--- a/static/js/sheets/SheetsWithRefPage.jsx
+++ b/static/js/sheets/SheetsWithRefPage.jsx
@@ -18,7 +18,7 @@ const SheetsWithRefPage = ({srefs, searchState, updateSearchState, updateApplied
 
     const enRefs = srefs.en;
     const shortLang = Sefaria._getShortInterfaceLang();
-    const displayRef = srefs[shortLang] || srefs.en;
+    const displayRef = srefs[shortLang] || enRefs;
     const sortTypeArray = SearchState.metadataByType['sheet'].sortTypeArray;
 
     const cloneFilters = (availableFilters, resetDocCounts = true) => {

--- a/static/js/sheets/SheetsWithRefPage.jsx
+++ b/static/js/sheets/SheetsWithRefPage.jsx
@@ -17,8 +17,7 @@ const SheetsWithRefPage = ({srefs, searchState, updateSearchState, updateApplied
     // they are never changed.
 
     const enRefs = srefs.en;
-    const shortLang = Sefaria._getShortInterfaceLang();
-    const displayRef = srefs[shortLang] || enRefs;
+    const displayRef = Sefaria._v(srefs) || enRefs;
     const sortTypeArray = SearchState.metadataByType['sheet'].sortTypeArray;
 
     const cloneFilters = (availableFilters, resetDocCounts = true) => {


### PR DESCRIPTION
# Overview

## Description
This PR fixes a big where uses in the library (Hebrew interface) select a text, then click on "דפי מקורות" in the sidebar, and when they arrive at chiburim.sefaria.org.il, the title for the page is in English (see the visuals below). 

There were two issues:
1. No translation in Strings.s for `Sheets with`
2. Only passing the English ref, versus passing the Hebrew ref as well

## Code Changes
1. `static/js/ReaderPanel.jsx` - Passes the entire ref object (with Hebrew and English) as props, instead of just English. 
2. `static/js/sefaria/strings.js` - Add Hebrew copy
3. `static/js/sheets/SheetsWithRefPage.jsx` - Parsing out the ref prop passed to separate out the Hebrew and English, and pass them through as needed. 

# Visually

## Before
<img width="1418" height="605" alt="Screenshot 2026-06-17 at 10 36 52" src="https://github.com/user-attachments/assets/d6f59b09-65c7-4fb1-b8f7-adaf223966e5" />

## After
<img width="1393" height="592" alt="Screenshot 2026-06-17 at 10 36 11" src="https://github.com/user-attachments/assets/f65a6eab-78bb-449e-9c58-3aca7d41f7cc" />
