### PR TITLE
fix(library): graceful degradation on Index title/root-key mismatch

### DIFF
--- a/sefaria/model/text.py
+++ b/sefaria/model/text.py
@@ -4433,6 +4433,10 @@ class Library(object):
         self._index_title_maps = {lang:{} for lang in self.langs}
 
         for tree in forest:
+            if tree.key not in self._index_map:
+                logger.error(
+                    "Index inconsistency: root node key %r has no matching Index.title; "
+                    "this record will be omitted from all_index_records", tree.key)
             try:
                 for lang in self.langs:
                     tree_titles = tree.title_dict(lang)
@@ -4958,7 +4962,14 @@ class Library(object):
         return root_nodes
 
     def all_index_records(self):
-        return [self._index_map[k] for k in list(self._index_title_maps["en"].keys())]
+        title_keys = list(self._index_title_maps["en"].keys())
+        missing = [k for k in title_keys if k not in self._index_map]
+        if missing:
+            logger.error(
+                "all_index_records: %d index(es) present in title map but missing from index map "
+                "(likely a partial title rename where Index.title != root node key): %s",
+                len(missing), missing)
+        return [self._index_map[k] for k in title_keys if k in self._index_map]
 
     def get_title_node_dict(self, lang="en"):
         """


### PR DESCRIPTION
## Symptom

On production, `init_library_cache()` — called at gunicorn `on_starting` — crashed every worker at boot with a `KeyError` in `all_index_records()`. The result was a total site outage: no worker could start.

## Root cause

`Library._build_index_maps()` builds two dicts keyed differently:

- `_index_map` — keyed by `Index.title`
- `_index_title_maps["en"]` — keyed by the root schema node `.key`

A partially-applied Index title rename left a record where `Index.title != root node key`. `all_index_records()` iterated over the title-map keys and looked them up in `_index_map`, so the mismatched key raised `KeyError` — before any request was ever served.

## What this PR changes

**`all_index_records()`** — instead of a one-liner that throws on mismatch, it now:
1. Collects all title-map keys.
2. Logs an `ERROR` naming every key that is present in the title map but absent from the index map.
3. Returns only the records that are present in both maps (skipping the bad one), so the cache build completes and the site stays up.

**`_build_index_maps()` / `for tree in forest:` loop** — adds a guard at the top of each iteration that logs an `ERROR` the moment a root node key has no matching `Index.title`, making the inconsistency visible at build time rather than only at read time.

`logger` is already imported/defined in `text.py`; no new imports needed.

## Scope

This PR is the **availability fix only** — it makes the site survive a bad record rather than hard-crashing.

- The underlying data repair for the affected book (aligning `Index.title` with its root node key) is handled separately.
- The front-end title-rename editor flow that allowed this mismatch to occur is also tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)