### PR TITLE
fix(library): skip Index records missing from index map (prod hotfix)

### DIFF
--- a/sefaria/model/text.py
+++ b/sefaria/model/text.py
@@ -5804,7 +5804,7 @@ class Library(object):
         """
         Returns an array of all index records
         """
-        return [self._index_map[k] for k in list(self._index_title_maps["en"].keys())]
+        return [self._index_map[k] for k in list(self._index_title_maps["en"].keys()) if k in self._index_map]
 
     def get_title_node_dict(self, lang="en"):
         """


### PR DESCRIPTION
## Symptom
A single malformed Index record takes the **entire site down at boot**. `init_library_cache()` (gunicorn `on_starting`) calls `library.get_toc_tree()` → `all_index_records()`, which throws `KeyError` and kills every worker.

## Root cause
A partially-applied Index **title rename** left a record whose root schema node `key` differs from its `title`. `all_index_records()` iterates `_index_title_maps["en"]` (keyed by root node `key`) but looks each up in `_index_map` (keyed by `Index.title`) — the mismatch raises `KeyError`.

## Change
One line: skip keys absent from `_index_map` instead of throwing. Availability-only fix — the data repair for the affected book and the front-end title-editor root cause are handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)