### PR TITLE
chore: fix spelling mistake

### DIFF
--- a/static/js/Editor.jsx
+++ b/static/js/Editor.jsx
@@ -1338,7 +1338,7 @@ const Element = (props) => {
 
             const pClasses = {center: element["text-align"] == "center" };
             return (
-                <div role="button" ontentEditable suppressContentEditableWarning
+                <div role="button" contentEditable suppressContentEditableWarning
                      aria-label={"Add new line"} data-trigger="true" className={classNames(addNewLineClasses)}
                      onClick={(event) => handleClick(event, editor)}
                 >


### PR DESCRIPTION
## Description
Fixes spelling mistake "ontentEditable" => "contentEditable"