### PR TITLE
Spelling mistake content editable

### DIFF
--- a/static/js/Editor.jsx
+++ b/static/js/Editor.jsx
@@ -1338,7 +1338,7 @@ const Element = (props) => {
 
             const pClasses = {center: element["text-align"] == "center" };
             return (
-                <div role="button" contentEditable suppressContentEditableWarning
+                <div role="button"
                      aria-label={"Add new line"} data-trigger="true" className={classNames(addNewLineClasses)}
                      onClick={(event) => handleClick(event, editor)}
                 >

--- a/static/js/Editor.jsx
+++ b/static/js/Editor.jsx
@@ -1338,7 +1338,7 @@ const Element = (props) => {
 
             const pClasses = {center: element["text-align"] == "center" };
             return (
-                <div role="button" ontentEditable suppressContentEditableWarning
+                <div role="button" contentEditable suppressContentEditableWarning
                      aria-label={"Add new line"} data-trigger="true" className={classNames(addNewLineClasses)}
                      onClick={(event) => handleClick(event, editor)}
                 >


### PR DESCRIPTION
## Description
Removes "contentEditable" entirely.

## Why explicit contentEditable breaks editing
Slate's <Editable> component renders one contentEditable={true} root, and the entire editing model assumes a single editing host. Slate maps browser DOM selections ↔ Slate paths (toSlatePoint / toSlateRange) under that assumption.

When I put contentEditable={true} on the outer wrapper, per the HTML spec that element becomes its own nested editing host. Then we would have an editing host (the wrapper) that:

Slate does not recognize as a node (no {...attributes}), and
creates a boundary the browser can root a selection in.
So when you click/type, the browser may place the caret in this nested host, but Slate can't resolve that DOM position to any node in its model → it can't translate input events into Slate operations → the model never updates → it looks non-editable. That's also exactly why React warns about contentEditable on an element with managed children (the warning you were suppressing with suppressContentEditableWarning).