### PR TITLE
Fix OpenAPI pipeline to sync with prod, not master

### DIFF
--- a/.github/workflows/readme-openapi-docs-sync.yml
+++ b/.github/workflows/readme-openapi-docs-sync.yml
@@ -8,7 +8,7 @@ on:
       # This workflow will run every time you push code to the following branch: `master`
       # Check out GitHub's docs for more info on configuring this:
       # https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
-      - master
+      - prod
     paths:
       - 'docs/openAPI.json'
 


### PR DESCRIPTION
## Description
This PR adjusts the ReadMe pipeline to push the docs to the ReadMe site on pushes to `prod`, not `master` in order to align with our branch-based deployment. 