### PR TITLE
Fix 404 bug on sheets

### DIFF
--- a/static/js/sefaria/sefaria.js
+++ b/static/js/sefaria/sefaria.js
@@ -2833,9 +2833,10 @@ _media: {},
     } else {
       // we need to get the heRef for each history item
       Promise.all(history_item_array.filter(x=>!x.secondary).map(h => new Promise((resolve, reject) => {
+        if (Sefaria.isSheetRef(h.ref)) { resolve(h); return; }   // sheet: keep without a bad API call
         Sefaria.getRef(h.ref).then(oref => {
-          h.he_ref = oref.heRef;
-          resolve(h);
+            h.he_ref = oref.heRef;
+            resolve(h);
         });
       }))).then(new_hist_array => {
         const cookie = Sefaria._inBrowser ? $.cookie : Sefaria.util.cookie;


### PR DESCRIPTION
## Description
We have a bug when when viewing a source sheet in Voices, the texts API was being called and 404'ing because Sheet IDs (i.e. `123456`) were being passed in as refs. 

## Code Changes
`static/js/sefaria/sefaria.js` - Adds a check in the `saveUserHistory` function if a ref is a sheet ID before calling the texts API, returns the sheet ID without the call for the sake of preserving history. 