### PR TITLE
chore: bound hanging pytest test in Continuous PyTest CI job [sc-45322]

### DIFF
--- a/.github/workflows/continuous.yaml
+++ b/.github/workflows/continuous.yaml
@@ -329,11 +329,12 @@ jobs:
           DEPLOY_ENV: sandbox-${{ steps.get-sha.outputs.sha_short }}
       - name: Wait For Job To Finish
         run: ./build/ci/waitForCIJob.bash
-        timeout-minutes: 60
+        timeout-minutes: 30
         env:
           # dependent on GITHUB_RUN_ID, which is implicitly passed in
           TEST_NAME: pytest
       - name: Get Logs From Cluster and propogate test result
+        if: always()
         run: "kubectl logs --tail=-1 -l ci-run=$GITHUB_RUN_ID,test-name=pytest; LASTLINE=`kubectl logs --tail=1 -l ci-run=$GITHUB_RUN_ID,test-name=pytest`; STAT=${LASTLINE: -1}; exit $STAT"
       - name: Cleanup pyTest Pod
         run: kubectl delete jobs -l ci-run=$GITHUB_RUN_ID,test-name=pytest

--- a/build/ci/createJobFromRollout.sh
+++ b/build/ci/createJobFromRollout.sh
@@ -24,7 +24,8 @@ EOF
 kubectl get rollout $DEPLOY_ENV-web -o yaml | yq '.spec.template.spec' > spec.yaml
 yq -i '.spec.template.spec += load("spec.yaml")' job.yaml
 yq -i '.spec.template.spec.restartPolicy = "Never"' job.yaml
-yq -i '.spec.template.spec.containers[0].args = ["-c", "pip3 install pytest-django; pytest -v -m \"not deep and not failing\" ./sefaria; echo $? > /dev/stdout; exit 0;"]' job.yaml
+yq -i '.spec.activeDeadlineSeconds = 1200' job.yaml
+yq -i '.spec.template.spec.containers[0].args = ["-c", "pip3 install pytest-django pytest-timeout; pytest -v --timeout=120 -m \"not deep and not failing\" ./sefaria; echo $? > /dev/stdout; exit 0;"]' job.yaml
 yq -i 'del(.spec.template.spec.containers[0].startupProbe)' job.yaml
 yq -i 'del(.spec.template.spec.containers[0].livenessProbe)' job.yaml
 yq -i 'del(.spec.template.spec.containers[0].readinessProbe)' job.yaml

--- a/build/ci/waitForCIJob.bash
+++ b/build/ci/waitForCIJob.bash
@@ -7,12 +7,27 @@ echo "GitHub Run ID $GITHUB_RUN_ID"
 
 #timeout ${WAIT_DURATION:-900} bash -c "while [[ $(kubectl get job -l ci-run=$GITHUB_RUN_ID,test-name=${TEST_NAME:-pytest} -o json | jq -r '.items[0].status.succeeded') != 1 ]]; do sleep 5; done"
 
-while [[ $(kubectl get job -l ci-run=$GITHUB_RUN_ID,test-name=${TEST_NAME:-pytest} -o json | jq -r '.items[0].status.succeeded') != 1 ]]
-do 
+while true
+do
+    # Tolerate transient kubectl/API errors without aborting the whole wait (set -e is on).
+    JOB_JSON=$(kubectl get job -l ci-run=$GITHUB_RUN_ID,test-name=${TEST_NAME:-pytest} -o json 2>/dev/null || true)
+    SUCCEEDED=$(echo "$JOB_JSON" | jq -r '.items[0].status.succeeded' 2>/dev/null || true)
+    FAILED_COND=$(echo "$JOB_JSON" | jq -r '.items[0].status.conditions[]? | select(.type=="Failed") | .type' 2>/dev/null || true)
+    if [[ "$SUCCEEDED" == "1" ]]; then
+        echo "Job succeeded"
+        break
+    fi
+    if [[ "$FAILED_COND" == "Failed" ]]; then
+        # Terminal failure (BackoffLimitExceeded / DeadlineExceeded): the pod was hard-killed
+        # and never printed its pytest status digit, so the downstream last-log-line check is
+        # unreliable. Fail this step explicitly; the "Get Logs" step (if: always()) still dumps logs.
+        echo "Job reached terminal Failed condition; failing the wait step"
+        exit 1
+    fi
     kubectl get job -l ci-run=$GITHUB_RUN_ID,test-name=${TEST_NAME:-pytest}
     kubectl get pod -l ci-run=$GITHUB_RUN_ID,test-name=${TEST_NAME:-pytest} || true
     kubectl logs -l ci-run=$GITHUB_RUN_ID,test-name=${TEST_NAME:-pytest} --tail 10 || true
-    sleep 30; 
+    sleep 30
 done
 
 echo "Job is complete"

--- a/requirements.txt
+++ b/requirements.txt
@@ -271,6 +271,8 @@ pytest~=7.4.4
     #   pytest-django
 pytest-django==4.9.0
     # via -r ./requirements.txt
+pytest-timeout==2.3.1
+    # via -r ./requirements.txt
 python-bidi==0.6.3
     # via -r ./requirements.txt
 python-dateutil==2.9.0.post0


### PR DESCRIPTION
## Problem

The **Continuous Testing: PyTest** job (`pytest-job` in `.github/workflows/continuous.yaml`) intermittently consumes its full 60-minute step timeout and blocks the merge queue. Tests run as a Kubernetes Job in a GKE dev sandbox (`createJobFromRollout.sh` → `pytest -v -m "not deep and not failing" ./sefaria`, single process), polled by `waitForCIJob.bash`.

Normal runs finish in ~5–8 min. The hang is branch-specific (e.g. run `28376042550`): pytest streams to ~7% then a single test hangs indefinitely, and nothing bounds it — so the GitHub step burns 60 min at ~7% completion.

Structural gaps (confirmed): no `pytest-timeout` (no per-test kill), no `activeDeadlineSeconds` on the Job (unbounded pod), `waitForCIJob.bash` only exited on `succeeded==1` (polled to the GHA timeout on any non-success), and the diagnostic log step was skipped on timeout (never showed *which* test hung).

## Fix

- **`pytest-timeout==2.3.1`** in `requirements.txt` + the job's inline `pip install`; `pytest --timeout=120` (default signal method) kills a hung test after 2 min, prints its traceback, and continues the suite.
- **`activeDeadlineSeconds: 1200`** (20 min) on the Job — hard backstop for hangs outside pytest (boot/Mongo-connect/signal-resistant).
- **`waitForCIJob.bash`** breaks on `succeeded==1` and **`exit 1`s on a terminal `Failed` condition** (BackoffLimitExceeded/DeadlineExceeded) so a crashed/deadline-killed job fails the step promptly. Hardened against transient `kubectl` errors under `set -e`.
- **`continuous.yaml`**: `Get Logs From Cluster` → `if: always()` (logs always captured); wait `timeout-minutes` 60 → 30.

Net: a hung test now fails in **~2 minutes with a traceback naming the test**, instead of a silent 60-min wall.

## Review note

Code review caught a self-introduced regression in an earlier cut: breaking out of the wait loop on a Failed condition let a terminally-failed job report **green** via the brittle `STAT=${LASTLINE: -1}` last-char check. Fixed with `exit 1` on terminal failure.

## Follow-ups (not in this PR)

`pytest-xdist -n auto` parallelism (needs parallel-safety check given the shared `dev-mongo` concurrency group), `--durations` to catch creeping slowness, splitting fast unit tests onto the GHA runner.

Story: sc-45322

🤖 Generated with [Claude Code](https://claude.com/claude-code)