### PR TITLE
hotfix(sefaria): guard visitor-storage helpers against SSR [sc-45324]

### DIFF
--- a/static/js/sefaria/sefaria.js
+++ b/static/js/sefaria/sefaria.js
@@ -2860,6 +2860,7 @@ _media: {},
     Sefaria.last_place = history_item_array.filter(x=>!x.secondary).concat(Sefaria.last_place);  // while technically we should remove dup. books, this list is only used on client
   },
     isNewVisitor: () => {
+        if (!Sefaria._inBrowser) { return true; }
         return (
             ("isNewVisitor" in sessionStorage &&
                 JSON.parse(sessionStorage.getItem("isNewVisitor"))) ||
@@ -2867,6 +2868,7 @@ _media: {},
         );
     },
     isReturningVisitor: () => {
+        if (!Sefaria._inBrowser) { return false; }
         return (
             !Sefaria.isNewVisitor() &&
             "isReturningVisitor" in localStorage &&
@@ -2874,13 +2876,15 @@ _media: {},
         );
     },
     markUserAsNewVisitor: () => {
+        if (!Sefaria._inBrowser) { return; }
         sessionStorage.setItem("isNewVisitor", "true");
         // Setting this at this time will make the current new visitor a returning one once their session is cleared
         localStorage.setItem("isReturningVisitor", "true");
     },
     markUserAsReturningVisitor: () => {
-      sessionStorage.setItem("isNewVisitor", "false");
-      localStorage.setItem("isReturningVisitor", "true");
+        if (!Sefaria._inBrowser) { return; }
+        sessionStorage.setItem("isNewVisitor", "false");
+        localStorage.setItem("isReturningVisitor", "true");
     },
   uploadProfilePhoto: (formData) => {
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
## Hotfix → preprod

Stops the production flood of the GCP **"Node Error Count Exceeded"** CRITICAL alert (firing ~every 10 min, `@here`, since ~5am 2026-06-30).

### Problem
`sessionStorage` / `localStorage` (browser-only) were being referenced during **server-side rendering**. `SiteWideBanner.jsx:263` (`ChatbotExperimentBanner`) calls `Sefaria.isReturningVisitor()` → `isNewVisitor()` → `sessionStorage` in its **synchronous render body** for every logged-out page render, throwing:

```
ReferenceError: sessionStorage is not defined
  at Object.isNewVisitor        static/js/sefaria/sefaria.js:2864
  at Object.isReturningVisitor  static/js/sefaria/sefaria.js:2871
  at II                         static/js/SiteWideBanner.jsx:263
  at ReactDOMServerRenderer ... renderToString  server.js:93
```

100% of the Node container's `severity=ERROR` log entries (last hour sampled in prod) were this single stack. GKE tags Node stderr as `severity=ERROR`, which feeds the `node_error_counter` log-based metric; the 5-min rate crossed the alert's `>1/sec` threshold ~Jun 29 as logged-out SSR banner traffic grew. The offending call site was added 2026-05-13 by **sc-43951** ("Deploy change to LA promo targeting logic on 17/5", PR #3293, commit `83c43e99f`) — it put the browser-only `sessionStorage` read onto the server-rendered, logged-out banner path.

### Fix
Guard the four visitor-storage helpers in `sefaria.js` (`isNewVisitor`, `isReturningVisitor`, `markUserAsNewVisitor`, `markUserAsReturningVisitor`) with the existing `Sefaria._inBrowser` convention (`typeof document !== "undefined"`). On the server they return safe defaults (new visitor / not returning / no-op writes) instead of throwing. **Browser behavior is unchanged.** 6-line diff.

### Review
High-effort review (parallel finders + cross-file caller trace) → **approved**, no blockers:
- Only one SSR-reachable call site (`SiteWideBanner.jsx:263`); `ReaderApp.jsx`, `Misc.jsx` ×2, `base.html` are all client-only.
- Returning + logged-out visitors get the banner inserted on the client rather than in SSR HTML when the experiment is enabled — a minor pop-in, and strictly better than the prior behavior (the `ReferenceError` crashed the **entire** `renderToString`, not just the banner). A localStorage-gated banner can't be server-rendered; render-on-mount is the correct pattern.

### Follow-up (separate, optional)
Make the `node_error_counter` metric content-specific (match real error patterns instead of all stderr) so routine Node stderr can't page `@here` CRITICAL.

Story: sc-45324 (fix) · sc-43951 (root cause)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
