### PR TITLE
fix(test): guard optional patot import so pytest collection doesn't abort

### DIFF
--- a/sefaria/helper/vector/embed_library_to_pgvector.py
+++ b/sefaria/helper/vector/embed_library_to_pgvector.py
@@ -48,9 +48,16 @@ if os.environ.get("TQDM_DISABLE"):
     _tqdm_module.tqdm.__init__ = _patched_tqdm_init
     _tqdm_auto_module.tqdm.__init__ = _patched_tqdm_init
 
-from patot import ChunkerConfig, PatotChunker
-from patot.records import SegmentRecord
-from patot.analytics import ChunkingRuntimeAnalytics
+# patot is an optional dependency, only present in the embedding job image (not the
+# web/test image). Guard the import so this module can be imported (and its pure helpers
+# tested) without patot installed; the `if PatotChunker is None` check in main() handles
+# the runtime case.
+try:
+    from patot import ChunkerConfig, PatotChunker
+    from patot.records import SegmentRecord
+    from patot.analytics import ChunkingRuntimeAnalytics
+except ModuleNotFoundError:
+    ChunkerConfig = PatotChunker = SegmentRecord = ChunkingRuntimeAnalytics = None
 
 _slugify = lambda text: re.sub(r"[^A-Za-z0-9]+", "_", text).strip("_").lower()
 


### PR DESCRIPTION
## Problem — master pytest is red for every PR

As of `6d9f03cdc` / `34b92613e` (merged this morning, #3454/#3460), the **Continuous Testing: PyTest** job fails at **collection** for all PRs:

```
ERROR sefaria/helper/tests/embed_library_to_pgvector_test.py
  sefaria/helper/vector/embed_library_to_pgvector.py:51: from patot import ChunkerConfig, PatotChunker
E   ModuleNotFoundError: No module named 'patot'
!!!! Interrupted: 1 error during collection !!!!
exit code 2
```

`embed_library_to_pgvector.py` imports `patot` at **module top-level**, but `patot` lives only in the embedding-job image — it's not in `requirements.txt` or the web/test image. `embed_library_to_pgvector_test.py` imports that module, so pytest hits the import during collection, and **a single collection error aborts the entire run** → 0 tests execute for every PR.

(Surfaced cleanly thanks to the new pytest timeout guardrails in #3455 — the job now fails fast in ~45s with a clear traceback instead of hanging.)

## Fix

The module **already** has `if PatotChunker is None:` in `main()` (with the message "See requirements.txt for the patot dependency") — patot was clearly meant to be optional; only the import wasn't guarded. Wrap it:

```python
try:
    from patot import ChunkerConfig, PatotChunker
    from patot.records import SegmentRecord
    from patot.analytics import ChunkingRuntimeAnalytics
except ModuleNotFoundError:
    ChunkerConfig = PatotChunker = SegmentRecord = ChunkingRuntimeAnalytics = None
```

Now the module imports without patot (collection succeeds, pure-helper tests run), and the existing `None` guard handles the runtime path. **No behavior change when patot is installed.**

## Verification

- `python3 -m py_compile sefaria/helper/vector/embed_library_to_pgvector.py` passes.
- This was the only `*_test.py`-reachable top-level `patot` import.

## Note

`sefaria/helper/vector/debug_single_ref.py` has the same unguarded top-level `patot` import, but it's a debug script not imported by any test, so it doesn't affect collection — left out to keep this surgical. Worth the same guard in a follow-up.

cc @nsantacruz (owner of the pgvector embed module)

🤖 Generated with [Claude Code](https://claude.com/claude-code)