### PR TITLE
chore: use raw strings

### DIFF
--- a/reader/templatetags/sefaria_tags.py
+++ b/reader/templatetags/sefaria_tags.py
@@ -357,7 +357,7 @@ def strip_tags(value):
 
 @register.filter(is_safe=True)
 def escape_quotes(value):
-	"""
+	r"""
 	Returns the given HTML with single and double quotes escpaed with \ for a JS context
 	"""
 	value = value.replace("'", "\\'")

--- a/sefaria/helper/normalization.py
+++ b/sefaria/helper/normalization.py
@@ -416,7 +416,7 @@ Normalization tools for mapping chars to words and vice versa
 
 
 def char_indices_from_word_indices(input_string, word_ranges, split_regex=None):
-    """
+    r"""
     ***Important***
     We use regular expression matching to solve this problem. We use the regex \s+ as default. This *should* replicate
     the behavior of str.split(), but use this with caution. It would be advisable to send the exact regex that was used

--- a/sefaria/history.py
+++ b/sefaria/history.py
@@ -295,7 +295,7 @@ def make_leaderboard(condition):
     This function queries and calculates for all currently matching history.
     """
 
-    reducer = Code("""
+    reducer = Code(r"""
                     function(obj, prev) {
 
                         // Total Points

--- a/sefaria/model/collection.py
+++ b/sefaria/model/collection.py
@@ -337,7 +337,7 @@ class Collection(abst.AbstractMongoRecord):
         """
         from sefaria.google_storage_manager import GoogleStorageManager
         bucket_name = GoogleStorageManager.COLLECTIONS_BUCKET
-        if isinstance(old_url, str) and re.search("^https?://storage\.googleapis\.com/", old_url):  # only try to delete images in google cloud storage
+        if isinstance(old_url, str) and re.search(r"^https?://storage\.googleapis\.com/", old_url):  # only try to delete images in google cloud storage
             GoogleStorageManager.delete_filename(old_url, bucket_name)
 
 

--- a/sefaria/model/garden.py
+++ b/sefaria/model/garden.py
@@ -519,7 +519,7 @@ class GardenStopRelationSet(abst.AbstractMongoSet):
 
 
 
-"""
+r"""
 def process_index_title_change_in_gardens(indx, **kwargs):
     if indx.is_commentary():
         pattern = r'^{} on '.format(re.escape(kwargs["old"]))

--- a/sefaria/model/schema.py
+++ b/sefaria/model/schema.py
@@ -975,7 +975,7 @@ class NumberedTitledTreeNode(TitledTreeNode):
         return self._addressTypes[depth]
 
     def full_regex(self, title, lang, anchored=True, compiled=True, capture_title=False, escape_titles=True, **kwargs):
-        """
+        r"""
         :return: Regex object. If kwargs[for_js] == True, returns the Regex string
         :param for_js: Defaults to False
         :param match_range: Defaults to False
@@ -2097,10 +2097,10 @@ class AddressType(object):
 
     @staticmethod
     def hebrew_number_regex():
-        """
+        r"""
         Regular expression component to capture a number expressed in Hebrew letters
         :return string:
-        \p{Hebrew} ~= [\\u05d0–\\u05ea]
+        \p{Hebrew} ~= [א–ת]
         """
         return r"""                                    # 1 of 3 styles:
         ((?=[\u05d0-\u05ea]+(?:"|\u05f4|\u201c|\u201d|'')[\u05d0-\u05ea])    # (1: ") Lookahead:  At least one letter, followed by double-quote, two single quotes, right fancy double quote, or gershayim, followed by  one letter

--- a/sefaria/model/topic.py
+++ b/sefaria/model/topic.py
@@ -1212,7 +1212,7 @@ def process_topic_description_change(topic, **kwargs):
 
     markdown_links = set()
     for lang, val in kwargs['new'].items():   # put each link in a set so we dont try to create duplicate of same link
-        for m in re.findall('\[.*?\]\((.*?)\)', val):
+        for m in re.findall(r'\[.*?\]\((.*?)\)', val):
             markdown_links.add(m)
 
     for markdown_link in markdown_links:

--- a/sefaria/model/webpage.py
+++ b/sefaria/model/webpage.py
@@ -501,7 +501,7 @@ def dedupe_identical_urls(test=True):
 
 
 def clean_webpages(test=True):
-    url_bad_regexes = WebPage.excluded_pages_url_regex()[:-1] + "|\d{3}\.\d{3}\.\d{3}\.\d{3})"  #delete any page that matches the regex produced by excluded_pages_url_regex() or in IP form
+    url_bad_regexes = WebPage.excluded_pages_url_regex()[:-1] + r"|\d{3}\.\d{3}\.\d{3}\.\d{3})"  #delete any page that matches the regex produced by excluded_pages_url_regex() or in IP form
 
 
 


### PR DESCRIPTION
## Description
Use raw strings, instead of string literals, to avoid SyntaxWarnings.