### PR TITLE
fix(sc-44272): render Turkish dotless ı via Crimson Text subset

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -80,8 +80,9 @@
     <script>
         WebFont.load({
           google: {
-            families: ['Crimson Text:100,200,300,400,500,600,700,800,900'],
-            text: 'ăǎġḥḤḫḳḲŏŠšṭżūẓŻāīēḗęîìi̧ ̆̄'
+            families: ['Crimson Text:100,200,300,400,500,600,700,800,900,400italic,600italic,700italic'],
+            // Turkish set (çÇğĞıİöÖşŞüÜ) appended for sc-44272 (dotless ı U+0131 / dotted İ U+0130).
+            text: 'ăǎġḥḤḫḳḲŏŠšṭżūẓŻāīēḗęîìi̧ ̆̄çÇğĞıİöÖşŞüÜ'
           },
           typekit: {
             id: 'aeg8div' // Adobe Garamond Pro


### PR DESCRIPTION
_(Claude writing on Daniel's behalf)_

## Problem
Turkish letters **ı İ ğ ş** render in a heavier, mismatched serif (Georgia) next to the Garamond body text, so they look bold/off. [sc-44272]

## Cause
These letters are Latin Extended-A, which our Adobe Garamond kit doesn't include. Crimson Text — the webfont we load specifically to fill diacritic gaps — is fetched as a character subset (`text:` in `base.html`) that didn't include them either. So they fall through the font stack to Georgia.

## Fix
Add the Turkish characters to the Crimson Text subset, and load Crimson's italic weights. The letters now render in Crimson Text — the same font every other diacritic on the site already uses — on every platform. 3 lines in `templates/base.html`.

## Testing
Verified the Garamond kit truly lacks these glyphs (cmap inspection), the new Google Fonts request serves them upright + italic, and on a local reader page the rendering font for ı/İ/ğ/ş moves Georgia → Crimson Text.

Related: sc-32314, sc-33594/sc-34507.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
