### PR TITLE
fix: drop duplicate django.contrib.postgres to unblock image builds

### DIFF
--- a/sefaria/settings.py
+++ b/sefaria/settings.py
@@ -175,7 +175,6 @@ INSTALLED_APPS = (
     # Uncomment the next line to enable admin documentation:
     # 'django.contrib.admindocs',
     'django_hosts',
-    'django.contrib.postgres',
     'pgvector.django',
     'semantic_search',
 )


### PR DESCRIPTION
_(Claude writing on Daniel's behalf)_

## Problem
Since the Preprod merge (#3475), `sefaria/settings.py` lists `django.contrib.postgres` twice in `INSTALLED_APPS`. Django refuses to start (`ImproperlyConfigured: Application labels aren't unique, duplicates: postgres`), so `collectstatic` fails and **Continuous Image Build (web) is red on master and on every PR based on it** (e.g. #3477).

## Fix
Remove the duplicate entry — one line.

This is the same commit as `da42cc0bc` on the `feature/sc-45064/hirsch-dedication-page-tweaks` branch (#3476), cherry-picked standalone so master CI is unblocked without waiting for that PR's review. If #3476 merges first, this PR becomes a no-op and can be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)