### PR TITLE
Remove duplicate from settings

### DIFF
--- a/sefaria/settings.py
+++ b/sefaria/settings.py
@@ -158,7 +158,6 @@ INSTALLED_APPS = (
     'reader',
     'django.contrib.staticfiles',
     'django.contrib.humanize',
-    'django.contrib.postgres',
     'emailusernames',
     'guides',
     'sefaria.gauth',


### PR DESCRIPTION
## Description
We accidentally duplicated `django.contrib.postgres` under `INSTALLED_APPS` which would cause the site to crash. This removes one instance. 