### PR TITLE
Fix for translations bug

### DIFF
--- a/sefaria/model/text.py
+++ b/sefaria/model/text.py
@@ -1408,14 +1408,13 @@ class Version(AbstractTextRecord, abst.AbstractMongoRecord, AbstractSchemaConten
         # add actualLanguage -- TODO: migration to get rid of bracket notation completely
         actualLanguage = getattr(self, "actualLanguage", None)
         versionTitle = getattr(self, "versionTitle", None)
-        if not actualLanguage and versionTitle:
+        if versionTitle:
             languageCode = re.search(r"\[([a-z]{2})\]$", versionTitle)
             if languageCode and languageCode.group(1):
                 actualLanguage = languageCode.group(1)
         self.actualLanguage = actualLanguage or self.language
 
-        if not hasattr(self, 'languageFamilyName'):
-            self.languageFamilyName = constants.LANGUAGE_CODES.get(self.actualLanguage) or constants.LANGUAGE_CODES[self.language]
+        self.languageFamilyName = constants.LANGUAGE_CODES.get(self.actualLanguage) or constants.LANGUAGE_CODES[self.language]
         self.isSource = getattr(self, "isSource", self.actualLanguage == 'he')
         if not hasattr(self, "isPrimary"):
             self.isPrimary = self.isSource or not VersionSet({'title': self.title}) #first version is primary


### PR DESCRIPTION
## Description
When someone changed the language in the version title (i.e. `Chafetz Chaim [en]` to `Chafetz Chaim [fr]`) it changed the label on the version successfully, but the version wasn't showing up under that language on the `/translations` page. 

The underlying issue was that the translations page was pulling the `actualLanguage` and `languageFamily` data, which was not being updated alongside changes to the `versionTitle`. This makes sure that any saved change to the `versionTitle` when passed through the `_normalize()` function checks to the `versionTitle` brackets as the source of truth. 

## Code Changes
In `sefaria/model/text.py` --> Always checking the `versionTitle` as the source of truth, even if `actualLanguage` is already set. 