### PR TITLE
fix(ci): restore get-gke-credentials v3 auth reverted by preprod merge

### DIFF
--- a/.github/workflows/continuous.yaml
+++ b/.github/workflows/continuous.yaml
@@ -244,12 +244,11 @@ jobs:
       - name: Set up yq
         uses: frenck/action-setup-yq@v1
       - name: Authenticate GHA Runner To Target Cluster
-        uses: google-github-actions/get-gke-credentials@v2
+        uses: google-github-actions/get-gke-credentials@v3
         with:
           cluster_name: ${{secrets.DEV_GKE_CLUSTER}}
           location: ${{secrets.DEV_GKE_REGION}}
           project_id: ${{secrets.DEV_GCP_PROJECT}}
-          use_auth_provider: true
       - name: Deploy Sandbox
         run: ./build/ci/sandbox-helm-deploy.sh build/ci/sandbox-values.yaml
         env:
@@ -304,12 +303,11 @@ jobs:
           project_id: ${{ secrets.DEV_PROJECT }}
           install_components: 'gke-gcloud-auth-plugin'
       - name: Authenticate GHA Runner To Target Cluster
-        uses: google-github-actions/get-gke-credentials@v2
+        uses: google-github-actions/get-gke-credentials@v3
         with:
           cluster_name: ${{secrets.DEV_GKE_CLUSTER}}
           location: ${{secrets.DEV_GKE_REGION}}
           project_id: ${{secrets.DEV_GCP_PROJECT}}
-          use_auth_provider: true
       - name: Set outputs
         id: get-sha
         run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
@@ -386,12 +384,11 @@ jobs:
           project_id: ${{ secrets.DEV_PROJECT }}
           install_components: 'gke-gcloud-auth-plugin'
       - name: Authenticate GHA Runner To Target Cluster
-        uses: google-github-actions/get-gke-credentials@v2
+        uses: google-github-actions/get-gke-credentials@v3
         with:
           cluster_name: ${{secrets.DEV_GKE_CLUSTER}}
           location: ${{secrets.DEV_GKE_REGION}}
           project_id: ${{secrets.DEV_GCP_PROJECT}}
-          use_auth_provider: true
       - name: Set outputs
         id: get-sha
         run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- The `preprod` → `master` merge commit `cb5b4c8e0` resolved a conflict in `.github/workflows/continuous.yaml` by keeping preprod's side, which silently reverted 3 hunks from #3470: the bump from `google-github-actions/get-gke-credentials@v2` to `@v3` and the removal of the deprecated `use_auth_provider: true` flag, across the sandbox deploy, integration-test, and continuous-test jobs.
- This restores those hunks exactly as merged in #3470 (verified with an empty diff against #3470's merge commit). No other part of #3470 was affected — the rest of its files were confirmed intact on `master`.

## Test plan
- [x] Diffed the restored `continuous.yaml` against #3470's merge commit (`191fc7523`) — exact match, zero diff
- [ ] Confirm the next CI run authenticates via `get-gke-credentials@v3` instead of `@v2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)