### PR TITLE
Limit oversized semantic linked refs

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -235,29 +235,60 @@ class KnnSearch(View):
             return ""
 
     @staticmethod
-    def _semantic_chunk_filters(base_filters, ref, ref_field):
+    def _semantic_chunk_filters(base_filters, ref_filter):
         filters = dict(base_filters or {})
-        filters[ref_field] = ref
+        filters.update(ref_filter)
         return filters
+
+    @staticmethod
+    def _segment_ref_filter_for_linked_ref(ref):
+        oref = Ref(ref)
+        if not (oref.is_segment_level() or (oref.is_section_level() and not oref.is_range())):
+            return None, []
+
+        segment_refs = [segment_ref.normal() for segment_ref in oref.all_segment_refs()]
+        if not segment_refs:
+            return None, []
+        if len(segment_refs) == 1:
+            return {"ref": segment_refs[0]}, segment_refs
+        return {"ref__in": segment_refs}, segment_refs
+
+    @staticmethod
+    def _is_supported_linked_ref(ref):
+        try:
+            oref = Ref(ref)
+        except Exception:
+            return False
+        return oref.is_segment_level() or (oref.is_section_level() and not oref.is_range())
 
     @classmethod
     def _semantic_chunks_for_linked_ref(cls, ref, query_embedding, base_filters):
         from semantic_search.search import semantic_search_by_embedding
 
-        for ref_field in ("chunked_from_ref", "ref"):
-            chunks = semantic_search_by_embedding(
-                query_embedding,
-                filters=cls._semantic_chunk_filters(base_filters, ref, ref_field),
-                limit=cls.LINKED_REF_SEMANTIC_CHUNK_LIMIT,
-            )
-            if chunks:
-                return chunks, ref_field
+        ref_filter, segment_refs = cls._segment_ref_filter_for_linked_ref(ref)
+        if ref_filter is None:
+            return [], None
+
+        vector_filters = cls._semantic_chunk_filters(base_filters, ref_filter)
+        chunks = semantic_search_by_embedding(
+            query_embedding,
+            filters=vector_filters,
+            limit=cls.LINKED_REF_SEMANTIC_CHUNK_LIMIT,
+        )
+        if chunks:
+            return chunks, next(iter(ref_filter.keys()))
         return [], None
 
     @classmethod
     def _serialize_linked_ref(cls, ref, include_text, query_embedding=None, filters=None):
         serialized = {"ref": ref}
         if include_text:
+            if not cls._is_supported_linked_ref(ref):
+                serialized.update({
+                    "text": "",
+                    "text_source": "omitted_unsupported_linked_ref",
+                })
+                return serialized
             text = cls._ref_text(ref)
             if len(text) > cls.LINKED_REF_FULL_TEXT_CHAR_LIMIT and query_embedding is not None:
                 chunks, ref_field = cls._semantic_chunks_for_linked_ref(ref, query_embedding, filters)

--- a/api/views.py
+++ b/api/views.py
@@ -1,4 +1,5 @@
 import json
+import logging
 
 from django.conf import settings
 from django.utils.decorators import method_decorator
@@ -10,6 +11,9 @@ from sefaria.model import *
 from sefaria.model.text_request_adapter import TextRequestAdapter
 from sefaria.system.exceptions import InputError, ComplexBookLevelRefError, DictionaryEntryNotFoundError
 from .api_warnings import *
+
+
+logger = logging.getLogger(__name__)
 
 
 class Text(View):
@@ -181,10 +185,19 @@ class KnnSearch(View):
     # - LIMIT: number of semantic hits used internally to build the link graph.
     # - DEPTH: graph hops to traverse from each semantic hit.
     # - STD_THRESHOLD/MIN_COUNT: outlier rule count >= max(min_count, mean + k*std).
+    # - FULL_TEXT_CHAR_LIMIT: linked refs larger than this are replaced with
+    #   semantic chunks to avoid oversized tool responses. Patot caps chunks at
+    #   500 BEREL tokens; recent output sampling put that near 1,300 chars, so
+    #   this threshold approximates one maximal chunk and keeps linked-ref
+    #   augmentation away from Claude Code's 50K-char tool persistence limit.
+    # - SEMANTIC_CHUNK_LIMIT: number of top filtered chunks returned for each
+    #   oversized linked ref.
     LINKED_REF_ENHANCEMENT_LIMIT = 50
     LINKED_REF_ENHANCEMENT_DEPTH = 1
     LINKED_REF_ENHANCEMENT_STD_THRESHOLD = 2
     LINKED_REF_ENHANCEMENT_MIN_COUNT = 3
+    LINKED_REF_FULL_TEXT_CHAR_LIMIT = 1300
+    LINKED_REF_SEMANTIC_CHUNK_LIMIT = 2
 
     @method_decorator(csrf_exempt)
     def dispatch(self, *args, **kwargs):
@@ -221,12 +234,84 @@ class KnnSearch(View):
         except Exception:
             return ""
 
+    @staticmethod
+    def _semantic_chunk_filters(base_filters, ref, ref_field):
+        filters = dict(base_filters or {})
+        filters[ref_field] = ref
+        return filters
+
     @classmethod
-    def _serialize_linked_ref(cls, ref, include_text):
+    def _semantic_chunks_for_linked_ref(cls, ref, query_embedding, base_filters):
+        from semantic_search.search import semantic_search_by_embedding
+
+        for ref_field in ("chunked_from_ref", "ref"):
+            chunks = semantic_search_by_embedding(
+                query_embedding,
+                filters=cls._semantic_chunk_filters(base_filters, ref, ref_field),
+                limit=cls.LINKED_REF_SEMANTIC_CHUNK_LIMIT,
+            )
+            if chunks:
+                return chunks, ref_field
+        return [], None
+
+    @classmethod
+    def _serialize_linked_ref(cls, ref, include_text, query_embedding=None, filters=None):
         serialized = {"ref": ref}
         if include_text:
-            serialized["text"] = cls._ref_text(ref)
+            text = cls._ref_text(ref)
+            if len(text) > cls.LINKED_REF_FULL_TEXT_CHAR_LIMIT and query_embedding is not None:
+                chunks, ref_field = cls._semantic_chunks_for_linked_ref(ref, query_embedding, filters)
+                if chunks:
+                    logger.info(
+                        "Replaced oversized linked ref text with semantic chunks",
+                        extra={
+                            "ref": ref,
+                            "original_text_char_count": len(text),
+                            "semantic_chunk_count": len(chunks),
+                            "semantic_chunk_filter_field": ref_field,
+                        },
+                    )
+                    return [
+                        {
+                            **cls._serialize_search_result(chunk, include_text=True),
+                            "text_source": "linked_ref_semantic_chunk",
+                            "linked_ref_parent": ref,
+                            "linked_ref_chunk_number": chunk_number,
+                            "linked_ref_chunk_count": len(chunks),
+                            "original_text_char_count": len(text),
+                            "semantic_chunk_limit": cls.LINKED_REF_SEMANTIC_CHUNK_LIMIT,
+                            "semantic_chunk_filter_field": ref_field,
+                        }
+                        for chunk_number, chunk in enumerate(chunks, start=1)
+                    ]
+                else:
+                    logger.warning(
+                        "Omitted oversized linked ref text because no semantic chunks were found",
+                        extra={
+                            "ref": ref,
+                            "original_text_char_count": len(text),
+                        },
+                    )
+                    serialized.update({
+                        "text": "",
+                        "text_source": "omitted_oversized_linked_ref",
+                        "original_text_char_count": len(text),
+                        "semantic_chunk_limit": cls.LINKED_REF_SEMANTIC_CHUNK_LIMIT,
+                    })
+                    return serialized
+            serialized["text"] = text
         return serialized
+
+    @classmethod
+    def _serialize_linked_refs(cls, refs, include_text, query_embedding=None, filters=None):
+        serialized_refs = []
+        for ref in refs:
+            serialized = cls._serialize_linked_ref(ref, include_text, query_embedding, filters)
+            if isinstance(serialized, list):
+                serialized_refs.extend(serialized)
+            else:
+                serialized_refs.append(serialized)
+        return serialized_refs
 
     @staticmethod
     def _top_linked_refs(enhancement, limit):
@@ -280,15 +365,17 @@ class KnnSearch(View):
         except ValueError as e:
             return jsonResponse({"error": str(e)}, status=400)
 
-        from semantic_search.search import semantic_search
         from semantic_search.embedder import EmbeddingError
 
         if not getattr(settings, "GEMINI_API_KEY", ""):
             return jsonResponse({"error": "Semantic search is not configured"}, status=503)
 
         try:
+            from semantic_search.search import get_query_embedding, semantic_search_by_embedding
+
             search_limit = max(result_limit, self.LINKED_REF_ENHANCEMENT_LIMIT) if include_linked_refs else result_limit
-            search_results = semantic_search(query, filters=filters, limit=search_limit)
+            query_embedding = get_query_embedding(query)
+            search_results = semantic_search_by_embedding(query_embedding, filters=filters, limit=search_limit)
         except EmbeddingError as e:
             return jsonResponse({"error": str(e)}, status=502)
         results = search_results[:result_limit]
@@ -311,10 +398,7 @@ class KnnSearch(View):
             )
             top_linked_refs = self._top_linked_refs(enhancement, linked_ref_limit)
             response.update({
-                "linked_refs": [
-                    self._serialize_linked_ref(ref, include_text)
-                    for ref in top_linked_refs
-                ],
+                "linked_refs": self._serialize_linked_refs(top_linked_refs, include_text, query_embedding, filters),
             })
 
         return jsonResponse(response)

--- a/semantic_search/models.py
+++ b/semantic_search/models.py
@@ -36,6 +36,7 @@ class SemanticTextChunk(models.Model):
     _ALLOWED_FILTER_FIELDS = frozenset({
         'index_title', 'language', 'version_title', 'ref', 'chunked_from_ref',
         'primary_category', 'is_primary', 'is_source', 'era_name', 'direction',
+        'ref__in',
     })
 
     class Meta:

--- a/semantic_search/search.py
+++ b/semantic_search/search.py
@@ -9,8 +9,20 @@ def semantic_search(
     filters: dict | None = None,
     limit: int = 10,
 ) -> list[SemanticTextChunk]:
+    embedding = get_query_embedding(query)
+    return semantic_search_by_embedding(embedding, filters=filters, limit=limit)
+
+
+def get_query_embedding(query: str) -> list[float]:
     api_key = getattr(settings, "GEMINI_API_KEY", "")
     if not api_key:
         raise ValueError("GEMINI_API_KEY is not configured")
-    embedding = embed_query(query, api_key=api_key)
+    return embed_query(query, api_key=api_key)
+
+
+def semantic_search_by_embedding(
+    embedding: list[float],
+    filters: dict | None = None,
+    limit: int = 10,
+) -> list[SemanticTextChunk]:
     return SemanticTextChunk().search_by_embedding(embedding, limit=limit, filters=filters)

--- a/semantic_search/tests/semantic_search_test.py
+++ b/semantic_search/tests/semantic_search_test.py
@@ -83,6 +83,10 @@ class TestSearchByEmbeddingFilters:
         kwargs = self._run({"language": "en"})
         assert kwargs == {"language": "en"}
 
+    def test_ref_in_filter_passes_through(self):
+        kwargs = self._run({"ref__in": ["Genesis 1:1", "Genesis 1:2"]})
+        assert kwargs == {"ref__in": ["Genesis 1:1", "Genesis 1:2"]}
+
     def test_unknown_field_is_dropped(self):
         kwargs = self._run({"bad__inject": "x"})
         assert "bad__inject" not in kwargs

--- a/semantic_search/tests/semantic_search_test.py
+++ b/semantic_search/tests/semantic_search_test.py
@@ -7,6 +7,7 @@ ORM-touching code is mocked at the SemanticTextChunk.objects boundary.
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+from django.test import override_settings
 import pytest
 
 from semantic_search.embedder import embed_query, l2_normalize_vector
@@ -17,7 +18,7 @@ from semantic_search.linked_refs import (
     get_mean_std_linked_ref_enhancements,
 )
 from semantic_search.router import SemanticSearchRouter
-from semantic_search.search import semantic_search
+from semantic_search.search import semantic_search, semantic_search_by_embedding
 from semantic_search.models import SemanticTextChunk
 
 
@@ -475,6 +476,7 @@ class TestEmbedQuery:
 # ---------------------------------------------------------------------------
 
 class TestSemanticSearch:
+    @override_settings(GEMINI_API_KEY="test-key")
     @patch("semantic_search.search.SemanticTextChunk")
     @patch("semantic_search.search.embed_query")
     def test_calls_embed_query_then_search_by_embedding(self, mock_embed, mock_chunk_cls):
@@ -487,6 +489,7 @@ class TestSemanticSearch:
             [0.5] * 1536, limit=10, filters=None
         )
 
+    @override_settings(GEMINI_API_KEY="test-key")
     @patch("semantic_search.search.SemanticTextChunk")
     @patch("semantic_search.search.embed_query")
     def test_forwards_filters_and_limit(self, mock_embed, mock_chunk_cls):
@@ -497,6 +500,7 @@ class TestSemanticSearch:
             [0.1] * 1536, limit=5, filters={"language": "en"}
         )
 
+    @override_settings(GEMINI_API_KEY="test-key")
     @patch("semantic_search.search.SemanticTextChunk")
     @patch("semantic_search.search.embed_query")
     def test_returns_search_results(self, mock_embed, mock_chunk_cls):
@@ -504,3 +508,13 @@ class TestSemanticSearch:
         expected = [MagicMock()]
         mock_chunk_cls.return_value.search_by_embedding.return_value = expected
         assert semantic_search("query") == expected
+
+    @patch("semantic_search.search.SemanticTextChunk")
+    def test_search_by_embedding_uses_existing_embedding(self, mock_chunk_cls):
+        embedding = [0.25] * 1536
+        expected = [MagicMock()]
+        mock_chunk_cls.return_value.search_by_embedding.return_value = expected
+        assert semantic_search_by_embedding(embedding, filters={"ref": "Genesis 1"}, limit=2) == expected
+        mock_chunk_cls.return_value.search_by_embedding.assert_called_once_with(
+            embedding, limit=2, filters={"ref": "Genesis 1"}
+        )


### PR DESCRIPTION
 Implemented linked-ref size control for semantic search.

  Oversized linked refs now use a 1,300-character threshold. If a linked ref’s full text exceeds that, the API reuses the original query embedding to
  retrieve the top 2 semantic chunks scoped to that ref, then returns those chunks as flattened linked-ref entries with parent/chunk metadata. This avoids
  sending very large linked-ref texts while preserving useful context.

  Also split semantic search into reusable get_query_embedding() and semantic_search_by_embedding() helpers, and added test coverage for the embedding reuse
  path.
