### PR TITLE
Fix blank sidebar on display-options click; replace binary popup with A/א toggle

### DIFF
--- a/static/js/ConnectionsPanelHeader.jsx
+++ b/static/js/ConnectionsPanelHeader.jsx
@@ -7,7 +7,6 @@ import Sefaria  from './sefaria/sefaria';
 import classNames  from 'classnames';
 import PropTypes  from 'prop-types';
 import Component      from 'react-class';
-import {ReaderPanelContext} from "./context";
 import {DropdownMenu} from "./common/DropdownMenu";
 import ReaderDisplayOptionsMenu from "./ReaderDisplayOptionsMenu";
 import Util from "./sefaria/util";
@@ -49,7 +48,7 @@ class ConnectionsPanelHeader extends Component {
     const excludedModes = ["Resources", "ConnectionsList"];
     if (!excludedModes.includes(this.props.connectionsMode)) {
       // Only modes were there's an actual source-text get the dropdown.
-      return <DropdownMenu buttonComponent={<DisplaySettingsButton/>} context={ReaderPanelContext}><ReaderDisplayOptionsMenu/></DropdownMenu>;
+      return <DropdownMenu buttonComponent={<DisplaySettingsButton/>} positioningClass="readerDropdownMenu"><ReaderDisplayOptionsMenu/></DropdownMenu>;
     }
     if (this.props.interfaceLang !== "english") {
       // if interface is Hebrew and we're not viewing actual source text in the sidebar, language switcher is turned off.

--- a/static/js/ConnectionsPanelHeader.jsx
+++ b/static/js/ConnectionsPanelHeader.jsx
@@ -1,4 +1,4 @@
-import {InterfaceText, EnglishText, HebrewText, LanguageToggleButton, CloseButton, DisplaySettingsButton} from "./Misc";
+import {InterfaceText, EnglishText, HebrewText, LanguageToggleButton, CloseButton} from "./Misc";
 import {RecentFilterSet} from "./ConnectionFilters";
 import React  from 'react';
 import ReactDOM  from 'react-dom';
@@ -7,8 +7,6 @@ import Sefaria  from './sefaria/sefaria';
 import classNames  from 'classnames';
 import PropTypes  from 'prop-types';
 import Component      from 'react-class';
-import {DropdownMenu} from "./common/DropdownMenu";
-import ReaderDisplayOptionsMenu from "./ReaderDisplayOptionsMenu";
 import Util from "./sefaria/util";
 
 
@@ -46,18 +44,14 @@ class ConnectionsPanelHeader extends Component {
       return null;
     }
     const excludedModes = ["Resources", "ConnectionsList"];
-    if (!excludedModes.includes(this.props.connectionsMode)) {
-      // Only modes were there's an actual source-text get the dropdown.
-      return <DropdownMenu buttonComponent={<DisplaySettingsButton/>} positioningClass="readerDropdownMenu"><ReaderDisplayOptionsMenu/></DropdownMenu>;
-    }
-    if (this.props.interfaceLang !== "english") {
+    if (excludedModes.includes(this.props.connectionsMode) && this.props.interfaceLang !== "english") {
       // if interface is Hebrew and we're not viewing actual source text in the sidebar, language switcher is turned off.
       return null;
     }
     const currentLang = Sefaria.util.getUrlVars()["lang2"];
     const nextLang = currentLang === "en" ? "he" : "en";
     const nextLangUrl = Sefaria.util.replaceUrlParam("lang2", nextLang);
-    // Otherwise provide the English/Hebrew toggle button.
+    // Provide the English/Hebrew toggle button.
     return <LanguageToggleButton toggleLanguage={this.props.toggleLanguage} url={nextLangUrl} />;
   }
   onClick(e) {


### PR DESCRIPTION
_(Claude writing on Daniel's behalf)_

Fixes [sc-45537](https://app.shortcut.com/sefaria/story/45537/blank-sidebar-appears-in-resources-panel-on-toggle-click-popup-unnecessary-for-binary-choice). Two commits, one file.

**1. Fix the blank sidebar.** The sidebar's display-options `<DropdownMenu>` was missing the `positioningClass="readerDropdownMenu"` prop that every other call site passes. Without it the popup anchored to the wrong ancestor and overflowed the sidebar, and the popup's auto-focus scrolled the `overflow:hidden` panel sideways — the "blank sidebar" was that exposed white background, not an extra panel. One line fixes it in every sidebar mode.

**2. Replace the popup with a one-click toggle.** In the sidebar the popup only ever offers the binary Source/Translation choice, so it added a redundant click. All sidebar modes now use the same one-click **A ↔ א** `LanguageToggleButton` as the Resources level — both paths set the same panel language option, so nothing is lost.

Notes for review:

- The change is confined to `ConnectionsPanelHeader.getLanguageSwitcher()`; the shared `ReaderDisplayOptionsMenu` (main reader, compare panels, book ToC, sheets) is untouched.
- Commit 1 is kept even though commit 2 removes the line it fixes — it documents the real root cause and ships independently if the UX change is debated.
- Hebrew-interface behavior is unchanged: the toggle is suppressed at the Resources/ConnectionsList levels only, exactly where the popup wasn't offered before.

**Testing:** verified live at the ticket's repro URL and on Genesis 1:1 → Rashi — one click flips source ↔ translation, icon flips, no popup, no layout shift; the sidebar panel shows zero horizontal overflow. Jest passes (no existing coverage of these components).
