### PR TITLE
chore: show authors of books returned

### DIFF
--- a/docs/arch_docs/search_improvements_arch.md
+++ b/docs/arch_docs/search_improvements_arch.md
@@ -64,9 +64,10 @@ One document per Topic. Authors are not a separate index — `AuthorTopic` is a 
 | `era` | `keyword` | — | Author-only: historical period |
 | `birthYear` | `integer` | — | Author-only: for display and filtering |
 | `deathYear` | `integer` | — | Author-only: for display and filtering |
-| `authored_slugs` | `keyword` | — | Author-only: slugs of books this author wrote |
+| `authored_titles_en` | `text` + `keyword` | `stemmed_english` | Author-only: denormalized titles of the author's works, **including English title variants** — the same title set the book doc indexes (`title_en` + `titleVariants`), so any query that returns a book in the Books tab also returns its author in the Authors tab (e.g. "Moreh Nevukhim" → Rambam) |
+| `authored_titles_he` | `text` + `keyword` | plain `text` | Author-only: Hebrew primary titles of the author's works (mirrors the book doc's `title_he`) |
 
-Author-only fields (`era`, `birthYear`, `deathYear`, `authored_slugs`) are sparse on topic documents. Document id = topic `slug`, so reindexing is idempotent.
+Author-only fields (`era`, `birthYear`, `deathYear`, `authored_titles_*`) are sparse on topic documents. Document id = topic `slug`, so reindexing is idempotent.
 
 **`book` index — Index (book) records**
 
@@ -289,7 +290,7 @@ This resolves the open **"eager vs. lazy entity search"** question (see [Open Qu
 
 - **No on-save freshness.** When a text is saved in Sefaria, a hook automatically updates its Elasticsearch entry right away. The `topic` and `book` indices don't have this — they only get updated when the cron job runs its full rebuild. So edits to a topic or book won't appear in search results until the next scheduled rebuild.
 - **Relevance is unproven at scale.** Field boosting is a reasonable first cut; default ranking and cross-language behavior still need tuning against real queries.
-- **Denormalization staleness.** `author_names` on book docs and `authored_slugs` on author docs are snapshots taken at index time; an author rename requires reindexing affected books to stay consistent.
+- **Denormalization staleness.** `author_names` on book docs and `authored_titles_*` on author docs are snapshots taken at index time; an author rename (or a book title/variant change) requires reindexing the affected docs to stay consistent.
 - **Numeric token false positives.** Queries containing numbers (e.g., "Genesis 1:1") match books with "1" in the title or `titleVariants` — "I Kings", "Vol. I", numbered tractates, etc. — producing noisy results. Needs a fix before production (e.g., exclude purely-numeric tokens from `titleVariants` matching, or treat numeric-heavy queries as ref queries rather than book searches).
 - **Cauldron test environment.** Getting Elasticsearch and the reindex cron job working correctly in our cauldron test environment carries non-trivial setup complexity. This needs to be budgeted as part of the production path — it is not automatic from the existing cron wiring.
 - **Prefix Matching** - To match strings like `Mo` to `Moses`, we use a strategy that treats ending word fragments as search prefixes. It should be noted that this approach comes with query cost and the main Elastic Search query performance risk to validate at scale.

--- a/sefaria/search.py
+++ b/sefaria/search.py
@@ -1193,6 +1193,18 @@ def _without_none(doc):
     return {k: v for k, v in doc.items() if v is not None}
 
 
+def _book_title_variants(index, lang):
+    """
+    The book-level title variants of an Index: the root node's own title group.
+    Not `Index.all_titles()` — that walks the whole schema tree for ref resolution,
+    so on complex texts it returns every chapter/section title crossed with every
+    root variant (e.g. "Moreh Nevukhim, Prefatory Remarks"), which are not book titles.
+    """
+    if not index.nodes:
+        return []
+    return index.nodes.title_group.all_titles(lang) or []
+
+
 def _authored_index_titles(index):
     """
     The searchable titles of one authored Index for the author's `authored_titles`
@@ -1209,7 +1221,7 @@ def _authored_index_titles(index):
     primary_en = index.get_title('en')
     if primary_en:
         en_titles.append(primary_en)
-    en_titles += [t for t in (index.all_titles('en') or []) if t != primary_en]
+    en_titles += [t for t in _book_title_variants(index, 'en') if t != primary_en]
     try:
         he = index.get_title('he')
     except Exception:
@@ -1359,7 +1371,7 @@ def make_book_index_document(index, author_name_cache=None):
         title_he = None
 
     categories = getattr(index, 'categories', None) or []
-    variants = [t for t in (index.all_titles('en') or []) if t != title_en]
+    variants = [t for t in _book_title_variants(index, 'en') if t != title_en]
 
     # compDate is stored in Mongo as a list of ints; collapse to one sortable int.
     # Mirror the text index: prefer end year, else start, else 3000 (sorts undated last).

--- a/sefaria/search.py
+++ b/sefaria/search.py
@@ -552,11 +552,13 @@ def put_topic_mapping(index_name):
                 'type': 'integer',
             },
             # Denormalized titles of the books this author wrote (analyzed text, split
-            # by language) so an author is findable by a work they authored — the
-            # mirror image of `author_names` on the book index. `norms: false` so a
-            # prolific author (a large title list) isn't penalized by field-length
-            # normalization; the `keyword` sub-field powers exact-match (tier 1), which
-            # is what ranks the true author of an exactly-titled work above its commentators.
+            # by language, incl. English title variants — the same title set the book
+            # index carries) so an author is findable by any name of a work they
+            # authored — the mirror image of `author_names` on the book index.
+            # `norms: false` so a prolific author (a large title list) isn't penalized
+            # by field-length normalization; the `keyword` sub-field powers exact-match
+            # (tier 1), which is what ranks the true author of an exactly-titled work
+            # above its commentators.
             'authored_titles_en': {
                 'type': 'text',
                 'analyzer': 'stemmed_english',
@@ -1191,6 +1193,30 @@ def _without_none(doc):
     return {k: v for k, v in doc.items() if v is not None}
 
 
+def _authored_index_titles(index):
+    """
+    The searchable titles of one authored Index for the author's `authored_titles`
+    fields: the primary EN title plus every English title variant, and the primary HE
+    title — the same title set `make_book_index_document` indexes for the book itself
+    (`title_en` + `titleVariants` + `title_he`). Mirroring it keeps author↔book search
+    symmetric: any query that returns a book by one of its titles also returns that
+    book's author (e.g. "Moreh Nevukhim", a variant of "Guide for the Perplexed",
+    finds Rambam).
+
+    :return: (en_titles, he_titles), primary title first, de-duped downstream
+    """
+    en_titles = []
+    primary_en = index.get_title('en')
+    if primary_en:
+        en_titles.append(primary_en)
+    en_titles += [t for t in (index.all_titles('en') or []) if t != primary_en]
+    try:
+        he = index.get_title('he')
+    except Exception:
+        he = None
+    return en_titles, ([he] if he else [])
+
+
 def _build_authored_titles_map():
     """
     Map every author slug to the titles of their works in one `IndexSet()` pass:
@@ -1205,16 +1231,10 @@ def _build_authored_titles_map():
         author_slugs = getattr(index, 'authors', None) or []
         if not author_slugs:
             continue
-        en = index.get_title('en')
-        try:
-            he = index.get_title('he')
-        except Exception:
-            he = None
+        en_titles, he_titles = _authored_index_titles(index)
         for slug in author_slugs:
-            if en:
-                titles_by_slug[slug]['en'].append(en)
-            if he:
-                titles_by_slug[slug]['he'].append(he)
+            titles_by_slug[slug]['en'] += en_titles
+            titles_by_slug[slug]['he'] += he_titles
     return titles_by_slug
 
 
@@ -1278,23 +1298,19 @@ def make_topic_index_document(topic, authored_titles_map=None):
         doc['era'] = topic.get_property('era')
         doc['birthYear'] = topic.get_property('birthYear')
         doc['deathYear'] = topic.get_property('deathYear')
-        # Denormalize the titles of this author's works (EN + HE) so the author is
-        # searchable by a book they wrote (e.g. "Mishneh Torah" -> Maimonides).
+        # Denormalize the titles of this author's works (EN incl. variants + HE, the
+        # same title set the book index carries — see _authored_index_titles) so the
+        # author is searchable by any name of a book they wrote (e.g. "Mishneh Torah"
+        # -> Maimonides, "Moreh Nevukhim" -> Rambam).
         if authored_titles_map is not None:
             authored = authored_titles_map.get(slug, {'en': [], 'he': []})
             authored_en, authored_he = authored['en'], authored['he']
         else:
             authored_en, authored_he = [], []
             for authored_index in IndexSet({"authors": slug}):
-                en = authored_index.get_title('en')
-                if en:
-                    authored_en.append(en)
-                try:
-                    he = authored_index.get_title('he')
-                except Exception:
-                    he = None
-                if he:
-                    authored_he.append(he)
+                en_titles, he_titles = _authored_index_titles(authored_index)
+                authored_en += en_titles
+                authored_he += he_titles
         doc['authored_titles_en'] = list(dict.fromkeys(authored_en))  # de-dup, preserve order
         doc['authored_titles_he'] = list(dict.fromkeys(authored_he))
 

--- a/sefaria/tests/search_test.py
+++ b/sefaria/tests/search_test.py
@@ -103,15 +103,24 @@ class _FakeAuthoredIndex:
         self._title_en = title_en
         self._title_he = title_he
         self._variants_en = variants_en or []
+
+        class _TG:
+            def all_titles(_self, lang):
+                if lang == "en":
+                    return [self._title_en] + self._variants_en
+                if lang == "he":
+                    return [self._title_he] if self._title_he else []
+                return []
+
+        class _Nodes:
+            title_group = _TG()
+
+        self.nodes = _Nodes()
         if authors is not None:
             self.authors = authors
 
     def get_title(self, lang="en"):
         return self._title_he if lang == "he" else self._title_en
-
-    def all_titles(self, lang):
-        return ([self._title_en] + self._variants_en) if lang == "en" else []
-
 
 def test_authored_index_titles_include_english_variants():
     """An author must be findable by every title its book is findable by — incl. variants."""

--- a/sefaria/tests/search_test.py
+++ b/sefaria/tests/search_test.py
@@ -3,7 +3,13 @@ instead of aborting the entire multi-hour run."""
 import pytest
 from elastic_transport import ApiError, ConnectionTimeout
 
-from sefaria.search import TextIndexer
+import sefaria.search
+from sefaria.search import (
+    TextIndexer,
+    _authored_index_titles,
+    _build_authored_titles_map,
+    make_topic_index_document,
+)
 
 
 class _FakeIndex:
@@ -89,6 +95,97 @@ def test_index_all_continues_past_bulk_connection_timeout(monkeypatch):
     fail = TextIndexer._failed_versions[0]
     assert fail["title"] == "BookB"
     assert fail["error_type"] == "ConnectionTimeout"
+
+
+class _FakeAuthoredIndex:
+    """An Index as seen by the authored_titles denormalization: primary titles + EN variants."""
+    def __init__(self, title_en, title_he=None, variants_en=None, authors=None):
+        self._title_en = title_en
+        self._title_he = title_he
+        self._variants_en = variants_en or []
+        if authors is not None:
+            self.authors = authors
+
+    def get_title(self, lang="en"):
+        return self._title_he if lang == "he" else self._title_en
+
+    def all_titles(self, lang):
+        return ([self._title_en] + self._variants_en) if lang == "en" else []
+
+
+def test_authored_index_titles_include_english_variants():
+    """An author must be findable by every title its book is findable by — incl. variants."""
+    index = _FakeAuthoredIndex(
+        "Guide for the Perplexed", "מורה נבוכים",
+        variants_en=["Moreh Nevukhim", "The Guide to the Perplexed"],
+    )
+    en, he = _authored_index_titles(index)
+    assert en == ["Guide for the Perplexed", "Moreh Nevukhim", "The Guide to the Perplexed"]
+    assert he == ["מורה נבוכים"]
+
+
+def test_authored_index_titles_missing_hebrew():
+    en, he = _authored_index_titles(_FakeAuthoredIndex("Some Book"))
+    assert en == ["Some Book"]
+    assert he == []
+
+
+def test_build_authored_titles_map_collects_variants_per_author(monkeypatch):
+    indexes = [
+        _FakeAuthoredIndex("Guide for the Perplexed", "מורה נבוכים",
+                           variants_en=["Moreh Nevukhim"], authors=["rambam"]),
+        _FakeAuthoredIndex("Mishneh Torah", "משנה תורה",
+                           variants_en=["Yad HaChazakah"], authors=["rambam"]),
+        _FakeAuthoredIndex("Unattributed Book"),  # no authors -> ignored
+    ]
+    monkeypatch.setattr(sefaria.search, "IndexSet", lambda *a, **k: iter(indexes))
+
+    titles_map = _build_authored_titles_map()
+
+    assert titles_map["rambam"]["en"] == [
+        "Guide for the Perplexed", "Moreh Nevukhim", "Mishneh Torah", "Yad HaChazakah",
+    ]
+    assert titles_map["rambam"]["he"] == ["מורה נבוכים", "משנה תורה"]
+    assert list(titles_map.keys()) == ["rambam"]
+
+
+class _FakeAuthorTopic:
+    slug = "rambam"
+    subclass = "author"
+    description = {"en": "", "he": ""}
+    numSources = 100
+
+    def get_primary_title(self, lang):
+        return "רמב\"ם" if lang == "he" else "Rambam"
+
+    def get_titles(self, lang, with_disambiguation=False):
+        return ["Rambam", "Maimonides"]
+
+    def get_property(self, key):
+        return {"era": "RI", "birthYear": 1138, "deathYear": 1204}.get(key)
+
+
+def test_make_topic_index_document_authored_titles_include_variants(monkeypatch):
+    """The per-topic fallback path (no precomputed map) must carry book title variants too."""
+    indexes = [
+        _FakeAuthoredIndex("Guide for the Perplexed", "מורה נבוכים",
+                           variants_en=["Moreh Nevukhim", "Guide for the Perplexed"]),
+    ]
+    monkeypatch.setattr(sefaria.search, "IndexSet", lambda *a, **k: iter(indexes))
+
+    doc = make_topic_index_document(_FakeAuthorTopic())
+
+    # variants included, primary first, duplicate variant de-duped
+    assert doc["authored_titles_en"] == ["Guide for the Perplexed", "Moreh Nevukhim"]
+    assert doc["authored_titles_he"] == ["מורה נבוכים"]
+
+
+def test_make_topic_index_document_authored_titles_from_map():
+    titles_map = {"rambam": {"en": ["Mishneh Torah", "Yad HaChazakah", "Mishneh Torah"],
+                             "he": ["משנה תורה"]}}
+    doc = make_topic_index_document(_FakeAuthorTopic(), titles_map)
+    assert doc["authored_titles_en"] == ["Mishneh Torah", "Yad HaChazakah"]
+    assert doc["authored_titles_he"] == ["משנה תורה"]
 
 
 @pytest.mark.parametrize("bad_exc", [


### PR DESCRIPTION
## Description
When you search for a book title, the Books tab finds the book, but the Authors tab didn't always show that book's author. Example: searching "Moreh Nevukhim" returned Guide for the Perplexed in the Books tab (that's one of its alternate titles), but Rambam — its author — was missing from the Authors tab.

Why it happened: Every author document in the Elasticsearch topic index carries an authored_titles field — a copied-in list of the titles of the books they wrote — and the author search matches against it. But that list only contained each book's primary title. The book search, on the other hand, also matches title variants (alternate spellings and names like "Moreh Nevukhim"). So a query matching a book only through a variant would find the book but not its author.

## Code Changes
When we build an author's document at index time, we now copy in the same set of titles the book itself is searchable by: the primary English title, all English title variants, and the primary Hebrew title. There's one new helper, _authored_index_titles() in sefaria/search.py, and both places that build author docs (the bulk reindex path and the single-topic fallback) use it — so the two paths can't drift apart. No Elasticsearch mapping change was needed; the field already accepts a list of strings.

The guiding rule: an author must be findable by any title their book is findable by. Since both tabs now search the same title text, any query that returns a book also returns its author.

What didn't change: Ranking still puts direct name matches first (a search for "Rashi" ranks Rashi above authors matched via a book title), and the Books tab's author-works aggregation ("Rambam" → his works grouped by category) still triggers only on real author-name queries.

Verified: Rebuilt the local index — "Moreh Nevukhim" now returns Rambam #1 in the Authors tab, and "Mishnah Berakhot" returns all the Mishnah commentators. Added 5 unit tests for the document builders; all 23 search tests pass.

Rollout note: This is index-time denormalization, so it needs a topic index reindex to take effect (the weekly cron covers it, or run scripts/reindex_entity_search.py --type topic).