### PR TITLE
chore: strip_markdown

### DIFF
--- a/sefaria/search.py
+++ b/sefaria/search.py
@@ -24,7 +24,7 @@ from sefaria.model.user_profile import user_link, public_user_data
 from sefaria.model.collection import CollectionSet
 from sefaria.system.database import db
 from sefaria.system.exceptions import InputError
-from sefaria.utils.util import strip_tags
+from sefaria.utils.util import strip_tags, strip_markdown
 from .settings import SEARCH_INDEX_NAME_TEXT, SEARCH_INDEX_NAME_SHEET
 from .settings import SEARCH_INDEX_NAME_TOPIC, SEARCH_INDEX_NAME_BOOK
 from sefaria.helper.search import get_elasticsearch_client, get_elasticsearch_client_for_indexer
@@ -1265,8 +1265,8 @@ def make_topic_index_document(topic, authored_titles_map=None):
         'title_en': title_en or None,
         'title_he': title_he or None,
         'titleVariants': variants,
-        'description_en': description.get('en', ''),
-        'description_he': description.get('he', ''),
+        'description_en': strip_markdown(description.get('en', '')),
+        'description_he': strip_markdown(description.get('he', '')),
         'numSources': getattr(topic, 'numSources', 0) or 0,
     }
 
@@ -1361,8 +1361,8 @@ def make_book_index_document(index, author_name_cache=None):
         'titleVariants': variants,
         'categories': categories,
         'path': "/".join(categories + [title_en]),  # mirrors the text index path shape
-        'description_en': getattr(index, 'enShortDesc', '') or '',
-        'description_he': getattr(index, 'heShortDesc', '') or '',
+        'description_en': strip_markdown(getattr(index, 'enShortDesc', '') or ''),
+        'description_he': strip_markdown(getattr(index, 'heShortDesc', '') or ''),
         'compDate': comp_date,
         'era': getattr(index, 'era', None),
         'authors': author_slugs,

--- a/sefaria/utils/tests/util_test.py
+++ b/sefaria/utils/tests/util_test.py
@@ -1,4 +1,4 @@
-from sefaria.utils.util import find_all_html_elements_indices, truncate_string
+from sefaria.utils.util import find_all_html_elements_indices, truncate_string, strip_markdown
 from sefaria.image_generator import html_to_text_canonical
 
 class TestFindAllHtmlElementsIndices:
@@ -67,6 +67,48 @@ class TestTruncateString:
         max_length = 22
         expected_output = "This is a long string…"
         assert truncate_string(string, min_length, max_length) == expected_output
+
+
+class TestStripMarkdown:
+
+    def test_empty_and_none(self):
+        assert strip_markdown("") == ""
+        assert strip_markdown(None) == ""
+
+    def test_plain_text_unchanged(self):
+        assert strip_markdown("A short description of a book.") == "A short description of a book."
+
+    def test_link(self):
+        # real sample from the 'animals' topic description
+        assert strip_markdown(
+            "the [book of Genesis](https://www.sefaria.org/Genesis?tab=contents) opens"
+        ) == "the book of Genesis opens"
+
+    def test_multiple_links(self):
+        assert strip_markdown(
+            "[Genesis](/Genesis) and [Exodus](/Exodus)"
+        ) == "Genesis and Exodus"
+
+    def test_asterisk_emphasis(self):
+        # real sample from the 'hoshana-rabbah' topic description
+        assert strip_markdown("reciting *hoshanot,* prayers") == "reciting hoshanot, prayers"
+
+    def test_underscore_emphasis(self):
+        # real sample from the 'gabriel-the-angel' topic description
+        assert strip_markdown("_The_ angel Gabriel") == "The angel Gabriel"
+
+    def test_bold(self):
+        assert strip_markdown("a **very** important idea") == "a very important idea"
+        assert strip_markdown("a __very__ important idea") == "a very important idea"
+
+    def test_emphasis_inside_link_text(self):
+        assert strip_markdown("[*Genesis*](/Genesis)") == "Genesis"
+
+    def test_html_stripped(self):
+        assert strip_markdown("a <b>bold</b> claim") == "a bold claim"
+
+    def test_hebrew_link(self):
+        assert strip_markdown("[ספר בראשית](/Genesis) נפתח") == "ספר בראשית נפתח"
 
 
 def test_html_to_text_canonical_cases():

--- a/sefaria/utils/util.py
+++ b/sefaria/utils/util.py
@@ -511,6 +511,22 @@ def strip_tags(html, remove_new_lines=False):
         stripped = re.sub(r"\n+", " ", stripped)
     return stripped
 
+
+def strip_markdown(text):
+    """
+    Returns `text` with markdown links, emphasis, and any HTML tags stripped,
+    leaving plain text.
+
+    Handles only the narrow markdown grammar that appears in topic/book
+    descriptions — [text](url) links, **bold**, and *emphasis*/_emphasis_ —
+    not arbitrary markdown.
+    """
+    text = re.sub(r'\[([^\]]*)\]\([^)]*\)', r'\1', text or '')  # [text](url) -> text
+    text = re.sub(r'(\*\*|__)(.+?)\1', r'\2', text)
+    text = re.sub(r'([*_])(.+?)\1', r'\2', text)
+    # strip_tags inserts a space per stripped tag; collapse the doubles it leaves
+    return re.sub(r'[ \t]{2,}', ' ', strip_tags(text))
+
 '''
 language code utils
 '''


### PR DESCRIPTION
## Description
Strip markdown from descriptions of books and topics when indexing ElasticSearch books and topics