### PR TITLE
Add SEARCH_INDEX_NAME_TOPIC and SEARCH_INDEX_NAME_BOOK settings

### DIFF
--- a/helm-chart/sefaria/templates/configmap/local-settings-file.yaml
+++ b/helm-chart/sefaria/templates/configmap/local-settings-file.yaml
@@ -182,6 +182,8 @@ data:
     SEARCH_INDEX_ON_SAVE = True
     SEARCH_INDEX_NAME_TEXT = os.getenv("SEARCH_INDEX_NAME_TEXT", "text")  # name of the ElasticSearch index to use
     SEARCH_INDEX_NAME_SHEET = os.getenv("SEARCH_INDEX_NAME_SHEET", "sheet")
+    SEARCH_INDEX_NAME_TOPIC = os.getenv("SEARCH_INDEX_NAME_TOPIC", "topic")
+    SEARCH_INDEX_NAME_BOOK = os.getenv("SEARCH_INDEX_NAME_BOOK", "book")
 
     USE_NODE = True
     NODE_HOST = "http://{}:3000".format(nodejsHost)

--- a/helm-chart/sefaria/templates/configmap/local-settings.yaml
+++ b/helm-chart/sefaria/templates/configmap/local-settings.yaml
@@ -38,6 +38,8 @@ data:
   SEARCH_SSL_ENABLE: {{ .Values.nginx.SEARCH_SSL_ENABLE | quote }}
   SEARCH_INDEX_NAME_TEXT: {{ .Values.localSettings.SEARCH_INDEX_NAME_TEXT | quote }}
   SEARCH_INDEX_NAME_SHEET: {{ .Values.localSettings.SEARCH_INDEX_NAME_SHEET | quote }}
+  SEARCH_INDEX_NAME_TOPIC: {{ .Values.localSettings.SEARCH_INDEX_NAME_TOPIC | quote }}
+  SEARCH_INDEX_NAME_BOOK: {{ .Values.localSettings.SEARCH_INDEX_NAME_BOOK | quote }}
   {{- if .Values.tasks.enabled }}
   REDIS_URL: {{ .Values.tasks.redis.url }}
   REDIS_PORT: {{ .Values.tasks.redis.port | quote }}

--- a/helm-chart/sefaria/values.yaml
+++ b/helm-chart/sefaria/values.yaml
@@ -458,6 +458,8 @@ localSettings:
   APSCHEDULER_NAME: "apscheduler-{{ .Values.deployEnv }}"
   SEARCH_INDEX_NAME_TEXT: "text"  # Override per cauldron for isolated indexes (e.g. "prod-sync_text")
   SEARCH_INDEX_NAME_SHEET: "sheet"  # Override per cauldron for isolated indexes (e.g. "prod-sync_sheet")
+  SEARCH_INDEX_NAME_TOPIC: "topic"  # Override per cauldron for isolated indexes (e.g. "prod-sync_topic")
+  SEARCH_INDEX_NAME_BOOK: "book"  # Override per cauldron for isolated indexes (e.g. "prod-sync_book")
   USE_CLOUDFLARE: false
   FRONT_END_URL: "http://www.sefaria.org"  # Use "http://${ENV_NAME}.cauldron.sefaria.org" in cauldrons
   OFFLINE: "False"

--- a/sefaria/local_settings_ci.py
+++ b/sefaria/local_settings_ci.py
@@ -82,6 +82,8 @@ SEARCH_URL = "http://localhost:9200"
 SEARCH_INDEX_ON_SAVE = False  # Whether to send texts and source sheet to Search Host for indexing after save
 SEARCH_INDEX_NAME_TEXT = 'text'  # name of the ElasticSearch index to use
 SEARCH_INDEX_NAME_SHEET = 'sheet'
+SEARCH_INDEX_NAME_TOPIC = 'topic'
+SEARCH_INDEX_NAME_BOOK = 'book'
 
 # Node Server
 USE_NODE = False

--- a/sefaria/local_settings_example.py
+++ b/sefaria/local_settings_example.py
@@ -179,6 +179,8 @@ SEARCH_URL = "http://localhost:9200"
 SEARCH_INDEX_ON_SAVE = False  # Whether to send texts and source sheet to Search Host for indexing after save
 SEARCH_INDEX_NAME_TEXT = 'text'  # name of the ElasticSearch index to use
 SEARCH_INDEX_NAME_SHEET = 'sheet'
+SEARCH_INDEX_NAME_TOPIC = 'topic'
+SEARCH_INDEX_NAME_BOOK = 'book'
 
 # Node Server
 USE_NODE = False


### PR DESCRIPTION
## Summary
- Adds `SEARCH_INDEX_NAME_TOPIC` and `SEARCH_INDEX_NAME_BOOK` as new overridable settings, mirroring the existing `SEARCH_INDEX_NAME_TEXT`/`SEARCH_INDEX_NAME_SHEET` pattern end-to-end.
- Scaffolding only — no code currently consumes these two settings yet.

## Changes
- `helm-chart/sefaria/values.yaml`: default values (`"topic"` / `"book"`), overridable per cauldron
- `helm-chart/sefaria/templates/configmap/local-settings.yaml`: configmap templating
- `helm-chart/sefaria/templates/configmap/local-settings-file.yaml`: generated `local_settings.py` on pods
- `sefaria/local_settings_example.py` / `sefaria/local_settings_ci.py`: repo-side dev/CI defaults

Note: these settings live in the Helm chart's plaintext configmap values, not the SOPS-encrypted prod secret — no prod decrypt access was needed.

Shortcut: https://app.shortcut.com/sefaria/story/45621

## Test plan
- [ ] Confirm `helm template` renders the new configmap keys correctly
- [ ] Confirm a deployed pod's `local_settings.py` includes `SEARCH_INDEX_NAME_TOPIC`/`SEARCH_INDEX_NAME_BOOK` with default fallback values
- [ ] Confirm per-cauldron override still works by overriding one of the new values in a values override file

🤖 Generated with [Claude Code](https://claude.com/claude-code)