### PR TITLE
feat(strapi localization): Display banners, modals, and sidebar ads independently per language

### DIFF
--- a/static/js/Misc.jsx
+++ b/static/js/Misc.jsx
@@ -11,6 +11,7 @@ import Component from 'react-class';
 import { usePaginatedDisplay } from './Hooks';
 import {AdContext, StrapiDataContext} from './context';
 import {matchesCountryTarget} from './sefaria/strapiTargeting';
+import {INTERFACE_LANG_TO_LOCALE} from './sefaria/strapiLocalization';
 import {getViewerCountryCandidates} from './sefaria/countryCandidates';
 import ReactCrop from 'react-image-crop';
 import 'react-image-crop/dist/ReactCrop.css';
@@ -2143,7 +2144,7 @@ const InterruptingMessage = ({
 
   const shouldShow = () => {
     if (!strapi.modal) return false;
-    if (Sefaria.interfaceLang === 'hebrew' && !strapi.modal.locales.includes('he')) return false;
+    if (!strapi.modal.locales.includes(INTERFACE_LANG_TO_LOCALE[Sefaria.interfaceLang])) return false;
     if (
       hasModalBeenInteractedWith(
         strapi.modal.internalModalName
@@ -2325,11 +2326,7 @@ const Banner = ({ onClose }) => {
 
   const shouldShow = () => {
     if (!strapi.banner) return false;
-    if (
-      Sefaria.interfaceLang === "hebrew" &&
-      !strapi.banner.locales.includes("he")
-    )
-      return false;
+    if (!strapi.banner.locales.includes(INTERFACE_LANG_TO_LOCALE[Sefaria.interfaceLang])) return false;
     if (Sefaria.experiments) return false;
     if (hasBannerBeenInteractedWith(strapi.banner.internalBannerName))
       return false;

--- a/static/js/Promotions.jsx
+++ b/static/js/Promotions.jsx
@@ -1,5 +1,6 @@
 import React, {useState, useContext, useEffect, useRef} from "react";
 import { AdContext, StrapiDataProvider, StrapiDataContext } from "./context";
+import { LOCALE_TO_INTERFACE_LANG } from "./sefaria/strapiLocalization";
 import classNames from "classnames";
 import Sefaria from "./sefaria/sefaria";
 import Util from "./sefaria/util";
@@ -31,51 +32,28 @@ const Promotions = () => {
               .filter((x) => x[0] === "!")
               .map((x) => x.slice(1));
             keywordTargetsArray = keywordTargetsArray.filter((x) => x[0] !== "!");
-            Sefaria._inAppAds.push({
-              campaignId: sidebarAd.internalCampaignId,
-              title: sidebarAd.title,
-              bodyText: sidebarAd.bodyText,
-              buttonText: sidebarAd.buttonText,
-              buttonURL: sidebarAd.buttonURL,
-              buttonIcon: sidebarAd.buttonIcon,
-              buttonLocation: sidebarAd.buttonAboveOrBelow,
-              hasBlueBackground: sidebarAd.hasBlueBackground,
-              isNewsletterSubscriptionInputForm: sidebarAd.isNewsletterSubscriptionInputForm,
-              newsletterMailingLists:
-                sidebarAd.newsletterMailingLists?.map(
-                  (mailingLists) => mailingLists.newsletterName
-                ) ?? [],
-              trigger: {
-                showTo: sidebarAd.showTo,
-                interfaceLang: "english",
-                startTimeDate: Date.parse(sidebarAd.startTime),
-                endTimeDate: Date.parse(sidebarAd.endTime),
-                keywordTargets: keywordTargetsArray,
-                excludeKeywordTargets: excludeKeywordTargets,
-              },
-              debug: sidebarAd.debug,
-            });
-            // Add a separate ad if there's a Hebrew translation. There can't be an ad with only Hebrew
-            if (sidebarAd.localizations?.length) {
-              const hebrewAttributes = sidebarAd.localizations[0];
-              const [buttonText, bodyText, buttonURL, title] = [
-                hebrewAttributes.buttonText,
-                hebrewAttributes.bodyText,
-                hebrewAttributes.buttonURL,
-                hebrewAttributes.title,
-              ];
+
+            // One ad per locale actually present on this document - a locale with no
+            // counterpart in another locale (e.g. Hebrew-only) is no longer skipped.
+            sidebarAd.locales.forEach((locale) => {
+              const localizedFields = sidebarAd.byLocale[locale];
               Sefaria._inAppAds.push({
                 campaignId: sidebarAd.internalCampaignId,
-                title: title,
-                bodyText: bodyText,
-                buttonText: buttonText,
-                buttonURL: buttonURL,
+                title: localizedFields.title,
+                bodyText: localizedFields.bodyText,
+                buttonText: localizedFields.buttonText,
+                buttonURL: localizedFields.buttonURL,
                 buttonIcon: sidebarAd.buttonIcon,
                 buttonLocation: sidebarAd.buttonAboveOrBelow,
                 hasBlueBackground: sidebarAd.hasBlueBackground,
+                isNewsletterSubscriptionInputForm: sidebarAd.isNewsletterSubscriptionInputForm,
+                newsletterMailingLists:
+                  sidebarAd.newsletterMailingLists?.map(
+                    (mailingLists) => mailingLists.newsletterName
+                  ) ?? [],
                 trigger: {
                   showTo: sidebarAd.showTo,
-                  interfaceLang: "hebrew",
+                  interfaceLang: LOCALE_TO_INTERFACE_LANG[locale],
                   startTimeDate: Date.parse(sidebarAd.startTime),
                   endTimeDate: Date.parse(sidebarAd.endTime),
                   keywordTargets: keywordTargetsArray,
@@ -83,7 +61,7 @@ const Promotions = () => {
                 },
                 debug: sidebarAd.debug,
               });
-            }
+            });
           });
           setInAppAds(Sefaria._inAppAds);
         }

--- a/static/js/Promotions.jsx
+++ b/static/js/Promotions.jsx
@@ -1,6 +1,6 @@
 import React, {useState, useContext, useEffect, useRef} from "react";
 import { AdContext, StrapiDataProvider, StrapiDataContext } from "./context";
-import { LOCALE_TO_INTERFACE_LANG } from "./sefaria/strapiLocalization";
+import { buildInAppAdsFromSidebarAds } from "./sefaria/sidebarAds";
 import classNames from "classnames";
 import Sefaria from "./sefaria/sefaria";
 import Util from "./sefaria/util";
@@ -24,45 +24,7 @@ const Promotions = () => {
         // Only an array is iterable here. A stale/incompatible payload may nest the ads under a wrapper object (Strapi v4's { data: [...] })
         // The wrong data type  must be treated as "no ads" rather than crashing on .forEach iterator
         if (Array.isArray(sidebarAds)) {
-          sidebarAds.forEach((sidebarAd) => {
-            let keywordTargetsArray = sidebarAd.keywords
-              .split(",")
-              .map((x) => x.trim().toLowerCase());
-            let excludeKeywordTargets = keywordTargetsArray
-              .filter((x) => x[0] === "!")
-              .map((x) => x.slice(1));
-            keywordTargetsArray = keywordTargetsArray.filter((x) => x[0] !== "!");
-
-            // One ad per locale actually present on this document - a locale with no
-            // counterpart in another locale (e.g. Hebrew-only) is no longer skipped.
-            sidebarAd.locales.forEach((locale) => {
-              const localizedFields = sidebarAd.byLocale[locale];
-              Sefaria._inAppAds.push({
-                campaignId: sidebarAd.internalCampaignId,
-                title: localizedFields.title,
-                bodyText: localizedFields.bodyText,
-                buttonText: localizedFields.buttonText,
-                buttonURL: localizedFields.buttonURL,
-                buttonIcon: sidebarAd.buttonIcon,
-                buttonLocation: sidebarAd.buttonAboveOrBelow,
-                hasBlueBackground: sidebarAd.hasBlueBackground,
-                isNewsletterSubscriptionInputForm: sidebarAd.isNewsletterSubscriptionInputForm,
-                newsletterMailingLists:
-                  sidebarAd.newsletterMailingLists?.map(
-                    (mailingLists) => mailingLists.newsletterName
-                  ) ?? [],
-                trigger: {
-                  showTo: sidebarAd.showTo,
-                  interfaceLang: LOCALE_TO_INTERFACE_LANG[locale],
-                  startTimeDate: Date.parse(sidebarAd.startTime),
-                  endTimeDate: Date.parse(sidebarAd.endTime),
-                  keywordTargets: keywordTargetsArray,
-                  excludeKeywordTargets: excludeKeywordTargets,
-                },
-                debug: sidebarAd.debug,
-              });
-            });
-          });
+          Sefaria._inAppAds = buildInAppAdsFromSidebarAds(sidebarAds);
           setInAppAds(Sefaria._inAppAds);
         }
       } catch (error) {

--- a/static/js/context.js
+++ b/static/js/context.js
@@ -18,11 +18,9 @@ AdContext.displayName = "AdContext";
 const StrapiDataContext = React.createContext({});
 StrapiDataContext.displayName = "StrapiDataContext";
 
-// Each content type's fields, queried per locale (below) instead of a single default-locale
-// query with a `localizations` child - that older shape could only ever discover documents
-// that have an English version, since a Strapi collection query with no `locale` argument
-// returns only the default locale. `documentId` is stable across every locale of a document
-// (Strapi v5), so it's the join key used to recombine the per-locale rows after the fetch.
+// Each content type's fields, queried per locale (below) instead of a single default-locale query with a `localizations` child - 
+// that older shape could only ever discover documents that have an English version, since a Strapi collection query with no `locale` argument returns only the default locale. 
+// `documentId` is stable across every locale of a document (Strapi v5), so it's the join key used to recombine the per-locale rows after the fetch.
 const bannerFields = `
             documentId
             internalBannerName
@@ -109,24 +107,25 @@ const sidebarAdFields = `
             }
 `;
 
-// Emits one aliased query field per supported locale (e.g. `en_banners`, `he_banners`),
-// so adding a locale to SUPPORTED_LOCALES fans out to every content type automatically.
+// Emits one aliased query field per supported locale (e.g. `en_banners`, `he_banners`), so adding a locale to SUPPORTED_LOCALES fans out to every content type automatically.
+// The `en_banners:` before the real `banners` field is a GraphQL alias:
+// it lets us query the same collection field once per locale in a single request and get each locale's rows back under a distinct response key (which rowsByLocale() reads below).
+// Without the alias GraphQL treats `en_banners` as a (nonexistent) field name and rejects the query.
 const buildLocalizedQueryBlock = (contentType, filtersExpression, fieldsSelection) =>
   SUPPORTED_LOCALES.map(
     (locale) => `
-          ${locale}_${contentType}(
+          ${locale}_${contentType}: ${contentType}(
             locale: "${locale}"
             filters: ${filtersExpression}
           ) {
             ${fieldsSelection}
           }
-`
+`,
   ).join("\n");
 
 // Gets data from a Strapi CMS instance to be used for displaying static content
 function StrapiDataProvider({ children }) {
-  const [dataFromStrapiHasBeenReceived, setDataFromStrapiHasBeenReceived] =
-    useState(false);
+  const [dataFromStrapiHasBeenReceived, setDataFromStrapiHasBeenReceived] = useState(false);
   const [strapiData, setStrapiData] = useState(null);
   const [modal, setModal] = useState(null);
   const [banner, setBanner] = useState(null);
@@ -158,7 +157,7 @@ function StrapiDataProvider({ children }) {
               bannerStartDate: { gte: "${startDate}" }
               and: [{ bannerEndDate: { lte: "${endDate}" } }]
             }`,
-            bannerFields
+            bannerFields,
           )}
           ${buildLocalizedQueryBlock(
             "modals",
@@ -166,7 +165,7 @@ function StrapiDataProvider({ children }) {
               modalStartDate: { gte: "${startDate}" }
               and: [{ modalEndDate: { lte: "${endDate}" } }]
             }`,
-            modalFields
+            modalFields,
           )}
           ${buildLocalizedQueryBlock(
             "sidebarAds",
@@ -174,14 +173,14 @@ function StrapiDataProvider({ children }) {
               startTime: { gte: "${startDate}" }
               and: [{ endTime: { lte: "${endDate}" } }]
             }`,
-            sidebarAdFields
+            sidebarAdFields,
           )}
         }
         `;
         // Use the new cache endpoint instead of calling Strapi directly to minimize API calls
         const url = new URL("/api/strapi/graphql-cache", window.location.origin);
-        url.searchParams.append('start_date', startDate.split('T')[0]); // Only use date part
-        url.searchParams.append('end_date', endDate.split('T')[0]);
+        url.searchParams.append("start_date", startDate.split("T")[0]); // Only use date part
+        url.searchParams.append("end_date", endDate.split("T")[0]);
 
         const result = fetch(url, {
           method: "POST",
@@ -207,8 +206,7 @@ function StrapiDataProvider({ children }) {
             const groupedBanners = groupByDocumentId(rowsByLocale("banners"), LOCALIZED_FIELDS.banner);
             const groupedSidebarAds = groupByDocumentId(rowsByLocale("sidebarAds"), LOCALIZED_FIELDS.sidebarAd);
 
-            // Promotions.jsx is the only consumer of strapiData; it iterates each grouped
-            // ad's `locales`/`byLocale` directly, so no InterfaceText normalization needed here.
+            // Promotions is the only consumer of strapiData; it iterates each grouped ad's `locales`/`byLocale` directly, so no InterfaceText normalization needed here.
             setStrapiData({ sidebarAds: groupedSidebarAds });
 
             let removeContentKeysFromLocalStorage = ({ prefix = "", except = "" } = {}) => {
@@ -216,10 +214,7 @@ function StrapiDataProvider({ children }) {
               // Removing keys while iterating affects the length of localStorage
               for (let i = 0; i < localStorage.length; i++) {
                 let key = localStorage.key(i);
-                if (
-                  key.startsWith(prefix) &&
-                  (except === "" || key !== prefix + except)
-                ) {
+                if (key.startsWith(prefix) && (except === "" || key !== prefix + except)) {
                   keysToRemove.push(key);
                 }
               }
@@ -232,9 +227,7 @@ function StrapiDataProvider({ children }) {
             if (groupedModals.length) {
               // Only one modal can be displayed currently. The first one that matches will be the one shown
               let matchedModal = groupedModals.find(
-                (modal) =>
-                  currentDate >= new Date(modal.modalStartDate) &&
-                  currentDate <= new Date(modal.modalEndDate)
+                (modal) => currentDate >= new Date(modal.modalStartDate) && currentDate <= new Date(modal.modalEndDate),
               );
               if (matchedModal) {
                 // Remove any other previous modals since there is potentially new modal to replace it
@@ -250,9 +243,7 @@ function StrapiDataProvider({ children }) {
             if (groupedBanners.length) {
               // Only one banner can be displayed currently. The first one that matches will be the one shown
               let matchedBanner = groupedBanners.find(
-                (b) =>
-                  currentDate >= new Date(b.bannerStartDate) &&
-                  currentDate <= new Date(b.bannerEndDate)
+                (b) => currentDate >= new Date(b.bannerStartDate) && currentDate <= new Date(b.bannerEndDate),
               );
 
               if (matchedBanner) {
@@ -288,9 +279,4 @@ function StrapiDataProvider({ children }) {
   );
 }
 
-export {
-  ReaderPanelContext,
-  AdContext,
-  StrapiDataProvider,
-  StrapiDataContext,
-};
+export { ReaderPanelContext, AdContext, StrapiDataProvider, StrapiDataContext };

--- a/static/js/context.js
+++ b/static/js/context.js
@@ -1,4 +1,11 @@
 import React, { useContext, useEffect, useState } from "react";
+import {
+  SUPPORTED_LOCALES,
+  LOCALIZED_FIELDS,
+  mapLocales,
+  groupByDocumentId,
+  buildInterfaceTextDoc,
+} from "./sefaria/strapiLocalization";
 
 const ReaderPanelContext = React.createContext({
   language: "english",
@@ -10,6 +17,111 @@ AdContext.displayName = "AdContext";
 
 const StrapiDataContext = React.createContext({});
 StrapiDataContext.displayName = "StrapiDataContext";
+
+// Each content type's fields, queried per locale (below) instead of a single default-locale
+// query with a `localizations` child - that older shape could only ever discover documents
+// that have an English version, since a Strapi collection query with no `locale` argument
+// returns only the default locale. `documentId` is stable across every locale of a document
+// (Strapi v5), so it's the join key used to recombine the per-locale rows after the fetch.
+const bannerFields = `
+            documentId
+            internalBannerName
+            bannerEndDate
+            bannerStartDate
+            bannerText
+            buttonText
+            buttonURL
+            showDelay
+            bannerBackgroundColor
+            createdAt
+            locale
+            publishedAt
+            shouldDeployOnMobile
+            showToNewVisitors
+            showToNonSustainers
+            showToReturningVisitors
+            showToSustainers
+            showTo
+            countriesToTarget {
+              countryMode
+              countries {
+                name
+                code
+              }
+            }
+            updatedAt
+`;
+
+const modalFields = `
+            documentId
+            internalModalName
+            buttonText
+            buttonURL
+            showDelay
+            createdAt
+            locale
+            modalEndDate
+            modalStartDate
+            modalHeader
+            modalText
+            publishedAt
+            shouldDeployOnMobile
+            showToNewVisitors
+            showToNonSustainers
+            showToReturningVisitors
+            showToSustainers
+            showTo
+            countriesToTarget {
+              countryMode
+              countries {
+                name
+                code
+              }
+            }
+            updatedAt
+`;
+
+const sidebarAdFields = `
+            documentId
+            buttonAboveOrBelow
+            title
+            bodyText
+            buttonText
+            buttonURL
+            buttonIcon {
+              url
+              alternativeText
+            }
+            createdAt
+            debug
+            endTime
+            hasBlueBackground
+            internalCampaignId
+            keywords
+            locale
+            publishedAt
+            showTo
+            startTime
+            updatedAt
+            isNewsletterSubscriptionInputForm
+            newsletterMailingLists {
+              newsletterName
+            }
+`;
+
+// Emits one aliased query field per supported locale (e.g. `en_banners`, `he_banners`),
+// so adding a locale to SUPPORTED_LOCALES fans out to every content type automatically.
+const buildLocalizedQueryBlock = (contentType, filtersExpression, fieldsSelection) =>
+  SUPPORTED_LOCALES.map(
+    (locale) => `
+          ${locale}_${contentType}(
+            locale: "${locale}"
+            filters: ${filtersExpression}
+          ) {
+            ${fieldsSelection}
+          }
+`
+  ).join("\n");
 
 // Gets data from a Strapi CMS instance to be used for displaying static content
 function StrapiDataProvider({ children }) {
@@ -40,124 +152,30 @@ function StrapiDataProvider({ children }) {
         // There is no conflict resolution for overlapping timeframes
         const query = `
         query {
-          banners(
-            filters: {
-              bannerStartDate: { gte: \"${startDate}\" }
-              and: [{ bannerEndDate: { lte: \"${endDate}\" } }]
-            }
-          ) {
-            documentId
-            internalBannerName
-            bannerEndDate
-            bannerStartDate
-            bannerText
-            buttonText
-            buttonURL
-            showDelay
-            bannerBackgroundColor
-            createdAt
-            locale
-            localizations {
-              locale
-              buttonText
-              buttonURL
-              bannerText
-            }
-            publishedAt
-            shouldDeployOnMobile
-            showToNewVisitors
-            showToNonSustainers
-            showToReturningVisitors
-            showToSustainers
-            showTo
-            countriesToTarget {
-              countryMode
-              countries {
-                name
-                code
-              }
-            }
-            updatedAt
-          }
-          modals(
-            filters: {
-              modalStartDate: { gte: \"${startDate}\" }
-              and: [{ modalEndDate: { lte: \"${endDate}\" } }]
-            }
-          ) {
-            documentId
-            internalModalName
-            buttonText
-            buttonURL
-            showDelay
-            createdAt
-            locale
-            localizations {
-              locale
-              buttonText
-              buttonURL
-              modalHeader
-              modalText
-            }
-            modalEndDate
-            modalStartDate
-            modalHeader
-            modalText
-            publishedAt
-            shouldDeployOnMobile
-            showToNewVisitors
-            showToNonSustainers
-            showToReturningVisitors
-            showToSustainers
-            showTo
-            countriesToTarget {
-              countryMode
-              countries {
-                name
-                code
-              }
-            }
-            updatedAt
-          }
-          sidebarAds(
-            filters: {
-              startTime: { gte: \"${startDate}\" }
-              and: [{ endTime: { lte: \"${endDate}\" } }]
-            }
-          ) {
-            documentId
-            buttonAboveOrBelow
-            title
-            bodyText
-            buttonText
-            buttonURL
-            buttonIcon {
-              url
-              alternativeText
-            }
-            createdAt
-            debug
-            endTime
-            hasBlueBackground
-            internalCampaignId
-            keywords
-            locale
-            localizations {
-              locale
-              title
-              bodyText
-              buttonText
-              buttonURL
-            }
-            publishedAt
-            showTo
-            startTime
-            updatedAt
-            isNewsletterSubscriptionInputForm
-            newsletterMailingLists {
-              newsletterName
-            }
-          }
+          ${buildLocalizedQueryBlock(
+            "banners",
+            `{
+              bannerStartDate: { gte: "${startDate}" }
+              and: [{ bannerEndDate: { lte: "${endDate}" } }]
+            }`,
+            bannerFields
+          )}
+          ${buildLocalizedQueryBlock(
+            "modals",
+            `{
+              modalStartDate: { gte: "${startDate}" }
+              and: [{ modalEndDate: { lte: "${endDate}" } }]
+            }`,
+            modalFields
+          )}
+          ${buildLocalizedQueryBlock(
+            "sidebarAds",
+            `{
+              startTime: { gte: "${startDate}" }
+              and: [{ endTime: { lte: "${endDate}" } }]
+            }`,
+            sidebarAdFields
+          )}
         }
         `;
         // Use the new cache endpoint instead of calling Strapi directly to minimize API calls
@@ -179,12 +197,19 @@ function StrapiDataProvider({ children }) {
             return response.json();
           })
           .then((result) => {
-            setStrapiData(result.data);
             setDataFromStrapiHasBeenReceived(true);
 
-            // Decompose the modals and banners from the GraphQL query response for easier handling
-            let modals = result.data?.modals;
-            let banners = result.data?.banners;
+            // Each content type's per-locale rows, keyed by locale, e.g. {en: [...], he: [...]}
+            const rowsByLocale = (contentType) =>
+              mapLocales((locale) => result.data?.[`${locale}_${contentType}`] || []);
+
+            const groupedModals = groupByDocumentId(rowsByLocale("modals"), LOCALIZED_FIELDS.modal);
+            const groupedBanners = groupByDocumentId(rowsByLocale("banners"), LOCALIZED_FIELDS.banner);
+            const groupedSidebarAds = groupByDocumentId(rowsByLocale("sidebarAds"), LOCALIZED_FIELDS.sidebarAd);
+
+            // Promotions.jsx is the only consumer of strapiData; it iterates each grouped
+            // ad's `locales`/`byLocale` directly, so no InterfaceText normalization needed here.
+            setStrapiData({ sidebarAds: groupedSidebarAds });
 
             let removeContentKeysFromLocalStorage = ({ prefix = "", except = "" } = {}) => {
               let keysToRemove = [];
@@ -204,96 +229,40 @@ function StrapiDataProvider({ children }) {
             };
 
             const currentDate = new Date();
-            if (modals?.length) {
+            if (groupedModals.length) {
               // Only one modal can be displayed currently. The first one that matches will be the one shown
-              let modal = modals.find(
+              let matchedModal = groupedModals.find(
                 (modal) =>
                   currentDate >= new Date(modal.modalStartDate) &&
                   currentDate <= new Date(modal.modalEndDate)
               );
-              if (modal) {
+              if (matchedModal) {
                 // Remove any other previous modals since there is potentially new modal to replace it
                 // However, do not remove the existing modal if the eligible one found is the same as the current one
                 removeContentKeysFromLocalStorage({
                   prefix: "modal_",
-                  except: modal.internalModalName,
+                  except: matchedModal.internalModalName,
                 });
-
-                // Check if there is a Hebrew translation for the modal
-                if (modal.localizations?.length) {
-                  let localization_attributes = modal.localizations[0];
-                  // Ignore the locale because only Hebrew is supported currently
-                  let { locale, ...hebrew_attributes } =
-                    localization_attributes;
-                  // Iterate over the localizable attributes in parallel to create an object compatible for use in an InterfaceText
-                  Object.keys(hebrew_attributes).forEach((attribute) => {
-                    modal[attribute] = {
-                      en: modal[attribute],
-                      he: hebrew_attributes[attribute],
-                    };
-                  });
-                  modal.locales = ["en", "he"];
-                } else {
-                  [
-                    "modalHeader",
-                    "modalText",
-                    "buttonText",
-                    "buttonURL",
-                  ].forEach((attribute) => {
-                    modal[attribute] = {
-                      en: modal[attribute],
-                      he: null,
-                    };
-                  });
-                  modal.locales = ["en"];
-                }
-                setModal(modal);
+                setModal(buildInterfaceTextDoc(matchedModal, LOCALIZED_FIELDS.modal));
               }
             }
 
-            if (banners?.length) {
+            if (groupedBanners.length) {
               // Only one banner can be displayed currently. The first one that matches will be the one shown
-              let banner = banners.find(
+              let matchedBanner = groupedBanners.find(
                 (b) =>
                   currentDate >= new Date(b.bannerStartDate) &&
                   currentDate <= new Date(b.bannerEndDate)
               );
 
-              if (banner) {
+              if (matchedBanner) {
                 // Remove any other previous banner since there is potentially new modal to replace it
                 // However, do not remove the existing banner if the eligible one found is the same as the current one
                 removeContentKeysFromLocalStorage({
                   prefix: "banner_",
-                  except: banner.internalBannerName,
+                  except: matchedBanner.internalBannerName,
                 });
-
-                // Check if there is a Hebrew translation
-                if (banner.localizations?.length) {
-                  let localization_attributes = banner.localizations[0];
-                  // Get the hebrew attributes
-                  let { locale, ...hebrew_attributes } =
-                    localization_attributes;
-                  // Iterate over the localizable attributes in parallel to create an object compatible for use in an InterfaceText
-                  Object.keys(hebrew_attributes).forEach((attribute) => {
-                    banner[attribute] = {
-                      en: banner[attribute],
-                      he: hebrew_attributes[attribute],
-                    };
-                  });
-                  banner.locales = ["en", "he"];
-                } else {
-                  // TODO: Make the GraphQL query return nilable attributes so the attributes (just their keys) can be iterated over within the localization object
-                  ["bannerText", "buttonText", "buttonURL"].forEach(
-                    (attribute) => {
-                      banner[attribute] = {
-                        en: banner[attribute],
-                        he: null,
-                      };
-                    }
-                  );
-                  banner.locales = ["en"];
-                }
-                setBanner(banner);
+                setBanner(buildInterfaceTextDoc(matchedBanner, LOCALIZED_FIELDS.banner));
               }
             }
           })

--- a/static/js/sefaria/sidebarAds.js
+++ b/static/js/sefaria/sidebarAds.js
@@ -1,0 +1,39 @@
+import { LOCALE_TO_INTERFACE_LANG } from "./strapiLocalization";
+
+// sidebarAds: array of grouped docs from groupByDocumentId (each carrying byLocale/locales).
+// One in-app ad per locale actually present on the document, so a locale with no
+// counterpart in another locale (e.g. Hebrew-only) is no longer skipped.
+const buildInAppAdsFromSidebarAds = (sidebarAds) =>
+  sidebarAds.flatMap((sidebarAd) => {
+    let keywordTargetsArray = sidebarAd.keywords.split(",").map((x) => x.trim().toLowerCase());
+    const excludeKeywordTargets = keywordTargetsArray.filter((x) => x[0] === "!").map((x) => x.slice(1));
+    keywordTargetsArray = keywordTargetsArray.filter((x) => x[0] !== "!");
+
+    return sidebarAd.locales.map((locale) => {
+      const localizedFields = sidebarAd.byLocale[locale];
+      return {
+        campaignId: sidebarAd.internalCampaignId,
+        title: localizedFields.title,
+        bodyText: localizedFields.bodyText,
+        buttonText: localizedFields.buttonText,
+        buttonURL: localizedFields.buttonURL,
+        buttonIcon: sidebarAd.buttonIcon,
+        buttonLocation: sidebarAd.buttonAboveOrBelow,
+        hasBlueBackground: sidebarAd.hasBlueBackground,
+        isNewsletterSubscriptionInputForm: sidebarAd.isNewsletterSubscriptionInputForm,
+        newsletterMailingLists:
+          sidebarAd.newsletterMailingLists?.map((mailingLists) => mailingLists.newsletterName) ?? [],
+        trigger: {
+          showTo: sidebarAd.showTo,
+          interfaceLang: LOCALE_TO_INTERFACE_LANG[locale],
+          startTimeDate: Date.parse(sidebarAd.startTime),
+          endTimeDate: Date.parse(sidebarAd.endTime),
+          keywordTargets: keywordTargetsArray,
+          excludeKeywordTargets: excludeKeywordTargets,
+        },
+        debug: sidebarAd.debug,
+      };
+    });
+  });
+
+export { buildInAppAdsFromSidebarAds };

--- a/static/js/sefaria/strapiLocalization.js
+++ b/static/js/sefaria/strapiLocalization.js
@@ -1,0 +1,83 @@
+// Locale plumbing shared by context.js (banners/modals) and Promotions.jsx (sidebar ads).
+// Every function here is pure: it returns new objects/arrays and never mutates its arguments.
+
+const SUPPORTED_LOCALES = ["en", "he"]; // first entry is the default/base locale
+
+const LOCALE_TO_INTERFACE_LANG = { en: "english", he: "hebrew" };
+
+const INTERFACE_LANG_TO_LOCALE = Object.fromEntries(
+  Object.entries(LOCALE_TO_INTERFACE_LANG).map(([locale, lang]) => [lang, locale])
+);
+
+const LOCALIZED_FIELDS = {
+  banner: ["bannerText", "buttonText", "buttonURL"],
+  modal: ["modalHeader", "modalText", "buttonText", "buttonURL"],
+  sidebarAd: ["title", "bodyText", "buttonText", "buttonURL"],
+};
+
+// Generic helpers (lodash/Ruby-style building blocks) -----------------------
+
+// groupBy([{a:1},{a:1},{a:2}], x => x.a) -> {1: [...], 2: [...]}
+// Not Object.groupBy: that's ES2024 and unpolyfilled in this build (babel.preset-env
+// here has no useBuiltIns/corejs option, and core-js/stable is only imported by a few
+// unrelated entry bundles) - unsafe to rely on in both the browser target and Jest (Node 20).
+const groupBy = (list, keyFn) => {
+  const result = {};
+  list.forEach((item) => {
+    const key = keyFn(item);
+    (result[key] || (result[key] = [])).push(item);
+  });
+  return result;
+};
+
+// keyBy([{id:1},{id:2}], x => x.id) -> {1: {id:1}, 2: {id:2}}
+const keyBy = (list, keyFn) => Object.fromEntries(list.map((item) => [keyFn(item), item]));
+
+// omit({a:1, b:2}, ["b"]) -> {a:1}
+const omit = (obj, keys) => {
+  const keysToDrop = new Set(keys);
+  return Object.fromEntries(Object.entries(obj).filter(([key]) => !keysToDrop.has(key)));
+};
+
+// mapLocales(locale => locale.toUpperCase()) -> {en: "EN", he: "HE"}
+const mapLocales = (fn) => Object.fromEntries(SUPPORTED_LOCALES.map((locale) => [locale, fn(locale)]));
+
+// Domain functions ------------------------------------------------------------
+
+// rowsByLocale: {en: [row, ...], he: [row, ...]} where each row carries its own
+// `documentId` and `locale` fields (the GraphQL alias's locale, per Strapi v5 docs).
+// Returns one entry per distinct documentId, merging whichever locales are present.
+const groupByDocumentId = (rowsByLocale, localizedFields) => {
+  const allRows = SUPPORTED_LOCALES.flatMap((locale) => rowsByLocale[locale] || []);
+  const rowsByDocumentId = groupBy(allRows, (row) => row.documentId);
+  return Object.values(rowsByDocumentId).map((rows) => {
+    const byLocale = keyBy(rows, (row) => row.locale);
+    // Non-text fields (dates, targeting, showTo, ...) are identical across locale
+    // rows of the same document, so any row can supply them.
+    const sharedFields = omit(rows[0], [...localizedFields, "locale"]);
+    return { ...sharedFields, byLocale, locales: rows.map((row) => row.locale) };
+  });
+};
+
+// Rewrites each localized field on a grouped doc into the {en, he} shape consumed
+// by InterfaceText and the manual .en/.he conditionals in Misc.jsx.
+const buildInterfaceTextDoc = (groupedDoc, localizedFields) => {
+  const { byLocale, locales, ...sharedFields } = groupedDoc;
+  const localizedValues = Object.fromEntries(
+    localizedFields.map((field) => [field, mapLocales((locale) => byLocale[locale]?.[field] ?? null)])
+  );
+  return { ...sharedFields, ...localizedValues, locales };
+};
+
+export {
+  SUPPORTED_LOCALES,
+  LOCALE_TO_INTERFACE_LANG,
+  INTERFACE_LANG_TO_LOCALE,
+  LOCALIZED_FIELDS,
+  groupBy,
+  keyBy,
+  omit,
+  mapLocales,
+  groupByDocumentId,
+  buildInterfaceTextDoc,
+};

--- a/static/js/sefaria/strapiLocalization.js
+++ b/static/js/sefaria/strapiLocalization.js
@@ -1,12 +1,11 @@
 // Locale plumbing shared by context.js (banners/modals) and Promotions.jsx (sidebar ads).
-// Every function here is pure: it returns new objects/arrays and never mutates its arguments.
 
 const SUPPORTED_LOCALES = ["en", "he"]; // first entry is the default/base locale
 
 const LOCALE_TO_INTERFACE_LANG = { en: "english", he: "hebrew" };
 
 const INTERFACE_LANG_TO_LOCALE = Object.fromEntries(
-  Object.entries(LOCALE_TO_INTERFACE_LANG).map(([locale, lang]) => [lang, locale])
+  Object.entries(LOCALE_TO_INTERFACE_LANG).map(([locale, lang]) => [lang, locale]),
 );
 
 const LOCALIZED_FIELDS = {
@@ -18,9 +17,12 @@ const LOCALIZED_FIELDS = {
 // Generic helpers (lodash/Ruby-style building blocks) -----------------------
 
 // groupBy([{a:1},{a:1},{a:2}], x => x.a) -> {1: [...], 2: [...]}
-// Not Object.groupBy: that's ES2024 and unpolyfilled in this build (babel.preset-env
-// here has no useBuiltIns/corejs option, and core-js/stable is only imported by a few
-// unrelated entry bundles) - unsafe to rely on in both the browser target and Jest (Node 20).
+// TODO: Come back to this
+// Not Object.groupBy: it's a built-in *method* (not syntax), so Babel passes it through unchanged and it relies on native runtime support. 
+// Jest runs on Node 20 (CI + local), which predates Object.groupBy (added in Node 21 / V8 12.1) - 
+// so it's `undefined` there and any test touching it throws `TypeError: Object.groupBy is not a function`. 
+// The Node test runtime, not the browser, is the constraint; modern browsers have supported it since ~2024. 
+// Hand-roll it so the code runs identically in both environments.
 const groupBy = (list, keyFn) => {
   const result = {};
   list.forEach((item) => {
@@ -42,8 +44,6 @@ const omit = (obj, keys) => {
 // mapLocales(locale => locale.toUpperCase()) -> {en: "EN", he: "HE"}
 const mapLocales = (fn) => Object.fromEntries(SUPPORTED_LOCALES.map((locale) => [locale, fn(locale)]));
 
-// Domain functions ------------------------------------------------------------
-
 // rowsByLocale: {en: [row, ...], he: [row, ...]} where each row carries its own
 // `documentId` and `locale` fields (the GraphQL alias's locale, per Strapi v5 docs).
 // Returns one entry per distinct documentId, merging whichever locales are present.
@@ -52,19 +52,17 @@ const groupByDocumentId = (rowsByLocale, localizedFields) => {
   const rowsByDocumentId = groupBy(allRows, (row) => row.documentId);
   return Object.values(rowsByDocumentId).map((rows) => {
     const byLocale = keyBy(rows, (row) => row.locale);
-    // Non-text fields (dates, targeting, showTo, ...) are identical across locale
-    // rows of the same document, so any row can supply them.
+    // Non-text fields (dates, targeting, showTo, ...) are identical across locale rows of the same document, so any row can supply them.
     const sharedFields = omit(rows[0], [...localizedFields, "locale"]);
     return { ...sharedFields, byLocale, locales: rows.map((row) => row.locale) };
   });
 };
 
-// Rewrites each localized field on a grouped doc into the {en, he} shape consumed
-// by InterfaceText and the manual .en/.he conditionals in Misc.jsx.
+// Rewrites each localized field on a grouped doc into the {en, he} object shape consumed by InterfaceText and the manual .en/.he conditionals in Misc.jsx.
 const buildInterfaceTextDoc = (groupedDoc, localizedFields) => {
   const { byLocale, locales, ...sharedFields } = groupedDoc;
   const localizedValues = Object.fromEntries(
-    localizedFields.map((field) => [field, mapLocales((locale) => byLocale[locale]?.[field] ?? null)])
+    localizedFields.map((field) => [field, mapLocales((locale) => byLocale[locale]?.[field] ?? null)]),
   );
   return { ...sharedFields, ...localizedValues, locales };
 };

--- a/static/js/sefaria/tests/sidebarAds.test.js
+++ b/static/js/sefaria/tests/sidebarAds.test.js
@@ -1,0 +1,111 @@
+/* Testing done using Jest */
+import { buildInAppAdsFromSidebarAds } from "../sidebarAds";
+import { groupByDocumentId, LOCALIZED_FIELDS } from "../strapiLocalization";
+
+describe("buildInAppAdsFromSidebarAds", function () {
+  const makeSidebarAd = (overrides = {}) => ({
+    internalCampaignId: "camp-1",
+    keywords: "Torah, Shabbat, !skip",
+    buttonIcon: "icon.png",
+    buttonAboveOrBelow: "above",
+    hasBlueBackground: true,
+    isNewsletterSubscriptionInputForm: false,
+    newsletterMailingLists: [{ newsletterName: "General" }],
+    showTo: "everyone",
+    startTime: "2026-01-01T00:00:00Z",
+    endTime: "2026-02-01T00:00:00Z",
+    debug: false,
+    locales: ["en", "he"],
+    byLocale: {
+      en: { title: "En Title", bodyText: "En Body", buttonText: "En Button", buttonURL: "https://example.com/en" },
+      he: { title: "He Title", bodyText: "He Body", buttonText: "He Button", buttonURL: "https://example.com/he" },
+    },
+    ...overrides,
+  });
+
+  it("produces one ad per locale present on the document", function () {
+    const [enAd, heAd] = buildInAppAdsFromSidebarAds([makeSidebarAd()]);
+
+    expect(enAd.trigger.interfaceLang).toBe("english");
+    expect(enAd.title).toBe("En Title");
+    expect(heAd.trigger.interfaceLang).toBe("hebrew");
+    expect(heAd.title).toBe("He Title");
+  });
+
+  it("produces a single hebrew ad for a hebrew-only document, with no english counterpart required", function () {
+    const heOnlyAd = makeSidebarAd({
+      locales: ["he"],
+      byLocale: {
+        he: { title: "He Only", bodyText: "Body", buttonText: "Click", buttonURL: "https://example.com/he" },
+      },
+    });
+
+    const ads = buildInAppAdsFromSidebarAds([heOnlyAd]);
+
+    expect(ads).toHaveLength(1);
+    expect(ads[0].trigger.interfaceLang).toBe("hebrew");
+    expect(ads[0].title).toBe("He Only");
+  });
+
+  it("splits keywords into targets and exclude-targets, trimmed and lowercased", function () {
+    const [ad] = buildInAppAdsFromSidebarAds([makeSidebarAd({ locales: ["en"] })]);
+
+    expect(ad.trigger.keywordTargets).toEqual(["torah", "shabbat"]);
+    expect(ad.trigger.excludeKeywordTargets).toEqual(["skip"]);
+  });
+
+  it("maps newsletterMailingLists to plain names and defaults to an empty array when absent", function () {
+    const [withLists] = buildInAppAdsFromSidebarAds([makeSidebarAd({ locales: ["en"] })]);
+    expect(withLists.newsletterMailingLists).toEqual(["General"]);
+
+    const [withoutLists] = buildInAppAdsFromSidebarAds([
+      makeSidebarAd({ locales: ["en"], newsletterMailingLists: undefined }),
+    ]);
+    expect(withoutLists.newsletterMailingLists).toEqual([]);
+  });
+
+  it("flattens multiple sidebar ads, each contributing their own locale-ads, into a single array", function () {
+    const ads = buildInAppAdsFromSidebarAds([
+      makeSidebarAd({ internalCampaignId: "camp-1", locales: ["en"] }),
+      makeSidebarAd({
+        internalCampaignId: "camp-2",
+        locales: ["he"],
+        byLocale: { he: { title: "T2", bodyText: "B2", buttonText: "C2", buttonURL: "u2" } },
+      }),
+    ]);
+
+    expect(ads).toHaveLength(2);
+    expect(ads.map((ad) => ad.campaignId)).toEqual(["camp-1", "camp-2"]);
+  });
+
+  it("composes with groupByDocumentId's output shape end-to-end for a hebrew-only strapi row", function () {
+    const rowsByLocale = {
+      en: [],
+      he: [
+        {
+          documentId: "doc-1",
+          locale: "he",
+          internalCampaignId: "camp-3",
+          keywords: "kabbalah",
+          buttonAboveOrBelow: "below",
+          hasBlueBackground: false,
+          showTo: "everyone",
+          startTime: "2026-01-01T00:00:00Z",
+          endTime: "2026-02-01T00:00:00Z",
+          debug: false,
+          title: "He title",
+          bodyText: "He body",
+          buttonText: "He button",
+          buttonURL: "https://example.com/he",
+        },
+      ],
+    };
+    const grouped = groupByDocumentId(rowsByLocale, LOCALIZED_FIELDS.sidebarAd);
+
+    const ads = buildInAppAdsFromSidebarAds(grouped);
+
+    expect(ads).toHaveLength(1);
+    expect(ads[0].trigger.interfaceLang).toBe("hebrew");
+    expect(ads[0].title).toBe("He title");
+  });
+});

--- a/static/js/sefaria/tests/strapiLocalization.test.js
+++ b/static/js/sefaria/tests/strapiLocalization.test.js
@@ -1,0 +1,170 @@
+/* Testing done using Jest */
+import {
+  SUPPORTED_LOCALES,
+  LOCALE_TO_INTERFACE_LANG,
+  INTERFACE_LANG_TO_LOCALE,
+  groupBy,
+  keyBy,
+  omit,
+  mapLocales,
+  groupByDocumentId,
+  buildInterfaceTextDoc,
+} from "../strapiLocalization";
+
+describe("config", function () {
+  it("SUPPORTED_LOCALES has en as the default/base locale first", function () {
+    expect(SUPPORTED_LOCALES[0]).toBe("en");
+    expect(SUPPORTED_LOCALES).toContain("he");
+  });
+
+  it("LOCALE_TO_INTERFACE_LANG and INTERFACE_LANG_TO_LOCALE are inverses", function () {
+    expect(LOCALE_TO_INTERFACE_LANG).toEqual({ en: "english", he: "hebrew" });
+    expect(INTERFACE_LANG_TO_LOCALE).toEqual({ english: "en", hebrew: "he" });
+  });
+});
+
+describe("groupBy", function () {
+  it("groups items under their key, preserving order within each group", function () {
+    const items = [{ a: 1, id: "x" }, { a: 2, id: "y" }, { a: 1, id: "z" }];
+    expect(groupBy(items, (item) => item.a)).toEqual({
+      1: [{ a: 1, id: "x" }, { a: 1, id: "z" }],
+      2: [{ a: 2, id: "y" }],
+    });
+  });
+
+  it("does not mutate the input list or its items", function () {
+    const items = [{ a: 1 }];
+    const itemsCopy = JSON.parse(JSON.stringify(items));
+    groupBy(items, (item) => item.a);
+    expect(items).toEqual(itemsCopy);
+  });
+
+  it("returns an empty object for an empty list", function () {
+    expect(groupBy([], (item) => item.a)).toEqual({});
+  });
+});
+
+describe("keyBy", function () {
+  it("indexes items by key", function () {
+    const items = [{ id: "en", v: 1 }, { id: "he", v: 2 }];
+    expect(keyBy(items, (item) => item.id)).toEqual({ en: { id: "en", v: 1 }, he: { id: "he", v: 2 } });
+  });
+
+  it("keeps the last item when keys collide", function () {
+    const items = [{ id: "en", v: 1 }, { id: "en", v: 2 }];
+    expect(keyBy(items, (item) => item.id)).toEqual({ en: { id: "en", v: 2 } });
+  });
+});
+
+describe("omit", function () {
+  it("drops the given keys and keeps the rest", function () {
+    expect(omit({ a: 1, b: 2, c: 3 }, ["b"])).toEqual({ a: 1, c: 3 });
+  });
+
+  it("does not mutate the input object", function () {
+    const obj = { a: 1, b: 2 };
+    omit(obj, ["b"]);
+    expect(obj).toEqual({ a: 1, b: 2 });
+  });
+
+  it("is a no-op when none of the keys are present", function () {
+    expect(omit({ a: 1 }, ["z"])).toEqual({ a: 1 });
+  });
+});
+
+describe("mapLocales", function () {
+  it("builds an object keyed by every supported locale", function () {
+    expect(mapLocales((locale) => locale.toUpperCase())).toEqual({ en: "EN", he: "HE" });
+  });
+});
+
+const bannerLocalizedFields = ["bannerText", "buttonText", "buttonURL"];
+
+const makeRow = (locale, overrides = {}) => ({
+  documentId: "doc-1",
+  locale,
+  internalBannerName: "spring-sale",
+  bannerStartDate: "2026-01-01",
+  bannerText: `text-${locale}`,
+  buttonText: `button-${locale}`,
+  buttonURL: `https://example.com/${locale}`,
+  ...overrides,
+});
+
+describe("groupByDocumentId", function () {
+  it("merges en and he rows of the same document into one entry with both locales present", function () {
+    const rowsByLocale = { en: [makeRow("en")], he: [makeRow("he")] };
+    const grouped = groupByDocumentId(rowsByLocale, bannerLocalizedFields);
+
+    expect(grouped).toHaveLength(1);
+    expect(grouped[0].documentId).toBe("doc-1");
+    expect(grouped[0].locales.sort()).toEqual(["en", "he"]);
+    expect(grouped[0].internalBannerName).toBe("spring-sale"); // shared, non-localized field
+    expect(grouped[0].byLocale.en.bannerText).toBe("text-en");
+    expect(grouped[0].byLocale.he.bannerText).toBe("text-he");
+  });
+
+  it("produces a he-only entry when no en row exists for the document", function () {
+    const rowsByLocale = { en: [], he: [makeRow("he")] };
+    const grouped = groupByDocumentId(rowsByLocale, bannerLocalizedFields);
+
+    expect(grouped).toHaveLength(1);
+    expect(grouped[0].locales).toEqual(["he"]);
+    expect(grouped[0].byLocale.en).toBeUndefined();
+    expect(grouped[0].byLocale.he.bannerText).toBe("text-he");
+  });
+
+  it("produces an en-only entry when no he row exists for the document", function () {
+    const rowsByLocale = { en: [makeRow("en")], he: [] };
+    const grouped = groupByDocumentId(rowsByLocale, bannerLocalizedFields);
+
+    expect(grouped).toHaveLength(1);
+    expect(grouped[0].locales).toEqual(["en"]);
+    expect(grouped[0].byLocale.he).toBeUndefined();
+  });
+
+  it("keeps distinct documents separate", function () {
+    const rowsByLocale = {
+      en: [makeRow("en", { documentId: "doc-1" }), makeRow("en", { documentId: "doc-2" })],
+      he: [makeRow("he", { documentId: "doc-1" })],
+    };
+    const grouped = groupByDocumentId(rowsByLocale, bannerLocalizedFields);
+
+    expect(grouped).toHaveLength(2);
+    const byId = keyBy(grouped, (doc) => doc.documentId);
+    expect(byId["doc-1"].locales.sort()).toEqual(["en", "he"]);
+    expect(byId["doc-2"].locales).toEqual(["en"]);
+  });
+});
+
+describe("buildInterfaceTextDoc", function () {
+  it("builds an {en, he} shape for each localized field when both locales are present", function () {
+    const rowsByLocale = { en: [makeRow("en")], he: [makeRow("he")] };
+    const [grouped] = groupByDocumentId(rowsByLocale, bannerLocalizedFields);
+    const doc = buildInterfaceTextDoc(grouped, bannerLocalizedFields);
+
+    expect(doc.bannerText).toEqual({ en: "text-en", he: "text-he" });
+    expect(doc.buttonText).toEqual({ en: "button-en", he: "button-he" });
+    expect(doc.locales.sort()).toEqual(["en", "he"]);
+    expect(doc.internalBannerName).toBe("spring-sale");
+    expect(doc.byLocale).toBeUndefined(); // internal grouping detail shouldn't leak
+  });
+
+  it("fills the missing locale with null for a he-only document", function () {
+    const rowsByLocale = { en: [], he: [makeRow("he")] };
+    const [grouped] = groupByDocumentId(rowsByLocale, bannerLocalizedFields);
+    const doc = buildInterfaceTextDoc(grouped, bannerLocalizedFields);
+
+    expect(doc.bannerText).toEqual({ en: null, he: "text-he" });
+    expect(doc.locales).toEqual(["he"]);
+  });
+
+  it("fills the missing locale with null for an en-only document", function () {
+    const rowsByLocale = { en: [makeRow("en")], he: [] };
+    const [grouped] = groupByDocumentId(rowsByLocale, bannerLocalizedFields);
+    const doc = buildInterfaceTextDoc(grouped, bannerLocalizedFields);
+
+    expect(doc.bannerText).toEqual({ en: "text-en", he: null });
+    expect(doc.locales).toEqual(["en"]);
+  });
+});

--- a/static/js/sefaria/tests/strapiLocalization.test.js
+++ b/static/js/sefaria/tests/strapiLocalization.test.js
@@ -25,9 +25,16 @@ describe("config", function () {
 
 describe("groupBy", function () {
   it("groups items under their key, preserving order within each group", function () {
-    const items = [{ a: 1, id: "x" }, { a: 2, id: "y" }, { a: 1, id: "z" }];
+    const items = [
+      { a: 1, id: "x" },
+      { a: 2, id: "y" },
+      { a: 1, id: "z" },
+    ];
     expect(groupBy(items, (item) => item.a)).toEqual({
-      1: [{ a: 1, id: "x" }, { a: 1, id: "z" }],
+      1: [
+        { a: 1, id: "x" },
+        { a: 1, id: "z" },
+      ],
       2: [{ a: 2, id: "y" }],
     });
   });
@@ -46,12 +53,18 @@ describe("groupBy", function () {
 
 describe("keyBy", function () {
   it("indexes items by key", function () {
-    const items = [{ id: "en", v: 1 }, { id: "he", v: 2 }];
+    const items = [
+      { id: "en", v: 1 },
+      { id: "he", v: 2 },
+    ];
     expect(keyBy(items, (item) => item.id)).toEqual({ en: { id: "en", v: 1 }, he: { id: "he", v: 2 } });
   });
 
   it("keeps the last item when keys collide", function () {
-    const items = [{ id: "en", v: 1 }, { id: "en", v: 2 }];
+    const items = [
+      { id: "en", v: 1 },
+      { id: "en", v: 2 },
+    ];
     expect(keyBy(items, (item) => item.id)).toEqual({ en: { id: "en", v: 2 } });
   });
 });


### PR DESCRIPTION
## Description

Banners, modals, and sidebar ads can have content in more than one locale. We currently support English (`en`) and Hebrew (`he`).

Before this PR, the frontend only fetched the **English** version of each item from Strapi and treated the other locales as translations attached to it. This caused two problems:

1. **Hebrew-only content was invisible.** If an editor created a banner, modal, or sidebar ad in Hebrew without also creating an English version, the frontend never fetched it. As a result, it never appeared, even for users with their interface set to Hebrew.
2. **Hebrew content depended on English.** A Hebrew version could only appear if an English version existed to carry it.

This PR makes each locale **independent**. Every locale of a piece of content is fetched and can be displayed on its own, regardless of whether the other locales exist.

## How it works

Strapi gives each document a `documentId` that remains the same across all of its locales. We use that as the key to stitch the different versions back together.

1. **Fetch every locale instead of only the default.** The GraphQL query now explicitly requests each locale using aliases such as `en_banners` and `he_banners`, with equivalent aliases for modals and sidebar ads. A Strapi collection query with no `locale` argument only returns the default locale, which is why Hebrew-only items previously disappeared.
2. **Regroup the results by `documentId`.** Rows representing the same document in different locales are merged into a single object. That object contains a `byLocale` map (`{ en: {...}, he: {...} }`) and a `locales` list containing only the locales that actually exist.
3. **Reshape the translatable fields for display.** Each translatable field, such as `bannerText`, becomes an `{ en, he }` object that the existing `InterfaceText` component already knows how to render. Missing locales are represented by `null` instead of causing the item to fail.

Adding another locale later only requires adding it to `SUPPORTED_LOCALES` and the query. The regrouping and display logic will handle it automatically.

## Files changed

**New shared helpers**

- `static/js/sefaria/strapiLocalization.js` *(new)* — contains the localization helpers shared by banners and modals (`context.js`) and sidebar ads (`Promotions.jsx`). It defines the supported locales, the locale-to-interface-language mappings, and the translatable fields for each content type. It also contains the small, pure helpers `groupByDocumentId` and `buildInterfaceTextDoc`, which regroup the per-locale rows and reshape them into the `{ en, he }` format. Keeping these functions pure and free of mutation makes them easy to test directly.
- `static/js/sefaria/sidebarAds.js` *(new)* — contains `buildInAppAdsFromSidebarAds()`, which turns the regrouped sidebar-ad documents into one in-app ad for each locale that exists. This allows a Hebrew-only ad to be displayed instead of skipped.

**Wiring**

- `static/js/context.js` — updates the banner and modal GraphQL query to fetch each locale separately using aliases, then regroups the results by `documentId` before storing them.
- `static/js/Promotions.jsx` — updates sidebar-ad rendering to use the shared regrouping logic and `buildInAppAdsFromSidebarAds()`, replacing the previous English-first implementation.
- `static/js/Misc.jsx` — updates banner and modal display logic to read the new `{ en, he }` field shape.

**Tests**

- `static/js/sefaria/tests/strapiLocalization.test.js` *(new)*
- `static/js/sefaria/tests/sidebarAds.test.js` *(new)*
- Adds tests covering regrouping by `documentId`, handling missing locales, and building sidebar ads.

## Design decisions

- **`documentId` is the join key.** It's the identifier Strapi keeps stable across every locale of a document, so it is the reliable way to determine that two rows represent the same item in different languages.
- **A missing locale becomes `null`, not an error.** If a document only exists in one locale, the other locale's fields are set to `null`. `InterfaceText` can then render nothing for the missing locale without crashing or requiring an empty English placeholder.
- **The pure helpers live in their own module.** Keeping the regrouping and reshaping logic outside React makes it possible to test directly and reuse across both the banner/modal and sidebar-ad paths.

## Notes

- **There is no behavior change for existing content.** Anything that already has an English version will continue to work as before. This only adds support for content that exists solely in another locale. This also allows content in other locales to be used in the future.
- The corresponding Strapi configuration must also be deployed before independent Hebrew content will appear.