### PR TITLE
Fix SSR crash in SiteWideBanner from module-scope translation call 

### DIFF
--- a/static/js/SiteWideBanner.jsx
+++ b/static/js/SiteWideBanner.jsx
@@ -233,7 +233,6 @@ SiteWideBanner.propTypes = {
   promoSessionLengthSeconds: PropTypes.number,
 };
 
-const CHATBOT_BANNER_MAIN_TEXT = Sefaria._("site_wide_banner.enhance_your_learning_experience");
 const CHATBOT_BANNER_SECONDARY_TEXT_HE = <div>נסו את <a href="https://help.sefaria.org/hc/he/articles/26006423836828-How-to-Use-the-Sefaria-Library-Assistant">עוזר הספרייה</a> שלנו, המופעל על ידי בינה מלאכותית, על מנת להעמיק את הבנתכם ולגלות מקורות חדשים.</div>;
 const CHATBOT_BANNER_SECONDARY_TEXT = <div>Try our AI-powered <a href="https://help.sefaria.org/hc/en-us/articles/26006423836828-How-to-Use-the-Sefaria-Library-Assistant">Library Assistant</a> to deepen your understanding and discover new texts.</div>;
 const CAMPAIGN_ID = "LA Stand Alone Promo";
@@ -269,7 +268,7 @@ const ChatbotExperimentBanner = ({ promoLearnMoreUrls, promoMaybeLaterJSON, prom
 
   return (
     <SiteWideBanner
-      mainText={CHATBOT_BANNER_MAIN_TEXT}
+      mainText={Sefaria._("site_wide_banner.enhance_your_learning_experience")}
       secondaryText={Sefaria._v({en: CHATBOT_BANNER_SECONDARY_TEXT, he: CHATBOT_BANNER_SECONDARY_TEXT_HE})}
       actionButtons={(track) => isLoggedIn ? (
         <button type="button" className="button small" onClick={() => { track("join"); handleJoin(); }} disabled={isActionPending}>


### PR DESCRIPTION
## Summary
SSR crashes with TypeError: Cannot read properties of undefined (reading 'slice') at Sefaria._getShortInterfaceLang(), thrown from SiteWideBanner.jsx:236.
Root cause: CHATBOT_BANNER_MAIN_TEXT was computed via Sefaria._(...) at module scope, so it runs once at require() time (server process startup via node/server.js, before any request-scoped Sefaria.interfaceLang is set), instead of per render.
This was previously latent — before 080e55fbf ("setting up weblate"), the arg was a plain string that didn't match the keyed-string-ID regex, so Sefaria._() fell through to a path wrapped in try/catch that silently swallowed the same underlying error. That commit changed the arg to "site_wide_banner.enhance_your_learning_experience", a keyed ID, which routes straight to _getShortInterfaceLang() — no try/catch — turning the same latent issue into a hard crash.
Fix: move the Sefaria._() call out of module scope and into the render, so it evaluates per-request with Sefaria.interfaceLang correctly populated.
