### PR TITLE
Fix mobile web search autosuggestion click not navigating [sc-36498]

### DIFF
--- a/static/js/HeaderAutocomplete.jsx
+++ b/static/js/HeaderAutocomplete.jsx
@@ -337,14 +337,14 @@ const SearchSuggestionFactory = ({ type, submitSearch, redirectToObject, inputVa
             SuggestionComponent: TextualSearchSuggestion
         },
         other: {
-            onSuggestionClick: () => {
+            onSuggestionClick: (item) => {
               gtag("event", "search_navto", {
                 "project": "Global Search",
                 "feature_name": "Nav To by Mouse",
                 "to": props.label,
                 "text": inputValue
               });
-              redirectToObject();
+              redirectToObject(item);
             },
             SuggestionComponent: EntitySearchSuggestion
         }

--- a/static/js/HeaderAutocomplete.jsx
+++ b/static/js/HeaderAutocomplete.jsx
@@ -257,8 +257,12 @@ const SearchInputBox = ({getInputProps, highlightedSuggestion, highlightedIndex,
 
     const blurSearch = (e) => {
       onBlur(e);
-      const oldValue = getVirtualKeyboardInputValue();
       const parent = document.getElementById('searchBox');
+      if (!parent) {
+        // the search box unmounts mid-blur when the mobile nav menu closes on navigation
+        return;
+      }
+      const oldValue = getVirtualKeyboardInputValue();
       if (!parent.contains(e.relatedTarget) && !document.getElementById('keyboardInputMaster')) {
         // debug: comment out the following line:
         setSearchFocused(false);


### PR DESCRIPTION
_(Claude writing on Daniel's behalf)_

**Bug** ([sc-36498](https://app.shortcut.com/sefaria/story/36498)): on mobile web, clicking a search autosuggestion seems to do nothing — the page actually navigates *behind* the still-open nav menu, which is only revealed after tapping the hamburger again.

**Cause:** since #2983, the entity branch of `SearchSuggestionFactory` calls `redirectToObject()` without the clicked item, so it throws a `TypeError` on `item.type` before reaching `onNavigate()`, which is what closes the mobile menu. The click still bubbles to the suggestion's `<a>` and navigates the panel under the overlay. (Desktop hits the same error but has no overlay, so it looks fine.)

**Fix:** pass the clicked item through to `redirectToObject(item)`. Plus a small guard in `blurSearch` for the search box unmounting mid-blur, which the now-closing menu exposed.

**Verified:** Playwright repro against prod with the locally built bundle swapped in — control (prod bundle) reproduces the bug; fixed bundle navigates to `/topics/joy`, closes the menu, no console errors.

**QA:** on mobile, hamburger → search "joy" → click the *Joy* topic suggestion → should navigate immediately and close the menu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
