### PR TITLE
feat: lazy load

### DIFF
--- a/reader/views.py
+++ b/reader/views.py
@@ -4904,12 +4904,12 @@ def entity_search_api(request):
         )
 
     try:
-        size = min(int(request.GET.get("size", 20)), 100)
+        size = max(1, min(int(request.GET.get("size", 20)), 100))
     except (TypeError, ValueError):
         size = 20
 
     try:
-        start = max(int(request.GET.get("start", 0)), 0)
+        start = max(0, min(int(request.GET.get("start", 0)), 10000 - size))
     except (TypeError, ValueError):
         start = 0
 

--- a/reader/views.py
+++ b/reader/views.py
@@ -4854,7 +4854,10 @@ def entity_search_api(request):
     Entity search endpoint powering the Topics / Authors / Books tabs.
 
     GET /api/entity-search?q=<query>&type=<topic|author|book>&sort=<relevance|alpha|year_asc|year_desc>
-                          &filter=<category path>&aggregate=<1|0>
+                          &filter=<category path>&aggregate=<1|0>&start=<offset>&size=<page size>
+
+    `start` (default 0) and `size` (default 20, capped at 100) page the results; the tab
+    fetches successive pages on scroll. `total` always reports the full match count.
 
     `topic` and `author` search the `topic` Elasticsearch index (filtered by subtype);
     `book` searches the `book` index, or — when the query resolves to an author — returns
@@ -4906,7 +4909,12 @@ def entity_search_api(request):
         size = 20
 
     try:
-        results = entity_search(query, entity_type, size=size, sort=sort, category_paths=category_paths,
+        start = max(int(request.GET.get("start", 0)), 0)
+    except (TypeError, ValueError):
+        start = 0
+
+    try:
+        results = entity_search(query, entity_type, start=start, size=size, sort=sort, category_paths=category_paths,
                                 aggregate=aggregate)
     except Exception as e:
         logger.error(f"entity_search_api failed - q: {query}, type: {entity_type}, sort: {sort}, filter: {category_paths}, aggregate: {aggregate}, error: {e}", exc_info=True)

--- a/sefaria/helper/search.py
+++ b/sefaria/helper/search.py
@@ -541,10 +541,15 @@ def _author_work_matches_query(query, hit):
     return q == (hit.get("title_en") or "").strip().lower() or q == (hit.get("title_he") or "").strip().lower()
 
 
-def _author_works_response(author, query, sort="relevance"):
+def _author_works_response(author, query, sort="relevance", start=0, size=None):
     """
     Build the aggregated author-works response: the author's works collapsed by
     category (reusing AuthorTopic aggregation).
+
+    The rows are built and sorted in full, then sliced by `start`/`size` for pagination;
+    `total` always reports the full row count so the tab badge and "more to load" checks
+    stay correct regardless of how many pages have been fetched. `size=None` returns every
+    row from `start` onward.
 
     Every row carries a `compDate`: an individual work's own composition year, or — for a
     category row, which collapses many works and dates into one entry — the average year
@@ -594,7 +599,9 @@ def _author_works_response(author, query, sort="relevance"):
             0 if (_author_work_matches_query(query, h) and not h.get("isCategory")) else 1,
             0 if h.get("isCategory") else 1,
         ))
-    return {"hits": hits, "total": len(hits), "author_slug": author.slug}
+    total = len(hits)
+    hits = hits[start:] if size is None else hits[start:start + size]
+    return {"hits": hits, "total": total, "author_slug": author.slug}
 
 
 def entity_search(query, type, start=0, size=20, sort="relevance", category_paths=None, aggregate=True):
@@ -633,7 +640,7 @@ def entity_search(query, type, start=0, size=20, sort="relevance", category_path
         if aggregate and not category_paths:
             author = _resolve_author(query, es_client)
             if author is not None:
-                return _author_works_response(author, query, sort=sort)
+                return _author_works_response(author, query, sort=sort, start=start, size=size)
         index_name = SEARCH_INDEX_NAME_BOOK
     else:
         index_name = SEARCH_INDEX_NAME_TOPIC

--- a/sefaria/helper/tests/search_test.py
+++ b/sefaria/helper/tests/search_test.py
@@ -231,6 +231,29 @@ def test_author_works_response_surfaces_eponymous_work():
     assert not response["hits"][0]["isCategory"]
 
 
+def test_author_works_response_paginates_with_full_total():
+    class _DummyAuthor:
+        slug = "rambam"
+
+        def get_aggregated_urls_for_authors_indexes(self):
+            return [
+                {"url": f"/w{i}", "title": {"en": f"Work {i:02d}", "he": ""},
+                 "description": {"en": "", "he": ""}, "isCategory": False,
+                 "categoryLabel": {"en": None, "he": None}, "categories": ["Halakhah"], "compDate": 1000 + i}
+                for i in range(5)
+            ]
+
+    # A page is a slice of the sorted rows, but `total` always reports the full count so the
+    # tab badge and "more to load" check stay correct across pages.
+    page = _author_works_response(_DummyAuthor(), "rambam", sort="alpha", start=2, size=2)
+    assert page["total"] == 5
+    assert [h["title_en"] for h in page["hits"]] == ["Work 02", "Work 03"]
+
+    # start past the end yields an empty page but still the full total.
+    tail = _author_works_response(_DummyAuthor(), "rambam", sort="alpha", start=10, size=2)
+    assert tail["total"] == 5 and tail["hits"] == []
+
+
 def test_entity_query_obj_exact_tier_is_case_insensitive():
     # Regression: the Tier-1 exact-match `term` clauses run against raw (un-normalized)
     # `.keyword` sub-fields, so they must set `case_insensitive` — otherwise a lowercase

--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -4700,6 +4700,17 @@ body .ui-autocomplete.dictionary-toc-autocomplete .ui-menu-item a.ui-state-focus
   margin-top: 30px;
 }
 
+/* "Loading more results..." — shown at the bottom of any search tab while the next page
+   loads on scroll. Small, non-italic grey, aligned to the card content inset. */
+.searchResultList .searchLoadMore,
+.entitySearchResults .searchLoadMore {
+  color: var(--medium-grey);
+  font-style: normal;
+  font-size: 14px;
+  line-height: 18px;
+  padding: 16px 20px;
+}
+
 /* SearchResultCard — multi-entity search result card */
 .searchResultCard {
   display: flex;

--- a/static/js/InfiniteScroll.jsx
+++ b/static/js/InfiniteScroll.jsx
@@ -27,15 +27,24 @@ const InfiniteScroll = ({ className, hasMore, isLoading, isLoadingMore, loadMore
                           scrollableSelector = '.content', children }) => {
   const ref = useRef(null);
   const latest = useRef({});
+  const pending = useRef(false);
   latest.current = { hasMore, isLoading, loadMore };
+
+  // Clear the pending guard once the parent acknowledges the request by flipping isLoading on,
+  // then back off. Without this, rapid scroll events between the loadMore() call and the next
+  // render (when isLoading becomes true) can dispatch duplicate page fetches.
+  useEffect(() => {
+    if (!isLoading) { pending.current = false; }
+  }, [isLoading]);
 
   useEffect(() => {
     const $scrollable = $(ref.current).closest(scrollableSelector);
     if (!$scrollable.length) { return; }
     const onScroll = () => {
       const { hasMore, isLoading, loadMore } = latest.current;
-      if (!hasMore || isLoading) { return; }
+      if (!hasMore || isLoading || pending.current) { return; }
       if ($scrollable.scrollTop() + $scrollable.innerHeight() + SCROLL_MARGIN >= $scrollable[0].scrollHeight) {
+        pending.current = true;
         loadMore();
       }
     };

--- a/static/js/InfiniteScroll.jsx
+++ b/static/js/InfiniteScroll.jsx
@@ -1,0 +1,59 @@
+import React, { useEffect, useRef } from 'react';
+import $ from './sefaria/sefariaJquery';
+import Sefaria from './sefaria/sefaria';
+import { LoadingMessage } from './Misc';
+
+// How close (px) to the bottom of the scroll container before we ask for the next page.
+const SCROLL_MARGIN = 300;
+
+// Weblate-managed strings (static/js/sefaria/i18n/interface/{en,he}.json). Resolved per
+// language so LoadingMessage's bilingual EnglishText/HebrewText split still works.
+const LOADING_MORE_STRING_ID = "search_page.loading_more_results";
+
+/**
+ * Wraps a results list and fires `loadMore` when the user scrolls near the bottom of the
+ * enclosing scroll container (`.content` by default). This is the single implementation of
+ * the search "delay -> message -> append" pattern, shared by the Sources list and the
+ * Books / Authors / Topics entity tabs.
+ *
+ * - `hasMore` / `isLoading` gate the trigger (never load past the end, never overlap a
+ *   running query). They're read through a ref so the scroll handler binds once and always
+ *   sees current values without re-attaching on every render.
+ * - `isLoadingMore` controls the bottom "Loading more results..." message — the caller sets
+ *   it only when appending to an existing list, so an *initial* load (skeleton / "Searching...")
+ *   is left to the parent.
+ */
+const InfiniteScroll = ({ className, hasMore, isLoading, isLoadingMore, loadMore,
+                          scrollableSelector = '.content', children }) => {
+  const ref = useRef(null);
+  const latest = useRef({});
+  latest.current = { hasMore, isLoading, loadMore };
+
+  useEffect(() => {
+    const $scrollable = $(ref.current).closest(scrollableSelector);
+    if (!$scrollable.length) { return; }
+    const onScroll = () => {
+      const { hasMore, isLoading, loadMore } = latest.current;
+      if (!hasMore || isLoading) { return; }
+      if ($scrollable.scrollTop() + $scrollable.innerHeight() + SCROLL_MARGIN >= $scrollable[0].scrollHeight) {
+        loadMore();
+      }
+    };
+    $scrollable.on('scroll.infiniteScroll', onScroll);
+    return () => $scrollable.off('scroll.infiniteScroll', onScroll);
+  }, [scrollableSelector]);
+
+  return (
+    <div className={className} ref={ref}>
+      {children}
+      {isLoadingMore
+        ? <LoadingMessage
+            className="searchLoadMore"
+            message={Sefaria._keyedString(LOADING_MORE_STRING_ID, "en")}
+            heMessage={Sefaria._keyedString(LOADING_MORE_STRING_ID, "he")} />
+        : null}
+    </div>
+  );
+};
+
+export default InfiniteScroll;

--- a/static/js/SearchPage.jsx
+++ b/static/js/SearchPage.jsx
@@ -275,7 +275,10 @@ class SearchPage extends Component {
   // how many hits we've accumulated so far.
   makeEntityEntry(data, prevHits = []) {
     const hits = prevHits.concat(data.hits);
-    return {hits, total: data.total, moreToLoad: hits.length < data.total, isLoadingMore: false};
+    // Cap at ES's default max_result_window so infinite scroll stops before sending an offset
+    // that ES would reject. `total` is kept intact for the count badge.
+    const loadableTotal = Math.min(data.total, 10000);
+    return {hits, total: data.total, moreToLoad: hits.length < loadableTotal, isLoadingMore: false};
   }
 
   loadNextEntityPage(type) {

--- a/static/js/SearchPage.jsx
+++ b/static/js/SearchPage.jsx
@@ -12,6 +12,7 @@ import {MobileFilterIconButton} from './SearchResultList';
 import {SearchResultList} from "./SearchResultList";
 import SearchSortDropdown, {ENTITY_SORT_OPTIONS, sortEntityHits} from './SearchSortDropdown';
 import SearchResultCard from './SearchResultCard';
+import InfiniteScroll from './InfiniteScroll';
 import {
   CategoryColorLine,
   InterfaceText,
@@ -176,7 +177,7 @@ const ENTITY_CARD_PROP_BUILDERS = {
 };
 
 
-const EntitySearchResults = ({type, data, query}) => {
+const EntitySearchResults = ({type, data, query, loadMore}) => {
   if (!data) {
     return <LoadingMessage message="Searching..." heMessage="מבצע חיפוש..." />;
   }
@@ -184,12 +185,17 @@ const EntitySearchResults = ({type, data, query}) => {
     return <LoadingMessage message="0 results." heMessage="0 תוצאות." />;
   }
   return (
-    <div className="entitySearchResults">
+    <InfiniteScroll
+      className="entitySearchResults"
+      hasMore={data.moreToLoad}
+      isLoading={data.isLoadingMore}
+      isLoadingMore={data.isLoadingMore}
+      loadMore={loadMore}>
       {data.hits.map(hit => {
         const cardProps = ENTITY_CARD_PROP_BUILDERS[type](hit, query);
         return <SearchResultCard key={cardProps.href} {...cardProps} />;
       })}
-    </div>
+    </InfiniteScroll>
   );
 };
 
@@ -258,10 +264,43 @@ class SearchPage extends Component {
       Sefaria.search.entitySearch(query, type)
           .then(data => {
             if (this.props.query !== query) { return; }  // a newer query superseded this one
-            this.setState(prev => ({entityData: {...prev.entityData, [type]: data}}));
+            this.setState(prev => ({entityData: {...prev.entityData, [type]: this.makeEntityEntry(data)}}));
           })
           .catch(() => {});  // count badge stays at "0", panel stays on the loading message
     });
+  }
+
+  // Normalize an API page into the paging entry the tab panels read. `total` is the full
+  // match count (so the badge and "more to load" stay correct), `moreToLoad` compares it to
+  // how many hits we've accumulated so far.
+  makeEntityEntry(data, prevHits = []) {
+    const hits = prevHits.concat(data.hits);
+    return {hits, total: data.total, moreToLoad: hits.length < data.total, isLoadingMore: false};
+  }
+
+  loadNextEntityPage(type) {
+    const query = this.props.query;
+    const cur = this.state.entityData[type];
+    if (!cur || cur.isLoadingMore || !cur.moreToLoad) { return; }
+    this.setState(prev => ({
+      entityData: {...prev.entityData, [type]: {...prev.entityData[type], isLoadingMore: true}},
+    }));
+    Sefaria.search.entitySearch(query, type, cur.hits.length)
+        .then(data => {
+          if (this.props.query !== query) { return; }  // a newer query superseded this one
+          this.setState(prev => {
+            const prevEntry = prev.entityData[type];
+            if (!prevEntry) { return null; }  // query was reset while this page was in flight
+            return {entityData: {...prev.entityData, [type]: this.makeEntityEntry(data, prevEntry.hits)}};
+          });
+        })
+        .catch(() => {
+          this.setState(prev => {
+            const prevEntry = prev.entityData[type];
+            if (!prevEntry) { return null; }
+            return {entityData: {...prev.entityData, [type]: {...prevEntry, isLoadingMore: false}}};
+          });
+        });
   }
 
   formatEntityCount(count) {
@@ -422,7 +461,8 @@ class SearchPage extends Component {
               />
           }
         </div>
-        <EntitySearchResults type="book" data={this.getSortedEntityData('book')} query={this.props.query}/>
+        <EntitySearchResults type="book" data={this.getSortedEntityData('book')} query={this.props.query}
+                             loadMore={() => this.loadNextEntityPage('book')}/>
       </div>,
       <div className="searchTabPanel" key="authors">
         <div className="searchSortBar">
@@ -437,7 +477,8 @@ class SearchPage extends Component {
               />
           }
         </div>
-        <EntitySearchResults type="author" data={this.getSortedEntityData('author')} query={this.props.query}/>
+        <EntitySearchResults type="author" data={this.getSortedEntityData('author')} query={this.props.query}
+                             loadMore={() => this.loadNextEntityPage('author')}/>
       </div>,
       <div className="searchTabPanel" key="topics">
         <div className="searchSortBar">
@@ -452,7 +493,8 @@ class SearchPage extends Component {
               />
           }
         </div>
-        <EntitySearchResults type="topic" data={this.getSortedEntityData('topic')} query={this.props.query}/>
+        <EntitySearchResults type="topic" data={this.getSortedEntityData('topic')} query={this.props.query}
+                             loadMore={() => this.loadNextEntityPage('topic')}/>
       </div>,
     ];
 
@@ -475,7 +517,7 @@ class SearchPage extends Component {
                       onQueryChange={this.props.onQueryChange}/>
                 </div>
 
-                {this.props.isQueryRunning
+                {this.props.isQueryRunning && !this.props.hits.length
                   ? <SearchLoadSkeleton />
                   : Sefaria.multiPanel
                     ? <TabView

--- a/static/js/SearchResultList.jsx
+++ b/static/js/SearchResultList.jsx
@@ -1,15 +1,14 @@
 import React, { useState } from 'react';
-import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import Component from 'react-class';
 import extend from 'extend';
 import classNames from 'classnames';
-import $ from './sefaria/sefariaJquery';
 import Sefaria from './sefaria/sefaria';
 import SearchTextResult from './SearchTextResult';
 import SearchSheetResult from './SearchSheetResult';
 import SearchState from './sefaria/searchState';
 import SearchResultCard from './SearchResultCard';
+import InfiniteScroll from './InfiniteScroll';
 import {
   DropdownModal,
   DropdownButton,
@@ -74,22 +73,6 @@ class SearchResultList extends Component {
     constructor(props) {
       super(props);
     }
-    componentDidMount() {
-        $(ReactDOM.findDOMNode(this)).closest(".content").on("scroll.infiteScroll", this.handleScroll);
-    }
-    componentWillUnmount() {
-        $(ReactDOM.findDOMNode(this)).closest(".content").off("scroll.infiniteScroll", this.handleScroll);
-    }
-    handleScroll() {
-      if (!this.props.moreToLoad) { return; }
-      if (this.props.isQueryRunning) { return; }
-
-      var $scrollable = $(ReactDOM.findDOMNode(this)).closest(".content");
-      var margin = 300;
-      if($scrollable.scrollTop() + $scrollable.innerHeight() + margin >= $scrollable[0].scrollHeight) {
-        this.props.loadNextPage();
-      }
-    }
     render () {
         if (!(this.props.query)) {  // Push this up? Thought is to choose on the SearchPage level whether to show a ResultList or an EmptySearchMessage.
             return null;
@@ -126,18 +109,26 @@ class SearchResultList extends Component {
           );
         }
 
-        const loadingMessage   = (<LoadingMessage message="Searching..." heMessage="מבצע חיפוש..." />);
         const noResultsMessage = (<LoadingMessage message="0 results." heMessage="0 תוצאות." />);
-        const queryFullyLoaded = !this.props.moreToLoad && !this.props.isQueryRunning;
+        // "Searching..." only shows on an initial load with no results yet (e.g. sidebar
+        // search-in-book, which renders this list directly without the page skeleton). Once
+        // results exist, a running query is a scroll-triggered next page, so the shared
+        // InfiniteScroll shows its "Loading more results..." message instead.
+        const initialLoadingMessage = (<LoadingMessage message="Searching..." heMessage="מבצע חיפוש..." />);
         const haveResults      = !!results.length;
-        results                = haveResults ? results : noResultsMessage;
 
         return (
           <div>
-              <div className="searchResultList">
-                  {queryFullyLoaded || haveResults ? results : null}
-                  {this.props.isQueryRunning ? loadingMessage : null}
-              </div>
+              <InfiniteScroll
+                  className="searchResultList"
+                  hasMore={this.props.moreToLoad}
+                  isLoading={this.props.isQueryRunning}
+                  isLoadingMore={this.props.isQueryRunning && haveResults}
+                  loadMore={this.props.loadNextPage}>
+                  {haveResults ? results : null}
+                  {!haveResults && this.props.isQueryRunning ? initialLoadingMessage : null}
+                  {!haveResults && !this.props.isQueryRunning ? noResultsMessage : null}
+              </InfiniteScroll>
           </div>
         );
     }

--- a/static/js/sefaria/i18n/interface/en.json
+++ b/static/js/sefaria/i18n/interface/en.json
@@ -375,6 +375,7 @@
   "search_filters.see_more": "See More",
   "search_page.chronological": "Chronological",
   "search_page.date_created": "Date Created",
+  "search_page.loading_more_results": "Loading more results...",
   "search_page.relevance": "Relevance",
   "search_page.results": "Results",
   "search_page.results_for": "Results for",

--- a/static/js/sefaria/i18n/interface/he.json
+++ b/static/js/sefaria/i18n/interface/he.json
@@ -375,6 +375,7 @@
   "search_filters.see_more": "עוד",
   "search_page.chronological": "כרונולוגי",
   "search_page.date_created": "Date Created",
+  "search_page.loading_more_results": "טוען עוד תוצאות...",
   "search_page.relevance": "רלוונטיות",
   "search_page.results": "תוצאות",
   "search_page.results_for": "תוצאות עבור",

--- a/static/js/sefaria/search.js
+++ b/static/js/sefaria/search.js
@@ -572,23 +572,22 @@ class Search {
       });
       return { availableFilters, registry: {}, orphans: [] };
     }
-    entitySearch(query, type) {
-        // Fetches the entity results themselves, so the hits are cached and reusable by the
-        // tab panels. The Books / Authors / Topics tab count badges read `total` off the
-        // response rather than counting the hits — the API returns at most one page (capped
-        // at 100), so `hits.length` would undercount broad queries.
+    entitySearch(query, type, start = 0) {
+        // Fetches one page of entity results (from `start`), so the tab panels can lazily
+        // load more on scroll. Each page is cached separately by `start`; `total` reports the
+        // full match count so the count badges and "more to load" checks stay correct.
         // QA escape hatch: appending &aggregate=0 to the search page URL turns off the
         // author-works aggregation on the Books tab (flat book hits instead of category
         // rows). Forwarded on every tab's request; the API ignores it for types that
         // never aggregate.
         const noAggregate = typeof window !== "undefined" &&
             new URLSearchParams(window.location.search).get("aggregate") === "0";
-        const cacheKey = `entitySearch|${type}|${query}${noAggregate ? "|noAggregate" : ""}`;
+        const cacheKey = `entitySearch|${type}|${query}|${start}${noAggregate ? "|noAggregate" : ""}`;
         const cacheResult = this.cache(cacheKey);
         if (cacheResult !== undefined) {
             return Promise.resolve(cacheResult);
         }
-        let url = `${Sefaria.apiHost}/api/entity-search?q=${encodeURIComponent(query)}&type=${encodeURIComponent(type)}`;
+        let url = `${Sefaria.apiHost}/api/entity-search?q=${encodeURIComponent(query)}&type=${encodeURIComponent(type)}&start=${start}`;
         if (noAggregate) { url += "&aggregate=0"; }
         // Wrapped in a real Promise because jQuery 2's Deferred has no .catch()
         return new Promise((resolve, reject) => {


### PR DESCRIPTION
## Description
This PR implements the lazy loading/infinite scroll across all 4 tabs of the new search UI, with the strings coming from weblate

## Code Changes
- Infinite scroll hook is not isolated, and called where needed
- New texts
- Small styling changes
- Pagination params to the backend of the entity search

## Notes
- When testing, use the query `שלום` and `Rabbi`