### PR TITLE
feat: show LA promo to first-session visitors

### DIFF
--- a/static/js/SiteWideBanner.jsx
+++ b/static/js/SiteWideBanner.jsx
@@ -257,9 +257,6 @@ const ChatbotExperimentBanner = ({ promoLearnMoreUrls, promoMaybeLaterJSON, prom
   };
 
   const isLoggedIn = !!Sefaria._uid;
-  if (!isLoggedIn && !Sefaria.isReturningVisitor()) {
-    return null;
-  }
   // Route anon login/register through the Library Assistant opt-in landing so that,
   // once they authenticate, they're auto-enrolled in the experiment and returned here —
   // the assistant then appears on reload with no extra "Join" click.


### PR DESCRIPTION
_(Claude writing on Daniel's behalf)_

## What changed
Removed the returning-visitor gate in `ChatbotExperimentBanner` (`static/js/SiteWideBanner.jsx`) that returned `null` for anonymous users in their first session. The dismissal/backoff re-show logic (`shouldHideForBackoff`, nudge schedule, cookie-based dismissal) is untouched, as is the `showChatbotBanner` gating in `ReaderApp.jsx`.

## Why
Per [sc-46166](https://app.shortcut.com/sefaria/story/46166): all users who haven't already opted in to the Library Assistant or dismissed the promo should see it, regardless of session number.

## How tested
- `npx jest` — all 7 suites, 126 tests pass. (No existing tests cover `SiteWideBanner`; none added since the repo has no @testing-library/react infra.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)