### PR TITLE
feat: hide LA promo banner on authentication screens

### DIFF
--- a/static/js/SiteWideBanner.jsx
+++ b/static/js/SiteWideBanner.jsx
@@ -241,7 +241,15 @@ const CHATBOT_BANNER_EXCLUDED_PATHS = ["/login", "/register", "/password/reset"]
 
 // Keep authentication and password-recovery screens focused on the task at hand.
 const isChatbotBannerExcludedPath = (path, moduleUrl) => {
-  const pathname = new URL(path, moduleUrl).pathname;
+  let pathname;
+  try {
+    // moduleUrl can be false (getModuleURL falls back to apiHost, which is empty
+    // during server-side rendering); only the pathname matters here, so any valid
+    // base keeps URL parsing from throwing mid-render.
+    pathname = new URL(path, moduleUrl || "https://www.sefaria.org").pathname;
+  } catch (e) {
+    return false;
+  }
   return CHATBOT_BANNER_EXCLUDED_PATHS.some(
     excludedPath => pathname === excludedPath || pathname.startsWith(`${excludedPath}/`)
   );

--- a/static/js/SiteWideBanner.jsx
+++ b/static/js/SiteWideBanner.jsx
@@ -238,12 +238,14 @@ const CHATBOT_BANNER_SECONDARY_TEXT = <div>Try our AI-powered <a href="https://h
 const CAMPAIGN_ID = "LA Stand Alone Promo";
 const PROJECT = 'Library Assistant';
 const CHATBOT_BANNER_EXCLUDED_PATHS = ["/login", "/register"];
+const PASSWORD_RESET_PATH = "/password/reset";
 
-// The Library Assistant opens automatically after login/registration, so promoting
-// it on the auth screens themselves would be redundant.
+// Keep authentication and password-recovery screens focused on the task at hand.
 const isChatbotBannerExcludedPath = (path) => {
   const pathname = path.split(/[?#]/)[0].replace(/\/+$/, "") || "/";
-  return CHATBOT_BANNER_EXCLUDED_PATHS.includes(pathname);
+  return CHATBOT_BANNER_EXCLUDED_PATHS.includes(pathname) ||
+    pathname === PASSWORD_RESET_PATH ||
+    pathname.startsWith(`${PASSWORD_RESET_PATH}/`);
 };
 
 const ChatbotExperimentBanner = ({ promoLearnMoreUrls, promoMaybeLaterJSON, promoSessionLengthSeconds }) => {

--- a/static/js/SiteWideBanner.jsx
+++ b/static/js/SiteWideBanner.jsx
@@ -237,6 +237,14 @@ const CHATBOT_BANNER_SECONDARY_TEXT_HE = <div>נסו את <a href="https://help.
 const CHATBOT_BANNER_SECONDARY_TEXT = <div>Try our AI-powered <a href="https://help.sefaria.org/hc/en-us/articles/26006423836828-How-to-Use-the-Sefaria-Library-Assistant">Library Assistant</a> to deepen your understanding and discover new texts.</div>;
 const CAMPAIGN_ID = "LA Stand Alone Promo";
 const PROJECT = 'Library Assistant';
+const CHATBOT_BANNER_EXCLUDED_PATHS = ["/login", "/register"];
+
+// The Library Assistant opens automatically after login/registration, so promoting
+// it on the auth screens themselves would be redundant.
+const isChatbotBannerExcludedPath = (path) => {
+  const pathname = path.split(/[?#]/)[0].replace(/\/+$/, "") || "/";
+  return CHATBOT_BANNER_EXCLUDED_PATHS.includes(pathname);
+};
 
 const ChatbotExperimentBanner = ({ promoLearnMoreUrls, promoMaybeLaterJSON, promoSessionLengthSeconds }) => {
   const [isActionPending, setIsActionPending] = useState(false);
@@ -256,6 +264,9 @@ const ChatbotExperimentBanner = ({ promoLearnMoreUrls, promoMaybeLaterJSON, prom
     }
   };
 
+  if (isChatbotBannerExcludedPath(Sefaria.util.currentPath())) {
+    return null;
+  }
   const isLoggedIn = !!Sefaria._uid;
   if (!isLoggedIn && !Sefaria.isReturningVisitor()) {
     return null;
@@ -294,4 +305,4 @@ ChatbotExperimentBanner.propTypes = {
   promoSessionLengthSeconds: PropTypes.number,
 };
 
-export { SiteWideBanner, ChatbotExperimentBanner };
+export { SiteWideBanner, ChatbotExperimentBanner, isChatbotBannerExcludedPath };

--- a/static/js/SiteWideBanner.jsx
+++ b/static/js/SiteWideBanner.jsx
@@ -237,15 +237,14 @@ const CHATBOT_BANNER_SECONDARY_TEXT_HE = <div>נסו את <a href="https://help.
 const CHATBOT_BANNER_SECONDARY_TEXT = <div>Try our AI-powered <a href="https://help.sefaria.org/hc/en-us/articles/26006423836828-How-to-Use-the-Sefaria-Library-Assistant">Library Assistant</a> to deepen your understanding and discover new texts.</div>;
 const CAMPAIGN_ID = "LA Stand Alone Promo";
 const PROJECT = 'Library Assistant';
-const CHATBOT_BANNER_EXCLUDED_PATHS = ["/login", "/register"];
-const PASSWORD_RESET_PATH = "/password/reset";
+const CHATBOT_BANNER_EXCLUDED_PATHS = ["/login", "/register", "/password/reset"];
 
 // Keep authentication and password-recovery screens focused on the task at hand.
 const isChatbotBannerExcludedPath = (path) => {
-  const pathname = path.split(/[?#]/)[0].replace(/\/+$/, "") || "/";
-  return CHATBOT_BANNER_EXCLUDED_PATHS.includes(pathname) ||
-    pathname === PASSWORD_RESET_PATH ||
-    pathname.startsWith(`${PASSWORD_RESET_PATH}/`);
+  const pathname = new URL(path, "https://www.sefaria.org").pathname;
+  return CHATBOT_BANNER_EXCLUDED_PATHS.some(
+    excludedPath => pathname === excludedPath || pathname.startsWith(`${excludedPath}/`)
+  );
 };
 
 const ChatbotExperimentBanner = ({ promoLearnMoreUrls, promoMaybeLaterJSON, promoSessionLengthSeconds }) => {

--- a/static/js/SiteWideBanner.jsx
+++ b/static/js/SiteWideBanner.jsx
@@ -240,8 +240,8 @@ const PROJECT = 'Library Assistant';
 const CHATBOT_BANNER_EXCLUDED_PATHS = ["/login", "/register", "/password/reset"];
 
 // Keep authentication and password-recovery screens focused on the task at hand.
-const isChatbotBannerExcludedPath = (path) => {
-  const pathname = new URL(path, "https://www.sefaria.org").pathname;
+const isChatbotBannerExcludedPath = (path, moduleUrl) => {
+  const pathname = new URL(path, moduleUrl).pathname;
   return CHATBOT_BANNER_EXCLUDED_PATHS.some(
     excludedPath => pathname === excludedPath || pathname.startsWith(`${excludedPath}/`)
   );
@@ -265,7 +265,7 @@ const ChatbotExperimentBanner = ({ promoLearnMoreUrls, promoMaybeLaterJSON, prom
     }
   };
 
-  if (isChatbotBannerExcludedPath(Sefaria.util.currentPath())) {
+  if (isChatbotBannerExcludedPath(Sefaria.util.currentPath(), Sefaria.getModuleURL())) {
     return null;
   }
   const isLoggedIn = !!Sefaria._uid;

--- a/static/js/tests/siteWideBanner.test.js
+++ b/static/js/tests/siteWideBanner.test.js
@@ -2,29 +2,36 @@
 import { isChatbotBannerExcludedPath } from "../SiteWideBanner";
 
 describe("isChatbotBannerExcludedPath", function () {
-  it("excludes the login page", function () {
-    expect(isChatbotBannerExcludedPath("/login")).toBe(true);
+  it.each([
+    "/login",
+    "/login/",
+    "/login?next=%2Ftexts",
+    "/register",
+    "/register/",
+    "/register/?next=%2Ftexts#top",
+    "/password/reset",
+    "/password/reset/",
+    "/password/reset?next=%2Ftexts",
+    "/password/reset/done/",
+    "/password/reset/complete/",
+    "/password/reset/confirm/user-id/token/",
+  ])("excludes %s", function (path) {
+    expect(isChatbotBannerExcludedPath(path)).toBe(true);
   });
 
-  it("excludes the register page", function () {
-    expect(isChatbotBannerExcludedPath("/register")).toBe(true);
-  });
-
-  it("tolerates trailing slashes", function () {
-    expect(isChatbotBannerExcludedPath("/login/")).toBe(true);
-    expect(isChatbotBannerExcludedPath("/register/")).toBe(true);
-  });
-
-  it("ignores query strings and hashes", function () {
-    expect(isChatbotBannerExcludedPath("/login?next=%2Ftexts")).toBe(true);
-    expect(isChatbotBannerExcludedPath("/register/?next=%2Ftexts#top")).toBe(true);
-  });
-
-  it("does not exclude other pages", function () {
-    expect(isChatbotBannerExcludedPath("/")).toBe(false);
-    expect(isChatbotBannerExcludedPath("/texts")).toBe(false);
-    expect(isChatbotBannerExcludedPath("/Genesis.1")).toBe(false);
-    expect(isChatbotBannerExcludedPath("/logout")).toBe(false);
-    expect(isChatbotBannerExcludedPath("/texts?next=%2Flogin")).toBe(false);
+  it.each([
+    "/",
+    "/texts",
+    "/Genesis.1",
+    "/about",
+    "/logout",
+    "/login-help",
+    "/register-interest",
+    "/password",
+    "/passwords/reset",
+    "/password/resetting",
+    "/texts?next=%2Flogin",
+  ])("does not exclude %s", function (path) {
+    expect(isChatbotBannerExcludedPath(path)).toBe(false);
   });
 });

--- a/static/js/tests/siteWideBanner.test.js
+++ b/static/js/tests/siteWideBanner.test.js
@@ -1,0 +1,30 @@
+/* Testing done using Jest */
+import { isChatbotBannerExcludedPath } from "../SiteWideBanner";
+
+describe("isChatbotBannerExcludedPath", function () {
+  it("excludes the login page", function () {
+    expect(isChatbotBannerExcludedPath("/login")).toBe(true);
+  });
+
+  it("excludes the register page", function () {
+    expect(isChatbotBannerExcludedPath("/register")).toBe(true);
+  });
+
+  it("tolerates trailing slashes", function () {
+    expect(isChatbotBannerExcludedPath("/login/")).toBe(true);
+    expect(isChatbotBannerExcludedPath("/register/")).toBe(true);
+  });
+
+  it("ignores query strings and hashes", function () {
+    expect(isChatbotBannerExcludedPath("/login?next=%2Ftexts")).toBe(true);
+    expect(isChatbotBannerExcludedPath("/register/?next=%2Ftexts#top")).toBe(true);
+  });
+
+  it("does not exclude other pages", function () {
+    expect(isChatbotBannerExcludedPath("/")).toBe(false);
+    expect(isChatbotBannerExcludedPath("/texts")).toBe(false);
+    expect(isChatbotBannerExcludedPath("/Genesis.1")).toBe(false);
+    expect(isChatbotBannerExcludedPath("/logout")).toBe(false);
+    expect(isChatbotBannerExcludedPath("/texts?next=%2Flogin")).toBe(false);
+  });
+});

--- a/static/js/tests/siteWideBanner.test.js
+++ b/static/js/tests/siteWideBanner.test.js
@@ -2,6 +2,8 @@
 import { isChatbotBannerExcludedPath } from "../SiteWideBanner";
 
 describe("isChatbotBannerExcludedPath", function () {
+  const moduleUrl = new URL("https://www.sefaria.org.il");
+
   it.each([
     "/login",
     "/login/",
@@ -16,7 +18,7 @@ describe("isChatbotBannerExcludedPath", function () {
     "/password/reset/complete/",
     "/password/reset/confirm/user-id/token/",
   ])("excludes %s", function (path) {
-    expect(isChatbotBannerExcludedPath(path)).toBe(true);
+    expect(isChatbotBannerExcludedPath(path, moduleUrl)).toBe(true);
   });
 
   it.each([
@@ -32,6 +34,6 @@ describe("isChatbotBannerExcludedPath", function () {
     "/password/resetting",
     "/texts?next=%2Flogin",
   ])("does not exclude %s", function (path) {
-    expect(isChatbotBannerExcludedPath(path)).toBe(false);
+    expect(isChatbotBannerExcludedPath(path, moduleUrl)).toBe(false);
   });
 });

--- a/static/js/tests/siteWideBanner.test.js
+++ b/static/js/tests/siteWideBanner.test.js
@@ -36,4 +36,15 @@ describe("isChatbotBannerExcludedPath", function () {
   ])("does not exclude %s", function (path) {
     expect(isChatbotBannerExcludedPath(path, moduleUrl)).toBe(false);
   });
+
+  // getModuleURL returns false when it cannot build a URL (e.g. server-side
+  // rendering, where apiHost is empty) — the helper must not throw.
+  it.each([false, undefined, ""])("still excludes /login when moduleUrl is %s", function (badModuleUrl) {
+    expect(isChatbotBannerExcludedPath("/login", badModuleUrl)).toBe(true);
+    expect(isChatbotBannerExcludedPath("/texts", badModuleUrl)).toBe(false);
+  });
+
+  it("returns false instead of throwing on an unparseable path", function () {
+    expect(isChatbotBannerExcludedPath("http://", false)).toBe(false);
+  });
 });


### PR DESCRIPTION
_(Claude and Codex writing on Daniel's behalf)_

## What

Hides the Library Assistant promo banner (`ChatbotExperimentBanner`) on authentication and password-recovery screens:

- `/login`
- `/register`
- the complete `/password/reset/...` route family

Shortcut story: https://app.shortcut.com/sefaria/story/46176

## Why

These screens should remain focused on authentication or account recovery. The Library Assistant already opens automatically after successful login or registration, so promoting it there is redundant.

## How

The banner keeps a small, product-specific path policy local to `SiteWideBanner.jsx`. It gets the path from the existing SSR-safe `Sefaria.util.currentPath()`, resolves it with the native `URL` parser against `Sefaria.getModuleURL()` (the configured active-module/interface-language domain), and checks one array of excluded route roots with a segment boundary. This covers the password-reset family while leaving unrelated paths such as `/password/resetting` eligible.

There is no existing reusable frontend auth-path classifier. The broader `headerMode` abstraction was deliberately not used because it also covers ordinary static/about pages where sitewide banners remain valid.

## How tested

Focused Jest coverage verifies:

- login and registration, including trailing slashes and query strings
- reset form, confirmation, done, and complete paths
- similarly named non-auth paths are not accidentally excluded

`npx jest static/js/tests/siteWideBanner.test.js --runInBand --no-watchman --roots static/js __mocks__` passes: 23 tests.
