### PR TITLE
feat: auto-enroll newly registered users in Library Assistant

### DIFF
--- a/reader/models.py
+++ b/reader/models.py
@@ -1,6 +1,8 @@
+from functools import partial
+
 from django.contrib.auth.models import User
 from django.core.exceptions import ObjectDoesNotExist
-from django.db import models
+from django.db import models, transaction
 
 from sefaria.helper.crm.tasks import dispatch_chatbot_opt_in_webhook
 
@@ -24,7 +26,7 @@ def _get_user_experiments(user):
         return False
 
 
-def _set_user_experiments(user, value):
+def _set_user_experiments(user, value, *, dispatch_webhook_on_commit=False):
     experiments_enabled = bool(value)
     settings, created = UserExperimentSettings.objects.get_or_create(user=user)
     changed = created or (experiments_enabled != settings.experiments)
@@ -38,7 +40,16 @@ def _set_user_experiments(user, value):
 
     if changed:
         interface_language = profile.settings.get("interface_language", "english")
-        dispatch_chatbot_opt_in_webhook(user.email, experiments_enabled, interface_language)
+        dispatch_webhook = partial(
+            dispatch_chatbot_opt_in_webhook,
+            user.email,
+            experiments_enabled,
+            interface_language,
+        )
+        if dispatch_webhook_on_commit:
+            transaction.on_commit(dispatch_webhook, robust=True)
+        else:
+            dispatch_webhook()
 
 
 if not hasattr(User, "experiments"):

--- a/reader/tests/register_auto_enroll_test.py
+++ b/reader/tests/register_auto_enroll_test.py
@@ -1,0 +1,88 @@
+import urllib.error
+import uuid
+from unittest import mock
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django_recaptcha.client import RecaptchaResponse
+
+from reader.models import UserExperimentSettings
+from sefaria.settings import MOBILE_APP_KEY
+from sefaria.system.database import db
+
+
+@mock.patch("urllib.request.urlopen", side_effect=urllib.error.URLError("no gravatar in tests"))
+@mock.patch("django_recaptcha.fields.client.submit", return_value=RecaptchaResponse(is_valid=True))
+@mock.patch("reader.models.dispatch_chatbot_opt_in_webhook")
+class RegisterAutoEnrollTest(TestCase):
+    """
+    Every newly registered user is automatically enrolled in the Library Assistant
+    experiment, no matter which registration flow they came through. Enrollment at
+    registration is what makes the assistant open on first load: the widget mounts
+    with default-open once the user is enabled, and a brand-new user has no stored
+    widget state to override that.
+    """
+    databases = "__all__"
+
+    def setUp(self):
+        token = uuid.uuid4().hex
+        self.email = f"la-register-{token}@example.com"
+        self.form_data = {
+            "email": self.email,
+            "first_name": "Test",
+            "last_name": "User",
+            "password1": f"pw-{token}",
+            "g-recaptcha-response": "PASSED",
+        }
+
+    def tearDown(self):
+        user = User.objects.filter(email=self.email).first()
+        if user:
+            db.profiles.delete_many({"id": user.id})
+            UserExperimentSettings.objects.filter(user=user).delete()
+
+    def _assert_enrolled(self):
+        user = User.objects.get(email=self.email)
+        self.assertTrue(
+            UserExperimentSettings.objects.filter(user=user, experiments=True).exists()
+        )
+        profile = db.profiles.find_one({"id": user.id})
+        self.assertIsNotNone(profile)
+        self.assertTrue(profile.get("experiments"))
+        return user
+
+    def test_web_form_registration_enrolls_user(self, mock_dispatch, _mock_captcha, _mock_urlopen):
+        response = self.client.post("/register/", self.form_data)
+
+        self.assertEqual(response.status_code, 302)
+        user = self._assert_enrolled()
+        mock_dispatch.assert_called_once()
+        self.assertEqual(mock_dispatch.call_args[0][0], user.email)
+        self.assertTrue(mock_dispatch.call_args[0][1])
+
+    def test_web_form_registration_logs_user_in(self, _mock_dispatch, _mock_captcha, _mock_urlopen):
+        self.client.post("/register/", self.form_data)
+
+        user = User.objects.get(email=self.email)
+        self.assertEqual(int(self.client.session["_auth_user_id"]), user.id)
+
+    def test_api_registration_enrolls_user(self, mock_dispatch, _mock_captcha, _mock_urlopen):
+        # The API form keeps Django's password confirmation field.
+        api_data = dict(
+            self.form_data,
+            password2=self.form_data["password1"],
+            mobile_app_key=MOBILE_APP_KEY,
+        )
+        response = self.client.post("/api/register/", api_data)
+
+        self.assertEqual(response.status_code, 200)
+        self._assert_enrolled()
+        mock_dispatch.assert_called_once()
+
+    def test_invalid_registration_does_not_enroll(self, mock_dispatch, _mock_captcha, _mock_urlopen):
+        bad_data = dict(self.form_data, password1="")
+        response = self.client.post("/register/", bad_data)
+
+        self.assertFalse(User.objects.filter(email=self.email).exists())
+        self.assertEqual(UserExperimentSettings.objects.count(), 0)
+        mock_dispatch.assert_not_called()

--- a/reader/tests/register_auto_enroll_test.py
+++ b/reader/tests/register_auto_enroll_test.py
@@ -56,10 +56,10 @@ class RegisterAutoEnrollTest(TestCase):
             response = self.client.post("/register/", self.form_data)
 
         self.assertEqual(response.status_code, 302)
+        user = self._assert_enrolled()
         mock_dispatch.assert_not_called()
         self.assertEqual(len(callbacks), 1)
         callbacks[0]()
-        user = self._assert_enrolled()
         mock_dispatch.assert_called_once()
         self.assertEqual(mock_dispatch.call_args[0][0], user.email)
         self.assertTrue(mock_dispatch.call_args[0][1])

--- a/reader/tests/register_auto_enroll_test.py
+++ b/reader/tests/register_auto_enroll_test.py
@@ -52,9 +52,13 @@ class RegisterAutoEnrollTest(TestCase):
         return user
 
     def test_web_form_registration_enrolls_user(self, mock_dispatch, _mock_captcha, _mock_urlopen):
-        response = self.client.post("/register/", self.form_data)
+        with self.captureOnCommitCallbacks() as callbacks:
+            response = self.client.post("/register/", self.form_data)
 
         self.assertEqual(response.status_code, 302)
+        mock_dispatch.assert_not_called()
+        self.assertEqual(len(callbacks), 1)
+        callbacks[0]()
         user = self._assert_enrolled()
         mock_dispatch.assert_called_once()
         self.assertEqual(mock_dispatch.call_args[0][0], user.email)
@@ -73,7 +77,8 @@ class RegisterAutoEnrollTest(TestCase):
             password2=self.form_data["password1"],
             mobile_app_key=MOBILE_APP_KEY,
         )
-        response = self.client.post("/api/register/", api_data)
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post("/api/register/", api_data)
 
         self.assertEqual(response.status_code, 200)
         self._assert_enrolled()

--- a/sefaria/views.py
+++ b/sefaria/views.py
@@ -72,7 +72,7 @@ from sefaria import tracker
 from sefaria.system.multiserver.coordinator import server_coordinator
 from sefaria.google_storage_manager import GoogleStorageManager
 from sefaria.sheets import get_sheet_categorization_info
-from reader.models import _set_user_experiments
+from reader import models as reader_models
 from reader.views import base_props, render_template
 from sefaria.helper.link import add_links_from_csv, delete_links_from_text, get_csv_links_by_refs, remove_links_from_csv
 from sefaria.forms import SefariaPasswordResetForm, SefariaSetPasswordForm, SefariaLoginForm
@@ -198,7 +198,7 @@ def process_register_form(request, auth_method='session'):
 
             # New users are enrolled in the Library Assistant automatically;
             # the account settings toggle remains the way to opt out.
-            _set_user_experiments(user, True)
+            reader_models._set_user_experiments(user, True)
 
         if auth_method == 'session':
             auth_login(request, user)

--- a/sefaria/views.py
+++ b/sefaria/views.py
@@ -72,6 +72,7 @@ from sefaria import tracker
 from sefaria.system.multiserver.coordinator import server_coordinator
 from sefaria.google_storage_manager import GoogleStorageManager
 from sefaria.sheets import get_sheet_categorization_info
+from reader.models import _set_user_experiments
 from reader.views import base_props, render_template
 from sefaria.helper.link import add_links_from_csv, delete_links_from_text, get_csv_links_by_refs, remove_links_from_csv
 from sefaria.forms import SefariaPasswordResetForm, SefariaSetPasswordForm, SefariaLoginForm
@@ -197,7 +198,6 @@ def process_register_form(request, auth_method='session'):
 
             # New users are enrolled in the Library Assistant automatically;
             # the account settings toggle remains the way to opt out.
-            from reader.models import _set_user_experiments
             _set_user_experiments(user, True)
 
         if auth_method == 'session':

--- a/sefaria/views.py
+++ b/sefaria/views.py
@@ -198,7 +198,12 @@ def process_register_form(request, auth_method='session'):
 
             # New users are enrolled in the Library Assistant automatically;
             # the account settings toggle remains the way to opt out.
-            reader_models._set_user_experiments(user, True)
+            # Wait for the user transaction to commit before writing to Mongo or
+            # dispatching the CRM webhook, neither of which can be rolled back here.
+            transaction.on_commit(
+                lambda: reader_models._set_user_experiments(user, True),
+                robust=True,
+            )
 
         if auth_method == 'session':
             auth_login(request, user)

--- a/sefaria/views.py
+++ b/sefaria/views.py
@@ -195,6 +195,11 @@ def process_register_form(request, auth_method='session'):
                 logger.warning("Error communicating with Google Storage Manager. {}".format(e))
             p.save()
 
+            # New users are enrolled in the Library Assistant automatically;
+            # the account settings toggle remains the way to opt out.
+            from reader.models import _set_user_experiments
+            _set_user_experiments(user, True)
+
         if auth_method == 'session':
             auth_login(request, user)
         elif auth_method == 'jwt':

--- a/sefaria/views.py
+++ b/sefaria/views.py
@@ -198,11 +198,12 @@ def process_register_form(request, auth_method='session'):
 
             # New users are enrolled in the Library Assistant automatically;
             # the account settings toggle remains the way to opt out.
-            # Wait for the user transaction to commit before writing to Mongo or
-            # dispatching the CRM webhook, neither of which can be rolled back here.
-            transaction.on_commit(
-                lambda: reader_models._set_user_experiments(user, True),
-                robust=True,
+            # CRM dispatch cannot be rolled back, so defer that side effect until
+            # the user transaction commits while keeping enrollment transactional.
+            reader_models._set_user_experiments(
+                user,
+                True,
+                dispatch_webhook_on_commit=True,
             )
 
         if auth_method == 'session':


### PR DESCRIPTION
_(Claude and Codex writing on Daniel's behalf)_

## What

Auto-enrolls every newly registered user in the Library Assistant experiment. Story: https://app.shortcut.com/sefaria/story/46170

Product direction: opt-in stops being a user choice for new registrations; the account settings toggle remains the opt-out.

## How

`process_register_form` is the shared registration path for both the web form and the mobile/JWT API. It calls the existing experiment setter while the registration transaction is active, so the required `UserExperimentSettings` row remains transactional and the Mongo profile is updated in the same lifecycle step.

The setter now has an opt-in `dispatch_webhook_on_commit` mode. Registration uses it to defer only the irreversible CRM dispatch until the PostgreSQL user transaction commits. Other existing setter callers retain their current immediate-dispatch behavior.

This means:

- failed registration cannot produce a ghost CRM enrollment
- enrollment failure still prevents the user transaction from committing
- an external queue failure cannot roll back a successfully committed user

Both #3559 and #3560 use the same module-level `reader_models` import, so the two PRs merge cleanly in either order.

## Why enabling at registration makes LA open automatically

The widget in `ReaderApp.jsx` renders `<lc-chatbot ... default-open={true}>` once the user is enabled. A brand-new user has no stored widget state to override that default, so the assistant opens automatically on the first library page load.

## How tested

`reader/tests/register_auto_enroll_test.py` covers:

- web registration creates enrollment before the commit callback, then dispatches CRM exactly once afterward
- web registration still logs the user in
- API/JWT registration enrolls too
- invalid registration creates no user, enrollment, or webhook

Final related run: `16 passed` across registration and experiment-setter/admin coverage.
