### PR TITLE
feat: auto-enroll never-opted-in users in Library Assistant at login

### DIFF
--- a/reader/tests/login_auto_enroll_test.py
+++ b/reader/tests/login_auto_enroll_test.py
@@ -1,0 +1,71 @@
+import uuid
+from unittest import mock
+
+from django.test import TestCase
+from emailusernames.utils import create_user
+
+from reader.models import UserExperimentSettings
+from sefaria.system.database import db
+
+
+@mock.patch("reader.models.dispatch_chatbot_opt_in_webhook")
+class LoginAutoEnrollTest(TestCase):
+    """
+    Existing account holders who have never made a Library Assistant choice are
+    auto-enrolled when they log in, so the assistant opens for them automatically.
+    Users who already hold a preference — enabled or disabled — are left untouched.
+    """
+    databases = "__all__"
+    url = "/login"
+    password = "password"
+
+    def setUp(self):
+        token = uuid.uuid4().hex
+        self.email = f"la-login-{token}@example.com"
+        # emailusernames stores a hashed email in the username column; its own
+        # create_user is required for the email auth backend to find the user.
+        self.user = create_user(self.email, self.password)
+        db.profiles.delete_many({"id": self.user.id})
+
+    def tearDown(self):
+        db.profiles.delete_many({"id": self.user.id})
+        UserExperimentSettings.objects.filter(user=self.user).delete()
+
+    def login(self):
+        return self.client.post(self.url, {"email": self.email, "password": self.password})
+
+    def test_never_enrolled_user_is_enrolled_on_login(self, mock_dispatch):
+        response = self.login()
+
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(
+            UserExperimentSettings.objects.filter(user=self.user, experiments=True).exists()
+        )
+        mock_dispatch.assert_called_once()
+
+    def test_user_who_disabled_assistant_stays_disabled(self, mock_dispatch):
+        UserExperimentSettings.objects.create(user=self.user, experiments=False)
+
+        response = self.login()
+
+        self.assertEqual(response.status_code, 302)
+        settings = UserExperimentSettings.objects.get(user=self.user)
+        self.assertFalse(settings.experiments)
+        mock_dispatch.assert_not_called()
+
+    def test_user_who_enabled_assistant_is_unchanged(self, mock_dispatch):
+        UserExperimentSettings.objects.create(user=self.user, experiments=True)
+
+        response = self.login()
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(UserExperimentSettings.objects.filter(user=self.user).count(), 1)
+        self.assertTrue(UserExperimentSettings.objects.get(user=self.user).experiments)
+        mock_dispatch.assert_not_called()
+
+    def test_failed_login_enrolls_nothing(self, mock_dispatch):
+        response = self.client.post(self.url, {"email": self.email, "password": "wrong"})
+
+        self.assertEqual(response.status_code, 200)  # form re-rendered with errors
+        self.assertFalse(UserExperimentSettings.objects.filter(user=self.user).exists())
+        mock_dispatch.assert_not_called()

--- a/sefaria/views.py
+++ b/sefaria/views.py
@@ -94,6 +94,17 @@ class StaticViewMixin:
 class CustomLoginView(StaticViewMixin, LoginView):
     authentication_form = SefariaLoginForm
 
+    def form_valid(self, form):
+        response = super().form_valid(form)
+        from reader.models import user_has_experiments, _set_user_experiments
+        user = self.request.user
+        # Users who have never made a Library Assistant choice are enrolled at login,
+        # so the assistant opens for them automatically. Users with an existing
+        # preference (enabled or disabled) are left untouched.
+        if not user_has_experiments(user):
+            _set_user_experiments(user, True)
+        return response
+
 class CustomLogoutView(StaticViewMixin, LogoutView):
     http_method_names = ["get", "post", "options"]
 

--- a/sefaria/views.py
+++ b/sefaria/views.py
@@ -72,6 +72,7 @@ from sefaria import tracker
 from sefaria.system.multiserver.coordinator import server_coordinator
 from sefaria.google_storage_manager import GoogleStorageManager
 from sefaria.sheets import get_sheet_categorization_info
+from reader.models import _set_user_experiments, user_has_experiments
 from reader.views import base_props, render_template
 from sefaria.helper.link import add_links_from_csv, delete_links_from_text, get_csv_links_by_refs, remove_links_from_csv
 from sefaria.forms import SefariaPasswordResetForm, SefariaSetPasswordForm, SefariaLoginForm
@@ -96,8 +97,7 @@ class CustomLoginView(StaticViewMixin, LoginView):
 
     def form_valid(self, form):
         response = super().form_valid(form)
-        from reader.models import user_has_experiments, _set_user_experiments
-        user = self.request.user
+        user = form.get_user()
         # Users who have never made a Library Assistant choice are enrolled at login,
         # so the assistant opens for them automatically. Users with an existing
         # preference (enabled or disabled) are left untouched.

--- a/sefaria/views.py
+++ b/sefaria/views.py
@@ -72,7 +72,7 @@ from sefaria import tracker
 from sefaria.system.multiserver.coordinator import server_coordinator
 from sefaria.google_storage_manager import GoogleStorageManager
 from sefaria.sheets import get_sheet_categorization_info
-from reader.models import _set_user_experiments, user_has_experiments
+from reader import models as reader_models
 from reader.views import base_props, render_template
 from sefaria.helper.link import add_links_from_csv, delete_links_from_text, get_csv_links_by_refs, remove_links_from_csv
 from sefaria.forms import SefariaPasswordResetForm, SefariaSetPasswordForm, SefariaLoginForm
@@ -101,8 +101,8 @@ class CustomLoginView(StaticViewMixin, LoginView):
         # Users who have never made a Library Assistant choice are enrolled at login,
         # so the assistant opens for them automatically. Users with an existing
         # preference (enabled or disabled) are left untouched.
-        if not user_has_experiments(user):
-            _set_user_experiments(user, True)
+        if not reader_models.user_has_experiments(user):
+            reader_models._set_user_experiments(user, True)
         return response
 
 class CustomLogoutView(StaticViewMixin, LogoutView):


### PR DESCRIPTION
_(Claude writing on Daniel's behalf)_

## What / why

Implements [sc-46171](https://app.shortcut.com/sefaria/story/46171): Library Assistant behavior for **existing account holders who log in** through any web login flow (e.g. "Log In" in navigation, not just via the LA promo).

On successful web login, if the user has never made a Library Assistant choice (no `UserExperimentSettings` row), they are enrolled with `experiments=True` via the existing `_set_user_experiments` helper (which also mirrors to the Mongo profile and fires the CRM opt-in webhook). Users who already hold a preference — in either state — are left completely untouched.

Change is a `form_valid` override on `CustomLoginView` in `sefaria/views.py` (super first, so login completes before enrollment), plus a new test file.

## Acceptance criteria → mechanism

- **Previously opted in AND disabled in settings → stays disabled.** The row exists, so login touches nothing; `_is_user_in_experiment` (context processor) requires `profile.experiments` truthy, so the widget never loads.
- **Previously opted in AND enabled → last open/minimized state, no change.** The row exists, so login touches nothing; the widget's open/minimized state lives inside the external `<lc-chatbot>` bundle and is not modified here.
- **Never opted in → LA opens automatically after login.** Enrollment happens during the login request itself, so the post-login page render already issues the chatbot token, and `<lc-chatbot ... default-open={true}>` (ReaderApp.jsx) mounts open for the newly enrolled user.

## Scoping

Web login only (`CustomLoginView`). The JWT `api/login` endpoint (mobile app) is deliberately untouched — the Library Assistant is web-only. `enable_library_assistant` and the settings toggle are unchanged.

## How tested

New `reader/tests/login_auto_enroll_test.py` (pytest, follows `enable_library_assistant_test.py` conventions, webhook mocked):

- never-enrolled user login → row created with `experiments=True`, webhook fired once
- user with row + `False` → stays `False`, no webhook
- user with row + `True` → unchanged single row, no webhook
- failed login → no enrollment, no webhook

All 4 pass locally; `reader/tests/enable_library_assistant_test.py` (9 tests) also passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
