### PR TITLE
fix(i18n): allow camelCase segments in keyed string IDs

### DIFF
--- a/static/js/sefaria/sefaria.js
+++ b/static/js/sefaria/sefaria.js
@@ -3610,10 +3610,12 @@ _media: {},
         return name;
     }
   },
-  _keyedStringIdRegex: /^[a-z0-9_]+(\.[a-z0-9_]+)+$/,
+  _keyedStringIdRegex: /^[a-z0-9_][a-zA-Z0-9_]*(\.[a-z0-9_][a-zA-Z0-9_]*)+$/,
   _isKeyedStringId: function(inputStr) {
-    // Keyed interface string IDs look like "header.log_in"; no legacy English
-    // interface string matches this shape.
+    // Keyed interface string IDs look like "header.log_in" or "search.exactMatchToggle.allResults";
+    // snake_case and camelCase segments are both allowed. Segments must not *start* with an
+    // uppercase letter: that is what keeps capitalized data values (e.g. "Gen.1", "b.Berakhot")
+    // from being mistaken for IDs, since no legacy English interface string matches this shape.
     return typeof inputStr === "string" && Sefaria._keyedStringIdRegex.test(inputStr);
   },
   _keyedString: function(id, lang) {

--- a/static/js/sefaria/sefaria.js
+++ b/static/js/sefaria/sefaria.js
@@ -3610,7 +3610,7 @@ _media: {},
         return name;
     }
   },
-  _keyedStringIdRegex: /^[a-z0-9_][a-zA-Z0-9_]*(\.[a-z0-9_][a-zA-Z0-9_]*)+$/,
+  _keyedStringIdRegex: /^[a-z0-9_][a-zA-Z0-9_]*(\.[a-z0-9_][a-zA-Z0-9_]*)+$/,  //matches snake_case or camelCase
   _isKeyedStringId: function(inputStr) {
     // Keyed interface string IDs look like "header.log_in" or "search.exactMatchToggle.allResults";
     // snake_case and camelCase segments are both allowed. Segments must not *start* with an

--- a/static/js/sefaria/tests/strings.test.js
+++ b/static/js/sefaria/tests/strings.test.js
@@ -6,8 +6,9 @@ describe('keyed interface strings', () => {
   const interfaceHe = require('../i18n/interface/he.json');
   const contextEn = require('../i18n/interface-context/en.json');
   const contextHe = require('../i18n/interface-context/he.json');
-  // Keep in sync with Sefaria._keyedStringIdRegex in sefaria.js.
-  const ID_RE = /^[a-z0-9_][a-zA-Z0-9_]*(\.[a-z0-9_][a-zA-Z0-9_]*)+$/;
+  // The router's own regex, not a copy: the contract is that every key is
+  // resolvable by Sefaria._(), so this must track whatever the router uses.
+  const ID_RE = Sefaria._keyedStringIdRegex;
 
   test('every key in every map is an ID matching the router regex', () => {
     [interfaceEn, interfaceHe, contextEn, contextHe].forEach(map =>

--- a/static/js/sefaria/tests/strings.test.js
+++ b/static/js/sefaria/tests/strings.test.js
@@ -6,12 +6,23 @@ describe('keyed interface strings', () => {
   const interfaceHe = require('../i18n/interface/he.json');
   const contextEn = require('../i18n/interface-context/en.json');
   const contextHe = require('../i18n/interface-context/he.json');
-  const ID_RE = /^[a-z0-9_]+(\.[a-z0-9_]+)+$/;
+  // Keep in sync with Sefaria._keyedStringIdRegex in sefaria.js.
+  const ID_RE = /^[a-z0-9_][a-zA-Z0-9_]*(\.[a-z0-9_][a-zA-Z0-9_]*)+$/;
 
   test('every key in every map is an ID matching the router regex', () => {
     [interfaceEn, interfaceHe, contextEn, contextHe].forEach(map =>
       Object.keys(map).forEach(id => expect(id).toMatch(ID_RE))
     );
+  });
+
+  test('ID shape accepts snake_case and camelCase but not capitalized data values', () => {
+    ['header.log_in', 'sheets.1_person_likes_this_sheet',
+     'search.exactMatchToggle.allResults'].forEach(id =>
+      expect(Sefaria._isKeyedStringId(id)).toBe(true));
+    // Capitalized data values reach Sefaria._() too; they must not route as IDs.
+    ['Gen.1', 'b.Berakhot', 'Mishnah Berakhot', 'Some untranslated string',
+     'common', 'e.g.'].forEach(s =>
+      expect(Sefaria._isKeyedStringId(s)).toBe(false));
   });
 
   test('en.json and he.json cover the same IDs in each map', () => {


### PR DESCRIPTION
## Problem

Jest is red on `master` as of 24e7b4d0d2 (Translations update from Sefaria Translations, #3566) — see [this run](https://github.com/Sefaria/Sefaria-Project/actions/runs/30557508964). Every PR branching from or merging master inherits the failure.

That sync added two camelCase keys to `i18n/interface/en.json` and `he.json`:

```json
"search.exactMatchToggle.allResults": "All Results",
"search.exactMatchToggle.exactMatch": "Exact Phrase",
```

They fail the ID shape enforced by `Sefaria._keyedStringIdRegex`, which only allowed snake_case keys.  This is a seemingly unnecessary restriction on Weblate users.  They should be able to use snake_case or camelCase.

## Fix

Widen the regex to allow uppercase letters anywhere **except the first character** of each dot-separated segment:

```js
/^[a-z0-9_][a-zA-Z0-9_]*(\.[a-z0-9_][a-zA-Z0-9_]*)+$/
```

The leading-character restriction is load-bearing. `_isKeyedStringId()` is a **classifier**, not just a validator — `Sefaria._()` uses it to decide whether an argument is a translation key to look up or a plain data value to pass through, and many legacy call sites pass raw titles and categories. Sefaria's data values are capitalized (`Gen.1`, `b.Berakhot`, `Mishnah Berakhot`); its keys are not. Keeping segment starts lowercase preserves that separation while allowing camelCase in the middle.

## Note

Both spellings are now legal, so `search.exactMatchToggle` and `search.exact_match_toggle` would be distinct keys with nothing flagging the inconsistency.  However, I think it's better to give Weblate users more flexibility than to restrict them to snake_case.
