### PR TITLE
feat: harvest meaningful search categories for autocomplete

### DIFF
--- a/sefaria/model/autospell.py
+++ b/sefaria/model/autospell.py
@@ -213,10 +213,10 @@ class AutoCompleter(object):
                 if is_category_boundary(child.primary_title("en")):
                     for grandchild in child.children:            # harvest one level
                         if isinstance(grandchild, TocCategory) and not is_category_boundary(grandchild.primary_title("en")):
-                            cats += [grandchild]
+                            cats.append(grandchild)
                     continue                                     # never descend past a boundary
                 if len(child.children) >= 2:
-                    cats += [child]
+                    cats.append(child)
                 walk(child)
 
         walk(otoc)

--- a/sefaria/model/autospell.py
+++ b/sefaria/model/autospell.py
@@ -11,6 +11,7 @@ import datrie
 from unidecode import unidecode
 from django.contrib.auth.models import User
 from sefaria.model import *
+from sefaria.model.category import TocCategory
 from sefaria.model.schema import SheetLibraryNode
 from sefaria.utils import hebrew
 from sefaria.model.following import aggregate_profiles
@@ -36,6 +37,21 @@ def strip_apostrophes(text):
 
 def normalize_chars(text):
     return strip_apostrophes("".join([c if c in letter_scope else unidecode(c) for c in text]))
+
+
+# Category nodes that are *collection boundaries* rather than meaningful text
+# categories (e.g. "Commentary", "Rishonim on Tanakh", "Other Kabbalah Works").
+# We drop the boundary node itself but harvest the good names one level below it
+# (Rashi, Ramban, Kessef Mishneh, ...), without descending into their repeated
+# per-book structure.  See AutoCompleter._get_search_categories.
+CATEGORY_BOUNDARY_EXACT = {"comment", "comments", "modern", "targum", "guides"}
+CATEGORY_BOUNDARY_RE = re.compile(
+    r"\b(commentary|commentaries|rishonim|acharonim|geonim|savoraim|other)\b")
+
+
+def is_category_boundary(name):
+    name = name.strip().lower()
+    return name in CATEGORY_BOUNDARY_EXACT or bool(CATEGORY_BOUNDARY_RE.search(name))
 
 
 def normalizer(lang):
@@ -88,7 +104,7 @@ class AutoCompleter(object):
             self.spell_checker.train_phrases(normal_titles)
             self.ngram_matcher.train_phrases(titles, normal_titles)
         if include_categories:
-            categories = self._get_main_categories(library.get_toc_tree().get_root())
+            categories = self._get_search_categories(library.get_toc_tree().get_root())
             category_names = [c.primary_title(lang) for c in categories]
             normal_category_names = [self.normalizer(c) for c in category_names]
             self.title_trie.add_titles_from_set(categories, "all_node_titles", "primary_title", "full_path", 2 * PAD)
@@ -176,14 +192,34 @@ class AutoCompleter(object):
         self.other_lang_ac = ac
 
     @staticmethod
-    def _get_main_categories(otoc):
+    def _get_search_categories(otoc):
+        """
+        Category nodes meaningful as search results.
+
+        - Keeps the base-text browse taxonomy (categories with >= 2 children).
+        - At a commentary/era/"Other" boundary (e.g. "Commentary", "Rishonim on
+          Tanakh", "Acharonim", "Other Kabbalah Works"): drops the boundary node,
+          but harvests its child *categories* (Rashi, Ramban, Kessef Mishneh, ...) --
+          lots of good names -- and does NOT descend into their repeated inner
+          structure.  Boundaries holding only texts (e.g. "Other Kabbalah Works")
+          contribute nothing here; those texts are already indexed as titles.
+        """
         cats = []
-        for child in otoc.children:
-            if child.children and child.primary_title("en") != "Commentary":
-                cats += [child]
-            for grandchild in child.children:
-                if grandchild.children and grandchild.primary_title("en") != "Commentary":
-                    cats += [grandchild]
+
+        def walk(node):
+            for child in node.children:
+                if not isinstance(child, TocCategory):
+                    continue
+                if is_category_boundary(child.primary_title("en")):
+                    for grandchild in child.children:            # harvest one level
+                        if isinstance(grandchild, TocCategory) and not is_category_boundary(grandchild.primary_title("en")):
+                            cats += [grandchild]
+                    continue                                     # never descend past a boundary
+                if len(child.children) >= 2:
+                    cats += [child]
+                walk(child)
+
+        walk(otoc)
         return cats
 
     def get_object(self, instring):


### PR DESCRIPTION
Replace AutoCompleter._get_main_categories with _get_search_categories, which builds the category feed for autocomplete from the TOC tree.

- Keep the base-text browse taxonomy (categories with >= 2 children), recursing to full depth instead of stopping at two levels.
- At commentary/era/"Other" boundaries ("Commentary", "Rishonim on X", "Acharonim", "Modern", "Other ... Works", "Targum", "Guides"): drop the boundary node but harvest the good names one level below it (Rashi, Ramban, Kessef Mishneh, ...), without descending into their repeated per-book structure.

This removes the tens of duplicated commentary sub-trees (e.g. a full "Mishneh Torah" structure repeated under each of its commentators) while surfacing the commentator/author names that are valuable as search terms.

## Description
_A brief description of the PR_

## Code Changes
_The following changes were made to the files below_

## Notes
_Any additional notes go here_