### PR TITLE
fix: update recaptcha check id for django-recaptcha 4.x

### DIFF
--- a/sefaria/local_settings_ci.py
+++ b/sefaria/local_settings_ci.py
@@ -34,7 +34,8 @@ DOMAIN_MODULES = {
     }
 }
 ALLOWED_HOSTS = ['127.0.0.1', "0.0.0.0", '[::1]', "localhost", "voices.localhost"]
-#SILENCED_SYSTEM_CHECKS = ['captcha.recaptcha_test_key_error']
+#SILENCED_SYSTEM_CHECKS = ['captcha.recaptcha_test_key_error',
+#                          'django_recaptcha.recaptcha_test_key_error']
 CSRF_TRUSTED_ORIGINS = ["https://*.sefaria.org"]
 ADMINS = (
      'you@example.com',

--- a/sefaria/local_settings_coolify.py
+++ b/sefaria/local_settings_coolify.py
@@ -1,6 +1,7 @@
 import os
 
-SILENCED_SYSTEM_CHECKS = ['captcha.recaptcha_test_key_error']
+SILENCED_SYSTEM_CHECKS = ['captcha.recaptcha_test_key_error',
+                          'django_recaptcha.recaptcha_test_key_error']
 ALLOWED_HOSTS = ['*']
 CSRF_TRUSTED_ORIGINS = ['https://*.sefaria.org']
 

--- a/sefaria/local_settings_example.py
+++ b/sefaria/local_settings_example.py
@@ -48,7 +48,8 @@ DATABASES = {
 
 
 ################ User-defined Settings ###########################################################################
-#SILENCED_SYSTEM_CHECKS = ['captcha.recaptcha_test_key_error']
+#SILENCED_SYSTEM_CHECKS = ['captcha.recaptcha_test_key_error',
+#                          'django_recaptcha.recaptcha_test_key_error']
 
 DOMAIN_MODULES = {
     "en": {


### PR DESCRIPTION
## What happened

`django-recaptcha` 4.0 renamed its module from `captcha` to `django_recaptcha`, which changed its system-check id:

```
captcha.recaptcha_test_key_error  ->  django_recaptcha.recaptcha_test_key_error
```

We pinned `django-recaptcha==4.0.0` in 873cad8115 (Django 1.11 → 6.0 on Python 3.12). Every `SILENCED_SYSTEM_CHECKS` entry using the old id therefore **stopped matching any registered check**. Django ignores silence entries that match nothing, so there was no warning — the suppression simply went dead and the check became fatal again.

This is not hypothetical. `mobile-content` images build against Sefaria-Project master and install our `requirements.txt`, so the first one built after 873cad8115 inherited 4.0.0. The check fired as an `ERROR`, `manage.py migrate` in that container's entrypoint aborted before gunicorn could start, and **`readonly.sefaria.org` was down (502) for ~22 hours on 2026-08-02/03**, crash-looping through 72 restarts.

```
SystemCheckError: System check identified some issues:
ERRORS:
?: (django_recaptcha.recaptcha_test_key_error) RECAPTCHA_PRIVATE_KEY or
   RECAPTCHA_PUBLIC_KEY is making use of the Google test keys
```

Worth noting the check treats a *missing* setting as a test key:

```python
private_key = getattr(settings, "RECAPTCHA_PRIVATE_KEY", TEST_PRIVATE_KEY)
```

So nothing was misconfigured. Hosts that legitimately serve no reCAPTCHA — no registration form, no login — still trip it, which is exactly why they had silenced it in the first place.

## What this changes

Three copies live in this repo:

| File | Status | Risk |
|---|---|---|
| `local_settings_coolify.py:3` | **active, not commented** | `settings.py:343` imports it when `COOLIFY` is set. Being a trailing `import *`, it also **overrides anything set earlier** — so any Coolify deployment on Django 6 has the same dead suppression today, and fixing it elsewhere would not help. |
| `local_settings_example.py:51` | commented | harmless at runtime, but this is what people copy |
| `local_settings_ci.py:37` | commented | same |

The commented templates are almost certainly the origin of the stale string that reached production config — the k8s-admin repo carries three copies of the same line.

## Why both ids instead of swapping

A silence entry that matches no registered check is a no-op, so keeping the 3.x id costs nothing and makes these files correct on either major version. Deployments pinning an older django-recaptcha keep working.

## Related

The matching fix for the k8s-admin repo (which holds the mobile-content deployment settings — three more copies) has been prepared separately; that repo lives in Cloud Source Repositories and needs someone with write access to push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
