### PR TITLE
feat(sso): surface sso_only_account on api/login/ for the mobile app

### DIFF
--- a/sefaria/urls_shared.py
+++ b/sefaria/urls_shared.py
@@ -13,7 +13,8 @@ import powered_by.views as powered_by_views
 from sefaria.heapdump import heapdump_view
 from sefaria.site.urls import site_urlpatterns
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
-from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
+from rest_framework_simplejwt.views import TokenRefreshView
+from sso.views import MobileTokenObtainPairView
 
 shared_patterns = [
     path('_allauth/', include('allauth.headless.urls')),
@@ -31,7 +32,7 @@ shared_patterns = [
         name='password_reset_complete'),
     re_path(fr'password/reset/done/$', sefaria_views.CustomPasswordResetDoneView.as_view(), name='password_reset_done'),
 
-    re_path(fr'api/login/$', TokenObtainPairView.as_view(), name='token_obtain_pair'),
+    re_path(fr'api/login/$', MobileTokenObtainPairView.as_view(), name='token_obtain_pair'),
     re_path(fr'api/login/refresh/$', TokenRefreshView.as_view(), name='token_refresh'),
 
     re_path(r'^saved/?$', reader_views.saved_content),

--- a/sso/tests/views_test.py
+++ b/sso/tests/views_test.py
@@ -299,6 +299,63 @@ class AppleMobileTest(TestCase):
         self.assertFalse(User.objects.get(pk=user.pk).has_usable_password())
 
 
+class MobileLoginTest(TestCase):
+    """api/login/ -- the SimpleJWT endpoint the mobile app posts to. Mobile
+    sends the email address in the 'username' field (see api.js's
+    Sefaria.api.login), matching this project's USERNAME_FIELD='username'
+    default-User-model setup."""
+
+    def setUp(self):
+        self.client = Client()
+        self.url = '/api/login/'
+
+    def _post(self, body):
+        return self.client.post(
+            self.url,
+            data=json.dumps(body),
+            content_type='application/json',
+        )
+
+    def test_valid_login_returns_tokens(self):
+        User.objects.create_user(username='ml-a@test.com', email='ml-a@test.com', password='pass123')
+        res = self._post({'username': 'ml-a@test.com', 'password': 'pass123'})
+        self.assertEqual(res.status_code, 200)
+        data = res.json()
+        self.assertIn('access', data)
+        self.assertIn('refresh', data)
+
+    def test_wrong_password_returns_generic_error_unchanged(self):
+        User.objects.create_user(username='ml-b@test.com', email='ml-b@test.com', password='correct')
+        res = self._post({'username': 'ml-b@test.com', 'password': 'wrong'})
+        self.assertEqual(res.status_code, 401)
+        data = res.json()
+        # Ordinary failures must keep SimpleJWT's stock shape -- no '_auth' key.
+        self.assertIn('detail', data)
+        self.assertNotIn('_auth', data)
+
+    def test_unknown_username_returns_generic_error_unchanged(self):
+        res = self._post({'username': 'ml-nobody@test.com', 'password': 'x'})
+        self.assertEqual(res.status_code, 401)
+        data = res.json()
+        self.assertIn('detail', data)
+        self.assertNotIn('_auth', data)
+
+    def test_sso_only_account_returns_code_and_providers(self):
+        user = User.objects.create_user(username='ml-sso@test.com', email='ml-sso@test.com', password='x')
+        user.set_unusable_password()
+        user.save()
+        SocialAccount.objects.create(user=user, provider='google', uid='mobile-12345')
+
+        res = self._post({'username': 'ml-sso@test.com', 'password': 'anything'})
+        self.assertEqual(res.status_code, 401)
+        data = res.json()
+        self.assertEqual(data['error'], 'auth.generic_error')
+        self.assertEqual(data['_auth']['code'], 'sso_only_account')
+        self.assertIn('google', data['_auth']['providers'])
+        self.assertNotIn('access', data)
+        self.assertNotIn('refresh', data)
+
+
 class PasswordResetApiTest(TestCase):
     def setUp(self):
         self.client = Client()

--- a/sso/views.py
+++ b/sso/views.py
@@ -13,7 +13,10 @@ from django.contrib.auth import authenticate, login as auth_login
 from django.http import JsonResponse
 from django.views.decorators.csrf import csrf_exempt, ensure_csrf_cookie
 from django.views.decorators.http import require_POST
+from rest_framework import exceptions
+from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
 from rest_framework_simplejwt.tokens import RefreshToken
+from rest_framework_simplejwt.views import TokenObtainPairView
 
 from emailusernames.utils import user_exists, get_user
 from sefaria.forms import SefariaPasswordResetForm
@@ -24,6 +27,59 @@ logger = structlog.get_logger(__name__)
 def _jwt_for_user(user):
     refresh = RefreshToken.for_user(user)
     return {"access": str(refresh.access_token), "refresh": str(refresh)}
+
+
+def sso_only_account_info(email):
+    """
+    Return the list of SSO provider ids linked to `email`'s account if that
+    account is SSO-only (no usable password), or None if the account can
+    (also) sign in with a password, or doesn't exist.
+
+    Shared by email_login (web, session-based) and MobileTokenObtainPairView
+    (mobile, JWT-based) so both surface the same 'this account only has
+    Google/Apple sign-in' signal on a failed credential check.
+    """
+    if not user_exists(email):
+        return None
+    user = get_user(email)
+    if user.has_usable_password() or not user.socialaccount_set.exists():
+        return None
+    return list(user.socialaccount_set.values_list("provider", flat=True))
+
+
+class SSOAwareTokenObtainPairSerializer(TokenObtainPairSerializer):
+    """
+    SimpleJWT's TokenObtainPairSerializer with SSO-only-account detection
+    layered onto the failure path. On success, behaves identically to the
+    stock serializer (returns {access, refresh}). On failure, if the account
+    turns out to be SSO-only, raises AuthenticationFailed with a structured
+    detail mirroring email_login's JSON shape instead of SimpleJWT's generic
+    'no active account' message. Any other failure is re-raised unchanged.
+    """
+
+    def validate(self, attrs):
+        try:
+            return super().validate(attrs)
+        except exceptions.AuthenticationFailed:
+            providers = sso_only_account_info(attrs.get(self.username_field, ""))
+            if providers:
+                raise exceptions.AuthenticationFailed(
+                    {
+                        "error": "auth.generic_error",
+                        "_auth": {"code": "sso_only_account", "providers": providers},
+                    }
+                )
+            raise
+
+
+class MobileTokenObtainPairView(TokenObtainPairView):
+    """
+    api/login/ -- the JWT login endpoint used by the mobile app. Identical to
+    SimpleJWT's stock TokenObtainPairView except for SSO-only-account
+    detection on the failure path; see SSOAwareTokenObtainPairSerializer.
+    """
+
+    serializer_class = SSOAwareTokenObtainPairSerializer
 
 
 def _clean_name(value):
@@ -200,7 +256,9 @@ def password_reset_api(request):
 def email_login(request):
     """
     JSON email/password login for the SSO auth page. Session-based (not JWT).
-    The existing /login form view and /api/login JWT endpoint are unchanged.
+    The existing /login form view is unchanged; /api/login (mobile, JWT) uses
+    the same SSO-only-account detection via sso_only_account_info -- see
+    MobileTokenObtainPairView.
 
     Body (JSON): { email, password }
 
@@ -219,17 +277,15 @@ def email_login(request):
 
     user = authenticate(request, username=email, password=password)
     if user is None:
-        if user_exists(email):
-            u = get_user(email)
-            if not u.has_usable_password() and u.socialaccount_set.exists():
-                providers = list(u.socialaccount_set.values_list("provider", flat=True))
-                return JsonResponse(
-                    {
-                        "error": "auth.generic_error",
-                        "_auth": {"code": "sso_only_account", "providers": providers},
-                    },
-                    status=401,
-                )
+        providers = sso_only_account_info(email)
+        if providers:
+            return JsonResponse(
+                {
+                    "error": "auth.generic_error",
+                    "_auth": {"code": "sso_only_account", "providers": providers},
+                },
+                status=401,
+            )
         return JsonResponse(
             {"error": "auth.invalid_credentials"}, status=401
         )


### PR DESCRIPTION
Targets `sso` (the head branch of #3511), not `master`. Stacks on it — no conflict.

## Why

The mobile app cannot tell a wrong password from an account that only has Google or Apple sign-in, so it has no way to tell the user to use the SSO buttons instead.

Web already handles this: #3511's `email_login` returns `401 {error, _auth: {code: 'sso_only_account', providers}}`. But the mobile app authenticates against a **different endpoint** — `api/login/`, which is stock SimpleJWT and returns the same generic *"no active account found"* for every failure. This closes only that gap.

## What changed

Three files.

- `sso/views.py` — `SSOAwareTokenObtainPairSerializer` delegates to SimpleJWT and decorates only the failure path; `MobileTokenObtainPairView` binds it. The SSO-only detection is extracted into `sso_only_account_info(email)`, which `email_login` now also calls so the two endpoints cannot drift.
- `sefaria/urls_shared.py` — `api/login/` points at the new view. `api/login/refresh/` untouched.
- `sso/tests/views_test.py` — four cases, one per row of the table below.

## Compatibility

The mobile app depends on this endpoint, so it is deliberately narrow:

| Path | Before | After |
|---|---|---|
| Success | `200 {access, refresh}` | identical |
| Wrong password | `401 {detail: "No active account…"}` | identical — original exception re-raised |
| Unknown user | `401 {detail: "No active account…"}` | identical |
| SSO-only account | `401 {detail: "No active account…"}` | `401 {error, _auth: {code, providers}}` |

DRF emits a dict-valued `detail` as the response body verbatim, so the new body is not nested under `detail` — verified against the installed DRF 3.15.2 and asserted in the tests.

## Please decide this before merging

**This extends account enumeration to `api/login/`.** An unauthenticated caller can now learn from the response body whether an email is registered and which providers are linked. Neither this endpoint nor `email_login` is throttled — there are no `DEFAULT_THROTTLE_CLASSES` anywhere.

The same exposure already ships on the web endpoint via #3511, so this doubles the surface rather than introducing a new class of leak, and it is inherent to showing a provider-specific message at all. But it is a tradeoff, not an oversight. The alternative is returning `sso_only_account` with no `providers` list and having the client show generic copy.

A timing side channel already exists independently: `check_password()` short-circuits for unusable passwords, so SSO-only accounts were already measurably faster to reject.

## Tests

`sso/tests/views_test.py` 28/28, full `sso/tests/` 47/47, against a real Postgres + Mongo.

## Note

An earlier revision of this PR also refactored the shared provider-lookup duplication across `clean_email`, `reader/views.py` and the web register client. That was out of scope for a mobile fix and has been removed — it is raised as a comment on #3511 instead, since it is that branch's code and its owner's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)