### PR TITLE
Set SESSION_COOKIE_AGE to 399 days so logins survive longer than two weeks

### DIFF
--- a/sefaria/local_settings_example.py
+++ b/sefaria/local_settings_example.py
@@ -358,6 +358,12 @@ SESSION_COOKIE_SECURE = True  # Set to True if using HTTPS
 SESSION_COOKIE_HTTPONLY = True  # Recommended for security
 SESSION_COOKIE_SAMESITE = 'Lax'  # Modern browsers require this
 
+# How long a login lasts, in seconds. 399 days sits just under the 400-day cap
+# browsers apply to cookie lifetimes. Governs both the sessionid cookie's
+# Max-Age and the server-side django_session.expire_date, so the two stay in
+# sync. Django's default is only 1209600 (2 weeks).
+SESSION_COOKIE_AGE = 399 * 24 * 60 * 60  # 34,473,600 seconds
+
 CSRF_COOKIE_SECURE = True  # Set to True if using HTTPS
 CSRF_COOKIE_HTTPONLY = False  # Must be False for CSRF tokens to work with JavaScript
 CSRF_COOKIE_SAMESITE = 'Lax'  # Modern browsers require this

--- a/sefaria/settings.py
+++ b/sefaria/settings.py
@@ -206,6 +206,18 @@ REST_FRAMEWORK = {
 }
 
 SESSION_SAVE_EVERY_REQUEST = True
+# Keep users signed in for as close to the browser ceiling as is safe. Chrome,
+# Firefox and Safari all clamp cookie lifetimes to 400 days; 399 leaves a day of
+# headroom so we never land on the boundary.
+#
+# This one setting drives BOTH the sessionid cookie's Max-Age and the
+# server-side django_session.expire_date, so the cookie can never outlive the
+# session record it points at. Combined with SESSION_SAVE_EVERY_REQUEST above,
+# the window rolls: every request pushes both out another 399 days.
+#
+# Django's own default is 1209600 (2 weeks), which is what we were silently
+# running on before.
+SESSION_COOKIE_AGE = 399 * 24 * 60 * 60  # 34,473,600 seconds
 SESSION_SERIALIZER = 'django.contrib.sessions.serializers.JSONSerializer' # this is the default anyway right now, but make sure
 
 LOCALE_PATHS = (

--- a/sefaria/system/tests/session_settings_test.py
+++ b/sefaria/system/tests/session_settings_test.py
@@ -1,0 +1,81 @@
+"""
+Tests for how long a login lasts.
+
+Sefaria left SESSION_COOKIE_AGE unset for years, so Django's own default of two
+weeks quietly governed session lifetime: users were signed out roughly a
+fortnight after their last visit. These tests pin the replacement value and,
+more importantly, pin the invariant that makes a long session safe -- a single
+setting drives both the sessionid cookie's Max-Age and the server-side session
+record's expiry, so the cookie can never outlive the session it points at.
+
+Note the filename: pytest.ini collects `sefaria/system/tests/*_test.py`, so a
+`test_*.py` name here would never run in CI.
+"""
+from datetime import timedelta
+
+from django.conf import settings
+from django.contrib.sessions.middleware import SessionMiddleware
+from django.http import HttpResponse
+from django.test import RequestFactory, override_settings
+from django.utils import timezone
+
+EXPECTED_AGE = 399 * 24 * 60 * 60  # 34,473,600 seconds
+BROWSER_COOKIE_CAP = 400 * 24 * 60 * 60
+
+
+def test_session_cookie_age_is_399_days():
+    assert settings.SESSION_COOKIE_AGE == EXPECTED_AGE
+
+
+def test_session_cookie_age_stays_under_the_browser_cap():
+    # Chrome, Firefox and Safari all clamp cookie lifetimes to 400 days. A value
+    # at or above the cap gets silently truncated by the browser, which would
+    # put the cookie and the server-side record back out of sync -- the exact
+    # failure mode this setting exists to prevent.
+    assert settings.SESSION_COOKIE_AGE < BROWSER_COOKIE_CAP
+
+
+def test_session_save_every_request_keeps_the_window_rolling():
+    # Without this the 399 days would run from login rather than from the user's
+    # last visit, and neither the cookie nor the session row would be refreshed.
+    assert settings.SESSION_SAVE_EVERY_REQUEST is True
+
+
+def test_sessions_do_not_expire_at_browser_close():
+    assert getattr(settings, "SESSION_EXPIRE_AT_BROWSER_CLOSE", False) is False
+
+
+@override_settings(SESSION_ENGINE="django.contrib.sessions.backends.signed_cookies")
+def test_session_cookie_max_age_comes_from_settings():
+    """
+    The browser-facing half: the Set-Cookie header carries SESSION_COOKIE_AGE as
+    its Max-Age. Uses the signed_cookies engine so the assertion is about cookie
+    mechanics and needs no database.
+    """
+    middleware = SessionMiddleware(lambda request: HttpResponse())
+    request = RequestFactory().get("/")
+    middleware.process_request(request)
+    request.session["uid"] = 1  # non-empty, so the session is actually saved
+
+    response = middleware.process_response(request, HttpResponse())
+
+    cookie = response.cookies[settings.SESSION_COOKIE_NAME]
+    assert int(cookie["max-age"]) == settings.SESSION_COOKIE_AGE
+    assert cookie["expires"]  # belt-and-braces for pre-Max-Age browsers
+
+
+def test_server_side_expiry_is_derived_from_the_same_setting():
+    """
+    The half that actually keeps a user logged in. get_expiry_age() is what
+    Django writes into django_session.expire_date; it derives from the same
+    SESSION_COOKIE_AGE that becomes the cookie's Max-Age. If these two ever
+    diverge, a valid-looking cookie can point at an already-dead session -- a
+    399-day cookie riding on a 14-day server record logs the user out anyway.
+    """
+    from django.contrib.sessions.backends.db import SessionStore
+
+    assert SessionStore().get_expiry_age() == settings.SESSION_COOKIE_AGE
+
+    expected = timezone.now() + timedelta(seconds=settings.SESSION_COOKIE_AGE)
+    drift = abs((SessionStore().get_expiry_date() - expected).total_seconds())
+    assert drift < 60

--- a/sefaria/system/tests/session_settings_test.py
+++ b/sefaria/system/tests/session_settings_test.py
@@ -72,10 +72,13 @@ def test_server_side_expiry_is_derived_from_the_same_setting():
     diverge, a valid-looking cookie can point at an already-dead session -- a
     399-day cookie riding on a 14-day server record logs the user out anyway.
     """
-    from django.contrib.sessions.backends.db import SessionStore
+    from importlib import import_module
 
-    assert SessionStore().get_expiry_age() == settings.SESSION_COOKIE_AGE
+    SessionStore = import_module(settings.SESSION_ENGINE).SessionStore
+    store = SessionStore()
+
+    assert store.get_expiry_age() == settings.SESSION_COOKIE_AGE
 
     expected = timezone.now() + timedelta(seconds=settings.SESSION_COOKIE_AGE)
-    drift = abs((SessionStore().get_expiry_date() - expected).total_seconds())
+    drift = abs((store.get_expiry_date() - expected).total_seconds())
     assert drift < 60


### PR DESCRIPTION
## Description

`SESSION_COOKIE_AGE` is not set anywhere in the codebase, so Django's default of
`1209600` seconds (2 weeks) has been governing how long a login lasts. Users get
signed out roughly a fortnight after their last visit, far short of the ~400-day
cookie lifetime browsers permit.

Because `SESSION_SAVE_EVERY_REQUEST` is already `True` (settings.py), the window
is *rolling*: the logout lands two weeks after a user's **last visit**, not two
weeks after login. That's why the symptom tends to get reported as "about a
month" rather than "exactly 14 days" — the interval a user perceives is always
longer than the setting itself.

This sets the session lifetime to 399 days, leaving a day of headroom under the
400-day cap Chrome, Firefox and Safari apply to cookie lifetimes. A value at or
above the cap gets silently truncated by the browser, which would put the cookie
back out of sync with the server-side record.

One setting covers both halves of the problem: Django feeds `SESSION_COOKIE_AGE`
to the `sessionid` cookie's `Max-Age` **and** to `django_session.expire_date`, so
the cookie cannot outlive the session record it points at. A long-lived cookie
riding on a short-lived server record would log the user out anyway.

## Code Changes

- `sefaria/settings.py` — adds `SESSION_COOKIE_AGE = 399 * 24 * 60 * 60`
  (34,473,600 seconds) alongside the existing `SESSION_SAVE_EVERY_REQUEST`.
- `sefaria/local_settings_example.py` — same value, documented for local dev.
- `sefaria/system/tests/session_settings_test.py` — new. Pins the value, pins
  that it stays under the 400-day browser cap, pins `SESSION_SAVE_EVERY_REQUEST`,
  and pins the invariant that matters: the cookie's `Max-Age` and
  `SessionStore.get_expiry_age()` (what becomes `django_session.expire_date`)
  both derive from the same setting. The cookie test uses the `signed_cookies`
  engine via `override_settings`, so no database is required.

## Notes

- **Existing sessions migrate themselves.** `SESSION_SAVE_EVERY_REQUEST = True`
  means each logged-in user's next request rewrites both the cookie and the DB
  row to +399 days. No data migration needed. Users already past their two weeks
  are gone regardless.
- **`django_session` will grow.** Rows now live 399 days instead of 14, and there
  is no `clearsessions` job today, so expired rows are never purged. A companion
  PR adds that cronjob to the helm chart. The two PRs are independent and can be
  accepted or rejected separately — this one is correct on its own, and the helm
  one is correct on its own.
- **Redis.** In production `SESSION_ENGINE` is `cached_db`, so sessions are also
  written to Redis DB 0, now with a 399-day TTL instead of 14 days. Eviction is
  safe (`cached_db` falls back to the database), but memory use is worth
  watching.
- **Security trade-off**, flagged deliberately for review: 399-day sessions live
  a long time on shared or public computers, and a stolen `sessionid` stays valid
  much longer. Django rotates the session key on login and on password change, so
  those paths are covered, but the longer window is a real policy decision, not
  just a config tweak.
- **Not the cause, in case it comes up:** the `default` Redis cache in the helm
  chart has `"TIMEOUT": 60 * 60 * 24 * 30`. That is *not* the session expiry —
  `cached_db.save()` passes an explicit per-key timeout that overrides the cache
  default, and on a cache miss `load()` falls back to the `django_session` row.
  It cannot log anyone out.
- **Test filename:** `session_settings_test.py`, not `test_session_settings.py`.
  `pytest.ini` collects `sefaria/system/tests/*_test.py`, so a `test_*.py` name in
  that directory is never collected. Worth a separate look: this means
  `test_middleware.py`, `test_database.py`, `test_decorators.py` and
  `test_language_module_switching.py` in that same directory are currently not
  running in CI. Out of scope here, left untouched.

🤖 Co-authored with [Claude Code](https://claude.com/claude-code)
