### PR TITLE
helm: make session lifetime configurable and add a clearsessions cronjob

### DIFF
--- a/envs/prod/helmrelease.yaml
+++ b/envs/prod/helmrelease.yaml
@@ -201,6 +201,8 @@ spec:
     cronJobs:
       regenerate:
         enabled: true
+      clearSessions:
+        enabled: true
       dailyEmailNotifications:
         enabled: true
       indexFromQueue:

--- a/helm-chart/sefaria/templates/configmap/local-settings-file.yaml
+++ b/helm-chart/sefaria/templates/configmap/local-settings-file.yaml
@@ -166,7 +166,14 @@ data:
     SESSION_COOKIE_SECURE = os.getenv("SESSION_COOKIE_SECURE", "true").lower() == "true"
     SESSION_COOKIE_HTTPONLY = os.getenv("SESSION_COOKIE_HTTPONLY", "true").lower() == "true"
     SESSION_COOKIE_SAMESITE = os.getenv("SESSION_COOKIE_SAMESITE", "Lax")
-    
+
+    # Session lifetime in seconds. Defaults to 399 days, just under the 400-day
+    # cap browsers place on cookie lifetimes. Sets both the sessionid cookie's
+    # Max-Age and django_session.expire_date, keeping the two in sync.
+    # "or" rather than a getenv default, so a set-but-empty env var falls back
+    # instead of raising ValueError and taking down every pod at import time.
+    SESSION_COOKIE_AGE = int(os.getenv("SESSION_COOKIE_AGE") or 399 * 24 * 60 * 60)
+
     CSRF_COOKIE_SECURE = os.getenv("CSRF_COOKIE_SECURE", "true").lower() == "true"
     CSRF_COOKIE_HTTPONLY = os.getenv("CSRF_COOKIE_HTTPONLY", "false").lower() == "true"  # Must be False for CSRF tokens to work with JavaScript
     CSRF_COOKIE_SAMESITE = os.getenv("CSRF_COOKIE_SAMESITE", "Lax")

--- a/helm-chart/sefaria/templates/configmap/local-settings.yaml
+++ b/helm-chart/sefaria/templates/configmap/local-settings.yaml
@@ -13,6 +13,9 @@ data:
   SESSION_COOKIE_SECURE: "true"
   SESSION_COOKIE_HTTPONLY: "true"
   SESSION_COOKIE_SAMESITE: "Lax"
+  # Session lifetime in seconds; 399 days by default (just under the 400-day
+  # cap browsers place on cookie lifetimes).
+  SESSION_COOKIE_AGE: "{{ .Values.localSettings.SESSION_COOKIE_AGE | default 34473600 }}"
   CSRF_COOKIE_SECURE: "true"
   CSRF_COOKIE_HTTPONLY: "false"
   CSRF_COOKIE_SAMESITE: "Lax"

--- a/helm-chart/sefaria/templates/cronjob/clear-sessions.yaml
+++ b/helm-chart/sefaria/templates/cronjob/clear-sessions.yaml
@@ -1,0 +1,68 @@
+{{- if .Values.cronJobs.clearSessions.enabled }}
+---
+# Purges expired rows from the django_session table.
+#
+# Django never deletes expired session records on its own -- the SESSION_ENGINE
+# (cached_db) only stops honoring them. With SESSION_COOKIE_AGE at 399 days each
+# row now sticks around ~28x longer than it did under Django's 2-week default,
+# so without this job the table grows without bound.
+#
+# clearsessions is Django's own management command: it deletes rows whose
+# expire_date has already passed, which is exactly the set no longer usable for
+# login. Live sessions are untouched. Stale entries left behind in the Redis
+# session cache expire on their own TTL, and a cache hit on a deleted row still
+# fails closed because cached_db re-validates against the database.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ .Values.deployEnv }}-clear-sessions
+  labels:
+    {{- include "sefaria.labels" . | nindent 4 }}
+spec:
+  schedule: "0 3 * * 0"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      template:
+        spec:
+          volumes:
+          - name: local-settings
+            configMap:
+              name: local-settings-file-{{ .Values.deployEnv }}
+              items:
+                - key: local_settings.py
+                  path: local_settings.py
+          containers:
+          - name: clear-sessions
+            image: "{{ .Values.web.containerImage.imageRegistry }}:{{ .Values.web.containerImage.tag }}"
+            env:
+            - name: REDIS_HOST
+              value: "redis-{{ .Values.deployEnv }}"
+            - name: NODEJS_HOST
+              value: "node-{{ .Values.deployEnv }}-{{ .Release.Revision }}"
+            - name: VARNISH_HOST
+              value: "varnish-{{ .Values.deployEnv }}-{{ .Release.Revision }}"
+            envFrom:
+            - secretRef:
+                name: {{ .Values.secrets.localSettings.ref }}
+                optional: true
+            - secretRef:
+                name: local-settings-secrets-{{ .Values.deployEnv }}
+                optional: true
+            - configMapRef:
+                name: local-settings-{{ .Values.deployEnv }}
+            volumeMounts:
+              - mountPath: /app/sefaria/local_settings.py
+                name: local-settings
+                subPath: local_settings.py
+                readOnly: true
+            command: ["bash"]
+            args: [
+              "-c",
+              "python manage.py clearsessions"
+            ]
+          restartPolicy: OnFailure
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 2
+{{- end }}

--- a/helm-chart/sefaria/values.yaml
+++ b/helm-chart/sefaria/values.yaml
@@ -423,6 +423,9 @@ cronJobs:
   # Settings for regenerating long cached data
   regenerate:
     enabled: true
+  # Purges expired django_session rows; see templates/cronjob/clear-sessions.yaml
+  clearSessions:
+    enabled: false
   dailyEmailNotifications:
     enabled: false
   indexFromQueue:
@@ -474,6 +477,7 @@ localSettings:
   SESSION_COOKIE_SECURE: true
   SESSION_COOKIE_HTTPONLY: true
   SESSION_COOKIE_SAMESITE: "Lax"
+  SESSION_COOKIE_AGE: 34473600  # 399 days, just under the browser 400-day cookie cap
   CSRF_COOKIE_SECURE: true
   CSRF_COOKIE_HTTPONLY: false
   CSRF_COOKIE_SAMESITE: "Lax"


### PR DESCRIPTION
## Description

Two deployment-side companions to raising the Django session lifetime to 399
days (separate PR against `sefaria/settings.py`). This PR stands on its own: the
generated `local_settings.py` defaults to 399 days whether or not the other PR
lands, and the cronjob is worth having regardless of the expiry value.

`clearsessions` matters more at a long expiry than a short one. Django never
deletes expired session records on its own — `cached_db` simply stops honouring
them — so `django_session` only ever grows. That was survivable at a 2-week
expiry; at 399 days each row sticks around ~28x longer.

## Code Changes

- `helm-chart/sefaria/templates/configmap/local-settings-file.yaml` — adds
  `SESSION_COOKIE_AGE`, read from an env var with a 399-day default, following
  the same pattern as the neighbouring `SESSION_COOKIE_*` settings. Uses
  `int(os.getenv(...) or default)` rather than a `getenv` default so a
  set-but-empty env var falls back instead of raising `ValueError` at import time
  and taking down every pod.
- `helm-chart/sefaria/templates/configmap/local-settings.yaml` — exposes
  `SESSION_COOKIE_AGE` to the pod environment, with a `| default` guard so a nil
  value can't render empty.
- `helm-chart/sefaria/values.yaml` — `localSettings.SESSION_COOKIE_AGE: 34473600`
  and `cronJobs.clearSessions.enabled: false`.
- `helm-chart/sefaria/templates/cronjob/clear-sessions.yaml` — new CronJob
  running `python manage.py clearsessions` weekly (Sundays 03:00), with
  `concurrencyPolicy: Forbid`. Structure mirrors the existing cronjob templates
  (same volumes, `envFrom`, image and history limits).
- `envs/prod/helmrelease.yaml` — enables the cronjob in production.

## Notes

- **Default off in the chart, on in production.** Cauldrons and other ephemeral
  environments have no reason to run it.
- **`clearsessions` only deletes rows whose `expire_date` has already passed** —
  exactly the set no longer usable for login. Live sessions are untouched. It is
  Django's own management command, not custom code. Stale entries left behind in
  the Redis session cache age out on their own TTL, and a cache hit on a deleted
  row still fails closed because `cached_db` re-validates against the database.
- **Schedule is a guess** — weekly at 03:00 Sunday, chosen to sit away from the
  existing backup and reindex jobs. Happy to move it if it collides with
  something I can't see from the chart.
- **Validation:** I could not run `helm template`/`helm lint` in my environment
  (no helm binary available), so the chart changes are validated structurally
  and by checking that every value the templates read is actually supplied by
  `values.yaml`. The sandbox CI deploy does a real `helm upgrade` against
  `./helm-chart/sefaria`, which should exercise this properly on the PR.

🤖 Co-authored with [Claude Code](https://claude.com/claude-code)