### PR TITLE
POC: wire search page to semantic KNN search (sc-45806)

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -1,6 +1,5 @@
 import json
 import logging
-from concurrent.futures import ThreadPoolExecutor
 
 from django.conf import settings
 from django.utils.decorators import method_decorator
@@ -467,79 +466,33 @@ class NaturalLanguageSearch(View):
     Elaborates a user's query with an LLM into a verbose English query and a
     Hebrew translation of it, then runs both through semantic search in
     parallel threads (semantic search responds differently to English vs.
-    Hebrew queries, so running both improves recall). Each leg fetches
-    SEMANTIC_RESULT_LIMIT semantic matches with no linked-ref lookup of its
-    own; the two chunk lists are unioned by ref, and linked refs are computed
-    once over that unioned set -- reusing the linked_refs already stored on
-    each chunk (see semantic_search.linked_refs), so unioning first and
-    linking second costs no extra DB lookups either.
+    Hebrew queries, so running both improves recall), scores every result's
+    relevance to the query with an LLM (keeping only 3-5 out of 5), and
+    generates a short LLM relevance summary for each retained result. The
+    full pipeline (see semantic_search.natural_language_search.run_natural_language_search)
+    runs as a Celery task -- this view only validates the request and enqueues it;
+    callers poll GET /api/async/<task_id> for progress and the final result.
     """
-
-    SEMANTIC_RESULT_LIMIT = 40
 
     @method_decorator(csrf_exempt)
     def dispatch(self, *args, **kwargs):
         return super().dispatch(*args, **kwargs)
 
     @classmethod
-    def _search_leg(cls, query):
-        from semantic_search.search import get_query_embedding, semantic_search_by_embedding
+    def enqueue(cls, query):
+        from sefaria.celery_setup.config import CeleryQueue
+        from semantic_search.tasks import natural_language_search_task
 
-        embedding = get_query_embedding(query)
-        chunks = semantic_search_by_embedding(embedding, limit=cls.SEMANTIC_RESULT_LIMIT)
-        return embedding, chunks
-
-    @classmethod
-    def run_search(cls, body):
-        if not isinstance(body, dict):
-            raise NaturalLanguageSearchError("JSON body must be an object", 400)
-        query = body.get("query", "").strip()
+        query = (query or "").strip()
         if not query:
             raise NaturalLanguageSearchError("Missing or empty 'query'", 400)
-
-        from semantic_search.embedder import EmbeddingError
-        from semantic_search.linked_refs import get_mean_std_linked_ref_enhancements
-        from semantic_search.natural_language_search import union_chunks_by_ref
-        from semantic_search.query_expansion import expand_query, QueryExpansionError
-
         if not getattr(settings, "GEMINI_API_KEY", ""):
             raise NaturalLanguageSearchError("Semantic search is not configured", 503)
 
-        try:
-            expansion = expand_query(query)
-        except QueryExpansionError as e:
-            raise NaturalLanguageSearchError(str(e), 502)
-
-        try:
-            with ThreadPoolExecutor(max_workers=2) as executor:
-                english_future = executor.submit(cls._search_leg, expansion.english)
-                hebrew_future = executor.submit(cls._search_leg, expansion.hebrew)
-                english_embedding, english_chunks = english_future.result()
-                _, hebrew_chunks = hebrew_future.result()
-        except EmbeddingError as e:
-            raise NaturalLanguageSearchError(str(e), 502)
-
-        union_chunks = union_chunks_by_ref(english_chunks, hebrew_chunks)
-
-        enhancement = get_mean_std_linked_ref_enhancements(
-            union_chunks,
-            link_depth=KnnSearch.LINKED_REF_ENHANCEMENT_DEPTH,
-            std_threshold=KnnSearch.LINKED_REF_ENHANCEMENT_STD_THRESHOLD,
-            min_count=KnnSearch.LINKED_REF_ENHANCEMENT_MIN_COUNT,
+        return natural_language_search_task.apply_async(
+            args=(query,),
+            queue=CeleryQueue.TASKS.value,
         )
-        top_linked_refs = KnnSearch._top_linked_refs(enhancement, KnnSearch.DEFAULT_LINKED_REF_LIMIT)
-
-        include_text = True
-        return {
-            "query": query,
-            "english_query": expansion.english,
-            "hebrew_query": expansion.hebrew,
-            "results": [KnnSearch._serialize_search_result(c, include_text) for c in union_chunks],
-            # Oversized-linked-ref chunk lookups (see KnnSearch._serialize_linked_ref)
-            # rank by distance from a single query embedding; English is used here
-            # as the representative embedding for that narrow fallback path.
-            "linked_refs": KnnSearch._serialize_linked_refs(top_linked_refs, include_text, english_embedding, None),
-        }
 
     def post(self, request):
         auth = request.headers.get("Authorization", "")
@@ -554,10 +507,12 @@ class NaturalLanguageSearch(View):
             body = json.loads(request.body)
         except (json.JSONDecodeError, UnicodeDecodeError):
             return jsonResponse({"error": "Invalid JSON body"}, status=400)
+        if not isinstance(body, dict):
+            return jsonResponse({"error": "JSON body must be an object"}, status=400)
 
         try:
-            response = self.run_search(body)
+            async_result = self.enqueue(body.get("query", ""))
         except NaturalLanguageSearchError as e:
             return jsonResponse({"error": str(e)}, status=e.status)
 
-        return jsonResponse(response)
+        return jsonResponse({"task_id": async_result.id}, status=202)

--- a/api/views.py
+++ b/api/views.py
@@ -167,6 +167,12 @@ class RefView(View):
         return jsonResponse(return_object)
 
 
+class KnnSearchError(Exception):
+    def __init__(self, message, status):
+        super().__init__(message)
+        self.status = status
+
+
 class KnnSearch(View):
     SEARCH_RESULT_FIELDS = (
         'ref', 'url', 'index_title', 'language', 'version_title',
@@ -354,6 +360,79 @@ class KnnSearch(View):
             )[:limit]
         ]
 
+    @classmethod
+    def run_search(cls, body):
+        """
+        Core KNN search logic, shared by the bearer-token-gated /api/knn-search
+        endpoint and any trusted same-origin caller. Raises KnnSearchError for
+        all validation/runtime failures; callers translate that into a response.
+        """
+        if not isinstance(body, dict):
+            raise KnnSearchError("JSON body must be an object", 400)
+        query = body.get("query", "").strip()
+        if not query:
+            raise KnnSearchError("Missing or empty 'query'", 400)
+
+        filters = body.get("filters") or None
+        if filters is not None and not isinstance(filters, dict):
+            raise KnnSearchError("'filters' must be an object", 400)
+
+        try:
+            result_limit = cls._limit_param(
+                body,
+                "result_limit",
+                body.get("limit", cls.DEFAULT_RESULT_LIMIT),
+                cls.MAX_RESULT_LIMIT,
+            )
+            linked_ref_limit = cls._limit_param(
+                body,
+                "linked_ref_limit",
+                cls.DEFAULT_LINKED_REF_LIMIT,
+                cls.MAX_LINKED_REF_LIMIT,
+            )
+            include_linked_refs = cls._bool_param(body, "include_linked_refs", False)
+            include_text = cls._bool_param(body, "include_text", True)
+        except ValueError as e:
+            raise KnnSearchError(str(e), 400)
+
+        from semantic_search.embedder import EmbeddingError
+
+        if not getattr(settings, "GEMINI_API_KEY", ""):
+            raise KnnSearchError("Semantic search is not configured", 503)
+
+        try:
+            from semantic_search.search import get_query_embedding, semantic_search_by_embedding
+
+            search_limit = max(result_limit, cls.LINKED_REF_ENHANCEMENT_LIMIT) if include_linked_refs else result_limit
+            query_embedding = get_query_embedding(query)
+            search_results = semantic_search_by_embedding(query_embedding, filters=filters, limit=search_limit)
+        except EmbeddingError as e:
+            raise KnnSearchError(str(e), 502)
+        results = search_results[:result_limit]
+
+        response = {
+            "results": [
+                cls._serialize_search_result(r, include_text)
+                for r in results
+            ]
+        }
+
+        if include_linked_refs:
+            from semantic_search.linked_refs import get_mean_std_linked_ref_enhancements
+
+            enhancement = get_mean_std_linked_ref_enhancements(
+                search_results[:cls.LINKED_REF_ENHANCEMENT_LIMIT],
+                link_depth=cls.LINKED_REF_ENHANCEMENT_DEPTH,
+                std_threshold=cls.LINKED_REF_ENHANCEMENT_STD_THRESHOLD,
+                min_count=cls.LINKED_REF_ENHANCEMENT_MIN_COUNT,
+            )
+            top_linked_refs = cls._top_linked_refs(enhancement, linked_ref_limit)
+            response.update({
+                "linked_refs": cls._serialize_linked_refs(top_linked_refs, include_text, query_embedding, filters),
+            })
+
+        return response
+
     def post(self, request):
         auth = request.headers.get("Authorization", "")
         if not auth.startswith("Bearer "):
@@ -368,68 +447,9 @@ class KnnSearch(View):
         except (json.JSONDecodeError, UnicodeDecodeError):
             return jsonResponse({"error": "Invalid JSON body"}, status=400)
 
-        if not isinstance(body, dict):
-            return jsonResponse({"error": "JSON body must be an object"}, status=400)
-        query = body.get("query", "").strip()
-        if not query:
-            return jsonResponse({"error": "Missing or empty 'query'"}, status=400)
-
-        filters = body.get("filters") or None
-        if filters is not None and not isinstance(filters, dict):
-            return jsonResponse({"error": "'filters' must be an object"}, status=400)
-
         try:
-            result_limit = self._limit_param(
-                body,
-                "result_limit",
-                body.get("limit", self.DEFAULT_RESULT_LIMIT),
-                self.MAX_RESULT_LIMIT,
-            )
-            linked_ref_limit = self._limit_param(
-                body,
-                "linked_ref_limit",
-                self.DEFAULT_LINKED_REF_LIMIT,
-                self.MAX_LINKED_REF_LIMIT,
-            )
-            include_linked_refs = self._bool_param(body, "include_linked_refs", False)
-            include_text = self._bool_param(body, "include_text", True)
-        except ValueError as e:
-            return jsonResponse({"error": str(e)}, status=400)
-
-        from semantic_search.embedder import EmbeddingError
-
-        if not getattr(settings, "GEMINI_API_KEY", ""):
-            return jsonResponse({"error": "Semantic search is not configured"}, status=503)
-
-        try:
-            from semantic_search.search import get_query_embedding, semantic_search_by_embedding
-
-            search_limit = max(result_limit, self.LINKED_REF_ENHANCEMENT_LIMIT) if include_linked_refs else result_limit
-            query_embedding = get_query_embedding(query)
-            search_results = semantic_search_by_embedding(query_embedding, filters=filters, limit=search_limit)
-        except EmbeddingError as e:
-            return jsonResponse({"error": str(e)}, status=502)
-        results = search_results[:result_limit]
-
-        response = {
-            "results": [
-                self._serialize_search_result(r, include_text)
-                for r in results
-            ]
-        }
-
-        if include_linked_refs:
-            from semantic_search.linked_refs import get_mean_std_linked_ref_enhancements
-
-            enhancement = get_mean_std_linked_ref_enhancements(
-                search_results[:self.LINKED_REF_ENHANCEMENT_LIMIT],
-                link_depth=self.LINKED_REF_ENHANCEMENT_DEPTH,
-                std_threshold=self.LINKED_REF_ENHANCEMENT_STD_THRESHOLD,
-                min_count=self.LINKED_REF_ENHANCEMENT_MIN_COUNT,
-            )
-            top_linked_refs = self._top_linked_refs(enhancement, linked_ref_limit)
-            response.update({
-                "linked_refs": self._serialize_linked_refs(top_linked_refs, include_text, query_embedding, filters),
-            })
+            response = self.run_search(body)
+        except KnnSearchError as e:
+            return jsonResponse({"error": str(e)}, status=e.status)
 
         return jsonResponse(response)

--- a/api/views.py
+++ b/api/views.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from concurrent.futures import ThreadPoolExecutor
 
 from django.conf import settings
 from django.utils.decorators import method_decorator
@@ -450,6 +451,113 @@ class KnnSearch(View):
         try:
             response = self.run_search(body)
         except KnnSearchError as e:
+            return jsonResponse({"error": str(e)}, status=e.status)
+
+        return jsonResponse(response)
+
+
+class NaturalLanguageSearchError(Exception):
+    def __init__(self, message, status):
+        super().__init__(message)
+        self.status = status
+
+
+class NaturalLanguageSearch(View):
+    """
+    Elaborates a user's query with an LLM into a verbose English query and a
+    Hebrew translation of it, then runs both through semantic search in
+    parallel threads (semantic search responds differently to English vs.
+    Hebrew queries, so running both improves recall). Each leg fetches
+    SEMANTIC_RESULT_LIMIT semantic matches with no linked-ref lookup of its
+    own; the two chunk lists are unioned by ref, and linked refs are computed
+    once over that unioned set -- reusing the linked_refs already stored on
+    each chunk (see semantic_search.linked_refs), so unioning first and
+    linking second costs no extra DB lookups either.
+    """
+
+    SEMANTIC_RESULT_LIMIT = 40
+
+    @method_decorator(csrf_exempt)
+    def dispatch(self, *args, **kwargs):
+        return super().dispatch(*args, **kwargs)
+
+    @classmethod
+    def _search_leg(cls, query):
+        from semantic_search.search import get_query_embedding, semantic_search_by_embedding
+
+        embedding = get_query_embedding(query)
+        chunks = semantic_search_by_embedding(embedding, limit=cls.SEMANTIC_RESULT_LIMIT)
+        return embedding, chunks
+
+    @classmethod
+    def run_search(cls, body):
+        if not isinstance(body, dict):
+            raise NaturalLanguageSearchError("JSON body must be an object", 400)
+        query = body.get("query", "").strip()
+        if not query:
+            raise NaturalLanguageSearchError("Missing or empty 'query'", 400)
+
+        from semantic_search.embedder import EmbeddingError
+        from semantic_search.linked_refs import get_mean_std_linked_ref_enhancements
+        from semantic_search.natural_language_search import union_chunks_by_ref
+        from semantic_search.query_expansion import expand_query, QueryExpansionError
+
+        if not getattr(settings, "GEMINI_API_KEY", ""):
+            raise NaturalLanguageSearchError("Semantic search is not configured", 503)
+
+        try:
+            expansion = expand_query(query)
+        except QueryExpansionError as e:
+            raise NaturalLanguageSearchError(str(e), 502)
+
+        try:
+            with ThreadPoolExecutor(max_workers=2) as executor:
+                english_future = executor.submit(cls._search_leg, expansion.english)
+                hebrew_future = executor.submit(cls._search_leg, expansion.hebrew)
+                english_embedding, english_chunks = english_future.result()
+                _, hebrew_chunks = hebrew_future.result()
+        except EmbeddingError as e:
+            raise NaturalLanguageSearchError(str(e), 502)
+
+        union_chunks = union_chunks_by_ref(english_chunks, hebrew_chunks)
+
+        enhancement = get_mean_std_linked_ref_enhancements(
+            union_chunks,
+            link_depth=KnnSearch.LINKED_REF_ENHANCEMENT_DEPTH,
+            std_threshold=KnnSearch.LINKED_REF_ENHANCEMENT_STD_THRESHOLD,
+            min_count=KnnSearch.LINKED_REF_ENHANCEMENT_MIN_COUNT,
+        )
+        top_linked_refs = KnnSearch._top_linked_refs(enhancement, KnnSearch.DEFAULT_LINKED_REF_LIMIT)
+
+        include_text = True
+        return {
+            "query": query,
+            "english_query": expansion.english,
+            "hebrew_query": expansion.hebrew,
+            "results": [KnnSearch._serialize_search_result(c, include_text) for c in union_chunks],
+            # Oversized-linked-ref chunk lookups (see KnnSearch._serialize_linked_ref)
+            # rank by distance from a single query embedding; English is used here
+            # as the representative embedding for that narrow fallback path.
+            "linked_refs": KnnSearch._serialize_linked_refs(top_linked_refs, include_text, english_embedding, None),
+        }
+
+    def post(self, request):
+        auth = request.headers.get("Authorization", "")
+        if not auth.startswith("Bearer "):
+            return jsonResponse({"error": "Unauthorized"}, status=401)
+        token = auth[len("Bearer "):]
+        expected = getattr(settings, "SEMANTIC_SEARCH_API_TOKEN", "")
+        if not expected or token != expected:
+            return jsonResponse({"error": "Unauthorized"}, status=401)
+
+        try:
+            body = json.loads(request.body)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            return jsonResponse({"error": "Invalid JSON body"}, status=400)
+
+        try:
+            response = self.run_search(body)
+        except NaturalLanguageSearchError as e:
             return jsonResponse({"error": str(e)}, status=e.status)
 
         return jsonResponse(response)

--- a/helm-chart/sefaria/templates/rollout/task.yaml
+++ b/helm-chart/sefaria/templates/rollout/task.yaml
@@ -135,6 +135,9 @@ spec:
               name: {{ template "sefaria.secrets.pgvectorPassword" . }}
               optional: true
           - secretRef:
+              name: {{ template "sefaria.secrets.geminiApiKey" . }}
+              optional: true
+          - secretRef:
               name: {{ .Values.secrets.localSettings.ref }}
               optional: true
           - configMapRef:

--- a/reader/views.py
+++ b/reader/views.py
@@ -4910,6 +4910,36 @@ def semantic_search_wrapper_api(request):
 
 
 @csrf_exempt
+def natural_language_search_wrapper_api(request):
+    """
+    Public, same-origin wrapper around NaturalLanguageSearch.run_search for the
+    search page. Unlike /api/natural-language-search (bearer-token gated, for
+    external/tool callers), this view is not token-protected -- it runs the same
+    search logic server-side so the shared SEMANTIC_SEARCH_API_TOKEN secret never
+    has to reach browser JS.
+    """
+    from api.views import NaturalLanguageSearch, NaturalLanguageSearchError
+
+    if request.method != "POST":
+        return jsonResponse({"error": "Unsupported HTTP method."}, status=405)
+
+    try:
+        body = json.loads(request.body)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return jsonResponse({"error": "Invalid JSON body"}, status=400)
+
+    if not isinstance(body, dict):
+        return jsonResponse({"error": "JSON body must be an object"}, status=400)
+
+    try:
+        response = NaturalLanguageSearch.run_search({"query": body.get("query", "")})
+    except NaturalLanguageSearchError as e:
+        return jsonResponse({"error": str(e)}, status=e.status)
+
+    return jsonResponse(response)
+
+
+@csrf_exempt
 def search_path_filter(request, book_title):
     oref = Ref(book_title)
 

--- a/reader/views.py
+++ b/reader/views.py
@@ -4871,6 +4871,44 @@ def search_wrapper_api(request, es6_compat=False):
         return jsonResponse({"error": "Error with connection to Elasticsearch. Total shards: {}, Shards successful: {}, Timed out: {}".format(response._shards.total, response._shards.successful, response.timed_out)}, callback=request.GET.get("callback", None))
     return jsonResponse({"error": "Unsupported HTTP method."}, callback=request.GET.get("callback", None))
 
+
+@csrf_exempt
+def semantic_search_wrapper_api(request):
+    """
+    Public, same-origin wrapper around KnnSearch.run_search for the search page.
+    Unlike /api/knn-search (bearer-token gated, for external/tool callers), this
+    view is not token-protected -- it runs the same search logic server-side so
+    the shared SEMANTIC_SEARCH_API_TOKEN secret never has to reach browser JS.
+    """
+    from api.views import KnnSearch, KnnSearchError
+
+    if request.method != "POST":
+        return jsonResponse({"error": "Unsupported HTTP method."}, status=405)
+
+    try:
+        body = json.loads(request.body)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return jsonResponse({"error": "Invalid JSON body"}, status=400)
+
+    if not isinstance(body, dict):
+        return jsonResponse({"error": "JSON body must be an object"}, status=400)
+
+    search_body = {
+        "query": body.get("query", ""),
+        "result_limit": 40,
+        "linked_ref_limit": 10,
+        "include_linked_refs": True,
+        "include_text": True,
+    }
+
+    try:
+        response = KnnSearch.run_search(search_body)
+    except KnnSearchError as e:
+        return jsonResponse({"error": str(e)}, status=e.status)
+
+    return jsonResponse(response)
+
+
 @csrf_exempt
 def search_path_filter(request, book_title):
     oref = Ref(book_title)

--- a/reader/views.py
+++ b/reader/views.py
@@ -4912,11 +4912,13 @@ def semantic_search_wrapper_api(request):
 @csrf_exempt
 def natural_language_search_wrapper_api(request):
     """
-    Public, same-origin wrapper around NaturalLanguageSearch.run_search for the
+    Public, same-origin wrapper around NaturalLanguageSearch.enqueue for the
     search page. Unlike /api/natural-language-search (bearer-token gated, for
-    external/tool callers), this view is not token-protected -- it runs the same
-    search logic server-side so the shared SEMANTIC_SEARCH_API_TOKEN secret never
-    has to reach browser JS.
+    external/tool callers), this view is not token-protected -- it enqueues the
+    same Celery task server-side so the shared SEMANTIC_SEARCH_API_TOKEN secret
+    never has to reach browser JS. Returns a task_id; the caller polls
+    GET /api/async/<task_id> (see sefaria.views.async_task_status_api) for
+    progress and the final result.
     """
     from api.views import NaturalLanguageSearch, NaturalLanguageSearchError
 
@@ -4932,11 +4934,11 @@ def natural_language_search_wrapper_api(request):
         return jsonResponse({"error": "JSON body must be an object"}, status=400)
 
     try:
-        response = NaturalLanguageSearch.run_search({"query": body.get("query", "")})
+        async_result = NaturalLanguageSearch.enqueue(body.get("query", ""))
     except NaturalLanguageSearchError as e:
         return jsonResponse({"error": str(e)}, status=e.status)
 
-    return jsonResponse(response)
+    return jsonResponse({"task_id": async_result.id}, status=202)
 
 
 @csrf_exempt

--- a/sefaria/celery_setup/app.py
+++ b/sefaria/celery_setup/app.py
@@ -4,4 +4,4 @@ from sefaria.celery_setup.config import generate_config_from_env
 app = Celery('sefaria')
 raw_config, redis_config, sentinel_config = generate_config_from_env()
 app.conf.update(**raw_config, result_expires=1800)
-app.autodiscover_tasks(packages=['sefaria.helper.llm', 'sefaria.helper.linker', 'sefaria.helper.crm', 'sefaria.helper.texts'])
+app.autodiscover_tasks(packages=['sefaria.helper.llm', 'sefaria.helper.linker', 'sefaria.helper.crm', 'sefaria.helper.texts', 'semantic_search'])

--- a/sefaria/local_settings_example.py
+++ b/sefaria/local_settings_example.py
@@ -367,4 +367,6 @@ CHATBOT_API_BASE_URL = os.getenv("CHATBOT_API_BASE_URL", "https://chat-dev.sefar
 CHATBOT_USE_LOCAL_SCRIPT = True
 
 GEMINI_API_KEY = ""  # API key for Gemini embedding model (used by semantic search)
-SEMANTIC_SEARCH_API_TOKEN = ""  # Bearer token for the /api/knn-search endpoint
+SEMANTIC_SEARCH_API_TOKEN = ""  # Bearer token for the /api/knn-search and /api/natural-language-search endpoints
+ANTHROPIC_API_KEY = ""  # API key for query elaboration (used by /api/natural-language-search)
+NATURAL_LANGUAGE_SEARCH_MODEL = "claude-sonnet-5"  # LLM model used to elaborate natural-language search queries

--- a/sefaria/urls_shared.py
+++ b/sefaria/urls_shared.py
@@ -166,6 +166,7 @@ shared_patterns = [
     path('api/dummy-search', reader_views.dummy_search_api),
     path('api/search-wrapper/es6', reader_views.search_wrapper_api, {'es6_compat': True}),
     path('api/search-wrapper/es8', reader_views.search_wrapper_api),
+    path('api/search-wrapper/semantic', reader_views.semantic_search_wrapper_api),
     path('api/search-wrapper', reader_views.search_wrapper_api, {'es6_compat': True}),
     path('api/search-path-filter/<path:book_title>', reader_views.search_path_filter),
 

--- a/sefaria/urls_shared.py
+++ b/sefaria/urls_shared.py
@@ -79,6 +79,7 @@ shared_patterns = [
     re_path(r'^api/versions/?$', reader_views.complete_version_api),
     path('api/v3/texts/<path:tref>', api_views.Text.as_view()),
     path('api/knn-search', api_views.KnnSearch.as_view()),
+    path('api/natural-language-search', api_views.NaturalLanguageSearch.as_view()),
     re_path(r'^api/index/?$', reader_views.table_of_contents_api),
     re_path(r'^api/opensearch-suggestions/?$', reader_views.opensearch_suggestions_api),
     re_path(r'^api/index/titles/?$', reader_views.text_titles_api),
@@ -167,6 +168,7 @@ shared_patterns = [
     path('api/search-wrapper/es6', reader_views.search_wrapper_api, {'es6_compat': True}),
     path('api/search-wrapper/es8', reader_views.search_wrapper_api),
     path('api/search-wrapper/semantic', reader_views.semantic_search_wrapper_api),
+    path('api/search-wrapper/natural-language', reader_views.natural_language_search_wrapper_api),
     path('api/search-wrapper', reader_views.search_wrapper_api, {'es6_compat': True}),
     path('api/search-path-filter/<path:book_title>', reader_views.search_path_filter),
 

--- a/semantic_search/linked_refs.py
+++ b/semantic_search/linked_refs.py
@@ -40,22 +40,33 @@ def _is_dictionary_oref(oref) -> bool:
     return bool(categories & {"Dictionary", "Dictionaries", "Lexicon"})
 
 
-def linked_refs_for(ref: str) -> list[str]:
-    from sefaria.model import LinkSet, Ref
+def _is_dictionary_ref_str(ref: str) -> bool:
+    from sefaria.model import Ref
 
     try:
-        oref = Ref(ref)
+        return _is_dictionary_oref(Ref(ref))
     except Exception:
+        return False
+
+
+def linked_refs_for(ref: str) -> list[str]:
+    """
+    Linked-ref lookup for hops beyond the initial search results (link_depth > 1).
+    Reads the linked_refs already computed onto matching semantic search chunks
+    in pgvector, instead of querying Mongo's links collection.
+    """
+    if _is_dictionary_ref_str(ref):
         return []
 
-    if _is_dictionary_oref(oref):
-        return []
+    seen = set()
+    candidates = []
+    for chunk in SemanticTextChunk().filter(ref=ref):
+        for candidate in chunk.linked_refs:
+            if candidate not in seen:
+                seen.add(candidate)
+                candidates.append(candidate)
 
-    return [
-        linked_ref.normal()
-        for linked_ref in LinkSet(oref).refs_from(oref)
-        if not _is_dictionary_oref(linked_ref)
-    ]
+    return [candidate for candidate in candidates if not _is_dictionary_ref_str(candidate)]
 
 
 def get_linked_ref_enhancements(
@@ -66,8 +77,9 @@ def get_linked_ref_enhancements(
     normalize_ref_func: Callable[[str], str] | None = None,
 ) -> LinkedRefEnhancement:
     """
-    Count refs linked from the semantic search result chunks via Mongo links,
-    optionally expanding through linked refs to collect additional graph hops.
+    Count refs linked from the semantic search result chunks, using the linked_refs
+    already stored on each chunk for the first hop and (optionally) expanding
+    through further graph hops for additional depth.
     """
     if link_depth < 1 or min_link_count < 1:
         return LinkedRefEnhancement(appended_refs=[], ref_counts={})
@@ -148,7 +160,8 @@ def get_linked_ref_counts(
     if link_depth < 1:
         return Counter()
 
-    if linked_refs_for_func is None:
+    using_default = linked_refs_for_func is None
+    if using_default:
         linked_refs_for_func = linked_refs_for
         normalize_ref_func = normalize_ref_func or normalize_ref
     else:
@@ -156,6 +169,20 @@ def get_linked_ref_counts(
 
     def normalize(ref: str) -> str:
         return normalize_ref_func(ref) if ref else ""
+
+    def candidate_refs_for_chunk(chunk) -> list[str]:
+        # Chunks arrive with their own linked_refs already populated (set at
+        # embedding time), so the first hop needs no lookup at all -- DB or
+        # otherwise. Dictionary-ref filtering (an in-memory library lookup, not
+        # a DB call) only runs when the real default is in play; a caller that
+        # injects its own linked_refs_for_func is assumed to be a test that
+        # wants to bypass it.
+        raw = getattr(chunk, "linked_refs", None) or []
+        if not using_default:
+            return raw
+        if _is_dictionary_ref_str(chunk.ref):
+            return []
+        return [r for r in raw if not _is_dictionary_ref_str(r)]
 
     original_refs = {
         normalized_ref
@@ -166,21 +193,30 @@ def get_linked_ref_counts(
         )
         if normalized_ref
     }
+
     counts = Counter()
     seen_frontier_refs = set()
-    current_refs = []
     seen_current_refs = set()
+    next_frontier = []
     for chunk in chunks:
         normalized_ref = normalize(chunk.ref)
-        if normalized_ref and normalized_ref not in seen_current_refs:
-            seen_current_refs.add(normalized_ref)
-            current_refs.append(normalized_ref)
+        if not normalized_ref or normalized_ref in seen_current_refs:
+            continue
+        seen_current_refs.add(normalized_ref)
+        for linked_ref in {normalize(r) for r in candidate_refs_for_chunk(chunk)}:
+            if not linked_ref or linked_ref in original_refs:
+                continue
+            counts[linked_ref] += 1
+            if linked_ref not in seen_frontier_refs:
+                seen_frontier_refs.add(linked_ref)
+                next_frontier.append(linked_ref)
 
-    for depth_index in range(link_depth):
+    current_refs = next_frontier
+    for _ in range(1, link_depth):
+        if not current_refs:
+            break
         next_frontier = []
         for ref in current_refs:
-            if not ref:
-                continue
             source_linked_refs = {
                 normalize(linked_ref)
                 for linked_ref in linked_refs_for_func(ref)
@@ -192,9 +228,6 @@ def get_linked_ref_counts(
                 if linked_ref not in seen_frontier_refs:
                     seen_frontier_refs.add(linked_ref)
                     next_frontier.append(linked_ref)
-
-        if depth_index == link_depth - 1 or not next_frontier:
-            break
         current_refs = next_frontier
 
     return counts

--- a/semantic_search/llm.py
+++ b/semantic_search/llm.py
@@ -1,0 +1,20 @@
+import os
+
+from django.conf import settings
+from langchain_anthropic import ChatAnthropic
+
+DEFAULT_MODEL = "claude-sonnet-5"
+
+
+class LLMConfigError(Exception):
+    pass
+
+
+def get_chat_llm(max_tokens: int = 1024) -> ChatAnthropic:
+    api_key = getattr(settings, "ANTHROPIC_API_KEY", "") or os.environ.get("ANTHROPIC_API_KEY", "")
+    if not api_key:
+        raise LLMConfigError("ANTHROPIC_API_KEY is not configured")
+    model = getattr(settings, "NATURAL_LANGUAGE_SEARCH_MODEL", DEFAULT_MODEL)
+    # temperature is not configurable on every model this can point to (e.g. it's
+    # rejected outright for claude-sonnet-5), so leave it at the provider default.
+    return ChatAnthropic(model=model, api_key=api_key, max_tokens=max_tokens)

--- a/semantic_search/natural_language_search.py
+++ b/semantic_search/natural_language_search.py
@@ -1,3 +1,14 @@
+import logging
+from concurrent.futures import ThreadPoolExecutor
+from typing import Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+SCORING_THREAD_COUNT = 25
+SUMMARY_THREAD_COUNT = 25
+SEMANTIC_RESULT_LIMIT = 40
+
+
 def union_chunks_by_ref(first: list, second: list) -> list:
     """
     Union two SemanticTextChunk lists by ref, keeping the first occurrence and
@@ -11,3 +22,131 @@ def union_chunks_by_ref(first: list, second: list) -> list:
         seen.add(chunk.ref)
         union.append(chunk)
     return union
+
+
+def union_chunks_with_origin(first: list, second: list) -> list[tuple]:
+    """
+    Union two SemanticTextChunk lists by ref (English-leg `first`, Hebrew-leg
+    `second`), tagging each chunk with where it came from: "english" (first
+    list only), "hebrew" (second list only), or "both" (present in both).
+    """
+    second_refs = {chunk.ref for chunk in second}
+    seen = set()
+    union = []
+    for chunk in first:
+        if chunk.ref in seen:
+            continue
+        seen.add(chunk.ref)
+        origin = "both" if chunk.ref in second_refs else "english"
+        union.append((chunk, origin))
+    for chunk in second:
+        if chunk.ref in seen:
+            continue
+        seen.add(chunk.ref)
+        union.append((chunk, "hebrew"))
+    return union
+
+
+def _search_leg(query: str):
+    from semantic_search.search import get_query_embedding, semantic_search_by_embedding
+
+    embedding = get_query_embedding(query)
+    chunks = semantic_search_by_embedding(embedding, limit=SEMANTIC_RESULT_LIMIT)
+    return embedding, chunks
+
+
+def run_natural_language_search(
+    query: str,
+    progress_callback: Optional[Callable[[str, dict], None]] = None,
+) -> dict:
+    """
+    Core natural-language search pipeline: LLM query expansion (EN + HE) ->
+    parallel semantic search on both -> union by ref -> linked-ref expansion
+    -> LLM relevance scoring (keep 3-5, sorted, ties broken by original order)
+    -> LLM relevance summary for each retained result.
+
+    progress_callback(phase, meta), when given, is called at each phase
+    transition and, during scoring/summarizing, after each individual item
+    completes -- meta always carries english_query/hebrew_query once known so
+    a caller polling mid-run never loses them on a later update.
+    """
+    from api.views import KnnSearch
+    from semantic_search.linked_refs import get_mean_std_linked_ref_enhancements
+    from semantic_search.query_expansion import expand_query
+    from semantic_search.relevance import (
+        MIN_RELEVANT_SCORE,
+        score_results_parallel,
+        summarize_results_parallel,
+    )
+
+    def report(phase: str, **meta):
+        if progress_callback:
+            progress_callback(phase, meta)
+
+    report("expanding_query")
+    expansion = expand_query(query)
+    queries = {"english_query": expansion.english, "hebrew_query": expansion.hebrew}
+
+    report("searching", **queries)
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        english_future = executor.submit(_search_leg, expansion.english)
+        hebrew_future = executor.submit(_search_leg, expansion.hebrew)
+        english_embedding, english_chunks = english_future.result()
+        _, hebrew_chunks = hebrew_future.result()
+
+    union_chunks = union_chunks_with_origin(english_chunks, hebrew_chunks)
+
+    report("expanding_links", **queries)
+    enhancement = get_mean_std_linked_ref_enhancements(
+        [chunk for chunk, _ in union_chunks],
+        link_depth=KnnSearch.LINKED_REF_ENHANCEMENT_DEPTH,
+        std_threshold=KnnSearch.LINKED_REF_ENHANCEMENT_STD_THRESHOLD,
+        min_count=KnnSearch.LINKED_REF_ENHANCEMENT_MIN_COUNT,
+    )
+    top_linked_refs = KnnSearch._top_linked_refs(enhancement, KnnSearch.DEFAULT_LINKED_REF_LIMIT)
+
+    items = [
+        {**KnnSearch._serialize_search_result(chunk, include_text=True), "source": origin}
+        for chunk, origin in union_chunks
+    ] + [
+        {**linked_item, "source": "linked"}
+        # english_embedding is used as the representative embedding here (as in
+        # the original sync endpoint) so oversized linked-ref text still falls
+        # back to ranked semantic chunks instead of being included in full.
+        for linked_item in KnnSearch._serialize_linked_refs(top_linked_refs, include_text=True, query_embedding=english_embedding)
+    ]
+
+    report("scoring", total=len(items), completed=0, **queries)
+    scores = score_results_parallel(
+        query,
+        items,
+        max_workers=SCORING_THREAD_COUNT,
+        on_progress=lambda completed, total: report("scoring", completed=completed, total=total, **queries),
+    )
+    scored_items = [
+        {**item, "score": score}
+        for item, score in zip(items, scores)
+        if score >= MIN_RELEVANT_SCORE
+    ]
+    # Python's sort is stable, so ties keep their original (pre-scoring) relative
+    # order -- ranking stays idempotent across repeat runs of the same search.
+    scored_items.sort(key=lambda item: -item["score"])
+
+    report("summarizing", total=len(scored_items), completed=0, **queries)
+    summaries = summarize_results_parallel(
+        query,
+        scored_items,
+        max_workers=SUMMARY_THREAD_COUNT,
+        on_progress=lambda completed, total: report("summarizing", completed=completed, total=total, **queries),
+    )
+    results = [
+        {**item, "summary": summary}
+        for item, summary in zip(scored_items, summaries)
+    ]
+
+    return {
+        "query": query,
+        "english_query": expansion.english,
+        "hebrew_query": expansion.hebrew,
+        "results": results,
+    }

--- a/semantic_search/natural_language_search.py
+++ b/semantic_search/natural_language_search.py
@@ -1,0 +1,13 @@
+def union_chunks_by_ref(first: list, second: list) -> list:
+    """
+    Union two SemanticTextChunk lists by ref, keeping the first occurrence and
+    dropping duplicates found in the second list.
+    """
+    seen = set()
+    union = []
+    for chunk in (*first, *second):
+        if chunk.ref in seen:
+            continue
+        seen.add(chunk.ref)
+        union.append(chunk)
+    return union

--- a/semantic_search/query_expansion.py
+++ b/semantic_search/query_expansion.py
@@ -1,0 +1,71 @@
+from dataclasses import dataclass
+from typing import cast
+
+from django.conf import settings
+from langchain_anthropic import ChatAnthropic
+from langchain_core.messages import HumanMessage, SystemMessage
+
+DEFAULT_MODEL = "claude-sonnet-5"
+
+_SYSTEM_PROMPT = (
+    "You expand short search queries about Jewish texts (Torah, Talmud, Midrash, "
+    "halakha, Jewish thought, and related subjects) into longer, more descriptive "
+    "queries for a semantic search engine over a library of Jewish texts. Elaborate "
+    "on the user's query by adding relevant context, synonyms, and related concepts, "
+    "while staying faithful to the original intent -- do not introduce a different "
+    "topic. Respond with two versions of the elaborated query: one in English, and "
+    "one in Hebrew that is a translation of the English version."
+)
+
+_QUERY_EXPANSION_SCHEMA = {
+    "title": "QueryExpansion",
+    "description": "An elaborated, more verbose version of a user's search query, in English and Hebrew.",
+    "type": "object",
+    "properties": {
+        "english": {
+            "type": "string",
+            "description": "The elaborated, verbose version of the query, in English.",
+        },
+        "hebrew": {
+            "type": "string",
+            "description": "A Hebrew translation of the elaborated English query.",
+        },
+    },
+    "required": ["english", "hebrew"],
+}
+
+
+class QueryExpansionError(Exception):
+    pass
+
+
+@dataclass(frozen=True)
+class QueryExpansion:
+    english: str
+    hebrew: str
+
+
+def expand_query(query: str) -> QueryExpansion:
+    llm = _get_llm()
+    structured_llm = llm.with_structured_output(_QUERY_EXPANSION_SCHEMA)
+    try:
+        result = cast(dict, structured_llm.invoke([
+            SystemMessage(content=_SYSTEM_PROMPT),
+            HumanMessage(content=query),
+        ]))
+    except Exception as e:
+        raise QueryExpansionError(f"Query expansion failed: {e}") from e
+
+    english = (result.get("english") or "").strip()
+    hebrew = (result.get("hebrew") or "").strip()
+    if not english or not hebrew:
+        raise QueryExpansionError(f"Query expansion returned an incomplete result: {result}")
+    return QueryExpansion(english=english, hebrew=hebrew)
+
+
+def _get_llm() -> ChatAnthropic:
+    api_key = getattr(settings, "ANTHROPIC_API_KEY", "")
+    if not api_key:
+        raise QueryExpansionError("ANTHROPIC_API_KEY is not configured")
+    model = getattr(settings, "NATURAL_LANGUAGE_SEARCH_MODEL", DEFAULT_MODEL)
+    return ChatAnthropic(model=model, api_key=api_key, max_tokens=1024, temperature=0)

--- a/semantic_search/query_expansion.py
+++ b/semantic_search/query_expansion.py
@@ -1,3 +1,4 @@
+import os
 from dataclasses import dataclass
 from typing import cast
 
@@ -64,8 +65,10 @@ def expand_query(query: str) -> QueryExpansion:
 
 
 def _get_llm() -> ChatAnthropic:
-    api_key = getattr(settings, "ANTHROPIC_API_KEY", "")
+    api_key = getattr(settings, "ANTHROPIC_API_KEY", "") or os.environ.get("ANTHROPIC_API_KEY", "")
     if not api_key:
         raise QueryExpansionError("ANTHROPIC_API_KEY is not configured")
     model = getattr(settings, "NATURAL_LANGUAGE_SEARCH_MODEL", DEFAULT_MODEL)
-    return ChatAnthropic(model=model, api_key=api_key, max_tokens=1024, temperature=0)
+    # temperature is not configurable on every model this can point to (e.g. it's
+    # rejected outright for claude-sonnet-5), so leave it at the provider default.
+    return ChatAnthropic(model=model, api_key=api_key, max_tokens=1024)

--- a/semantic_search/query_expansion.py
+++ b/semantic_search/query_expansion.py
@@ -1,12 +1,9 @@
-import os
 from dataclasses import dataclass
 from typing import cast
 
-from django.conf import settings
-from langchain_anthropic import ChatAnthropic
 from langchain_core.messages import HumanMessage, SystemMessage
 
-DEFAULT_MODEL = "claude-sonnet-5"
+from semantic_search.llm import LLMConfigError, get_chat_llm
 
 _SYSTEM_PROMPT = (
     "You expand short search queries about Jewish texts (Torah, Talmud, Midrash, "
@@ -47,7 +44,10 @@ class QueryExpansion:
 
 
 def expand_query(query: str) -> QueryExpansion:
-    llm = _get_llm()
+    try:
+        llm = get_chat_llm()
+    except LLMConfigError as e:
+        raise QueryExpansionError(str(e)) from e
     structured_llm = llm.with_structured_output(_QUERY_EXPANSION_SCHEMA)
     try:
         result = cast(dict, structured_llm.invoke([
@@ -62,13 +62,3 @@ def expand_query(query: str) -> QueryExpansion:
     if not english or not hebrew:
         raise QueryExpansionError(f"Query expansion returned an incomplete result: {result}")
     return QueryExpansion(english=english, hebrew=hebrew)
-
-
-def _get_llm() -> ChatAnthropic:
-    api_key = getattr(settings, "ANTHROPIC_API_KEY", "") or os.environ.get("ANTHROPIC_API_KEY", "")
-    if not api_key:
-        raise QueryExpansionError("ANTHROPIC_API_KEY is not configured")
-    model = getattr(settings, "NATURAL_LANGUAGE_SEARCH_MODEL", DEFAULT_MODEL)
-    # temperature is not configurable on every model this can point to (e.g. it's
-    # rejected outright for claude-sonnet-5), so leave it at the provider default.
-    return ChatAnthropic(model=model, api_key=api_key, max_tokens=1024)

--- a/semantic_search/relevance.py
+++ b/semantic_search/relevance.py
@@ -1,0 +1,116 @@
+import logging
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Callable, Optional
+
+from langchain_core.messages import HumanMessage, SystemMessage
+
+from semantic_search.llm import get_chat_llm
+
+logger = logging.getLogger(__name__)
+
+MIN_RELEVANT_SCORE = 3
+MAX_SCORE = 5
+
+_SCORE_SYSTEM_PROMPT = (
+    "You rate how relevant a passage from a Jewish text library is to a user's search "
+    "query, on a scale from 1 to 5: 1 means not at all relevant, 5 means highly relevant. "
+    "Judge relevance to the query's subject matter and intent, not merely keyword overlap."
+)
+
+_SCORE_SCHEMA = {
+    "title": "RelevanceScore",
+    "description": "A 1-5 relevance rating of a search result against a query.",
+    "type": "object",
+    "properties": {
+        "score": {
+            "type": "integer",
+            "description": "Relevance rating from 1 (not at all relevant) to 5 (highly relevant).",
+        },
+    },
+    "required": ["score"],
+}
+
+_SUMMARY_SYSTEM_PROMPT = (
+    "You write a one or two sentence summary explaining why a passage from a Jewish text "
+    "library is relevant to a user's search query. Be concise and specific to this passage; "
+    "do not restate the query verbatim."
+)
+
+
+def score_result(query: str, result_text: str) -> int:
+    """
+    Returns 0 (rather than raising) on any failure, so a single bad LLM call
+    can't take down the whole search -- 0 is below MIN_RELEVANT_SCORE and gets
+    filtered out downstream like a genuinely irrelevant result.
+    """
+    try:
+        llm = get_chat_llm()
+        structured_llm = llm.with_structured_output(_SCORE_SCHEMA)
+        result = structured_llm.invoke([
+            SystemMessage(content=_SCORE_SYSTEM_PROMPT),
+            HumanMessage(content=f"Query: {query}\n\nPassage:\n{result_text}"),
+        ])
+        score = int(result.get("score") or 0)
+        return max(0, min(score, MAX_SCORE))
+    except Exception as e:
+        logger.warning(f"score_result failed: {e}")
+        return 0
+
+
+def summarize_result(query: str, result_text: str) -> str:
+    """Returns "" (rather than raising) on any failure -- see score_result."""
+    try:
+        llm = get_chat_llm()
+        result = llm.invoke([
+            SystemMessage(content=_SUMMARY_SYSTEM_PROMPT),
+            HumanMessage(content=f"Query: {query}\n\nPassage:\n{result_text}"),
+        ])
+        return (result.content or "").strip()
+    except Exception as e:
+        logger.warning(f"summarize_result failed: {e}")
+        return ""
+
+
+def _run_parallel(
+    fn: Callable[[str, str], object],
+    query: str,
+    items: list[dict],
+    text_key: str = "text",
+    max_workers: int = 25,
+    on_progress: Optional[Callable[[int, int], None]] = None,
+) -> list:
+    total = len(items)
+    results: list = [None] * total
+    if total == 0:
+        return results
+
+    completed = 0
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        future_to_index = {
+            executor.submit(fn, query, item.get(text_key, "")): i
+            for i, item in enumerate(items)
+        }
+        for future in as_completed(future_to_index):
+            results[future_to_index[future]] = future.result()
+            completed += 1
+            if on_progress:
+                on_progress(completed, total)
+    return results
+
+
+def score_results_parallel(
+    query: str,
+    items: list[dict],
+    max_workers: int = 25,
+    on_progress: Optional[Callable[[int, int], None]] = None,
+) -> list[int]:
+    return _run_parallel(score_result, query, items, max_workers=max_workers, on_progress=on_progress)
+
+
+def summarize_results_parallel(
+    query: str,
+    items: list[dict],
+    max_workers: int = 25,
+    on_progress: Optional[Callable[[int, int], None]] = None,
+) -> list[str]:
+    return _run_parallel(summarize_result, query, items, max_workers=max_workers, on_progress=on_progress)

--- a/semantic_search/relevance.py
+++ b/semantic_search/relevance.py
@@ -13,8 +13,42 @@ MAX_SCORE = 5
 
 _SCORE_SYSTEM_PROMPT = (
     "You rate how relevant a passage from a Jewish text library is to a user's search "
-    "query, on a scale from 1 to 5: 1 means not at all relevant, 5 means highly relevant. "
-    "Judge relevance to the query's subject matter and intent, not merely keyword overlap."
+    "query, on a scale from 1 to 5. Use judgement -- the same work can be authoritative "
+    "for one query and merely tangential for another, depending on whether it is actually "
+    "the source being asked about. The passage may be preceded by its Ref and/or Work -- "
+    "use that to identify what the source actually is; judge the work's authoritativeness "
+    "by its identity, not by the register or style of the (possibly loosely translated or "
+    "paraphrased) passage text.\n\n"
+    "5 - An authoritative source directly relevant to the query: the passage is actually "
+    "the source for the law or idea the query asks about, AND it is authoritative.\n"
+    "Authoritative is a question about the nature of the WORK, not about how well it "
+    "answers the query (that's the level-4 test) and not about matching its name against a "
+    "fixed list. Ask: is this passage itself one of the formative texts in the chain of "
+    "transmission that Orthodox rabbis treat as mesora -- Tanakh, Mishnah, Tosefta, Talmud "
+    "Bavli and Yerushalmi, halachic and aggadic Midrash, and the classical codes (e.g. "
+    "Mishneh Torah, Shulchan Arukh) -- or a source of comparable formative standing? Or is "
+    "it a later work that explains, popularizes, applies, or responds based on those "
+    "formative texts? A contemporary halachic guide, a responsum, or an inspirational essay "
+    "does not become authoritative by being accurate, thorough, or correctly citing the "
+    "right primary sources -- however well it answers the question, it stays at level 4 "
+    "because it is not itself a formative source. When more than one authoritative source "
+    "addresses the same law, the more foundational one is the better level-5 candidate (e.g. "
+    "a Mishnah over a Tosefta or Talmudic discussion restating the same law), but any of "
+    "them can earn 5 if it is genuinely the source being asked about. (Example: for \"can I "
+    "eat meat with milk?\", Exodus 23:19 is a level 5 source.) Only use this level when the "
+    "passage is actually the source for the query's subject -- an authoritative work that "
+    "merely touches on the topic without being the source for it is not a 5.\n"
+    "4 - A non-authoritative source directly relevant to the question, OR an authoritative "
+    "source that is merely adjacent to the question rather than being the actual source for "
+    "it: it fully or mostly answers the user's question, or contains all the information "
+    "needed to construct an answer.\n"
+    "3 - A partially relevant source, authoritative or not: touches on themes relevant to "
+    "the question and may spark follow-up questions, but does not itself answer the "
+    "question.\n"
+    "2 - Mentions ideas related to the query but does not spark follow-up questions -- it "
+    "happens to touch on similar themes without being useful to the query.\n"
+    "1 - Not at all relevant: a false positive the user would not be interested in reading "
+    "based on their query."
 )
 
 _SCORE_SCHEMA = {
@@ -37,7 +71,17 @@ _SUMMARY_SYSTEM_PROMPT = (
 )
 
 
-def score_result(query: str, result_text: str) -> int:
+def _format_passage_message(query: str, result_text: str, ref: str = "", index_title: str = "") -> str:
+    source_lines = []
+    if ref:
+        source_lines.append(f"Ref: {ref}")
+    if index_title and index_title != ref:
+        source_lines.append(f"Work: {index_title}")
+    source_block = ("\n".join(source_lines) + "\n\n") if source_lines else ""
+    return f"Query: {query}\n\n{source_block}Passage:\n{result_text}"
+
+
+def score_result(query: str, result_text: str, ref: str = "", index_title: str = "") -> int:
     """
     Returns 0 (rather than raising) on any failure, so a single bad LLM call
     can't take down the whole search -- 0 is below MIN_RELEVANT_SCORE and gets
@@ -48,7 +92,7 @@ def score_result(query: str, result_text: str) -> int:
         structured_llm = llm.with_structured_output(_SCORE_SCHEMA)
         result = structured_llm.invoke([
             SystemMessage(content=_SCORE_SYSTEM_PROMPT),
-            HumanMessage(content=f"Query: {query}\n\nPassage:\n{result_text}"),
+            HumanMessage(content=_format_passage_message(query, result_text, ref, index_title)),
         ])
         score = int(result.get("score") or 0)
         return max(0, min(score, MAX_SCORE))
@@ -57,13 +101,13 @@ def score_result(query: str, result_text: str) -> int:
         return 0
 
 
-def summarize_result(query: str, result_text: str) -> str:
+def summarize_result(query: str, result_text: str, ref: str = "", index_title: str = "") -> str:
     """Returns "" (rather than raising) on any failure -- see score_result."""
     try:
         llm = get_chat_llm()
         result = llm.invoke([
             SystemMessage(content=_SUMMARY_SYSTEM_PROMPT),
-            HumanMessage(content=f"Query: {query}\n\nPassage:\n{result_text}"),
+            HumanMessage(content=_format_passage_message(query, result_text, ref, index_title)),
         ])
         return (result.content or "").strip()
     except Exception as e:
@@ -72,7 +116,7 @@ def summarize_result(query: str, result_text: str) -> str:
 
 
 def _run_parallel(
-    fn: Callable[[str, str], object],
+    fn: Callable[..., object],
     query: str,
     items: list[dict],
     text_key: str = "text",
@@ -87,7 +131,13 @@ def _run_parallel(
     completed = 0
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         future_to_index = {
-            executor.submit(fn, query, item.get(text_key, "")): i
+            executor.submit(
+                fn,
+                query,
+                item.get(text_key, ""),
+                ref=item.get("ref", ""),
+                index_title=item.get("index_title", ""),
+            ): i
             for i, item in enumerate(items)
         }
         for future in as_completed(future_to_index):

--- a/semantic_search/tasks.py
+++ b/semantic_search/tasks.py
@@ -1,0 +1,10 @@
+from sefaria.celery_setup.app import app
+from semantic_search.natural_language_search import run_natural_language_search
+
+
+@app.task(bind=True, name="semantic_search.natural_language_search", acks_late=True)
+def natural_language_search_task(self, query: str) -> dict:
+    def progress(phase: str, meta: dict):
+        self.update_state(state="PROGRESS", meta={"phase": phase, **meta})
+
+    return run_natural_language_search(query, progress_callback=progress)

--- a/semantic_search/tests/semantic_search_test.py
+++ b/semantic_search/tests/semantic_search_test.py
@@ -18,8 +18,18 @@ from semantic_search.linked_refs import (
     get_mean_std_linked_ref_enhancements,
     linked_refs_for,
 )
-from semantic_search.natural_language_search import union_chunks_by_ref
+from semantic_search.natural_language_search import (
+    run_natural_language_search,
+    union_chunks_by_ref,
+    union_chunks_with_origin,
+)
 from semantic_search.query_expansion import QueryExpansion, QueryExpansionError, expand_query
+from semantic_search.relevance import (
+    score_result,
+    score_results_parallel,
+    summarize_result,
+    summarize_results_parallel,
+)
 from semantic_search.router import SemanticSearchRouter
 from semantic_search.search import semantic_search, semantic_search_by_embedding
 from semantic_search.models import SemanticTextChunk
@@ -565,7 +575,7 @@ class TestSemanticSearch:
 
 class TestExpandQuery:
     @override_settings(ANTHROPIC_API_KEY="test-key")
-    @patch("semantic_search.query_expansion.ChatAnthropic")
+    @patch("semantic_search.llm.ChatAnthropic")
     def test_returns_query_expansion_from_structured_output(self, mock_chat_cls):
         mock_structured = mock_chat_cls.return_value.with_structured_output.return_value
         mock_structured.invoke.return_value = {
@@ -581,7 +591,7 @@ class TestExpandQuery:
         )
 
     @override_settings(ANTHROPIC_API_KEY="test-key")
-    @patch("semantic_search.query_expansion.ChatAnthropic")
+    @patch("semantic_search.llm.ChatAnthropic")
     def test_uses_default_model_when_unconfigured(self, mock_chat_cls):
         mock_chat_cls.return_value.with_structured_output.return_value.invoke.return_value = {
             "english": "x", "hebrew": "y",
@@ -592,7 +602,7 @@ class TestExpandQuery:
         assert mock_chat_cls.call_args.kwargs["model"] == "claude-sonnet-5"
 
     @override_settings(ANTHROPIC_API_KEY="test-key", NATURAL_LANGUAGE_SEARCH_MODEL="claude-custom-model")
-    @patch("semantic_search.query_expansion.ChatAnthropic")
+    @patch("semantic_search.llm.ChatAnthropic")
     def test_uses_configured_model(self, mock_chat_cls):
         mock_chat_cls.return_value.with_structured_output.return_value.invoke.return_value = {
             "english": "x", "hebrew": "y",
@@ -609,7 +619,7 @@ class TestExpandQuery:
             expand_query("query")
 
     @override_settings(ANTHROPIC_API_KEY="test-key")
-    @patch("semantic_search.query_expansion.ChatAnthropic")
+    @patch("semantic_search.llm.ChatAnthropic")
     def test_raises_when_result_missing_fields(self, mock_chat_cls):
         mock_chat_cls.return_value.with_structured_output.return_value.invoke.return_value = {
             "english": "", "hebrew": "",
@@ -619,7 +629,7 @@ class TestExpandQuery:
             expand_query("query")
 
     @override_settings(ANTHROPIC_API_KEY="test-key")
-    @patch("semantic_search.query_expansion.ChatAnthropic")
+    @patch("semantic_search.llm.ChatAnthropic")
     def test_raises_when_llm_call_fails(self, mock_chat_cls):
         mock_chat_cls.return_value.with_structured_output.return_value.invoke.side_effect = RuntimeError("boom")
 
@@ -644,3 +654,242 @@ class TestUnionChunksByRef:
 
     def test_empty_lists_return_empty(self):
         assert union_chunks_by_ref([], []) == []
+
+
+class TestUnionChunksWithOrigin:
+    def test_english_only_chunk_tagged_english(self):
+        chunk = make_chunk(ref="Genesis 1:1")
+        assert union_chunks_with_origin([chunk], []) == [(chunk, "english")]
+
+    def test_hebrew_only_chunk_tagged_hebrew(self):
+        chunk = make_chunk(ref="Genesis 1:1")
+        assert union_chunks_with_origin([], [chunk]) == [(chunk, "hebrew")]
+
+    def test_chunk_in_both_lists_tagged_both_and_kept_once(self):
+        english_chunk = make_chunk(ref="Genesis 1:1", language="en")
+        hebrew_chunk = make_chunk(ref="Genesis 1:1", language="he")
+        assert union_chunks_with_origin([english_chunk], [hebrew_chunk]) == [(english_chunk, "both")]
+
+    def test_preserves_english_first_then_hebrew_only_order(self):
+        a = make_chunk(ref="A")
+        b = make_chunk(ref="B")
+        c = make_chunk(ref="C")
+        result = union_chunks_with_origin([a, b], [b, c])
+        assert result == [(a, "english"), (b, "both"), (c, "hebrew")]
+
+    def test_empty_lists_return_empty(self):
+        assert union_chunks_with_origin([], []) == []
+
+
+# ---------------------------------------------------------------------------
+# relevance
+# ---------------------------------------------------------------------------
+
+class TestScoreResult:
+    @patch("semantic_search.relevance.get_chat_llm")
+    def test_returns_score_from_structured_output(self, mock_get_llm):
+        mock_get_llm.return_value.with_structured_output.return_value.invoke.return_value = {"score": 4}
+        assert score_result("query", "some passage") == 4
+
+    @patch("semantic_search.relevance.get_chat_llm")
+    def test_clamps_score_above_max(self, mock_get_llm):
+        mock_get_llm.return_value.with_structured_output.return_value.invoke.return_value = {"score": 9}
+        assert score_result("query", "text") == 5
+
+    @patch("semantic_search.relevance.get_chat_llm")
+    def test_clamps_score_below_zero(self, mock_get_llm):
+        mock_get_llm.return_value.with_structured_output.return_value.invoke.return_value = {"score": -3}
+        assert score_result("query", "text") == 0
+
+    @patch("semantic_search.relevance.get_chat_llm")
+    def test_returns_zero_on_llm_exception(self, mock_get_llm):
+        mock_get_llm.return_value.with_structured_output.return_value.invoke.side_effect = RuntimeError("boom")
+        assert score_result("query", "text") == 0
+
+    @patch("semantic_search.relevance.get_chat_llm", side_effect=RuntimeError("no key"))
+    def test_returns_zero_on_llm_config_error(self, mock_get_llm):
+        assert score_result("query", "text") == 0
+
+
+class TestSummarizeResult:
+    @patch("semantic_search.relevance.get_chat_llm")
+    def test_returns_stripped_content(self, mock_get_llm):
+        mock_get_llm.return_value.invoke.return_value = SimpleNamespace(content="  relevant because X  ")
+        assert summarize_result("query", "text") == "relevant because X"
+
+    @patch("semantic_search.relevance.get_chat_llm")
+    def test_returns_empty_string_on_exception(self, mock_get_llm):
+        mock_get_llm.return_value.invoke.side_effect = RuntimeError("boom")
+        assert summarize_result("query", "text") == ""
+
+
+class TestScoreResultsParallel:
+    def test_preserves_original_order_regardless_of_completion_order(self):
+        items = [{"text": f"item-{i}"} for i in range(10)]
+
+        def fake_score(query, text):
+            # deliberately return based on content, not call order, so the test
+            # can't pass just by luck of thread scheduling
+            return int(text.split("-")[1]) % 5
+
+        with patch("semantic_search.relevance.score_result", side_effect=fake_score):
+            scores = score_results_parallel("query", items, max_workers=5)
+
+        assert scores == [i % 5 for i in range(10)]
+
+    def test_calls_on_progress_once_per_item_with_final_total(self):
+        items = [{"text": f"item-{i}"} for i in range(6)]
+        progress_calls = []
+
+        with patch("semantic_search.relevance.score_result", return_value=3):
+            score_results_parallel(
+                "query", items, max_workers=3,
+                on_progress=lambda completed, total: progress_calls.append((completed, total)),
+            )
+
+        assert len(progress_calls) == 6
+        assert [c for c, _ in sorted(progress_calls)] == [1, 2, 3, 4, 5, 6]
+        assert all(total == 6 for _, total in progress_calls)
+
+    def test_empty_items_returns_empty_list_and_skips_progress(self):
+        progress_calls = []
+        scores = score_results_parallel(
+            "query", [], on_progress=lambda completed, total: progress_calls.append((completed, total)),
+        )
+        assert scores == []
+        assert progress_calls == []
+
+
+class TestSummarizeResultsParallel:
+    def test_preserves_original_order_regardless_of_completion_order(self):
+        items = [{"text": f"item-{i}"} for i in range(8)]
+
+        def fake_summarize(query, text):
+            return f"summary-{text}"
+
+        with patch("semantic_search.relevance.summarize_result", side_effect=fake_summarize):
+            summaries = summarize_results_parallel("query", items, max_workers=4)
+
+        assert summaries == [f"summary-item-{i}" for i in range(8)]
+
+
+# ---------------------------------------------------------------------------
+# run_natural_language_search
+# ---------------------------------------------------------------------------
+
+class TestRunNaturalLanguageSearch:
+    @patch("semantic_search.relevance.summarize_results_parallel")
+    @patch("semantic_search.relevance.score_results_parallel")
+    @patch("semantic_search.linked_refs.get_mean_std_linked_ref_enhancements")
+    @patch("semantic_search.natural_language_search._search_leg")
+    @patch("semantic_search.query_expansion.expand_query")
+    def test_filters_low_scores_sorts_and_annotates_source_and_summary(
+        self, mock_expand, mock_search_leg, mock_link_enh, mock_score, mock_summarize,
+    ):
+        mock_expand.return_value = QueryExpansion(english="en query", hebrew="he query")
+
+        english_chunk = make_chunk(ref="A", text="text-a")
+        hebrew_chunk = make_chunk(ref="B", text="text-b")
+
+        def fake_search_leg(leg_query):
+            # keyed by query text (not call order) so this is safe under real
+            # ThreadPoolExecutor scheduling, which doesn't guarantee call order
+            return {
+                "en query": ([0.1], [english_chunk]),
+                "he query": ([0.2], [hebrew_chunk]),
+            }[leg_query]
+
+        mock_search_leg.side_effect = fake_search_leg
+        mock_link_enh.return_value = SimpleNamespace(ref_counts={})
+        mock_score.return_value = [2, 4]  # item 0 (A) filtered out, item 1 (B) kept
+        mock_summarize.return_value = ["B is relevant because..."]
+
+        with patch("api.views.KnnSearch._top_linked_refs", return_value=[]), \
+             patch(
+                 "api.views.KnnSearch._serialize_search_result",
+                 side_effect=lambda chunk, include_text: {"ref": chunk.ref, "text": chunk.text},
+             ), \
+             patch("api.views.KnnSearch._serialize_linked_refs", return_value=[]):
+            result = run_natural_language_search("original query")
+
+        assert result["query"] == "original query"
+        assert result["english_query"] == "en query"
+        assert result["hebrew_query"] == "he query"
+        assert result["results"] == [{
+            "ref": "B", "text": "text-b", "source": "hebrew",
+            "score": 4, "summary": "B is relevant because...",
+        }]
+        # scoring runs against the original raw query, over both items (pre-filter)
+        assert mock_score.call_args.args[0] == "original query"
+        assert len(mock_score.call_args.args[1]) == 2
+        # summarizing only runs on the item that survived the score filter
+        assert mock_summarize.call_args.args[0] == "original query"
+        assert len(mock_summarize.call_args.args[1]) == 1
+
+    @patch("semantic_search.relevance.summarize_results_parallel")
+    @patch("semantic_search.relevance.score_results_parallel")
+    @patch("semantic_search.linked_refs.get_mean_std_linked_ref_enhancements")
+    @patch("semantic_search.natural_language_search._search_leg")
+    @patch("semantic_search.query_expansion.expand_query")
+    def test_sorts_by_score_descending_stable_on_ties(
+        self, mock_expand, mock_search_leg, mock_link_enh, mock_score, mock_summarize,
+    ):
+        mock_expand.return_value = QueryExpansion(english="en query", hebrew="he query")
+
+        chunk_a = make_chunk(ref="A", text="text-a")
+        chunk_c = make_chunk(ref="C", text="text-c")
+        mock_search_leg.side_effect = lambda leg_query: {
+            "en query": ([0.1], [chunk_a, chunk_c]),
+            "he query": ([0.2], []),
+        }[leg_query]
+        mock_link_enh.return_value = SimpleNamespace(ref_counts={})
+        mock_score.return_value = [3, 5]  # A=3, C=5 -> C should sort first
+        mock_summarize.return_value = ["summary-c", "summary-a"]
+
+        with patch("api.views.KnnSearch._top_linked_refs", return_value=[]), \
+             patch(
+                 "api.views.KnnSearch._serialize_search_result",
+                 side_effect=lambda chunk, include_text: {"ref": chunk.ref, "text": chunk.text},
+             ), \
+             patch("api.views.KnnSearch._serialize_linked_refs", return_value=[]):
+            result = run_natural_language_search("original query")
+
+        assert [r["ref"] for r in result["results"]] == ["C", "A"]
+        assert [r["score"] for r in result["results"]] == [5, 3]
+
+    @patch("semantic_search.relevance.summarize_results_parallel")
+    @patch("semantic_search.relevance.score_results_parallel")
+    @patch("semantic_search.linked_refs.get_mean_std_linked_ref_enhancements")
+    @patch("semantic_search.natural_language_search._search_leg")
+    @patch("semantic_search.query_expansion.expand_query")
+    def test_reports_progress_through_all_phases(
+        self, mock_expand, mock_search_leg, mock_link_enh, mock_score, mock_summarize,
+    ):
+        mock_expand.return_value = QueryExpansion(english="en query", hebrew="he query")
+        chunk = make_chunk(ref="A", text="text-a")
+        mock_search_leg.side_effect = lambda leg_query: {
+            "en query": ([0.1], [chunk]),
+            "he query": ([0.2], []),
+        }[leg_query]
+        mock_link_enh.return_value = SimpleNamespace(ref_counts={})
+        mock_score.return_value = [4]
+        mock_summarize.return_value = ["summary"]
+
+        phases = []
+
+        with patch("api.views.KnnSearch._top_linked_refs", return_value=[]), \
+             patch(
+                 "api.views.KnnSearch._serialize_search_result",
+                 side_effect=lambda chunk, include_text: {"ref": chunk.ref, "text": chunk.text},
+             ), \
+             patch("api.views.KnnSearch._serialize_linked_refs", return_value=[]):
+            run_natural_language_search(
+                "original query",
+                progress_callback=lambda phase, meta: phases.append(phase),
+            )
+
+        assert phases[0] == "expanding_query"
+        assert "searching" in phases
+        assert "expanding_links" in phases
+        assert "scoring" in phases
+        assert phases[-1] == "summarizing"

--- a/semantic_search/tests/semantic_search_test.py
+++ b/semantic_search/tests/semantic_search_test.py
@@ -603,6 +603,7 @@ class TestExpandQuery:
         assert mock_chat_cls.call_args.kwargs["model"] == "claude-custom-model"
 
     @override_settings(ANTHROPIC_API_KEY="")
+    @patch.dict("os.environ", {"ANTHROPIC_API_KEY": ""})
     def test_raises_when_api_key_missing(self):
         with pytest.raises(QueryExpansionError):
             expand_query("query")

--- a/semantic_search/tests/semantic_search_test.py
+++ b/semantic_search/tests/semantic_search_test.py
@@ -16,7 +16,10 @@ from semantic_search.linked_refs import (
     get_linked_ref_counts,
     get_linked_ref_enhancements,
     get_mean_std_linked_ref_enhancements,
+    linked_refs_for,
 )
+from semantic_search.natural_language_search import union_chunks_by_ref
+from semantic_search.query_expansion import QueryExpansion, QueryExpansionError, expand_query
 from semantic_search.router import SemanticSearchRouter
 from semantic_search.search import semantic_search, semantic_search_by_embedding
 from semantic_search.models import SemanticTextChunk
@@ -26,6 +29,7 @@ def make_chunk(**overrides):
     defaults = dict(
         ref="Genesis 1:1",
         chunked_from_ref="Genesis 1",
+        linked_refs=[],
     )
     defaults.update(overrides)
     return SimpleNamespace(**defaults)
@@ -213,100 +217,101 @@ class TestLinkedRefEnhancement:
             )
         )
 
-    def test_collects_full_count_distribution(self):
-        linked_refs_for = MagicMock(side_effect= {
-            "Genesis 1:1": ["Ref A", "Ref B"],
-            "Genesis 1:2": ["Ref B", "Ref C"],
-        }.get)
+    # -- hop 0: reads chunk.linked_refs directly, no linked_refs_for_func call ---
+
+    def test_collects_full_count_distribution_from_chunk_linked_refs(self):
         chunks = [
-            make_chunk(ref="Genesis 1:1"),
-            make_chunk(ref="Genesis 1:2"),
+            make_chunk(ref="Genesis 1:1", linked_refs=["Ref A", "Ref B"]),
+            make_chunk(ref="Genesis 1:2", linked_refs=["Ref B", "Ref C"]),
         ]
-        assert dict(get_linked_ref_counts(chunks, linked_refs_for_func=linked_refs_for)) == {
-            "Ref A": 1,
-            "Ref B": 2,
-            "Ref C": 1,
-        }
+        result = get_linked_ref_counts(chunks, linked_refs_for_func=lambda ref: [])
+        assert dict(result) == {"Ref A": 1, "Ref B": 2, "Ref C": 1}
+
+    def test_depth_one_never_calls_linked_refs_for_func(self):
+        linked_refs_for_mock = MagicMock(return_value=[])
+        chunks = [make_chunk(ref="Genesis 1:1", linked_refs=["Ref A"])]
+
+        get_linked_ref_counts(chunks, link_depth=1, linked_refs_for_func=linked_refs_for_mock)
+
+        linked_refs_for_mock.assert_not_called()
+
+    def test_default_path_filters_dictionary_candidates_at_hop_zero(self):
+        chunks = [make_chunk(ref="Genesis 1:1", linked_refs=["Ref A", "Dict Entry"])]
+
+        def fake_is_dict(ref):
+            return ref == "Dict Entry"
+
+        with patch("semantic_search.linked_refs._is_dictionary_ref_str", side_effect=fake_is_dict), \
+             patch("semantic_search.linked_refs.normalize_ref", side_effect=lambda r: r):
+            result = get_linked_ref_counts(chunks)
+
+        assert dict(result) == {"Ref A": 1}
 
     def test_counts_direct_linked_refs_and_applies_threshold(self):
-        linked_refs_for = MagicMock(side_effect= {
-            "Genesis 1:1": ["Ref A", "Ref B"],
-            "Genesis 1:2": ["Ref B", "Ref C"],
-        }.get)
         chunks = [
-            make_chunk(ref="Genesis 1:1"),
-            make_chunk(ref="Genesis 1:2"),
+            make_chunk(ref="Genesis 1:1", linked_refs=["Ref A", "Ref B"]),
+            make_chunk(ref="Genesis 1:2", linked_refs=["Ref B", "Ref C"]),
         ]
         result = get_linked_ref_enhancements(
             chunks,
             link_depth=1,
             min_link_count=2,
-            linked_refs_for_func=linked_refs_for,
+            linked_refs_for_func=lambda ref: [],
         )
         assert result.appended_refs == ["Ref B"]
         assert result.ref_counts == {"Ref B": 2}
 
-    def test_normalizes_and_dedupes_source_refs_before_retrieving_links(self):
-        linked_refs_for = MagicMock(return_value=["Ref A"])
+    def test_deduplicates_source_refs_before_counting(self):
         normalizer = mapping_normalizer({
             "Rashi on Deut. 28:6:1": "Rashi on Deuteronomy 28:6:1",
             "Rashi on Deuteronomy 28:6:1": "Rashi on Deuteronomy 28:6:1",
         })
         chunks = [
-            make_chunk(ref="Rashi on Deut. 28:6:1"),
-            make_chunk(ref="Rashi on Deuteronomy 28:6:1"),
+            make_chunk(ref="Rashi on Deut. 28:6:1", linked_refs=["Ref A"]),
+            # Same normalized source ref as above -- its linked_refs should not
+            # also be counted, since the first chunk already represents this source.
+            make_chunk(ref="Rashi on Deuteronomy 28:6:1", linked_refs=["Ref A", "Ref Z"]),
         ]
 
         result = get_linked_ref_counts(
             chunks,
-            linked_refs_for_func=linked_refs_for,
+            linked_refs_for_func=lambda ref: [],
             normalize_ref_func=normalizer,
         )
 
-        linked_refs_for.assert_called_once_with("Rashi on Deuteronomy 28:6:1")
         assert result == {"Ref A": 1}
 
     def test_normalizes_linked_refs_before_counting(self):
-        linked_refs_for = MagicMock(side_effect= {
-            "Genesis 1:1": ["Deut. 28:6"],
-            "Genesis 1:2": ["Deuteronomy 28:6"],
-        }.get)
+        chunks = [
+            make_chunk(ref="Genesis 1:1", linked_refs=["Deut. 28:6"]),
+            make_chunk(ref="Genesis 1:2", linked_refs=["Deuteronomy 28:6"]),
+        ]
         normalizer = mapping_normalizer({
+            "Genesis 1:1": "Genesis 1:1",
+            "Genesis 1:2": "Genesis 1:2",
             "Deut. 28:6": "Deuteronomy 28:6",
             "Deuteronomy 28:6": "Deuteronomy 28:6",
         })
-        chunks = [
-            make_chunk(ref="Genesis 1:1"),
-            make_chunk(ref="Genesis 1:2"),
-        ]
 
         result = get_linked_ref_counts(
             chunks,
-            linked_refs_for_func=linked_refs_for,
+            linked_refs_for_func=lambda ref: [],
             normalize_ref_func=normalizer,
         )
 
         assert result == {"Deuteronomy 28:6": 2}
 
     def test_mean_2std_threshold_returns_statistical_outliers(self):
-        linked_refs_for = MagicMock(side_effect= {
-            "Genesis 1:1": ["Ref A", "Ref Outlier"],
-            "Genesis 1:2": ["Ref B", "Ref Outlier"],
-            "Genesis 1:3": ["Ref C", "Ref Outlier"],
-            "Genesis 1:4": ["Ref D", "Ref Outlier"],
-            "Genesis 1:5": ["Ref E", "Ref Outlier"],
-            "Genesis 1:6": ["Ref F", "Ref Outlier"],
-            "Genesis 1:7": ["Ref G", "Ref Outlier"],
-            "Genesis 1:8": ["Ref H", "Ref Outlier"],
-            "Genesis 1:9": ["Ref I", "Ref Outlier"],
-            "Genesis 1:10": ["Ref J", "Ref Outlier"],
-        }.get)
         chunks = [
-            make_chunk(ref=f"Genesis 1:{i}", chunked_from_ref="Genesis 1")
+            make_chunk(
+                ref=f"Genesis 1:{i}",
+                chunked_from_ref="Genesis 1",
+                linked_refs=[f"Ref {chr(64 + i)}", "Ref Outlier"],
+            )
             for i in range(1, 11)
         ]
 
-        result = get_mean_std_linked_ref_enhancements(chunks, linked_refs_for_func=linked_refs_for)
+        result = get_mean_std_linked_ref_enhancements(chunks, linked_refs_for_func=lambda ref: [])
 
         assert result.threshold_method == "mean_plus_std_multiplier"
         assert result.appended_refs == ["Ref Outlier"]
@@ -314,16 +319,12 @@ class TestLinkedRefEnhancement:
         assert result.count_threshold > result.mean_count
 
     def test_mean_std_threshold_uses_min_count_floor_when_counts_have_no_variance(self):
-        linked_refs_for = MagicMock(side_effect= {
-            "Genesis 1:1": ["Ref A"],
-            "Genesis 1:2": ["Ref B"],
-        }.get)
         chunks = [
-            make_chunk(ref="Genesis 1:1"),
-            make_chunk(ref="Genesis 1:2"),
+            make_chunk(ref="Genesis 1:1", linked_refs=["Ref A"]),
+            make_chunk(ref="Genesis 1:2", linked_refs=["Ref B"]),
         ]
 
-        result = get_mean_std_linked_ref_enhancements(chunks, linked_refs_for_func=linked_refs_for)
+        result = get_mean_std_linked_ref_enhancements(chunks, linked_refs_for_func=lambda ref: [])
 
         assert result.appended_refs == []
         assert result.ref_counts == {}
@@ -332,85 +333,80 @@ class TestLinkedRefEnhancement:
         assert result.min_count == 3
 
     def test_mean_std_threshold_accepts_std_multiplier(self):
-        linked_refs_for = MagicMock(side_effect= {
-            "Genesis 1:1": ["Ref A", "Ref SemiOutlier"],
-            "Genesis 1:2": ["Ref B", "Ref SemiOutlier"],
-            "Genesis 1:3": ["Ref C", "Ref SemiOutlier"],
-        }.get)
         chunks = [
-            make_chunk(ref=f"Genesis 1:{i}", chunked_from_ref="Genesis 1")
+            make_chunk(
+                ref=f"Genesis 1:{i}",
+                chunked_from_ref="Genesis 1",
+                linked_refs=[f"Ref {chr(64 + i)}", "Ref SemiOutlier"],
+            )
             for i in range(1, 4)
         ]
 
         stricter = get_mean_std_linked_ref_enhancements(
             chunks,
             std_threshold=2,
-            linked_refs_for_func=linked_refs_for,
+            linked_refs_for_func=lambda ref: [],
         )
         looser = get_mean_std_linked_ref_enhancements(
             chunks,
             std_threshold=1,
-            linked_refs_for_func=linked_refs_for,
+            linked_refs_for_func=lambda ref: [],
         )
 
         assert stricter.appended_refs == []
         assert looser.appended_refs == ["Ref SemiOutlier"]
 
     def test_mean_std_threshold_allows_min_count_override(self):
-        linked_refs_for = MagicMock(side_effect= {
-            "Genesis 1:1": ["Ref A"],
-            "Genesis 1:2": ["Ref B"],
-        }.get)
         chunks = [
-            make_chunk(ref="Genesis 1:1"),
-            make_chunk(ref="Genesis 1:2"),
+            make_chunk(ref="Genesis 1:1", linked_refs=["Ref A"]),
+            make_chunk(ref="Genesis 1:2", linked_refs=["Ref B"]),
         ]
 
         result = get_mean_std_linked_ref_enhancements(
             chunks,
             min_count=1,
-            linked_refs_for_func=linked_refs_for,
+            linked_refs_for_func=lambda ref: [],
         )
 
         assert result.appended_refs == ["Ref A", "Ref B"]
         assert result.count_threshold == 1
 
     def test_excludes_original_result_refs(self):
-        linked_refs_for = MagicMock(side_effect= {
-            "Genesis 1:1": ["Genesis 1:1", "Genesis 1", "Ref B"],
-            "Genesis 1:2": ["Ref B"],
-        }.get)
         chunks = [
-            make_chunk(ref="Genesis 1:1", chunked_from_ref="Genesis 1"),
-            make_chunk(ref="Genesis 1:2"),
+            make_chunk(
+                ref="Genesis 1:1",
+                chunked_from_ref="Genesis 1",
+                linked_refs=["Genesis 1:1", "Genesis 1", "Ref B"],
+            ),
+            make_chunk(ref="Genesis 1:2", linked_refs=["Ref B"]),
         ]
         result = get_linked_ref_enhancements(
             chunks,
             link_depth=1,
             min_link_count=1,
-            linked_refs_for_func=linked_refs_for,
+            linked_refs_for_func=lambda ref: [],
         )
         assert result.appended_refs == ["Ref B"]
 
-    def test_depth_two_fetches_and_counts_next_hop_links_from_source(self):
-        linked_refs_for = MagicMock(side_effect= {
-            "Genesis 1:1": ["Ref B", "Ref D"],
+    # -- hop >= 1: falls back to linked_refs_for_func -----------------------
+
+    def test_depth_two_fetches_next_hop_links_via_linked_refs_for_func(self):
+        linked_refs_for_mock = MagicMock(side_effect={
             "Ref B": ["Ref D", "Ref E"],
             "Ref D": [],
         }.get)
-        chunks = [
-            make_chunk(ref="Genesis 1:1"),
-        ]
+        chunks = [make_chunk(ref="Genesis 1:1", linked_refs=["Ref B", "Ref D"])]
 
         result = get_linked_ref_enhancements(
             chunks,
             link_depth=2,
             min_link_count=2,
-            linked_refs_for_func=linked_refs_for,
+            linked_refs_for_func=linked_refs_for_mock,
         )
 
-        linked_refs_for.assert_any_call("Ref B")
-        linked_refs_for.assert_any_call("Ref D")
+        called_refs = [call.args[0] for call in linked_refs_for_mock.call_args_list]
+        assert "Genesis 1:1" not in called_refs
+        assert set(called_refs) == {"Ref B", "Ref D"}
         assert result.appended_refs == ["Ref D"]
         assert result.ref_counts == {"Ref D": 2}
 
@@ -418,6 +414,45 @@ class TestLinkedRefEnhancement:
         chunk = make_chunk()
         assert get_linked_ref_enhancements([chunk], link_depth=0, min_link_count=1).appended_refs == []
         assert get_linked_ref_enhancements([chunk], link_depth=1, min_link_count=0).appended_refs == []
+
+
+class TestLinkedRefsForDefault:
+    def test_reads_linked_refs_from_matching_chunks(self):
+        mock_objects = MagicMock()
+        mock_objects.filter.return_value = [
+            make_chunk(ref="Genesis 1:1", linked_refs=["Ref A", "Ref B"]),
+            make_chunk(ref="Genesis 1:1", linked_refs=["Ref B", "Ref C"]),
+        ]
+        with patch("semantic_search.models.SemanticTextChunk.objects", mock_objects), \
+             patch("semantic_search.linked_refs._is_dictionary_ref_str", return_value=False):
+            result = linked_refs_for("Genesis 1:1")
+
+        mock_objects.filter.assert_called_once_with(ref="Genesis 1:1")
+        assert result == ["Ref A", "Ref B", "Ref C"]
+
+    def test_returns_empty_when_source_is_dictionary_ref(self):
+        mock_objects = MagicMock()
+        with patch("semantic_search.models.SemanticTextChunk.objects", mock_objects), \
+             patch("semantic_search.linked_refs._is_dictionary_ref_str", return_value=True):
+            result = linked_refs_for("Klein Dictionary, א")
+
+        assert result == []
+        mock_objects.filter.assert_not_called()
+
+    def test_filters_out_dictionary_candidates(self):
+        mock_objects = MagicMock()
+        mock_objects.filter.return_value = [
+            make_chunk(ref="Genesis 1:1", linked_refs=["Ref A", "Dict Entry"]),
+        ]
+
+        def fake_is_dict(ref):
+            return ref == "Dict Entry"
+
+        with patch("semantic_search.models.SemanticTextChunk.objects", mock_objects), \
+             patch("semantic_search.linked_refs._is_dictionary_ref_str", side_effect=fake_is_dict):
+            result = linked_refs_for("Genesis 1:1")
+
+        assert result == ["Ref A"]
 
 
 # ---------------------------------------------------------------------------
@@ -522,3 +557,89 @@ class TestSemanticSearch:
         mock_chunk_cls.return_value.search_by_embedding.assert_called_once_with(
             embedding, limit=2, filters={"ref": "Genesis 1"}
         )
+
+
+# ---------------------------------------------------------------------------
+# expand_query
+# ---------------------------------------------------------------------------
+
+class TestExpandQuery:
+    @override_settings(ANTHROPIC_API_KEY="test-key")
+    @patch("semantic_search.query_expansion.ChatAnthropic")
+    def test_returns_query_expansion_from_structured_output(self, mock_chat_cls):
+        mock_structured = mock_chat_cls.return_value.with_structured_output.return_value
+        mock_structured.invoke.return_value = {
+            "english": "elaborated english query",
+            "hebrew": "שאילתה מורחבת בעברית",
+        }
+
+        result = expand_query("shabbat candles")
+
+        assert result == QueryExpansion(
+            english="elaborated english query",
+            hebrew="שאילתה מורחבת בעברית",
+        )
+
+    @override_settings(ANTHROPIC_API_KEY="test-key")
+    @patch("semantic_search.query_expansion.ChatAnthropic")
+    def test_uses_default_model_when_unconfigured(self, mock_chat_cls):
+        mock_chat_cls.return_value.with_structured_output.return_value.invoke.return_value = {
+            "english": "x", "hebrew": "y",
+        }
+
+        expand_query("query")
+
+        assert mock_chat_cls.call_args.kwargs["model"] == "claude-sonnet-5"
+
+    @override_settings(ANTHROPIC_API_KEY="test-key", NATURAL_LANGUAGE_SEARCH_MODEL="claude-custom-model")
+    @patch("semantic_search.query_expansion.ChatAnthropic")
+    def test_uses_configured_model(self, mock_chat_cls):
+        mock_chat_cls.return_value.with_structured_output.return_value.invoke.return_value = {
+            "english": "x", "hebrew": "y",
+        }
+
+        expand_query("query")
+
+        assert mock_chat_cls.call_args.kwargs["model"] == "claude-custom-model"
+
+    @override_settings(ANTHROPIC_API_KEY="")
+    def test_raises_when_api_key_missing(self):
+        with pytest.raises(QueryExpansionError):
+            expand_query("query")
+
+    @override_settings(ANTHROPIC_API_KEY="test-key")
+    @patch("semantic_search.query_expansion.ChatAnthropic")
+    def test_raises_when_result_missing_fields(self, mock_chat_cls):
+        mock_chat_cls.return_value.with_structured_output.return_value.invoke.return_value = {
+            "english": "", "hebrew": "",
+        }
+
+        with pytest.raises(QueryExpansionError):
+            expand_query("query")
+
+    @override_settings(ANTHROPIC_API_KEY="test-key")
+    @patch("semantic_search.query_expansion.ChatAnthropic")
+    def test_raises_when_llm_call_fails(self, mock_chat_cls):
+        mock_chat_cls.return_value.with_structured_output.return_value.invoke.side_effect = RuntimeError("boom")
+
+        with pytest.raises(QueryExpansionError):
+            expand_query("query")
+
+
+# ---------------------------------------------------------------------------
+# natural_language_search helpers
+# ---------------------------------------------------------------------------
+
+class TestUnionChunksByRef:
+    def test_unions_disjoint_lists(self):
+        first = [make_chunk(ref="Genesis 1:1")]
+        second = [make_chunk(ref="Genesis 1:2")]
+        assert union_chunks_by_ref(first, second) == first + second
+
+    def test_dedupes_by_ref_keeping_first_occurrence(self):
+        english_chunk = make_chunk(ref="Genesis 1:1", language="en")
+        hebrew_chunk = make_chunk(ref="Genesis 1:1", language="he")
+        assert union_chunks_by_ref([english_chunk], [hebrew_chunk]) == [english_chunk]
+
+    def test_empty_lists_return_empty(self):
+        assert union_chunks_by_ref([], []) == []

--- a/semantic_search/tests/semantic_search_test.py
+++ b/semantic_search/tests/semantic_search_test.py
@@ -710,6 +710,26 @@ class TestScoreResult:
     def test_returns_zero_on_llm_config_error(self, mock_get_llm):
         assert score_result("query", "text") == 0
 
+    @patch("semantic_search.relevance.get_chat_llm")
+    def test_passes_ref_and_index_title_to_llm(self, mock_get_llm):
+        structured_llm = mock_get_llm.return_value.with_structured_output.return_value
+        structured_llm.invoke.return_value = {"score": 5}
+        score_result("query", "text", ref="Genesis 3:14", index_title="Genesis")
+
+        message_content = structured_llm.invoke.call_args[0][0][1].content
+        assert "Ref: Genesis 3:14" in message_content
+        assert "Work: Genesis" in message_content
+
+    @patch("semantic_search.relevance.get_chat_llm")
+    def test_omits_source_block_when_ref_and_index_title_missing(self, mock_get_llm):
+        structured_llm = mock_get_llm.return_value.with_structured_output.return_value
+        structured_llm.invoke.return_value = {"score": 5}
+        score_result("query", "text")
+
+        message_content = structured_llm.invoke.call_args[0][0][1].content
+        assert "Ref:" not in message_content
+        assert "Work:" not in message_content
+
 
 class TestSummarizeResult:
     @patch("semantic_search.relevance.get_chat_llm")
@@ -722,12 +742,21 @@ class TestSummarizeResult:
         mock_get_llm.return_value.invoke.side_effect = RuntimeError("boom")
         assert summarize_result("query", "text") == ""
 
+    @patch("semantic_search.relevance.get_chat_llm")
+    def test_passes_ref_and_index_title_to_llm(self, mock_get_llm):
+        mock_get_llm.return_value.invoke.return_value = SimpleNamespace(content="summary")
+        summarize_result("query", "text", ref="Taanit 30a:13", index_title="Taanit")
+
+        message_content = mock_get_llm.return_value.invoke.call_args[0][0][1].content
+        assert "Ref: Taanit 30a:13" in message_content
+        assert "Work: Taanit" in message_content
+
 
 class TestScoreResultsParallel:
     def test_preserves_original_order_regardless_of_completion_order(self):
         items = [{"text": f"item-{i}"} for i in range(10)]
 
-        def fake_score(query, text):
+        def fake_score(query, text, **kwargs):
             # deliberately return based on content, not call order, so the test
             # can't pass just by luck of thread scheduling
             return int(text.split("-")[1]) % 5
@@ -759,12 +788,25 @@ class TestScoreResultsParallel:
         assert scores == []
         assert progress_calls == []
 
+    def test_forwards_ref_and_index_title_from_items(self):
+        items = [{"text": "item-0", "ref": "Genesis 3:14", "index_title": "Genesis"}]
+        calls = []
+
+        def fake_score(query, text, **kwargs):
+            calls.append(kwargs)
+            return 5
+
+        with patch("semantic_search.relevance.score_result", side_effect=fake_score):
+            score_results_parallel("query", items)
+
+        assert calls == [{"ref": "Genesis 3:14", "index_title": "Genesis"}]
+
 
 class TestSummarizeResultsParallel:
     def test_preserves_original_order_regardless_of_completion_order(self):
         items = [{"text": f"item-{i}"} for i in range(8)]
 
-        def fake_summarize(query, text):
+        def fake_summarize(query, text, **kwargs):
             return f"summary-{text}"
 
         with patch("semantic_search.relevance.summarize_result", side_effect=fake_summarize):

--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -4415,6 +4415,10 @@ body .ui-autocomplete.dictionary-toc-autocomplete .ui-menu-item a.ui-state-focus
 .searchContent .result-title {
   font-size: 24px;
   margin-bottom: 15px;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
 }
 .sheetResult .result-title {
   --english-font: var(--english-sans-serif-font-family);
@@ -4476,6 +4480,25 @@ body .ui-autocomplete.dictionary-toc-autocomplete .ui-menu-item a.ui-state-focus
 }
 .searchContent .result .result-title:hover {
   text-decoration: underline;
+}
+.resultOriginChip {
+  display: inline-block;
+  font-family: "Roboto", "Helvetica Neue", "Helvetica", sans-serif;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1;
+  padding: 4px 10px;
+  border-radius: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}
+.resultOriginChip.semantic {
+  background-color: var(--highlight-blue-light);
+  color: var(--sefaria-blue);
+}
+.resultOriginChip.link {
+  background-color: #F1F1F0;
+  color: var(--medium-grey);
 }
 .readerPanel.english .searchContent .snippet.he,
 .readerPanel.hebrew .searchContent .snippet.en,

--- a/static/js/ReaderPanel.jsx
+++ b/static/js/ReaderPanel.jsx
@@ -40,6 +40,7 @@ import {
 import {ContentText} from "./ContentText";
 import SheetsWithRefPage from "./sheets/SheetsWithRefPage";
 import {ElasticSearchQuerier} from "./ElasticSearchQuerier";
+import {SemanticSearchQuerier} from "./SemanticSearchQuerier";
 import {SheetsHomePage} from "./sheets/SheetsHomePage";
 import {TopicsLandingPage} from "./TopicLandingPage/TopicsLandingPage";
 import ReaderDisplayOptionsMenu from "./ReaderDisplayOptionsMenu";
@@ -942,7 +943,8 @@ class ReaderPanel extends Component {
                     }/>);
 
     } else if (this.state.menuOpen === "search" && this.state.searchQuery) {
-      menu = (<ElasticSearchQuerier
+      menu = this.state.searchState?.type === "sheet" ? (
+                <ElasticSearchQuerier
                     query={this.state.searchQuery}
                     searchState={this.state['searchState']}
                     resetSearchFilters={this.props.resetSearchFilters}
@@ -956,7 +958,15 @@ class ReaderPanel extends Component {
                     updateAppliedOptionField={this.props.updateSearchOptionField}
                     updateAppliedOptionSort={this.props.updateSearchOptionSort}
                     registerAvailableFilters={this.props.registerAvailableFilters}
-                    compare={this.state.compare}/>);
+                    compare={this.state.compare}/>
+             ) : (
+                <SemanticSearchQuerier
+                    query={this.state.searchQuery}
+                    panelsOpen={this.props.panelsOpen}
+                    onResultClick={this.props.onSearchResultClick}
+                    close={this.props.closePanel}
+                    onQueryChange={this.props.onQueryChange}/>
+             );
     } else if (this.state.menuOpen === "topics") {
       if (this.state.navigationTopicCategory) {
         menu = (

--- a/static/js/SearchPage.jsx
+++ b/static/js/SearchPage.jsx
@@ -92,6 +92,12 @@ class SearchPage extends Component {
                       variant="solid"
                       size={24}
                     />}
+                    {(this.props.englishQuery || this.props.hebrewQuery) && (
+                      <div className="searchExpandedQuery">
+                        <InterfaceText>search_page.searched_for</InterfaceText>&nbsp;
+                        <InterfaceText text={{en: this.props.englishQuery, he: this.props.hebrewQuery}}/>
+                      </div>
+                    )}
                   </div>
                   <div className="searchTopMatter">
                     <div className="searchResultCount">
@@ -130,6 +136,8 @@ class SearchPage extends Component {
 
 SearchPage.propTypes = {
   query:                    PropTypes.string,
+  englishQuery:             PropTypes.string,
+  hebrewQuery:              PropTypes.string,
   type:                      PropTypes.oneOf(["text", "sheet", "semantic"]),
   searchState:              PropTypes.object,
   settings:                 PropTypes.object,

--- a/static/js/SearchPage.jsx
+++ b/static/js/SearchPage.jsx
@@ -29,6 +29,7 @@ class SearchPage extends Component {
     const classes = classNames({readerNavMenu: 1, compare: this.props.compare});
     const {aiBadgeText} = this.props;
     const showAiBadge = aiBadgeText != null;
+    const hideFiltersAndSort = this.props.type === "semantic";
     const searchResultList = <SearchResultList
         query={this.props.query}
         hits={this.props.hits}
@@ -51,7 +52,7 @@ class SearchPage extends Component {
       </>
     );
 
-    const sortFilterControls = Sefaria.multiPanel && !this.props.compare ?
+    const sortFilterControls = hideFiltersAndSort ? null : (Sefaria.multiPanel && !this.props.compare ?
       <SearchSortBox
           type={this.props.type}
           sortTypeArray={this.props.sortTypeArray}
@@ -60,7 +61,7 @@ class SearchPage extends Component {
       :
       <SearchFilterButton
           openMobileFilters={() => this.setState({mobileFiltersOpen: true})}
-          nFilters={this.props.searchState.appliedFilters.length}/>;
+          nFilters={this.props.searchState.appliedFilters.length}/>);
 
     if (this.props.searchInBook) {
       return searchResultList;
@@ -104,7 +105,7 @@ class SearchPage extends Component {
                 {searchResultList}
               </div>
 
-              {(Sefaria.multiPanel && !this.props.compare) || this.state.mobileFiltersOpen ?
+              {!hideFiltersAndSort && ((Sefaria.multiPanel && !this.props.compare) || this.state.mobileFiltersOpen) ?
                   <div
                       className={Sefaria.multiPanel && !this.props.compare ? "navSidebar" : "mobileSearchFilters"}>
                     {this.props.totalResults?.getValue() > 0 ?
@@ -129,7 +130,7 @@ class SearchPage extends Component {
 
 SearchPage.propTypes = {
   query:                    PropTypes.string,
-  type:                      PropTypes.oneOf(["text", "sheet"]),
+  type:                      PropTypes.oneOf(["text", "sheet", "semantic"]),
   searchState:              PropTypes.object,
   settings:                 PropTypes.object,
   panelsOpen:               PropTypes.number,

--- a/static/js/SearchResultList.jsx
+++ b/static/js/SearchResultList.jsx
@@ -126,6 +126,14 @@ class SearchResultList extends Component {
           }
 
 
+        } else if (type === "semantic") {
+          results = this.props.hits.map(result =>
+            <SearchTextResult
+              data={result}
+              query={this.props.query}
+              key={result._id}
+              onResultClick={this.props.onResultClick} />
+          );
         } else if (type === "sheet") {
           results = this.props.hits.map((result, i) =>
             <SearchSheetResult

--- a/static/js/SearchTextResult.jsx
+++ b/static/js/SearchTextResult.jsx
@@ -95,8 +95,10 @@ class SearchTextResult extends Component {
         const href = s.version
             ? `/${Sefaria.normRef(s.ref)}?v${s.lang}=${Sefaria.util.encodeVtitle(s.version)}&qh=${this.props.query}`
             : `/${Sefaria.normRef(s.ref)}?qh=${this.props.query}`;
-        const originLabel = data.resultOrigin === "semantic" ? "Semantic Match"
-            : data.resultOrigin === "link" ? "Related Link"
+        const originLabel = data.resultOrigin === "english" ? "English Query Match"
+            : data.resultOrigin === "hebrew" ? "Hebrew Query Match"
+            : data.resultOrigin === "both" ? "English & Hebrew Match"
+            : data.resultOrigin === "linked" ? "Related Link"
             : null;
 
         const more_results_caret =
@@ -141,6 +143,7 @@ class SearchTextResult extends Component {
                 <ColorBarBox tref={s.ref}>
                     <div className={snippetClasses} dangerouslySetInnerHTML={snippetMarkup.markup}></div>
                 </ColorBarBox>
+                {data.summary && <div className="resultSummary">{data.summary}</div>}
                 <div className="version">
                     {Sefaria.interfaceLang === 'hebrew' && s.hebrew_version_title || s.version}
                 </div>

--- a/static/js/SearchTextResult.jsx
+++ b/static/js/SearchTextResult.jsx
@@ -92,7 +92,12 @@ class SearchTextResult extends Component {
     render() {
         var data = this.props.data;
         var s = this.props.data._source;
-        const href = `/${Sefaria.normRef(s.ref)}?v${s.lang}=${Sefaria.util.encodeVtitle(s.version)}&qh=${this.props.query}`;
+        const href = s.version
+            ? `/${Sefaria.normRef(s.ref)}?v${s.lang}=${Sefaria.util.encodeVtitle(s.version)}&qh=${this.props.query}`
+            : `/${Sefaria.normRef(s.ref)}?qh=${this.props.query}`;
+        const originLabel = data.resultOrigin === "semantic" ? "Semantic Match"
+            : data.resultOrigin === "link" ? "Related Link"
+            : null;
 
         const more_results_caret =
             (this.state.duplicatesShown)
@@ -130,6 +135,7 @@ class SearchTextResult extends Component {
                 <a href={href} onClick={this.handleResultClick}>
                     <div className="result-title">
                         <InterfaceText text={{en: s.ref, he: s.heRef}}/>
+                        {originLabel && <span className={classNames({resultOriginChip: 1, [data.resultOrigin]: 1})}>{originLabel}</span>}
                     </div>
                 </a>
                 <ColorBarBox tref={s.ref}>

--- a/static/js/SemanticSearchQuerier.jsx
+++ b/static/js/SemanticSearchQuerier.jsx
@@ -51,7 +51,7 @@ class SemanticSearchQuerier extends Component {
         if (this._runningQuery) {
             this._runningQuery.abort();
         }
-        this.setState({isQueryRunning: true, error: false});
+        this.setState({isQueryRunning: true, error: false, hits: []});
         this._runningQuery = $.ajax({
             url: `${Sefaria.apiHost}/api/search-wrapper/semantic`,
             type: "POST",

--- a/static/js/SemanticSearchQuerier.jsx
+++ b/static/js/SemanticSearchQuerier.jsx
@@ -1,0 +1,105 @@
+import Component from "react-class";
+import {SearchTotal} from "./sefaria/searchTotal";
+import Sefaria from "./sefaria/sefaria";
+import $ from "./sefaria/sefariaJquery";
+import PropTypes from "prop-types";
+import React from "react";
+import SearchPage from "./SearchPage";
+
+/**
+ * Feeds the search page from the KNN semantic search API (/api/search-wrapper/semantic)
+ * instead of Elasticsearch. POC: no filters, no sort, no pagination -- a single capped
+ * batch of semantic matches followed by link-origin matches.
+ */
+class SemanticSearchQuerier extends Component {
+    constructor(props) {
+      super(props);
+      this.state = {
+        isQueryRunning: false,
+        hits:           [],
+        error:          false,
+      };
+    }
+    componentDidMount() {
+        this._executeQuery(this.props.query);
+    }
+    componentWillReceiveProps(newProps) {
+        if (this.props.query !== newProps.query) {
+            this._executeQuery(newProps.query);
+        }
+    }
+    componentWillUnmount() {
+        if (this._runningQuery) {
+            this._runningQuery.abort();
+        }
+    }
+    _normalizeResult(result, resultOrigin) {
+        return {
+            _id: `${resultOrigin}:${result.ref}`,
+            resultOrigin,
+            _source: {
+                ref: result.ref,
+                heRef: result.ref,
+                version: result.version_title,
+                lang: result.language,
+                exact: result.text || "",
+            },
+        };
+    }
+    _executeQuery(query) {
+        if (!query) { return; }
+        if (this._runningQuery) {
+            this._runningQuery.abort();
+        }
+        this.setState({isQueryRunning: true, error: false});
+        this._runningQuery = $.ajax({
+            url: `${Sefaria.apiHost}/api/search-wrapper/semantic`,
+            type: "POST",
+            data: JSON.stringify({query}),
+            contentType: "application/json; charset=utf-8",
+            crossDomain: true,
+            processData: false,
+            dataType: "json",
+            success: data => {
+                const semanticHits = (data.results || []).map(r => this._normalizeResult(r, "semantic"));
+                const linkHits = (data.linked_refs || []).map(r => this._normalizeResult(r, "link"));
+                this.setState({
+                    isQueryRunning: false,
+                    hits: semanticHits.concat(linkHits),
+                });
+            },
+            error: () => {
+                this.setState({isQueryRunning: false, error: true});
+            },
+        });
+    }
+    render () {
+        return <SearchPage
+                    key={"searchPage"}
+                    moreToLoad={false}
+                    isQueryRunning={this.state.isQueryRunning}
+                    searchTopMsg="search_page.results_for"
+                    query={this.props.query}
+                    sortTypeArray={[]}
+                    hits={this.state.hits}
+                    totalResults={new SearchTotal({value: this.state.hits.length})}
+                    type="semantic"
+                    searchState={{sortType: null, appliedFilters: []}}
+                    panelsOpen={this.props.panelsOpen}
+                    onResultClick={this.props.onResultClick}
+                    close={this.props.close}
+                    onQueryChange={this.props.onQueryChange}
+                    topics={[]}
+                  />;
+    }
+}
+
+SemanticSearchQuerier.propTypes = {
+    query: PropTypes.string,
+    onResultClick: PropTypes.func,
+    close: PropTypes.func,
+    panelsOpen: PropTypes.number,
+    onQueryChange: PropTypes.func,
+};
+
+export { SemanticSearchQuerier };

--- a/static/js/SemanticSearchQuerier.jsx
+++ b/static/js/SemanticSearchQuerier.jsx
@@ -1,7 +1,6 @@
 import Component from "react-class";
 import {SearchTotal} from "./sefaria/searchTotal";
 import Sefaria from "./sefaria/sefaria";
-import $ from "./sefaria/sefariaJquery";
 import PropTypes from "prop-types";
 import React from "react";
 import SearchPage from "./SearchPage";
@@ -9,10 +8,12 @@ import SearchPage from "./SearchPage";
 /**
  * Feeds the search page from the natural-language search API
  * (/api/search-wrapper/natural-language) instead of Elasticsearch. That endpoint
- * elaborates the query with an LLM into English and Hebrew versions, runs both
- * through semantic KNN search in parallel, and unions the results. POC: no
- * filters, no sort, no pagination -- semantic matches followed by link-origin
- * matches.
+ * enqueues a Celery task that elaborates the query with an LLM into English and
+ * Hebrew versions, runs both through semantic KNN search in parallel, scores
+ * every result's relevance to the query with an LLM (keeping only the 3-5s out
+ * of 5), and writes a short LLM relevance summary for each retained result --
+ * linked-ref matches are annotated the same way, not returned separately. The
+ * task's progress is polled via Sefaria.pollTask.
  */
 class SemanticSearchQuerier extends Component {
     constructor(props) {
@@ -21,6 +22,8 @@ class SemanticSearchQuerier extends Component {
         isQueryRunning: false,
         hits:           [],
         error:          false,
+        englishQuery:   null,
+        hebrewQuery:    null,
       };
     }
     componentDidMount() {
@@ -32,14 +35,15 @@ class SemanticSearchQuerier extends Component {
         }
     }
     componentWillUnmount() {
-        if (this._runningQuery) {
-            this._runningQuery.abort();
+        if (this._abortController) {
+            this._abortController.abort();
         }
     }
     _normalizeResult(result, resultOrigin) {
         return {
             _id: `${resultOrigin}:${result.ref}`,
             resultOrigin,
+            summary: result.summary || "",
             _source: {
                 ref: result.ref,
                 heRef: result.ref,
@@ -49,32 +53,54 @@ class SemanticSearchQuerier extends Component {
             },
         };
     }
-    _executeQuery(query) {
+    async _executeQuery(query) {
         if (!query) { return; }
-        if (this._runningQuery) {
-            this._runningQuery.abort();
+        if (this._abortController) {
+            this._abortController.abort();
         }
-        this.setState({isQueryRunning: true, error: false, hits: []});
-        this._runningQuery = $.ajax({
-            url: `${Sefaria.apiHost}/api/search-wrapper/natural-language`,
-            type: "POST",
-            data: JSON.stringify({query}),
-            contentType: "application/json; charset=utf-8",
-            crossDomain: true,
-            processData: false,
-            dataType: "json",
-            success: data => {
-                const semanticHits = (data.results || []).map(r => this._normalizeResult(r, "semantic"));
-                const linkHits = (data.linked_refs || []).map(r => this._normalizeResult(r, "link"));
-                this.setState({
-                    isQueryRunning: false,
-                    hits: semanticHits.concat(linkHits),
-                });
-            },
-            error: () => {
-                this.setState({isQueryRunning: false, error: true});
-            },
+        const controller = new AbortController();
+        this._abortController = controller;
+        this.setState({
+            isQueryRunning: true,
+            error:          false,
+            hits:           [],
+            englishQuery:   null,
+            hebrewQuery:    null,
         });
+
+        try {
+            const startResp = await fetch(`${Sefaria.apiHost}/api/search-wrapper/natural-language`, {
+                method:      "POST",
+                headers:     {"Content-Type": "application/json; charset=utf-8"},
+                body:        JSON.stringify({query}),
+                credentials: "include",
+                signal:      controller.signal,
+            });
+            if (!startResp.ok) { throw new Error("Failed to start natural-language search"); }
+            const {task_id} = await startResp.json();
+
+            const result = await Sefaria.pollTask(task_id, {
+                signal: controller.signal,
+                onProgress: meta => {
+                    if (!meta) { return; }
+                    const update = {};
+                    if (meta.english_query) { update.englishQuery = meta.english_query; }
+                    if (meta.hebrew_query) { update.hebrewQuery = meta.hebrew_query; }
+                    if (Object.keys(update).length) { this.setState(update); }
+                },
+            });
+
+            const hits = (result.results || []).map(r => this._normalizeResult(r, r.source));
+            this.setState({
+                isQueryRunning: false,
+                hits,
+                englishQuery: result.english_query,
+                hebrewQuery: result.hebrew_query,
+            });
+        } catch (e) {
+            if (controller.signal.aborted || e.name === "AbortError") { return; }
+            this.setState({isQueryRunning: false, error: true});
+        }
     }
     render () {
         return <SearchPage
@@ -83,6 +109,8 @@ class SemanticSearchQuerier extends Component {
                     isQueryRunning={this.state.isQueryRunning}
                     searchTopMsg="search_page.results_for"
                     query={this.props.query}
+                    englishQuery={this.state.englishQuery}
+                    hebrewQuery={this.state.hebrewQuery}
                     sortTypeArray={[]}
                     hits={this.state.hits}
                     totalResults={new SearchTotal({value: this.state.hits.length})}

--- a/static/js/SemanticSearchQuerier.jsx
+++ b/static/js/SemanticSearchQuerier.jsx
@@ -7,9 +7,12 @@ import React from "react";
 import SearchPage from "./SearchPage";
 
 /**
- * Feeds the search page from the KNN semantic search API (/api/search-wrapper/semantic)
- * instead of Elasticsearch. POC: no filters, no sort, no pagination -- a single capped
- * batch of semantic matches followed by link-origin matches.
+ * Feeds the search page from the natural-language search API
+ * (/api/search-wrapper/natural-language) instead of Elasticsearch. That endpoint
+ * elaborates the query with an LLM into English and Hebrew versions, runs both
+ * through semantic KNN search in parallel, and unions the results. POC: no
+ * filters, no sort, no pagination -- semantic matches followed by link-origin
+ * matches.
  */
 class SemanticSearchQuerier extends Component {
     constructor(props) {
@@ -53,7 +56,7 @@ class SemanticSearchQuerier extends Component {
         }
         this.setState({isQueryRunning: true, error: false, hits: []});
         this._runningQuery = $.ajax({
-            url: `${Sefaria.apiHost}/api/search-wrapper/semantic`,
+            url: `${Sefaria.apiHost}/api/search-wrapper/natural-language`,
             type: "POST",
             data: JSON.stringify({query}),
             contentType: "application/json; charset=utf-8",

--- a/static/js/SemanticSearchQuerier.jsx
+++ b/static/js/SemanticSearchQuerier.jsx
@@ -24,6 +24,9 @@ class SemanticSearchQuerier extends Component {
         error:          false,
         englishQuery:   null,
         hebrewQuery:    null,
+        phase:          null,
+        phaseCompleted: null,
+        phaseTotal:     null,
       };
     }
     componentDidMount() {
@@ -66,6 +69,9 @@ class SemanticSearchQuerier extends Component {
             hits:           [],
             englishQuery:   null,
             hebrewQuery:    null,
+            phase:          null,
+            phaseCompleted: null,
+            phaseTotal:     null,
         });
 
         try {
@@ -86,6 +92,9 @@ class SemanticSearchQuerier extends Component {
                     const update = {};
                     if (meta.english_query) { update.englishQuery = meta.english_query; }
                     if (meta.hebrew_query) { update.hebrewQuery = meta.hebrew_query; }
+                    if (meta.phase) { update.phase = meta.phase; }
+                    update.phaseCompleted = typeof meta.completed === "number" ? meta.completed : null;
+                    update.phaseTotal = typeof meta.total === "number" ? meta.total : null;
                     if (Object.keys(update).length) { this.setState(update); }
                 },
             });
@@ -96,10 +105,13 @@ class SemanticSearchQuerier extends Component {
                 hits,
                 englishQuery: result.english_query,
                 hebrewQuery: result.hebrew_query,
+                phase: null,
+                phaseCompleted: null,
+                phaseTotal: null,
             });
         } catch (e) {
             if (controller.signal.aborted || e.name === "AbortError") { return; }
-            this.setState({isQueryRunning: false, error: true});
+            this.setState({isQueryRunning: false, error: true, phase: null, phaseCompleted: null, phaseTotal: null});
         }
     }
     render () {

--- a/static/js/sefaria/i18n/interface/en.json
+++ b/static/js/sefaria/i18n/interface/en.json
@@ -373,6 +373,7 @@
     "search_page.relevance": "Relevance",
     "search_page.results": "Results",
     "search_page.results_for": "Results for",
+    "search_page.searched_for": "Searched for",
     "search_page.sheets_with": "Sheets With",
     "search_page.views": "Views",
     "sefaria.admin": "Admin",

--- a/static/js/sefaria/i18n/interface/he.json
+++ b/static/js/sefaria/i18n/interface/he.json
@@ -373,6 +373,7 @@
     "search_page.relevance": "רלוונטיות",
     "search_page.results": "תוצאות",
     "search_page.results_for": "תוצאות עבור",
+    "search_page.searched_for": "חיפוש עבור",
     "search_page.sheets_with": "דפי מקורות עם",
     "search_page.views": "צפיות",
     "sefaria.admin": "עריכה",

--- a/static/js/sefaria/sefaria.js
+++ b/static/js/sefaria/sefaria.js
@@ -3537,15 +3537,22 @@ _media: {},
    * Returns a Promise that resolves with the task result on success, or rejects
    * with an Error on task failure or network error. Network errors set
    * err.isNetworkError = true so callers can show a different message.
+   * If `signal` is aborted (a standard AbortSignal), polling stops silently --
+   * the returned Promise never resolves or rejects, so callers who abort
+   * because a newer request superseded this one don't need to special-case
+   * "aborted" in their .then()/.catch().
    * @param {string} taskId
    * @param {number} [interval=3000] ms between polls
+   * @param {AbortSignal} [signal]
    * @returns {Promise}
    */
-  pollTask(taskId, { interval = 3000, onProgress } = {}) {
+  pollTask(taskId, { interval = 3000, onProgress, signal } = {}) {
     return new Promise((resolve, reject) => {
       const handle = setInterval(async () => {
+        if (signal?.aborted) { clearInterval(handle); return; }
         try {
           const resp = await fetch("/api/async/" + taskId);
+          if (signal?.aborted) { clearInterval(handle); return; }
           if (!resp.ok) {
             clearInterval(handle);
             const err = new Error("Network error polling task " + taskId);
@@ -3554,6 +3561,7 @@ _media: {},
             return;
           }
           const data = await resp.json();
+          if (signal?.aborted) { clearInterval(handle); return; }
           if (!data.ready) {
             if (onProgress && data.meta) onProgress(data.meta);
             return;
@@ -3566,6 +3574,7 @@ _media: {},
           }
         } catch (e) {
           clearInterval(handle);
+          if (signal?.aborted) { return; }
           e.isNetworkError = true;
           reject(e);
         }


### PR DESCRIPTION
## Summary
- Disables Elasticsearch keyword search on the `/search` page (text search only) and instead renders results from the semantic KNN search pipeline.
- Up to 40 direct semantic matches, followed by up to 10 link-origin matches (refs frequently linked-to from the top semantic hits), each labeled with a chip in the result title (`Semantic Match` / `Related Link`).
- Filter sidebar and sort dropdown are hidden on semantic results — not useful for this few, non-facetable results.
- Sheet search is untouched (still keyword/Elasticsearch) since the KNN index only covers texts.

### Why a new backend endpoint?
`/api/knn-search` is gated by a shared `Authorization: Bearer <SEMANTIC_SEARCH_API_TOKEN>` secret intended for server-to-server/tool callers. Calling it directly from browser JS would ship that secret to every visitor. Instead:
- `KnnSearch.post()` was split into a thin auth/dispatch wrapper and a reusable `KnnSearch.run_search(body)` classmethod (`api/views.py`).
- A new public, same-origin view `semantic_search_wrapper_api` (`reader/views.py`, routed at `POST /api/search-wrapper/semantic`) calls `run_search` directly server-side — no token required, same trust model as the existing `search_wrapper_api`.

### Frontend
- New `SemanticSearchQuerier.jsx` (sibling to `ElasticSearchQuerier.jsx`) posts to the new endpoint, tags each hit `resultOrigin: 'semantic'|'link'`, and feeds `SearchPage`.
- `SearchResultList.jsx` gets a new `type === "semantic"` render branch (avoids the `!!result._source.version` filter, which would silently drop every link-origin result).
- `SearchTextResult.jsx` renders the origin chip and falls back to a version-less href for link-origin rows (which lack `version`/`lang`).
- `SearchPage.jsx` hides the sort/filter controls when `type === "semantic"`.
- `ReaderPanel.jsx` mounts `SemanticSearchQuerier` for text search, keeps `ElasticSearchQuerier` for sheet search.

## Test plan
- [x] `webpack` build succeeds across all bundles.
- [x] Django imports cleanly; exercised `/api/search-wrapper/semantic` via Django test client — correctly calls Gemini to embed the query and reaches the pgvector query (failed only on local Postgres not running in this sandbox).
- [ ] Manual: `docker-compose up`, open `/search?q=...`, confirm no filter sidebar/sort dropdown, semantic results first with chips, link results below with chips, click-through navigates correctly.
- [ ] Manual: confirm sheet search on the search page is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)