### PR TITLE
fix(sso): accept the iOS bundle ID as an Apple token audience

### DIFF
--- a/sefaria/settings.py
+++ b/sefaria/settings.py
@@ -400,6 +400,8 @@ SOCIALACCOUNT_EMAIL_AUTHENTICATION = True
 SOCIALACCOUNT_EMAIL_AUTHENTICATION_AUTO_CONNECT = True
 # Env vars take precedence (production injects these via the deploy environment);
 # fall back to the local_settings values imported above (used in local dev).
+_APPLE_WEB_CLIENT_ID = os.environ.get('APPLE_SSO_CLIENT_ID') or APPLE_SSO_CLIENT_ID
+_APPLE_NATIVE_BUNDLE_ID = os.environ.get('APPLE_SSO_IOS_BUNDLE_ID') or APPLE_SSO_IOS_BUNDLE_ID
 SOCIALACCOUNT_PROVIDERS = {
     'google': {
         'APP': {'client_id': os.environ.get('GOOGLE_SSO_CLIENT_ID') or GOOGLE_SSO_CLIENT_ID, 'secret': '', 'key': ''},
@@ -407,17 +409,16 @@ SOCIALACCOUNT_PROVIDERS = {
     },
     'apple': {
         'APP': {
-            'client_id': os.environ.get('APPLE_SSO_CLIENT_ID') or APPLE_SSO_CLIENT_ID,
+            # allauth reads the accepted 'aud's from a comma-separated
+            # client_id (AppleProvider.get_auds); there is no 'audience'
+            # setting. Web ID first -- api calls use client_id.split(",")[0].
+            'client_id': ','.join(filter(None, (_APPLE_WEB_CLIENT_ID, _APPLE_NATIVE_BUNDLE_ID))),
             # allauth's Apple client signs its own client-secret JWT from these:
             # 'secret' -> Key ID (JWT 'kid' header), 'key' -> Team ID (JWT 'iss' claim).
             'secret': os.environ.get('APPLE_SSO_KEY_ID') or APPLE_SSO_KEY_ID,
             'key': os.environ.get('APPLE_SSO_TEAM_ID') or APPLE_SSO_TEAM_ID,
             'settings': {
                 'certificate_key': os.environ.get('APPLE_SSO_PRIVATE_KEY') or APPLE_SSO_PRIVATE_KEY,
-                'audience': [
-                    os.environ.get('APPLE_SSO_CLIENT_ID') or APPLE_SSO_CLIENT_ID,
-                    os.environ.get('APPLE_SSO_IOS_BUNDLE_ID') or APPLE_SSO_IOS_BUNDLE_ID,
-                ],
             },
         },
     },


### PR DESCRIPTION
## Problem

Native iOS "Sign in with Apple" fails against the SSO backend. The app reaches the Apple sheet, gets an identity token, POSTs it to `/api/auth/apple/mobile`, and gets back:

```json
{"error": "auth.social_signin_failed"}
```

The response body is deliberately generic. The `soo` pod log names the real cause:

```json
{"error": "['Invalid token.']", "event": "apple token verification failed",
 "logger": "sso.views", "severity": "warning"}
```

Web Apple sign-in is unaffected and has always worked.

## Cause

Apple stamps `aud` differently per surface:

| Surface | `aud` |
|---|---|
| Web JS SDK | `org.sefaria.web.signin` (Services ID) |
| Native iOS | `org.sefaria.sefariaApp` (bundle ID) |

Both need to be accepted. `settings.py` declared that list as:

```python
'settings': {
    'audience': [APPLE_SSO_CLIENT_ID, APPLE_SSO_IOS_BUNDLE_ID],
},
```

**allauth has no `audience` setting.** The key is silently ignored. The allowed audiences come from exactly one place — `allauth/socialaccount/providers/apple/provider.py:88` (65.8.0):

```python
def get_auds(self):
    return [aud.strip() for aud in self.app.client_id.split(",")]
```

A comma-separated `client_id` is allauth's idiom for multiple audiences. Since `client_id` held only the Services ID, `get_auds()` returned `['org.sefaria.web.signin']` and every native iOS token failed audience validation.

`APPLE_SSO_IOS_BUNDLE_ID` was already plumbed correctly from the sealed secret through to `settings.py` — it just landed in a dict key nobody reads.

## Fix

Join both IDs into `client_id`; drop the dead `audience` key.

## Why web behaviour is unchanged

The change is strictly additive — it only widens the set of accepted `aud` values. Everything that *sends* a client ID keeps sending the Services ID alone:

- `AppleOAuth2Adapter.client_class = AppleOAuth2Client`, and `AppleOAuth2Client.get_client_id()` is `consumer_key.split(",")[0]` — commented in allauth as *"We support multiple client_ids, but use the first one for api calls"*. The Services ID stays first, so the authorize redirect, the token exchange, and the client-secret JWT's `sub` are all byte-identical.
- `reader/views.py:399` builds the web SDK's `appleClientId` from the `APPLE_SSO_CLIENT_ID` setting directly, not from `SOCIALACCOUNT_PROVIDERS`, so it is untouched.

## Scope

Backend only. **No Sefaria-Mobile change is required** — the client was already sending a valid token to the right endpoint.

## Verification

- Reproduced on the `soo` cauldron: two `POST /api/auth/apple/mobile` → 400, each with `apple token verification failed error=['Invalid token.']`.
- Root cause read from the deployed allauth 65.8.0 source in the pod.
- Confirmed no other code path reads `APP['settings']['audience']` or `app.client_id` for Apple.

Needs a redeploy of a cauldron to verify the iOS sign-in completes end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P6SyKh9dkDroXyNma5X9UN
