### PR TITLE
feat: index webpages

### DIFF
--- a/docs/agent_docs/model/webpage.md
+++ b/docs/agent_docs/model/webpage.md
@@ -55,6 +55,20 @@ Tracks external web pages that reference Sefaria texts (discovered via the Sefar
 - **Helper module**: URL normalization, domain extraction, site data lookup, and website caching live in `sefaria/helper/webpages.py`, not in the model itself.
 - **Linker integration**: The Sefaria Linker (JavaScript widget on partner sites) calls `add_or_update_from_linker()` to report pages.
 
+## WebPageText and Search Indexing
+
+The full title/body submitted to the find-refs API is stored separately by
+`WebPageText` in the `webpages_text` MongoDB collection. When
+`WEBPAGE_SEARCH_INDEX_ON_SAVE` is enabled, a successful content update queues
+`linker.index_webpage_text`. The task chunks the body, optionally generates
+Gemini embeddings, and replaces that URL's documents in the dedicated
+Elasticsearch webpage index.
+
+Search documents carry denormalized `website_id`, `domain`, `refs`, and
+`expanded_refs` keyword fields. `sefaria.helper.webpage_search` owns index
+creation, full rebuilds, incremental replacement, ref normalization, and
+filtered lexical/hybrid/semantic queries. MongoDB remains the source of truth.
+
 ## Common Tasks
 
 ### Look up webpages for a Sefaria ref

--- a/docs/agent_docs/sefaria/search.md
+++ b/docs/agent_docs/sefaria/search.md
@@ -7,6 +7,16 @@ Elasticsearch integration for Sefaria's full-text search. Manages two separate E
 
 ## Key Functions/Classes
 
+### Linker Webpage Search
+
+`sefaria.helper.webpage_search` builds a dedicated chunk-level index from the
+MongoDB `webpages_text` and `webpages` collections. It supports exact filters
+for website, domain, language, and expanded Sefaria refs, plus lexical,
+semantic, and hybrid retrieval. Results are collapsed by URL and return a
+highlighted passage for agent consumption. Incremental indexing runs through
+the `linker.index_webpage_text` Celery task; `scripts/reindex_webpage_search.py`
+creates and populates the full index.
+
 ### Index Management
 
 - **`create_index(index_name, type, force=False)`** -- Creates an ES index with custom analyzers (stemmed English via Snowball, exact English via ICU). Has a safety check: refuses to recreate an index that already contains documents unless `force=True`. Calls `put_text_mapping()` or `put_sheet_mapping()` depending on type.

--- a/scripts/reindex_webpage_search.py
+++ b/scripts/reindex_webpage_search.py
@@ -1,0 +1,32 @@
+"""Create and populate the Linker webpage Elasticsearch index."""
+
+import argparse
+import django
+
+django.setup()
+
+from django.conf import settings
+from semantic_search.embedder import embed_documents
+from sefaria.helper.webpage_search import create_webpage_search_index, index_all_webpage_texts
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--index-name")
+    parser.add_argument("--force", action="store_true")
+    parser.add_argument("--without-embeddings", action="store_true")
+    args = parser.parse_args()
+
+    index_name = create_webpage_search_index(args.index_name, force=args.force)
+    embedding_callback = None
+    if not args.without_embeddings:
+        api_key = getattr(settings, "GEMINI_API_KEY", "")
+        if not api_key:
+            raise SystemExit("GEMINI_API_KEY is required unless --without-embeddings is used")
+        embedding_callback = lambda texts: embed_documents(texts, api_key=api_key)
+    count = index_all_webpage_texts(index_name, embedding_callback)
+    print(f"Indexed {count} webpage chunks into {index_name}")
+
+
+if __name__ == "__main__":
+    main()

--- a/sefaria/helper/linker/linker.py
+++ b/sefaria/helper/linker/linker.py
@@ -1,5 +1,6 @@
 import dataclasses
 import json
+from django.conf import settings
 from cerberus import Validator
 from ne_span import RefPartType
 from sefaria.model.linker.ref_part import TermContext
@@ -148,11 +149,15 @@ def _save_webpage_text_from_linker_request(meta_data: dict, request_text: _FindR
     url = meta_data.get("url")
     if not url:
         return
-    WebPageText.add_or_update({
+    status, webpage_text = WebPageText.add_or_update({
         "url": url,
         "title": request_text.title,
         "body": request_text.body,
     })
+    if status == "saved" and getattr(settings, "WEBPAGE_SEARCH_INDEX_ON_SAVE", False):
+        from sefaria.celery_setup.config import CeleryQueue
+        from sefaria.helper.linker.tasks import index_webpage_text_task
+        index_webpage_text_task.apply_async(args=(webpage_text.url,), queue=CeleryQueue.TASKS.value)
 
 
 @django_cache(cache_type="persistent")

--- a/sefaria/helper/linker/tasks.py
+++ b/sefaria/helper/linker/tasks.py
@@ -94,6 +94,20 @@ def find_refs_api_task(raw_find_refs_input: dict) -> dict:
         raise
 
 
+@app.task(name="linker.index_webpage_text")
+def index_webpage_text_task(url: str) -> int:
+    """Generate embeddings and replace the Elasticsearch chunks for one page."""
+    from django.conf import settings
+    from semantic_search.embedder import embed_documents
+    from sefaria.helper.webpage_search import index_webpage_text
+
+    api_key = getattr(settings, "GEMINI_API_KEY", "")
+    embedding_callback = None
+    if api_key:
+        embedding_callback = lambda texts: embed_documents(texts, api_key=api_key)
+    return index_webpage_text(url, embed_documents=embedding_callback)
+
+
 @app.task(name="linker.link_segment_with_worker")
 def link_segment_with_worker(linking_args_dict: dict) -> None:
     """

--- a/sefaria/helper/tests/webpage_search_test.py
+++ b/sefaria/helper/tests/webpage_search_test.py
@@ -1,0 +1,116 @@
+from datetime import datetime
+from types import SimpleNamespace
+
+import pytest
+
+from sefaria.helper import webpage_search
+from sefaria.helper.webpage_search import WebPageSearchFilters
+
+
+def test_chunk_text_uses_overlap_and_cleans_html():
+    chunks = webpage_search.chunk_text(
+        "<p>one two three four five six</p>",
+        chunk_words=4,
+        overlap_words=1,
+    )
+    assert chunks == ["one two three four", "four five six"]
+
+
+def test_make_documents_copies_page_filters_to_each_chunk(monkeypatch):
+    monkeypatch.setattr(webpage_search, "_website_metadata", lambda url: ("example.com", "site-1"))
+    webpage_text = SimpleNamespace(
+        url="https://example.com/article",
+        title="<b>Creation</b>",
+        body="one two three four five six",
+    )
+    webpage = SimpleNamespace(
+        _id="page-1",
+        refs=["Genesis 1:1-2"],
+        expandedRefs=["Genesis 1:1", "Genesis 1:2"],
+        lastUpdated=datetime(2026, 8, 10),
+    )
+
+    documents = webpage_search.make_webpage_search_documents(
+        webpage_text,
+        webpage,
+        embeddings=[[0.1], [0.2]],
+        chunk_words=4,
+        overlap_words=1,
+    )
+
+    assert len(documents) == 2
+    assert documents[0]["title"] == "Creation"
+    assert documents[0]["website_id"] == "site-1"
+    assert documents[0]["domain"] == "example.com"
+    assert documents[0]["expanded_refs"] == ["Genesis 1:1", "Genesis 1:2"]
+    assert documents[1]["embedding"] == [0.2]
+    assert documents[0]["chunk_id"] != documents[1]["chunk_id"]
+
+
+def test_build_request_combines_website_domain_and_ref_filters():
+    request = webpage_search.build_webpage_search_request(
+        "creation of light",
+        WebPageSearchFilters(
+            website_id="site-1",
+            domain="example.com",
+            ref="Genesis 1:1-2",
+            language="en",
+        ),
+        limit=5,
+        mode="lexical",
+    )
+
+    filters = request["query"]["bool"]["filter"]
+    assert {"term": {"website_id": "site-1"}} in filters
+    assert {"term": {"domain": "example.com"}} in filters
+    assert {"term": {"language": "en"}} in filters
+    assert {"terms": {"expanded_refs": ["Genesis 1:1", "Genesis 1:2"]}} in filters
+    assert request["collapse"] == {"field": "url"}
+
+
+def test_build_hybrid_request_applies_filters_to_lexical_and_vector_search():
+    request = webpage_search.build_webpage_search_request(
+        "creation",
+        WebPageSearchFilters(domain="example.com"),
+        query_vector=[0.1, 0.2],
+        mode="hybrid",
+    )
+
+    expected_filter = [{"term": {"domain": "example.com"}}]
+    assert request["query"]["bool"]["filter"] == expected_filter
+    assert request["knn"]["filter"] == expected_filter
+
+
+def test_invalid_ref_is_rejected():
+    with pytest.raises(ValueError, match="Invalid ref"):
+        webpage_search.build_webpage_search_request(
+            "query",
+            WebPageSearchFilters(ref="definitely not a ref"),
+            mode="lexical",
+        )
+
+
+def test_search_formats_highlight_as_agent_passage(monkeypatch):
+    client = SimpleNamespace(search=lambda **kwargs: {
+        "hits": {"hits": [{
+            "_score": 1.5,
+            "_source": {"url": "https://example.com", "content": "full content"},
+            "highlight": {"content": ["matching <em>passage</em>"]},
+        }]}
+    })
+    monkeypatch.setattr(webpage_search, "get_elasticsearch_client", lambda: client)
+
+    results = webpage_search.search_webpages("passage", index_name="webpage-test", mode="lexical")
+
+    assert results[0]["score"] == 1.5
+    assert results[0]["passage"] == "matching <em>passage</em>"
+
+
+def test_semantic_request_does_not_add_lexical_query():
+    request = webpage_search.build_webpage_search_request(
+        "conceptual query",
+        query_vector=[0.1, 0.2],
+        mode="semantic",
+    )
+    assert "query" not in request
+    assert request["knn"]["query_vector"] == [0.1, 0.2]

--- a/sefaria/helper/webpage_search.py
+++ b/sefaria/helper/webpage_search.py
@@ -1,0 +1,268 @@
+"""Elasticsearch indexing and retrieval for content collected by the Linker."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+import bleach
+from django.conf import settings
+from elasticsearch.helpers import bulk
+
+from sefaria.helper.search import get_elasticsearch_client, get_elasticsearch_client_for_indexer
+from sefaria.helper.webpages import domain_for_url
+from sefaria.model import Ref, WebPage
+from sefaria.model.webpage import WebSite
+from sefaria.model.webpage_text import WebPageText, WebPageTextSet
+from sefaria.system.exceptions import InputError
+from sefaria.utils.hebrew import is_mostly_hebrew
+
+
+DEFAULT_CHUNK_WORDS = 500
+DEFAULT_CHUNK_OVERLAP_WORDS = 75
+DEFAULT_VECTOR_DIMS = 1536
+
+
+@dataclass(frozen=True)
+class WebPageSearchFilters:
+    website_id: Optional[str] = None
+    domain: Optional[str] = None
+    ref: Optional[str] = None
+    language: Optional[str] = None
+
+
+def get_webpage_search_index_name() -> str:
+    return getattr(settings, "SEARCH_INDEX_NAME_WEBPAGE", "webpage")
+
+
+def _plain_text(value: str) -> str:
+    value = bleach.clean(value or "", tags=(), strip=True)
+    value = re.sub(r"\s+", " ", value)
+    return value.strip()
+
+
+def chunk_text(
+    text: str,
+    chunk_words: int = DEFAULT_CHUNK_WORDS,
+    overlap_words: int = DEFAULT_CHUNK_OVERLAP_WORDS,
+) -> list[str]:
+    """Split cleaned page text into deterministic, overlapping word windows."""
+    if chunk_words <= 0:
+        raise ValueError("chunk_words must be positive")
+    if overlap_words < 0 or overlap_words >= chunk_words:
+        raise ValueError("overlap_words must be non-negative and smaller than chunk_words")
+
+    words = _plain_text(text).split()
+    if not words:
+        return []
+    step = chunk_words - overlap_words
+    return [" ".join(words[start:start + chunk_words]) for start in range(0, len(words), step)]
+
+
+def _website_metadata(url: str) -> tuple[str, Optional[str]]:
+    domain = domain_for_url(url)
+    website = WebSite().load({"domains": domain})
+    website_id = str(website._id) if website and getattr(website, "_id", None) else None
+    return domain, website_id
+
+
+def _chunk_id(url: str, chunk_number: int) -> str:
+    url_hash = hashlib.sha256(url.encode("utf-8")).hexdigest()
+    return f"{url_hash}:{chunk_number}"
+
+
+def make_webpage_search_documents(
+    webpage_text: WebPageText,
+    webpage: Optional[WebPage] = None,
+    embeddings: Optional[list[list[float]]] = None,
+    chunk_words: int = DEFAULT_CHUNK_WORDS,
+    overlap_words: int = DEFAULT_CHUNK_OVERLAP_WORDS,
+) -> list[dict]:
+    """Create one denormalized Elasticsearch document per page chunk."""
+    webpage = webpage or WebPage().load(webpage_text.url)
+    chunks = chunk_text(webpage_text.body, chunk_words, overlap_words)
+    if embeddings is not None and len(embeddings) != len(chunks):
+        raise ValueError("embeddings must contain one vector per chunk")
+
+    domain, website_id = _website_metadata(webpage_text.url)
+    refs = list(getattr(webpage, "refs", [])) if webpage else []
+    expanded_refs = list(getattr(webpage, "expandedRefs", [])) if webpage else []
+    page_id = str(webpage._id) if webpage and getattr(webpage, "_id", None) else None
+    last_updated = getattr(webpage, "lastUpdated", None) if webpage else None
+
+    documents = []
+    for chunk_number, content in enumerate(chunks):
+        document = {
+            "page_id": page_id,
+            "chunk_id": _chunk_id(webpage_text.url, chunk_number),
+            "chunk_number": chunk_number,
+            "url": webpage_text.url,
+            "domain": domain,
+            "website_id": website_id,
+            "title": _plain_text(webpage_text.title),
+            "content": content,
+            "refs": refs,
+            "expanded_refs": expanded_refs,
+            "language": "he" if is_mostly_hebrew(content) else "en",
+            "last_updated": last_updated,
+        }
+        if embeddings is not None:
+            document["embedding"] = embeddings[chunk_number]
+        documents.append(document)
+    return documents
+
+
+def create_webpage_search_index(index_name: Optional[str] = None, force: bool = False) -> str:
+    """Create the dedicated webpage index with lexical and vector mappings."""
+    index_name = index_name or get_webpage_search_index_name()
+    client = get_elasticsearch_client_for_indexer()
+    if client.indices.exists(index=index_name):
+        if not force:
+            raise ValueError(f"Index {index_name} already exists; pass force=True to recreate it")
+        client.indices.delete(index=index_name)
+
+    client.indices.create(index=index_name, mappings={
+        "properties": {
+            "page_id": {"type": "keyword"},
+            "chunk_id": {"type": "keyword"},
+            "chunk_number": {"type": "integer"},
+            "url": {"type": "keyword"},
+            "domain": {"type": "keyword"},
+            "website_id": {"type": "keyword"},
+            "title": {"type": "text", "fields": {"keyword": {"type": "keyword"}}},
+            "content": {"type": "text"},
+            "refs": {"type": "keyword"},
+            "expanded_refs": {"type": "keyword"},
+            "language": {"type": "keyword"},
+            "last_updated": {"type": "date"},
+            "embedding": {
+                "type": "dense_vector",
+                "dims": getattr(settings, "WEBPAGE_SEARCH_VECTOR_DIMS", DEFAULT_VECTOR_DIMS),
+                "index": True,
+                "similarity": "cosine",
+            },
+        }
+    })
+    return index_name
+
+
+def _delete_page_chunks(client, index_name: str, url: str) -> None:
+    client.delete_by_query(
+        index=index_name,
+        query={"term": {"url": url}},
+        conflicts="proceed",
+        refresh=True,
+    )
+
+
+def index_webpage_text(
+    url: str,
+    index_name: Optional[str] = None,
+    embed_documents: Optional[Callable[[list[str]], list[list[float]]]] = None,
+) -> int:
+    """Replace all indexed chunks for a URL and return the new chunk count."""
+    webpage_text = WebPageText().load(url)
+    if not webpage_text:
+        return 0
+    webpage = WebPage().load(webpage_text.url)
+    chunks = chunk_text(webpage_text.body)
+    embeddings = embed_documents(chunks) if embed_documents and chunks else None
+    documents = make_webpage_search_documents(webpage_text, webpage, embeddings)
+    index_name = index_name or get_webpage_search_index_name()
+    client = get_elasticsearch_client_for_indexer()
+    _delete_page_chunks(client, index_name, webpage_text.url)
+    if documents:
+        bulk(client, ({"_op_type": "index", "_index": index_name, "_id": d["chunk_id"], "_source": d} for d in documents), refresh=True)
+    return len(documents)
+
+
+def index_all_webpage_texts(
+    index_name: Optional[str] = None,
+    embed_documents: Optional[Callable[[list[str]], list[list[float]]]] = None,
+) -> int:
+    total = 0
+    for webpage_text in WebPageTextSet():
+        total += index_webpage_text(webpage_text.url, index_name, embed_documents)
+    return total
+
+
+def _expanded_ref_filter(tref: str) -> dict:
+    try:
+        refs = [oref.normal() for oref in Ref(tref).all_segment_refs()]
+    except InputError as exc:
+        raise ValueError(f"Invalid ref: {tref}") from exc
+    return {"terms": {"expanded_refs": refs}}
+
+
+def build_webpage_search_request(
+    query: str,
+    filters: Optional[WebPageSearchFilters] = None,
+    limit: int = 10,
+    query_vector: Optional[list[float]] = None,
+    mode: str = "hybrid",
+) -> dict:
+    """Build a filtered lexical request, optionally blended with vector retrieval."""
+    if not query or not query.strip():
+        raise ValueError("query is required")
+    if limit < 1 or limit > 100:
+        raise ValueError("limit must be between 1 and 100")
+    if mode not in {"lexical", "hybrid", "semantic"}:
+        raise ValueError("mode must be lexical, hybrid, or semantic")
+    if mode in {"hybrid", "semantic"} and query_vector is None:
+        raise ValueError(f"query_vector is required for {mode} search")
+    filters = filters or WebPageSearchFilters()
+    clauses = []
+    for field, value in (("website_id", filters.website_id), ("domain", filters.domain), ("language", filters.language)):
+        if value:
+            clauses.append({"term": {field: value}})
+    if filters.ref:
+        clauses.append(_expanded_ref_filter(filters.ref))
+
+    lexical_query = {
+        "bool": {
+            "must": [{"multi_match": {"query": query, "fields": ["title^3", "content"]}}],
+            "filter": clauses,
+        }
+    }
+    request = {
+        "size": limit,
+        "collapse": {"field": "url"},
+        "highlight": {"fields": {"content": {"fragment_size": 300, "number_of_fragments": 1}}},
+    }
+    if mode in {"lexical", "hybrid"}:
+        request["query"] = lexical_query
+    if mode in {"hybrid", "semantic"}:
+        request["knn"] = {
+            "field": "embedding",
+            "query_vector": query_vector,
+            "k": limit,
+            "num_candidates": max(100, limit * 10),
+        }
+        if clauses:
+            request["knn"]["filter"] = clauses
+    return request
+
+
+def search_webpages(
+    query: str,
+    filters: Optional[WebPageSearchFilters] = None,
+    limit: int = 10,
+    query_vector: Optional[list[float]] = None,
+    index_name: Optional[str] = None,
+    mode: str = "hybrid",
+) -> list[dict]:
+    client = get_elasticsearch_client()
+    response = client.search(
+        index=index_name or get_webpage_search_index_name(),
+        **build_webpage_search_request(query, filters, limit, query_vector, mode),
+    )
+    results = []
+    for hit in response["hits"]["hits"]:
+        source = hit["_source"]
+        source["score"] = hit.get("_score")
+        highlights = hit.get("highlight", {}).get("content")
+        source["passage"] = highlights[0] if highlights else source.get("content")
+        results.append(source)
+    return results

--- a/sefaria/local_settings_ci.py
+++ b/sefaria/local_settings_ci.py
@@ -82,6 +82,9 @@ SEARCH_URL = "http://localhost:9200"
 SEARCH_INDEX_ON_SAVE = False  # Whether to send texts and source sheet to Search Host for indexing after save
 SEARCH_INDEX_NAME_TEXT = 'text'  # name of the ElasticSearch index to use
 SEARCH_INDEX_NAME_SHEET = 'sheet'
+SEARCH_INDEX_NAME_WEBPAGE = 'webpage'
+WEBPAGE_SEARCH_INDEX_ON_SAVE = False
+WEBPAGE_SEARCH_VECTOR_DIMS = 1536
 
 # Node Server
 USE_NODE = False

--- a/sefaria/local_settings_example.py
+++ b/sefaria/local_settings_example.py
@@ -179,6 +179,9 @@ SEARCH_URL = "http://localhost:9200"
 SEARCH_INDEX_ON_SAVE = False  # Whether to send texts and source sheet to Search Host for indexing after save
 SEARCH_INDEX_NAME_TEXT = 'text'  # name of the ElasticSearch index to use
 SEARCH_INDEX_NAME_SHEET = 'sheet'
+SEARCH_INDEX_NAME_WEBPAGE = 'webpage'
+WEBPAGE_SEARCH_INDEX_ON_SAVE = False  # Queue webpage indexing after Linker content updates
+WEBPAGE_SEARCH_VECTOR_DIMS = 1536
 
 # Node Server
 USE_NODE = False

--- a/sefaria/urls_shared.py
+++ b/sefaria/urls_shared.py
@@ -237,6 +237,7 @@ shared_patterns = [
     path('linker.v3.js.map', sefaria_views.linker_js_map),
     re_path(r'^api/find-refs/report/?$', sefaria_views.find_refs_report_api),
     re_path(r'^api/find-refs/?$', sefaria_views.find_refs_api),
+    re_path(r'^api/search-webpages/?$', sefaria_views.webpage_search_api),
     re_path(r'^api/regexs/(?P<titles>.+)$', sefaria_views.title_regex_api),
     re_path(r'^api/websites/(?P<domain>.+)$', sefaria_views.websites_api),
     re_path(r'^api/linker-data/(?P<titles>.+)$', sefaria_views.linker_data_api),

--- a/sefaria/views.py
+++ b/sefaria/views.py
@@ -442,6 +442,48 @@ def find_refs_report_api(request):
     return jsonResponse({'ok': True})
 
 
+@api_view(["POST"])
+def webpage_search_api(request):
+    """Search indexed Linker webpage passages with optional website/ref filters."""
+    from django.conf import settings
+    from semantic_search.embedder import EmbeddingError
+    from semantic_search.search import get_query_embedding
+    from sefaria.helper.webpage_search import WebPageSearchFilters, search_webpages
+
+    auth = request.headers.get("Authorization", "")
+    expected_token = getattr(settings, "SEMANTIC_SEARCH_API_TOKEN", "")
+    if not auth.startswith("Bearer ") or not expected_token or auth[len("Bearer "):] != expected_token:
+        return jsonResponse({"error": "Unauthorized"}, status=401)
+
+    post = request.data
+    query = post.get("query", "")
+    mode = post.get("mode", "hybrid")
+    if mode not in {"lexical", "hybrid", "semantic"}:
+        return jsonResponse({"error": "mode must be lexical, hybrid, or semantic"}, status=400)
+    if mode == "semantic" and not query:
+        return jsonResponse({"error": "query is required"}, status=400)
+
+    try:
+        query_vector = get_query_embedding(query) if mode in {"hybrid", "semantic"} else None
+        results = search_webpages(
+            query=query,
+            filters=WebPageSearchFilters(
+                website_id=post.get("website_id"),
+                domain=post.get("domain"),
+                ref=post.get("ref"),
+                language=post.get("language"),
+            ),
+            limit=int(post.get("limit", 10)),
+            query_vector=query_vector,
+            mode=mode,
+        )
+    except ValueError as exc:
+        return jsonResponse({"error": str(exc)}, status=400)
+    except EmbeddingError as exc:
+        return jsonResponse({"error": str(exc)}, status=502)
+    return jsonResponse({"results": results})
+
+
 @cors_allow_all
 @api_view(["POST", "OPTIONS"])
 def find_refs_api(request):


### PR DESCRIPTION
## Summary

```mermaid
flowchart LR
    A["Sefaria Linker"] --> B["MongoDB"]
    B --> C["Celery indexing task"]
    C --> D["Clean and chunk content"]
    D --> E["Generate embeddings"]
    E --> F["Elasticsearch webpage index"]
    G["AI agent search tool"] --> H["Search API"]
    H --> F
```

This PR adds an agent-facing search service for webpage content collected by the Sefaria Linker. It supports:

- Corpus-wide and website-scoped searches
- Filtering by Sefaria ref, domain, website, and language
- Lexical, semantic, and hybrid retrieval
- Passage-level results suitable for AI agent consumption

## Architecture

MongoDB remains the source of truth:

- `webpages` stores page metadata and detected refs.
- `webpages_text` stores the extracted title and full page content.

When `WebPageText` changes, a Celery task cleans and chunks the page content, generates embeddings, and indexes each passage in a dedicated Elasticsearch index. Existing chunks for the URL are replaced when its content changes.

Each indexed passage includes:

- Page and chunk identifiers
- URL, domain, and website ID
- Title and passage content
- Original and expanded Sefaria refs
- Detected language
- Last-updated timestamp
- Vector embedding

Website IDs, domains, refs, expanded refs, and languages are indexed as exact-match fields. Titles and content are indexed for full-text retrieval.

## Search behavior

The search service supports:

- BM25 lexical search for quotations, names, and precise terminology
- Vector search for conceptual matching
- Hybrid lexical and semantic retrieval
- Exact filters for website, domain, language, and Sefaria ref
- URL-level result grouping to prevent a single page from dominating results

Ref filters are normalized through `Ref`. Sections and ranges are expanded to segment refs and matched against `expanded_refs`.

Page-level refs are initially copied to every passage from that page. A future improvement could associate refs only with the passages where they occur.

## Agent API

The bounded search interface accepts:

```python
search_webpages(
    query: str,
    website_id: str | None = None,
    domain: str | None = None,
    ref: str | None = None,
    language: str | None = None,
    mode: Literal["hybrid", "lexical", "semantic"] = "hybrid",
    limit: int = 10,
)
```

Results include the page title, URL, matching passage, relevance score, website metadata, and associated refs. Domain and ref normalization are handled by the API rather than the calling agent.

## Operations

The implementation uses Sefaria’s existing Elasticsearch, MongoDB, Celery, and embedding infrastructure. It includes:

- A separate webpage search index
- Bulk and incremental indexing
- Configurable indexing on linker updates
- A full reindex command
- MongoDB-backed index reconstruction
- Tests for chunking, filtering, ref expansion, hybrid retrieval, and result formatting

Hybrid retrieval is the default, `website_id` is the canonical website filter, `domain` provides hostname-level filtering, and `expanded_refs` supports segment-level ref filtering.