### PR TITLE
fix(helm): validate postgres dump before dropping the staging database

### DIFF
--- a/helm-chart/sefaria/templates/cronjob/sync-postgres-production-data.yaml
+++ b/helm-chart/sefaria/templates/cronjob/sync-postgres-production-data.yaml
@@ -96,6 +96,27 @@ spec:
                     exit 1
                   fi
 
+                  # Inspect the archive BEFORE dropping anything. Both faults below are
+                  # visible in the file while the old database is still intact, so a bad
+                  # dump costs a failed job rather than the environment.
+                  echo "Inspecting dump archive..."
+                  pg_restore --list /storage/pg.dump > /storage/full.toc
+
+                  # A dump lacking --section=post-data restores cleanly but carries no
+                  # indexes or constraints. Refuse it rather than sit silently unindexed.
+                  if ! grep -qE ' (INDEX|CONSTRAINT|FK CONSTRAINT) ' /storage/full.toc; then
+                    echo "ERROR: dump has no post-data section (no indexes or constraints)."
+                    echo "Refusing to drop $PGDATABASE for a dump that cannot restore them."
+                    exit 1
+                  fi
+
+                  # Dumps taken from a server where 'public' is a user-owned schema carry an
+                  # explicit "CREATE SCHEMA public", which collides with the one template0
+                  # already provides -- and --exit-on-error turns that into a full rollback.
+                  # Drop the entry instead of pre-dropping the schema, so dumps that omit it
+                  # (the PG15+ default) still restore.
+                  grep -v ' SCHEMA - public ' /storage/full.toc > /storage/restore.toc
+
                   # An array, not a string: word-splitting a string would let a stray space
                   # in a value silently become an extra argument.
                   PSQL=(psql -v ON_ERROR_STOP=1 -h "$PGHOST" -U "$PGUSER" -d postgres)
@@ -111,10 +132,11 @@ spec:
                   # leaving a half-populated database.
                   echo "Restoring PostgreSQL data..."
                   pg_restore --no-owner --no-privileges --exit-on-error --single-transaction \
+                    --use-list=/storage/restore.toc \
                     --dbname="$PGDATABASE" --host="$PGHOST" --username="$PGUSER" /storage/pg.dump
 
-                  # A dump lacking --section=post-data restores cleanly but carries no
-                  # indexes or constraints. Fail rather than sit silently unindexed.
+                  # The pre-flight check above proves the dump *contains* post-data; this
+                  # proves it landed.
                   echo "Verifying indexes and constraints were restored..."
                   IDX_COUNT=$(psql -v ON_ERROR_STOP=1 -h "$PGHOST" -U "$PGUSER" -d "$PGDATABASE" -tAc \
                     "SELECT count(*) FROM pg_index i JOIN pg_class c ON c.oid = i.indrelid

--- a/helm-chart/sefaria/templates/cronjob/sync-postgres-production-data.yaml
+++ b/helm-chart/sefaria/templates/cronjob/sync-postgres-production-data.yaml
@@ -110,12 +110,20 @@ spec:
                     exit 1
                   fi
 
-                  # Dumps taken from a server where 'public' is a user-owned schema carry an
-                  # explicit "CREATE SCHEMA public", which collides with the one template0
-                  # already provides -- and --exit-on-error turns that into a full rollback.
-                  # Drop the entry instead of pre-dropping the schema, so dumps that omit it
-                  # (the PG15+ default) still restore.
-                  grep -v ' SCHEMA - public ' /storage/full.toc > /storage/restore.toc
+                  # Dumps whose source server owns 'public' as a user schema carry both a
+                  # "CREATE SCHEMA public" entry and its COMMENT. Either collides with the
+                  # schema template0 already provides, and --exit-on-error turns one
+                  # collision into a full rollback. Filter the entries rather than
+                  # pre-dropping the schema, so dumps that omit them (the PG15+ default)
+                  # still restore.
+                  PUBLIC_SCHEMA_TOC='[[:space:]](SCHEMA[[:space:]]+-|COMMENT[[:space:]]+-[[:space:]]+SCHEMA)[[:space:]]+public([[:space:]]|$)'
+                  grep -vE "$PUBLIC_SCHEMA_TOC" /storage/full.toc > /storage/restore.toc
+
+                  # Log the counts: a filter that silently matches nothing is precisely the
+                  # failure this guards against, so make it visible rather than implicit.
+                  TOC_TOTAL=$(grep -cv '^;' /storage/full.toc || true)
+                  TOC_KEPT=$(grep -cv '^;' /storage/restore.toc || true)
+                  echo "TOC: $TOC_TOTAL entries, $TOC_KEPT to restore, $((TOC_TOTAL - TOC_KEPT)) public-schema entries filtered."
 
                   # An array, not a string: word-splitting a string would let a stray space
                   # in a value silently become an extra argument.


### PR DESCRIPTION
Follow-up to #3594, which is merged and running. The new drop-and-recreate sync failed four times today and **emptied staging's Postgres** in the process.

## What happened

```
Dropping and recreating database sefariastaging...
DROP DATABASE
CREATE DATABASE
Restoring PostgreSQL data...
pg_restore: error: could not execute query: ERROR:  schema "public" already exists
Command was: CREATE SCHEMA public;
```

The dump carries an explicit `CREATE SCHEMA public` — visible in the pre-#3594 logs as `TOC entry 3; 2615 2200 SCHEMA public postgres` — because its source server owns `public` as a user schema. A database created `TEMPLATE template0` already has that schema, so the entry collides on entry 3, and `--exit-on-error --single-transaction` rolls the whole restore back.

#3594 read those two `--clean` errors as artifacts of `--clean`. Only the `DROP SCHEMA` half was; the `CREATE SCHEMA public` half lives in the archive unconditionally and survived the switch to drop-and-recreate. `--clean` had tolerated it (`errors ignored on restore: 2`) and the table data landed anyway — which is exactly why this read as "the job fails but data is fine".

## Impact

Staging is empty. Verified on `postgres-18`:

| Check | Value |
|---|---|
| `auth_user` rows | **0** (was 265,345) |
| `sefariastaging` size | **9126 kB** (production `sefaria_auth`: 547 MB) |
| indexes | 70 |
| `django_migrations` applied | all 38, at `2026-08-11 12:08:44` |

Every migration bears one timestamp three minutes *after* the 12:05:39 failure, and the only populated tables are Django's own bookkeeping (`auth_permission`, `django_content_type`, `django_site`). The app reconnected to the empty database and rebuilt the schema — the indexes are migration output, not restored data.

## The fix

Inspect the archive with `pg_restore --list` *before* dropping anything:

- **Refuse a dump with no post-data section.** Production's dumps are still frozen at 40003385 bytes (identical 07-19 → 08-09), predating the `--section=post-data` fix, so a restore that *did* succeed would produce an unindexed database. This moves #3594's post-restore index assertion to where it can still prevent harm; the post-restore check stays, now confirming post-data landed rather than discovering it was absent.
- **Filter the schema entry via `--use-list`** rather than pre-dropping `public`, so dumps that omit the entry (the PG15+ default) keep working.

Ordering matters beyond this one bug: `backoffLimit: 1` gives two pods per job, and both ran the drop today. A retry re-dropped rather than retrying against surviving data. With the drop gated behind a validated dump, the retry is harmless.

## Verification

- `helm template` renders; `bash -n` on the extracted container script passes.
- TOC greps exercised against three shapes: today's dump (**refused**, no drop), a post-data dump (**passes**, 1 schema entry filtered), and a PG15+ dump lacking the entry (**passes**, filter is a no-op).

## Note for reviewers

This job authenticates to `postgres-18` — the instance that also holds production's 547 MB `sefaria_auth` — as `sefaria`, which is a **superuser**. The exact-string guard on `postgres.db != sefaria_auth` is the only barrier, and it covers one name; `pre-mdl` (203 MB) and `sefaria_audit` (134 MB) sit on the same instance unguarded. Out of scope here, worth a follow-up.

The job will stay red until production ships #3594's backup fix and produces a dump with post-data — correctly so, and now without cost. Repopulating staging is a separate decision: the 08-09 dump would restore ~12-week-old unindexed data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VaP5RZqJXTxVrhzfnToAdZ
