### PR TITLE
feat: use and not or

### DIFF
--- a/sefaria/helper/search.py
+++ b/sefaria/helper/search.py
@@ -8,9 +8,9 @@ from remote_config.keys import (
     SEARCH_ENTITY_FIELD_BOOSTS_AUTHOR,
     SEARCH_ENTITY_FIELD_BOOSTS_BOOK,
 )
-import string
 import structlog
 import re
+import unicodedata
 
 # This module must not import sefaria.model at module level: it is imported by
 # sefaria/model/dependencies.py while sefaria.model's own __init__ is still running
@@ -348,6 +348,35 @@ _ENTITY_SECONDARY_KEYWORD_FIELDS = {
     "book": ["titleVariants.keyword"],
 }
 
+# The all-prefixes tier (see get_entity_query_obj) builds `prefix` queries, which are NOT run
+# through an analyzer — each term is compared raw against the tokens already stored in the
+# index. So the query has to be split the same way the `exact_english` analyzer splits the
+# titles it indexed, or the terms silently match nothing. The three steps below mirror that
+# analyzer's own pipeline (icu_normalizer char_filter -> standard tokenizer -> icu_folding);
+# every example cited was confirmed against a live index via the _analyze API.
+#
+# Step 1: fold the typographic quotes the way icu_folding does, so "Me’am" and "רמב״ם" carry
+# the ASCII forms actually stored ("me'am", 'רמב"ם').
+_ENTITY_QUOTE_FOLDING = str.maketrans({"’": "'", "׳": "'", "״": '"'})
+# Step 3: approximate the `standard` tokenizer's word boundaries (Unicode UAX #29). Break on
+# whitespace and punctuation, but keep a quote sitting *between* two letters — that tokenizer
+# does not split there, so "Ba'al ha-Turim" is [ba'al, ha, turim] and "רמב״ם" is one token.
+# (Splitting on all punctuation, as a naive reading suggests, would wreck far more of these
+# than the hyphens it fixes.) A *trailing* quote survives only after a Hebrew letter — the
+# "ר׳" = Rabbi abbreviation — and is dropped after a Latin one ("Yosi'" -> yosi).
+_ENTITY_TOKEN_RE = re.compile(r"\w+(?:['\"]\w+)*(?:(?<=[֐-׿])')?", re.UNICODE)
+
+
+def _entity_query_tokens(query):
+    """Split `query` into terms comparable to the tokens `exact_english` actually stores."""
+    query = query.translate(_ENTITY_QUOTE_FOLDING)
+    # Step 2: strip combining marks (icu_folding). This has to happen *before* tokenizing,
+    # as the analyzer's char_filter does: Hebrew niqqud are combining marks that `\w` will
+    # not match, so leaving them in place would split "בְּרֵאשִׁית" into four tokens.
+    query = "".join(c for c in unicodedata.normalize("NFKD", query) if not unicodedata.combining(c))
+    return _ENTITY_TOKEN_RE.findall(query)
+
+
 # Exact-match boosts are applied via constant_score (below), so they are IDF-independent:
 # an exact primary-title hit contributes a fixed, dominant amount that a longer title merely
 # *containing* the query words — or an exact hit on a variant — can never sum past. This is
@@ -466,7 +495,7 @@ def get_entity_query_obj(query, type="topic", search_obj=None, start=0, size=20,
     # the analyzed (lowercased) tokens and each prefix hit scores a constant 1, so a field's
     # bool-must totals the token count; dis_max keeps the best field instead of summing fields.
     # Only built for multi-word queries — for one word this duplicates tier 5.
-    tokens = [t for t in (tok.strip(string.punctuation) for tok in query.split()) if t]
+    tokens = _entity_query_tokens(query)
     tier4_all_prefix = None
     if len(tokens) > 1:
         per_field = [Q("bool", must=[Q("prefix", **{f: {"value": t, "case_insensitive": True}})

--- a/sefaria/helper/search.py
+++ b/sefaria/helper/search.py
@@ -8,6 +8,7 @@ from remote_config.keys import (
     SEARCH_ENTITY_FIELD_BOOSTS_AUTHOR,
     SEARCH_ENTITY_FIELD_BOOSTS_BOOK,
 )
+import string
 import structlog
 import re
 
@@ -262,10 +263,10 @@ _ENTITY_ALPHA_SORT_FIELD = "title_en.sort"  # lowercased keyword sub-field (see 
 # the year their result card displays. Changing either derivation needs a reindex.
 _ENTITY_YEAR_SORT_FIELDS = {"author": "sortYear", "book": "compDate"}
 
-# Default per-field match boosts for the tier-3 best_fields multi_match, in priority
-# order: title -> title variants -> the name/works fields (author names on books,
-# authored titles on authors). Descriptions are deliberately excluded from search
-# entirely — a description mention is not a meaningful entity match.
+# Default per-field match boosts for the all-words (tier 3) and any-word (tier 6)
+# multi_match clauses, in priority order: title -> title variants -> the name/works fields
+# (author names on books, authored titles on authors). Descriptions are deliberately
+# excluded from search entirely — a description mention is not a meaningful entity match.
 #
 # These defaults double as the *allow-list* of valid field names. A RemoteConfig
 # override (see _ENTITY_FIELD_BOOSTS_RC_KEYS / _resolve_entity_field_boosts) may change
@@ -289,9 +290,9 @@ _ENTITY_FIELD_BOOSTS_RC_KEYS = {
 
 def _resolve_entity_field_boosts(type):
     """
-    Return the tier-3 multi_match field list (["title_en^3", "titleVariants^2", ...]) for
-    `type`, applying any RemoteConfig per-field boost overrides on top of the hardcoded
-    defaults in _DEFAULT_ENTITY_FIELD_BOOSTS.
+    Return the multi_match field list (["title_en^3", "titleVariants^2", ...]) used by the
+    all-words and any-word tiers for `type`, applying any RemoteConfig per-field boost
+    overrides on top of the hardcoded defaults in _DEFAULT_ENTITY_FIELD_BOOSTS.
 
     The defaults are the source of truth for *which* fields are searchable; the RemoteConfig
     JSON only tunes their boosts. So an override is honored only when:
@@ -395,11 +396,19 @@ def get_entity_query_obj(query, type="topic", search_obj=None, start=0, size=20,
                          partial tiers below on a longer title, and no exact *variant* hit, can
                          sum past it.
       2. Exact phrase  — `match_phrase` on title fields.
-      3. All words     — `multi_match best_fields` over the per-type field list (with
-                         per-field ^N boosts: title > variants > name/works; descriptions
-                         are not searched).
-      4. Begins with   — `match_phrase_prefix` on title fields ("Mos" -> "Moses").
-      5. Contains      — provided implicitly by the `stemmed_english` analyzer on tier 3.
+      3. All words     — `multi_match cross_fields` with `operator: and` over the per-type
+                         field list (with per-field ^N boosts: title > variants > name/works;
+                         descriptions are not searched). Every query word must match, but the
+                         words may split across fields — "Rambam Torah" finds Mishneh Torah
+                         via author_names + title_en.
+      4. All prefixes  — every query word matches the *start* of a word in one title field
+                         ("Or Chaim" -> "Orach Chaim", "Orchot Chaim"). This is what keeps
+                         near-misses ranked above single-word matches: "Chafetz Chaim" fails
+                         it because nothing there starts with "Or". Multi-word queries only.
+      5. Begins with   — `match_phrase_prefix` on title fields ("Mos" -> "Moses").
+      6. Any word      — the old OR match at a deliberately tiny boost, so results matching
+                         only part of the query stay findable but sink below everything that
+                         matched all of it.
 
     Relevance is *purely textual* — the match tiers above are the whole score. Topic/author
     results were briefly multiplied by a log-scaled `numSources` popularity factor; that was
@@ -448,12 +457,32 @@ def get_entity_query_obj(query, type="topic", search_obj=None, start=0, size=20,
                      for kf in secondary_kw]
     # Tier 2 — exact phrase over the (analyzed) title fields.
     tier2_phrase = Q("multi_match", query=query, fields=title_fields, type="phrase", boost=4)
-    # Tier 3 — all query words, best matching field wins (per-field ^N boosts inside `fields`).
-    tier3_words = Q("multi_match", query=query, fields=fields, type="best_fields", boost=2)
-    # Tier 4 — prefix / begins-with on titles only.
-    tier4_prefix = Q("multi_match", query=query, fields=title_fields, type="phrase_prefix", boost=1)
-    text_query = Q("bool", should=[*tier1_primary, *tier1_variant, tier2_phrase, tier3_words, tier4_prefix],
-                   minimum_should_match=1)
+    # Tier 3 — ALL query words must match (operator "and"), not any one of them. cross_fields
+    # lets the words land in different fields ("Rambam Torah": author_names + title_en) as
+    # long as every word matches somewhere; per-field ^N boosts still apply inside `fields`.
+    tier3_all_words = Q("multi_match", query=query, fields=fields, type="cross_fields",
+                        operator="and", boost=2)
+    # Tier 4 — every word as a prefix, all within a single title field. `prefix` runs against
+    # the analyzed (lowercased) tokens and each prefix hit scores a constant 1, so a field's
+    # bool-must totals the token count; dis_max keeps the best field instead of summing fields.
+    # Only built for multi-word queries — for one word this duplicates tier 5.
+    tokens = [t for t in (tok.strip(string.punctuation) for tok in query.split()) if t]
+    tier4_all_prefix = None
+    if len(tokens) > 1:
+        per_field = [Q("bool", must=[Q("prefix", **{f: {"value": t, "case_insensitive": True}})
+                                     for t in tokens])
+                     for f in title_fields]
+        tier4_all_prefix = Q("dis_max", queries=per_field, boost=1.5)
+    # Tier 5 — prefix / begins-with on titles only.
+    tier5_prefix = Q("multi_match", query=query, fields=title_fields, type="phrase_prefix", boost=1)
+    # Tier 6 — any word (OR). The tiny boost keeps partial matches present at the bottom of
+    # the results without letting a common word ("Chaim") crowd out all-word matches above.
+    tier6_any_word = Q("multi_match", query=query, fields=fields, type="best_fields", boost=0.1)
+    tiers = [*tier1_primary, *tier1_variant, tier2_phrase, tier3_all_words]
+    if tier4_all_prefix is not None:
+        tiers.append(tier4_all_prefix)
+    tiers += [tier5_prefix, tier6_any_word]
+    text_query = Q("bool", should=tiers, minimum_should_match=1)
 
     # topic and author both live in the topic index; filter by subtype.
     if type in ("topic", "author"):

--- a/sefaria/helper/tests/search_test.py
+++ b/sefaria/helper/tests/search_test.py
@@ -271,6 +271,68 @@ def test_entity_query_obj_exact_tier_is_case_insensitive():
         assert spec["case_insensitive"] is True, f"{field} exact-match tier must be case-insensitive"
 
 
+def _entity_should_clauses(query, entity_type):
+    s = get_entity_query_obj(query, entity_type).to_dict()
+    q = s["query"]
+    # topic/author (and filtered book) queries wrap the text query in a bool must
+    if "must" in q.get("bool", {}):
+        q = q["bool"]["must"][0]
+    return q["bool"]["should"]
+
+
+def test_entity_query_obj_all_words_is_and():
+    # A multi-word query must not degrade to OR: the all-words tier requires every word
+    # (operator "and"), and cross_fields lets the words split across fields ("Rambam
+    # Torah" -> author_names + title_en) as long as all of them match somewhere.
+    for entity_type in ("topic", "author", "book"):
+        shoulds = _entity_should_clauses("Or Chaim", entity_type)
+        all_words = [c["multi_match"] for c in shoulds
+                     if "multi_match" in c and c["multi_match"].get("operator") == "and"]
+        assert len(all_words) == 1, "expected exactly one AND multi_match tier"
+        assert all_words[0]["type"] == "cross_fields"
+        # the AND tier must outweigh the any-word tier by a wide margin
+        any_word = [c["multi_match"] for c in shoulds
+                    if "multi_match" in c and c["multi_match"].get("type") == "best_fields"]
+        assert len(any_word) == 1, "expected exactly one any-word (OR) multi_match tier"
+        assert all_words[0]["boost"] > any_word[0]["boost"] * 10
+
+
+def test_entity_query_obj_all_prefix_tier_multi_word_only():
+    # "Or Chaim" should rank "Orach Chaim"/"Orchot Chaim" (every word matches a word-start
+    # in one title field) above one-word matches like "Chafetz Chaim". The tier is a
+    # dis_max of per-title-field bools, each requiring a case-insensitive prefix per word.
+    shoulds = _entity_should_clauses("Or Chaim", "book")
+    dis_max = [c["dis_max"] for c in shoulds if "dis_max" in c]
+    assert len(dis_max) == 1, "expected the all-prefixes dis_max tier for a multi-word query"
+    per_field = dis_max[0]["queries"]
+    assert len(per_field) == len(["title_en", "title_he", "titleVariants"])
+    for field_bool in per_field:
+        musts = field_bool["bool"]["must"]
+        values = [list(m["prefix"].values())[0]["value"] for m in musts]
+        assert values == ["Or", "Chaim"]
+        assert all(list(m["prefix"].values())[0]["case_insensitive"] is True for m in musts)
+
+    # single-word query: the tier would just duplicate the phrase_prefix tier, so it's absent
+    shoulds = _entity_should_clauses("Chaim", "book")
+    assert not any("dis_max" in c for c in shoulds)
+
+
+def test_entity_query_obj_partial_matches_kept_at_bottom():
+    # Product decision (2026-08-11): one-word matches stay findable, but only via the
+    # tiny-boost any-word tier — so the match set still includes them while every tier
+    # above (exact / phrase / all-words / all-prefixes / begins-with) outscores them.
+    shoulds = _entity_should_clauses("Or Chaim", "book")
+    boosts = []
+    for c in shoulds:
+        if "multi_match" in c:
+            boosts.append(c["multi_match"]["boost"])
+        elif "dis_max" in c:
+            boosts.append(c["dis_max"]["boost"])
+    any_word_boost = min(boosts)
+    assert any_word_boost <= 0.1
+    assert all(b >= 1 for b in boosts if b != any_word_boost)
+
+
 def test_author_works_response_eponymous_beats_matching_category():
     # Regression: when a category row's title happens to equal the query, it must not sort
     # ahead of the actual eponymous (non-category) work. The eponymous tier explicitly


### PR DESCRIPTION
## Description
The calculation of relevance is re-factored here to handle queries like "Or Chaim" differently so that the results will be "Or HaChaim" first, then "Orach Chayim", then "Chafetz Chaim".

## Code Changes
This comment helps explain the change:
```
      1. Exact match   — `constant_score` on the `.keyword` title sub-fields, split into a
                         dominant *primary-title* boost and a lower *variant / authored-work*
                         boost. constant_score makes these contributions fixed (IDF-independent),
                         so an exact primary-title hit always wins outright: no pile-up of the
                         partial tiers below on a longer title, and no exact *variant* hit, can
                         sum past it.
      2. Exact phrase  — `match_phrase` on title fields.
      3. All words     — `multi_match cross_fields` with `operator: and` over the per-type
                         field list (with per-field ^N boosts: title > variants > name/works;
                         descriptions are not searched). Every query word must match, but the
                         words may split across fields — "Rambam Torah" finds Mishneh Torah
                         via author_names + title_en.
      4. All prefixes  — every query word matches the *start* of a word in one title field
                         ("Or Chaim" -> "Orach Chaim", "Orchot Chaim"). This is what keeps
                         near-misses ranked above single-word matches: "Chafetz Chaim" fails
                         it because nothing there starts with "Or". Multi-word queries only.
      5. Begins with   — `match_phrase_prefix` on title fields ("Mos" -> "Moses").
      6. Any word      — the old OR match at a deliberately tiny boost, so results matching
                         only part of the query stay findable but sink below everything that
                         matched all of it.
```