### PR TITLE
fix(helm): nginx structured log emits invalid JSON (escape=json)

### DIFF
--- a/helm-chart/sefaria/conf/nginx.template.conf.tpl
+++ b/helm-chart/sefaria/conf/nginx.template.conf.tpl
@@ -21,7 +21,7 @@ http {
   {{- end }}
 
   # https://nginx.org/en/docs/varindex.html
-  log_format structured '{ "requestDuration": $request_time, "envName": "${ENV_NAME}", "stackComponent": "nginx", "host": "$hostname", "severity": "info", "httpRequest": { "requestMethod": "$request_method", "requestUrl": "$request_uri", "requestSize": $request_length, "status":  $status, "responseSize": $body_bytes_sent, "userAgent":  "$http_user_agent", "remoteIp": "$http_x_original_forwarded_for", "referer": "$http_referer", "latency": ${request_time}, "protocol": "$server_protocol", "forwardedHTTP": "$http_x_forwarded_proto" }, "remoteUser": "$remote_user", "timeLocal": "$time_local" }';
+  log_format structured escape=json '{ "requestDuration": $request_time, "envName": "${ENV_NAME}", "stackComponent": "nginx", "host": "$hostname", "severity": "info", "httpRequest": { "requestMethod": "$request_method", "requestUrl": "$request_uri", "requestSize": $request_length, "status":  $status, "responseSize": $body_bytes_sent, "userAgent":  "$http_user_agent", "remoteIp": "$http_x_original_forwarded_for", "referer": "$http_referer", "latency": ${request_time}, "protocol": "$server_protocol", "forwardedHTTP": "$http_x_forwarded_proto" }, "remoteUser": "$remote_user", "timeLocal": "$time_local" }';
   access_log /dev/stdout structured;
   client_max_body_size 32M;
 


### PR DESCRIPTION
_(Claude writing on Daniel's behalf)_

Shortcut story: [sc-46548](https://app.shortcut.com/sefaria/story/46548)

## The bug

`helm-chart/sefaria/conf/nginx.template.conf.tpl` defines a `log_format` whose body is JSON, but the directive has always run with nginx's **default** escaping. Default escaping encodes a double quote as `\x22` and a backslash as `\x5C`. Neither `\xNN` form is valid JSON.

So any request whose `User-Agent` or `Referer` contains a double quote or a backslash emits a malformed line. Cloud Logging cannot parse it as JSON, so the entry lands in `textPayload` with `jsonPayload` / `httpRequest` NULL — and it silently disappears from every existing BigQuery query and dashboard over `NginxRequestLogs`.

The affected population is disproportionately *weird* traffic: hand-rolled scripts, scrapers, malformed agents. That is exactly the traffic the API-key classification work needs to see, which is how this was found.

## The fix

One token, one file: `log_format structured` → `log_format structured escape=json`. Everything else on the line is byte-identical. `escape=json` requires nginx ≥ 1.11.8; our image is `opentracing/nginx-opentracing:nginx-1.23.3`, so it is supported.

Verified locally by running the same log format through nginx 1.23.3 with a hostile request, before and after:

```
# before (default escaping) — invalid JSON
"userAgent":  "bad\x22quote\x5Cback", "referer": "http://x/?q=\x22z\x22"

# after (escape=json) — valid JSON
"userAgent":  "bad\"quote\\back",     "referer": "http://x/?q=\"z\""
```

## ⚠️ Side effect — please read if you query these logs

With default escaping an **empty** variable is written as `-`. With `escape=json` it is written as the **empty string**. Confirmed in the same local run.

Fields that change from `"-"` to `""` on the day this ships: `referer`, `userAgent`, `remoteIp`, `remoteUser`, `forwardedHTTP`.

Action for downstream consumers:
- **Datadog** (`source:nginx`, enabled on prod and staging) — please confirm no monitor, facet, or log-based metric keys off `referer:-` / `user_agent:-`.
- **BigQuery** — any query comparing these fields against `'-'` needs updating. The robust pattern that works on both sides of the change is `NULLIF(NULLIF(x,'-'),'')`.

Shipping this as its own commit/PR, separate from the field additions that follow it, precisely so it can be reverted independently if a monitor turns out to depend on `-`.

## Blast radius

Helm-chart-only change. `deploy-static.yaml`'s `detect` job sets `chart_changed=true` / `app_changed=false`, so **`release-chart` runs and `release-app` is skipped — no container image is rebuilt**. No Python or JS test surface is touched.

No request-path behaviour change: `log_format` does not affect routing, headers, caching, or upstream selection.

No new `${…}` token is introduced, so the `envsubst` whitelist in `templates/configmap/nginx.yaml` needs no edit, and no new Helm action is introduced.

Commit is typed `fix(helm):` so semantic-release cuts a patch chart version — a type outside the `release-rules.sh` list would merge cleanly and silently ship nothing.

## Validation done locally

- `helm template` over `helm-chart/sefaria` renders clean; the rendered `nginx-conf-*` ConfigMap contains the `escape=json` token.
- Rendered ConfigMap → `envsubst` (with the production whitelist) → `nginx -t -c` inside `opentracing/nginx-opentracing:nginx-1.23.3`: **syntax is ok, test is successful**.
- Before/after log-line comparison in that same image (the snippet above).
- `ct lint` was not run — `ct` is not installed on this machine; CI's `helm.yaml` runs it on any branch touching `helm-chart/**`.

## Verification plan after deploy

1. **Staging** (`sefariastaging.org`, `deployEnv: sefariastaging`): confirm the `HelmRelease` picked up the new chart version, and that the `*-nginx` Argo Rollout completes with pods Ready — a bad `log_format` is a *startup* failure, so a healthy rollout is the real smoke test.
2. `curl -H 'User-Agent: bad"quote\' https://sefariastaging.org/api/...` and read the nginx pod's stdout: the line must be **valid JSON** (parse it, don't eyeball it).
3. **BigQuery**, ~15–30 min later: the count of unparsed rows (`textPayload IS NOT NULL`) in `NginxRequestLogs` should drop to ~0 for `envName = 'sefariastaging'`, and then for `production` after promotion. That drop is itself the measurement of how much data we have been losing.

Promotion to preprod and prod is the usual manual two-step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
