### PR TITLE
feat(sso): surface sso_only_account on the mobile JWT login endpoint

### DIFF
--- a/sefaria/urls_shared.py
+++ b/sefaria/urls_shared.py
@@ -13,7 +13,8 @@ import powered_by.views as powered_by_views
 from sefaria.heapdump import heapdump_view
 from sefaria.site.urls import site_urlpatterns
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
-from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
+from rest_framework_simplejwt.views import TokenRefreshView
+from sso.views import MobileTokenObtainPairView
 
 shared_patterns = [
     path('_allauth/', include('allauth.headless.urls')),
@@ -31,7 +32,7 @@ shared_patterns = [
         name='password_reset_complete'),
     re_path(fr'password/reset/done/$', sefaria_views.CustomPasswordResetDoneView.as_view(), name='password_reset_done'),
 
-    re_path(fr'api/login/$', TokenObtainPairView.as_view(), name='token_obtain_pair'),
+    re_path(fr'api/login/$', MobileTokenObtainPairView.as_view(), name='token_obtain_pair'),
     re_path(fr'api/login/refresh/$', TokenRefreshView.as_view(), name='token_refresh'),
 
     re_path(r'^saved/?$', reader_views.saved_content),

--- a/sso/tests/views_test.py
+++ b/sso/tests/views_test.py
@@ -369,6 +369,61 @@ class AppleMobileTest(TestCase):
         self.assertFalse(User.objects.get(pk=user.pk).has_usable_password())
 
 
+class MobileLoginTest(TestCase):
+    """api/login/ -- the SimpleJWT endpoint the mobile app posts email/password
+    to (see MobileTokenObtainPairView). Mobile sends the email address in the
+    'username' field, matching this project's default-User-model USERNAME_FIELD
+    ('username', populated with the email -- see _sso_only_user above)."""
+
+    def setUp(self):
+        self.client = Client()
+        self.url = '/api/login/'
+
+    def _post(self, body):
+        return self.client.post(
+            self.url,
+            data=json.dumps(body),
+            content_type='application/json',
+        )
+
+    def test_valid_login_returns_tokens_unchanged(self):
+        User.objects.create_user(username='ml-a@test.com', email='ml-a@test.com', password='pass123')
+        res = self._post({'username': 'ml-a@test.com', 'password': 'pass123'})
+        self.assertEqual(res.status_code, 200)
+        data = res.json()
+        self.assertIn('access', data)
+        self.assertIn('refresh', data)
+
+    def test_wrong_password_on_normal_account_returns_stock_401(self):
+        User.objects.create_user(username='ml-b@test.com', email='ml-b@test.com', password='correct')
+        res = self._post({'username': 'ml-b@test.com', 'password': 'wrong'})
+        self.assertEqual(res.status_code, 401)
+        data = res.json()
+        # Ordinary failures keep SimpleJWT's stock shape -- no '_auth' key.
+        self.assertIn('detail', data)
+        self.assertNotIn('_auth', data)
+
+    def test_unknown_username_returns_stock_401(self):
+        res = self._post({'username': 'ml-nobody@test.com', 'password': 'x'})
+        self.assertEqual(res.status_code, 401)
+        data = res.json()
+        self.assertIn('detail', data)
+        self.assertNotIn('_auth', data)
+
+    def test_sso_only_account_returns_sso_only_account_error(self):
+        user = _sso_only_user('ml-sso@test.com')
+        SocialAccount.objects.create(user=user, provider='google', uid='mobile-12345')
+
+        res = self._post({'username': 'ml-sso@test.com', 'password': 'anything'})
+        self.assertEqual(res.status_code, 401)
+        data = res.json()
+        self.assertEqual(data['error'], 'auth.generic_error')
+        self.assertEqual(data['_auth']['code'], 'sso_only_account')
+        self.assertIn('google', data['_auth']['providers'])
+        self.assertNotIn('access', data)
+        self.assertNotIn('refresh', data)
+
+
 class PasswordResetApiTest(TestCase):
     def setUp(self):
         self.client = Client()

--- a/sso/views.py
+++ b/sso/views.py
@@ -13,7 +13,9 @@ from django.contrib.auth import authenticate, login as auth_login
 from django.http import JsonResponse
 from django.views.decorators.csrf import csrf_exempt, ensure_csrf_cookie
 from django.views.decorators.http import require_POST
+from rest_framework.exceptions import AuthenticationFailed
 from rest_framework_simplejwt.tokens import RefreshToken
+from rest_framework_simplejwt.views import TokenObtainPairView
 
 from emailusernames.utils import user_exists, get_user
 from sefaria.forms import SefariaPasswordResetForm
@@ -50,6 +52,30 @@ def _sso_only_account_error(email):
         },
         status=401,
     )
+
+
+class MobileTokenObtainPairView(TokenObtainPairView):
+    """
+    api/login/ -- the stock SimpleJWT endpoint the mobile app posts
+    email/password to. Identical to TokenObtainPairView except that a failed
+    login is checked against _sso_only_account_error before falling back to
+    SimpleJWT's generic 401, so mobile gets the same 'this account only has
+    Google/Apple sign-in' signal that email_login already gives web.
+
+    Kept at the existing api/login/ URL (not a new endpoint) so apps already
+    in the wild pick up the richer error without an app store release.
+    """
+
+    def post(self, request, *args, **kwargs):
+        try:
+            return super().post(request, *args, **kwargs)
+        except AuthenticationFailed:
+            username_field = self.get_serializer_class().username_field
+            email = request.data.get(username_field, "")
+            err = _sso_only_account_error(email)
+            if err:
+                return err
+            raise
 
 
 def _social_login_or_error(


### PR DESCRIPTION
## Summary

Mobile's email/password login hits `api/login/`, which is stock `django-rest-framework-simplejwt` `TokenObtainPairView`. On bad credentials it returns a generic 401 `{"detail": "No active account found with the given credentials"}` -- there is no way to tell the iOS/Android app that the account exists but only has Google or Apple sign-in linked, so a user with an SSO-only account who tries their email/password just sees a failed login with no explanation.

The web session login path already solves this: `sso.views.email_login` (the JSON login behind `POST api/auth/login`) calls `_sso_only_account_error(email)` and, when the account is SSO-only, returns
```json
{"error": "auth.generic_error", "_auth": {"code": "sso_only_account", "providers": ["google", "apple"]}}
```
at 401. That helper was not wired into the JWT path mobile actually uses.

This PR wires it in via `MobileTokenObtainPairView`, a thin `TokenObtainPairView` subclass in `sso/views.py` that overrides `post()` to catch simplejwt's `AuthenticationFailed` and, only then, consult `_sso_only_account_error(email)`:
- if it matches, return that response (same body/shape web already returns -- reused verbatim, not reimplemented)
- otherwise re-raise, so a genuine wrong password or unknown account still gets simplejwt's stock 401 unchanged

`sefaria/urls_shared.py`'s `api/login/` route now points at `MobileTokenObtainPairView` instead of `TokenObtainPairView` directly. **The URL is unchanged** -- apps already in the wild that POST to `api/login/` pick up the richer error immediately, with no store release required. A new endpoint would only help clients built after the change ships.

Import direction: `sefaria/urls_shared.py` already imports `sso.urls` (`include('sso.urls')`), so `sso` -> `sefaria` is the existing dependency direction (`sso/views.py` imports `sefaria.forms`). Importing `sso.views.MobileTokenObtainPairView` from `sefaria/urls_shared.py` follows the same direction and introduces no cycle.

Mobile side: once this ships, `Sefaria.api.login`'s error handler can check `_auth.code === 'sso_only_account'` and use `_auth.providers` to show "This email is registered via Google Sign-In" (etc.) instead of a generic failed-login message.

Related: #3609 (which introduced `_sso_only_account_error` and wired it into `password_reset_api` and `email_login`, but not the JWT endpoint -- this PR closes that gap).

Story: sc-46556

## Test plan
- [x] `sso/tests/views_test.py::MobileLoginTest` (new): valid login still returns `{access, refresh}` at 200; wrong password on a normal account returns stock simplejwt 401 (`detail`, no `_auth`); unknown username returns stock 401; SSO-only account returns `_auth.code == 'sso_only_account'` with `providers` and no tokens.
- [x] Ran the full `sso/tests/views_test.py` suite locally (31 passed) to confirm no regressions to the existing SSO/email/social-login tests.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JMEqissBzfRtQuukMijY4u