### PR TITLE
fix(helm): verify mongo restore completeness and allow skipping collections

### DIFF
--- a/helm-chart/sefaria/templates/configmap/mongo-restore.yaml
+++ b/helm-chart/sefaria/templates/configmap/mongo-restore.yaml
@@ -14,8 +14,17 @@ data:
   restore-mongo.sh: |-
     #!/bin/bash
     set -e
+    set -o pipefail
 
-    tar xzvf /storage/dump.tar.gz -C /storage 
+    # Excluded at extraction time, so skipped bytes never hit the (disk-bound) untar.
+    TAR_EXCLUDES=()
+    {{- range .Values.restore.excludeCollections }}
+    echo "Skipping collection: {{ . }}"
+    TAR_EXCLUDES+=( "--exclude=./dump/sefaria/{{ . }}.bson" "--exclude=./dump/sefaria/{{ . }}.metadata.json" )
+    {{- end }}
+
+    tar xzf /storage/dump.tar.gz -C /storage ${TAR_EXCLUDES[@]+"${TAR_EXCLUDES[@]}"}
+
     if [[ -z "$MONGO_HOST" ]]; then
       echo "Mongo Host not specified"
       exit 1
@@ -48,4 +57,32 @@ data:
     {{- end }}
 
     mongorestore --drop --uri="$URI" -v -d "${DATABASE}" --dir=/storage/dump/sefaria
+
+    {{- if .Values.restore.verify }}
+
+    # Compare what was extracted against what mongo actually has, so a truncated
+    # restore fails instead of passing for a good one. Excluded collections are
+    # not on disk, so they are not expected -- nothing to hardcode.
+    echo "Verifying restore completeness..."
+
+    EXPECTED=$(cd /storage/dump/sefaria && ls -1 ./*.bson 2>/dev/null | sed -e 's|^\./||' -e 's|\.bson$||' | sort)
+    if [[ -z "$EXPECTED" ]]; then
+      echo "ERROR: no .bson files found in the extracted dump -- nothing was restored"
+      exit 1
+    fi
+
+    ACTUAL=$(mongo --quiet "$URI" --eval \
+      "db.getSiblingDB('${DATABASE}').getCollectionNames().forEach(function(c){print(c)})" | sort)
+
+    MISSING=$(comm -23 <(echo "$EXPECTED") <(echo "$ACTUAL") || true)
+
+    if [[ -n "$MISSING" ]]; then
+      echo "ERROR: restore is incomplete. Expected $(echo "$EXPECTED" | wc -l) collections, found $(echo "$ACTUAL" | wc -l)."
+      echo "Missing collections:"
+      echo "$MISSING" | sed 's/^/  - /'
+      exit 1
+    fi
+
+    echo "Restore verified: $(echo "$ACTUAL" | wc -l) collections present in ${DATABASE}"
+    {{- end }}
 {{- end }}

--- a/helm-chart/sefaria/values.yaml
+++ b/helm-chart/sefaria/values.yaml
@@ -55,6 +55,11 @@ restore:
   bucket: sefaria-mongo-backup
   # tarball:
   serviceAccount: database-backup-read
+  # Collections to skip, excluded at extraction time so they never hit disk.
+  # `sheets` alone is ~14GB of the ~27GB dump.
+  excludeCollections: []
+  # Fail the job if mongo is missing any collection that was extracted.
+  verify: true
 # config to backup environment DB
 backup:
   mongo:


### PR DESCRIPTION
Follow-up to Sefaria/cauldrons#152. That PR stopped a timed-out restore from *reporting success*; this one stops an incomplete restore from *going unnoticed at all*, and gives cauldrons a way to skip the expensive half of the dump.

Independent of #152 and safe to merge in either order.

## 1. `restore.verify` (default `true`)

Nothing in the pipeline ever checked that `mongorestore` produced a complete database, which is why a cauldron with 8 of 73 collections looked identical to a healthy one. After the restore, the job now compares the collections extracted from the dump against what mongo actually holds:

```
ERROR: restore is incomplete. Expected 73 collections, found 8.
Missing collections:
  - apikeys
  - arukh_hashulchan
  ...
```

Self-calibrating — the expected set is derived from the `.bson` files on disk, so excluded collections are not expected and no collection list is hardcoded anywhere.

**Scope limit worth knowing:** this catches an incomplete restore that *finishes*. A restore killed mid-flight by the Helm hook timeout never reaches the check — that path is what `install.timeout` / `install.remediation` in cauldrons#152 handles. The two are complementary, which is why both exist.

## 2. `restore.excludeCollections` (default `[]`)

```yaml
restore:
  excludeCollections: [sheets]
```

Exclusion happens at **tar-extraction time**, not restore time, so skipped bytes are never written to local disk. That matters because the untar is the disk-bound stage and the slowest part of a restore — measured at 13 m 38 s of a 30 m budget, running at 37 MB/s against a node disk at 98% utilization. So excluding a collection saves time twice.

`sheets` is ~14.2 GB of the ~27 GB dump. For cauldrons that never exercise user sheets, this roughly halves the restore.

## Verification

Template renders and the generated bash passes `bash -n` in all three configurations (default / with exclusions / verify off). The exclude and detection logic was functionally tested against a fake dump built with the real `./dump/<db>/<coll>.bson` layout:

| case | result |
|---|---|
| exclusions removed from extraction | ✅ only non-excluded `.bson` present |
| complete restore | ✅ passes |
| truncated restore | ✅ fails, names the missing collections |
| mongo has extra collections (views) | ✅ passes, no false positive |

`helm lint` clean; full-chart `helm template` exits 0.

## Not changed here

The `[[ ! -z "MONGO_REPLICASET_NAME" ]]` test just above the edited region is missing its `$`, so it is always true and appends an empty `&replicaSet=` to the URI. Restores work today, so correcting it would change connection-string behaviour for every environment — left for its own change rather than smuggled into this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HFb3rAtzXJ4Ue7w4G3c4VW
