### PR TITLE
feat(sso): surface sso_only_account on the mobile JWT login endpoint

### DIFF
--- a/sefaria/urls_shared.py
+++ b/sefaria/urls_shared.py
@@ -13,7 +13,8 @@ import powered_by.views as powered_by_views
 from sefaria.heapdump import heapdump_view
 from sefaria.site.urls import site_urlpatterns
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
-from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
+from rest_framework_simplejwt.views import TokenRefreshView
+from sso.views import MobileTokenObtainPairView
 
 shared_patterns = [
     path('_allauth/', include('allauth.headless.urls')),
@@ -31,7 +32,7 @@ shared_patterns = [
         name='password_reset_complete'),
     re_path(fr'password/reset/done/$', sefaria_views.CustomPasswordResetDoneView.as_view(), name='password_reset_done'),
 
-    re_path(fr'api/login/$', TokenObtainPairView.as_view(), name='token_obtain_pair'),
+    re_path(fr'api/login/$', MobileTokenObtainPairView.as_view(), name='token_obtain_pair'),
     re_path(fr'api/login/refresh/$', TokenRefreshView.as_view(), name='token_refresh'),
 
     re_path(r'^saved/?$', reader_views.saved_content),

--- a/sso/tests/views_test.py
+++ b/sso/tests/views_test.py
@@ -14,61 +14,69 @@ from allauth.socialaccount.models import SocialAccount
 class EmailLoginTest(TestCase):
     def setUp(self):
         self.client = Client()
-        self.url = '/api/auth/login'
+        self.url = "/api/auth/login"
 
     def _post(self, body):
         return self.client.post(
             self.url,
             data=json.dumps(body),
-            content_type='application/json',
+            content_type="application/json",
         )
 
     def test_valid_login(self):
-        User.objects.create_user(username='a@test.com', email='a@test.com', password='pass123')
-        res = self._post({'email': 'a@test.com', 'password': 'pass123'})
+        User.objects.create_user(
+            username="a@test.com", email="a@test.com", password="pass123"
+        )
+        res = self._post({"email": "a@test.com", "password": "pass123"})
         self.assertEqual(res.status_code, 200)
-        self.assertIn('_auth_user_id', self.client.session)
+        self.assertIn("_auth_user_id", self.client.session)
 
     def test_wrong_password(self):
-        User.objects.create_user(username='b@test.com', email='b@test.com', password='correct')
-        res = self._post({'email': 'b@test.com', 'password': 'wrong'})
+        User.objects.create_user(
+            username="b@test.com", email="b@test.com", password="correct"
+        )
+        res = self._post({"email": "b@test.com", "password": "wrong"})
         self.assertEqual(res.status_code, 401)
         data = res.json()
-        self.assertIn('error', data)
-        self.assertNotIn('_auth', data)
+        self.assertIn("error", data)
+        self.assertNotIn("_auth", data)
 
     def test_unknown_email(self):
-        res = self._post({'email': 'nobody@test.com', 'password': 'x'})
+        res = self._post({"email": "nobody@test.com", "password": "x"})
         self.assertEqual(res.status_code, 401)
-        self.assertIn('error', res.json())
+        self.assertIn("error", res.json())
 
     def test_sso_only_account(self):
-        user = User.objects.create_user(username='sso@test.com', email='sso@test.com', password='x')
+        user = User.objects.create_user(
+            username="sso@test.com", email="sso@test.com", password="x"
+        )
         user.set_unusable_password()
         user.save()
-        SocialAccount.objects.create(user=user, provider='google', uid='12345')
+        SocialAccount.objects.create(user=user, provider="google", uid="12345")
 
-        res = self._post({'email': 'sso@test.com', 'password': 'anything'})
+        res = self._post({"email": "sso@test.com", "password": "anything"})
         self.assertEqual(res.status_code, 401)
         data = res.json()
-        self.assertEqual(data['_auth']['code'], 'sso_only_account')
-        self.assertIn('google', data['_auth']['providers'])
+        self.assertEqual(data["_auth"]["code"], "sso_only_account")
+        self.assertIn("google", data["_auth"]["providers"])
 
     def test_invalid_json(self):
-        res = self.client.post(self.url, data='not-json', content_type='application/json')
+        res = self.client.post(
+            self.url, data="not-json", content_type="application/json"
+        )
         self.assertEqual(res.status_code, 400)
 
 
 class AppleCallbackTest(TestCase):
     def setUp(self):
         self.client = Client()
-        self.url = '/api/auth/apple/callback'
+        self.url = "/api/auth/apple/callback"
 
     def _post(self, body):
         return self.client.post(
             self.url,
             data=json.dumps(body),
-            content_type='application/json',
+            content_type="application/json",
         )
 
     def test_missing_id_token(self):
@@ -76,23 +84,23 @@ class AppleCallbackTest(TestCase):
         self.assertEqual(res.status_code, 400)
 
     def test_invalid_json(self):
-        res = self.client.post(self.url, data='bad', content_type='application/json')
+        res = self.client.post(self.url, data="bad", content_type="application/json")
         self.assertEqual(res.status_code, 400)
 
     def test_invalid_token_returns_400(self):
-        with patch('sso.views.get_social_adapter') as mock_get_adapter:
+        with patch("sso.views.get_social_adapter") as mock_get_adapter:
             provider = MagicMock()
-            provider.verify_token.side_effect = Exception('bad token')
+            provider.verify_token.side_effect = Exception("bad token")
             mock_get_adapter.return_value.get_provider.return_value = provider
-            res = self._post({'id_token': 'bogus'})
+            res = self._post({"id_token": "bogus"})
         self.assertEqual(res.status_code, 400)
 
-    @patch('sso.views.complete_social_login')
+    @patch("sso.views.complete_social_login")
     def test_success_injects_name(self, mock_complete):
-        with patch('sso.views.get_social_adapter') as mock_get_adapter:
+        with patch("sso.views.get_social_adapter") as mock_get_adapter:
             sl = MagicMock()
-            sl.user.first_name = ''
-            sl.user.last_name = ''
+            sl.user.first_name = ""
+            sl.user.last_name = ""
             provider = MagicMock()
             provider.verify_token.return_value = sl
             mock_get_adapter.return_value.get_provider.return_value = provider
@@ -103,27 +111,31 @@ class AppleCallbackTest(TestCase):
 
             mock_complete.side_effect = set_authenticated
 
-            res = self._post({'id_token': 'valid', 'first_name': 'Alice', 'last_name': 'Smith'})
+            res = self._post(
+                {"id_token": "valid", "first_name": "Alice", "last_name": "Smith"}
+            )
 
         self.assertEqual(res.status_code, 200)
-        self.assertEqual(sl.user.first_name, 'Alice')
-        self.assertEqual(sl.user.last_name, 'Smith')
+        self.assertEqual(sl.user.first_name, "Alice")
+        self.assertEqual(sl.user.last_name, "Smith")
 
-    @patch('sso.views.complete_social_login')
+    @patch("sso.views.complete_social_login")
     def test_does_not_overwrite_existing_name(self, mock_complete):
-        with patch('sso.views.get_social_adapter') as mock_get_adapter:
+        with patch("sso.views.get_social_adapter") as mock_get_adapter:
             sl = MagicMock()
-            sl.user.first_name = 'Bob'
-            sl.user.last_name = 'Jones'
+            sl.user.first_name = "Bob"
+            sl.user.last_name = "Jones"
             provider = MagicMock()
             provider.verify_token.return_value = sl
             mock_get_adapter.return_value.get_provider.return_value = provider
             mock_complete.side_effect = lambda req, s: None
 
-            res = self._post({'id_token': 'valid', 'first_name': 'Other', 'last_name': 'Name'})
+            res = self._post(
+                {"id_token": "valid", "first_name": "Other", "last_name": "Name"}
+            )
 
-        self.assertEqual(sl.user.first_name, 'Bob')
-        self.assertEqual(sl.user.last_name, 'Jones')
+        self.assertEqual(sl.user.first_name, "Bob")
+        self.assertEqual(sl.user.last_name, "Jones")
 
 
 def _sso_only_user(email):
@@ -145,17 +157,19 @@ class GoogleMobileTest(TestCase):
 
     def setUp(self):
         self.client = Client()
-        self.url = '/api/auth/google/mobile'
+        self.url = "/api/auth/google/mobile"
 
     def _post(self, body):
         return self.client.post(
             self.url,
             data=json.dumps(body),
-            content_type='application/json',
+            content_type="application/json",
         )
 
     def test_invalid_json(self):
-        res = self.client.post(self.url, data='not-json', content_type='application/json')
+        res = self.client.post(
+            self.url, data="not-json", content_type="application/json"
+        )
         self.assertEqual(res.status_code, 400)
 
     def test_missing_id_token(self):
@@ -168,38 +182,40 @@ class GoogleMobileTest(TestCase):
         # GoogleOneTap payload shape) — see the `or data.get("credential")` in
         # sso.views.google_mobile. apple_mobile has no such alias; see
         # AppleMobileTest.test_credential_alias_is_not_accepted below.
-        with patch('sso.views.get_social_adapter') as mock_get_adapter:
+        with patch("sso.views.get_social_adapter") as mock_get_adapter:
             provider = MagicMock()
-            provider.verify_token.side_effect = Exception('bad token')
+            provider.verify_token.side_effect = Exception("bad token")
             mock_get_adapter.return_value.get_provider.return_value = provider
-            res = self._post({'credential': 'bogus'})
+            res = self._post({"credential": "bogus"})
         self.assertEqual(res.status_code, 400)
         provider.verify_token.assert_called_once()
 
     def test_invalid_token_returns_400(self):
-        with patch('sso.views.get_social_adapter') as mock_get_adapter:
+        with patch("sso.views.get_social_adapter") as mock_get_adapter:
             provider = MagicMock()
-            provider.verify_token.side_effect = Exception('bad token')
+            provider.verify_token.side_effect = Exception("bad token")
             mock_get_adapter.return_value.get_provider.return_value = provider
-            res = self._post({'id_token': 'bogus'})
+            res = self._post({"id_token": "bogus"})
         self.assertEqual(res.status_code, 400)
 
-    @patch('sso.views.complete_social_login')
+    @patch("sso.views.complete_social_login")
     def test_success_returns_jwt_for_password_less_sso_user(self, mock_complete):
-        user = _sso_only_user('gm@test.com')
+        user = _sso_only_user("gm@test.com")
         # complete_social_login is mocked below and never touches
         # request.session, so a fresh Client() would never pick up a session
         # cookie regardless of whether request.session.flush() runs — that
         # would make the assertions below pass even if flush() were deleted.
         # force_login first so there is a real, populated session to flush.
-        session_owner = User.objects.create_user(username='session-owner@test.com', email='session-owner@test.com')
+        session_owner = User.objects.create_user(
+            username="session-owner@test.com", email="session-owner@test.com"
+        )
         self.client.force_login(session_owner)
-        self.assertIn('_auth_user_id', self.client.session)
+        self.assertIn("_auth_user_id", self.client.session)
 
-        with patch('sso.views.get_social_adapter') as mock_get_adapter:
+        with patch("sso.views.get_social_adapter") as mock_get_adapter:
             sl = MagicMock()
-            sl.user.first_name = 'Existing'
-            sl.user.last_name = 'User'
+            sl.user.first_name = "Existing"
+            sl.user.last_name = "User"
             provider = MagicMock()
             provider.verify_token.return_value = sl
             mock_get_adapter.return_value.get_provider.return_value = provider
@@ -209,16 +225,16 @@ class GoogleMobileTest(TestCase):
 
             mock_complete.side_effect = set_authenticated
 
-            res = self._post({'id_token': 'valid'})
+            res = self._post({"id_token": "valid"})
 
         self.assertEqual(res.status_code, 200)
         data = res.json()
-        self.assertIn('access', data)
-        self.assertIn('refresh', data)
+        self.assertIn("access", data)
+        self.assertIn("refresh", data)
         # The pre-existing session must actually be gone, not just never created.
-        self.assertNotIn('_auth_user_id', self.client.session)
+        self.assertNotIn("_auth_user_id", self.client.session)
         # A flushed session cookie is deleted by resending it empty with Max-Age=0, not omitted.
-        self.assertEqual(res.cookies['sessionid'].value, '')
+        self.assertEqual(res.cookies["sessionid"].value, "")
         # The account issued tokens for genuinely has no password to steal.
         self.assertFalse(User.objects.get(pk=user.pk).has_usable_password())
 
@@ -240,45 +256,61 @@ class GoogleMobileEmailOverrideTest(TestCase):
     complete_social_login(), so this exercises the same code regardless of
     which entry point is used.
     """
+
     def setUp(self):
         self.client = Client()
-        self.url = '/api/auth/google/mobile'
+        self.url = "/api/auth/google/mobile"
 
-    def _real_sociallogin(self, email, verified, uid='google-uid-1'):
-        request = RequestFactory().get('/')
-        provider = get_social_adapter(request).get_provider(request, 'google')
-        return provider.sociallogin_from_response(request, {
-            'sub': uid,
-            'email': email,
-            'email_verified': verified,
-            'given_name': 'Vic',
-            'family_name': 'Tim',
-        })
+    def _real_sociallogin(self, email, verified, uid="google-uid-1"):
+        request = RequestFactory().get("/")
+        provider = get_social_adapter(request).get_provider(request, "google")
+        return provider.sociallogin_from_response(
+            request,
+            {
+                "sub": uid,
+                "email": email,
+                "email_verified": verified,
+                "given_name": "Vic",
+                "family_name": "Tim",
+            },
+        )
 
     def _assert_takes_over_existing_account(self, email, verified, uid):
-        existing = User.objects.create_user(username=email, email=email, password='attacker-set-pw')
+        existing = User.objects.create_user(
+            username=email, email=email, password="attacker-set-pw"
+        )
         self.assertTrue(existing.has_usable_password())
         sociallogin = self._real_sociallogin(email, verified=verified, uid=uid)
 
-        with patch('sso.views.get_social_adapter') as mock_get_adapter:
+        with patch("sso.views.get_social_adapter") as mock_get_adapter:
             provider = MagicMock()
             provider.verify_token.return_value = sociallogin
             mock_get_adapter.return_value.get_provider.return_value = provider
-            res = self.client.post(self.url, data=json.dumps({'id_token': 'valid'}), content_type='application/json')
+            res = self.client.post(
+                self.url,
+                data=json.dumps({"id_token": "valid"}),
+                content_type="application/json",
+            )
 
         self.assertEqual(res.status_code, 200)
-        self.assertIn('access', res.json())
+        self.assertIn("access", res.json())
 
         existing.refresh_from_db()
         self.assertFalse(existing.has_usable_password())
-        self.assertTrue(SocialAccount.objects.filter(user=existing, provider='google', uid=uid).exists())
+        self.assertTrue(
+            SocialAccount.objects.filter(
+                user=existing, provider="google", uid=uid
+            ).exists()
+        )
         self.assertEqual(User.objects.count(), 1)  # no duplicate account was created
 
     def test_unverified_email_still_takes_over_existing_account(self):
         # Exercises SefariaSocialAccountAdapter.pre_social_login directly:
         # allauth's own lookup() doesn't match an unverified email, so our
         # hook is the one performing the takeover.
-        self._assert_takes_over_existing_account('victim@test.com', verified=False, uid='google-uid-1')
+        self._assert_takes_over_existing_account(
+            "victim@test.com", verified=False, uid="google-uid-1"
+        )
 
     def test_verified_email_also_takes_over_existing_account(self):
         # The common real-world case (an ordinary Gmail login, provider marks
@@ -289,7 +321,9 @@ class GoogleMobileEmailOverrideTest(TestCase):
         # (SOCIALACCOUNT_EMAIL_AUTHENTICATION + _AUTO_CONNECT). This guards
         # against a regression where our hook's is_existing check stops
         # matching allauth's actual behavior and interferes with this path.
-        self._assert_takes_over_existing_account('victim2@test.com', verified=True, uid='google-uid-2')
+        self._assert_takes_over_existing_account(
+            "victim2@test.com", verified=True, uid="google-uid-2"
+        )
 
 
 class AppleMobileTest(TestCase):
@@ -298,17 +332,19 @@ class AppleMobileTest(TestCase):
 
     def setUp(self):
         self.client = Client()
-        self.url = '/api/auth/apple/mobile'
+        self.url = "/api/auth/apple/mobile"
 
     def _post(self, body):
         return self.client.post(
             self.url,
             data=json.dumps(body),
-            content_type='application/json',
+            content_type="application/json",
         )
 
     def test_invalid_json(self):
-        res = self.client.post(self.url, data='not-json', content_type='application/json')
+        res = self.client.post(
+            self.url, data="not-json", content_type="application/json"
+        )
         self.assertEqual(res.status_code, 400)
 
     def test_missing_id_token(self):
@@ -320,33 +356,35 @@ class AppleMobileTest(TestCase):
         # sso.views.apple_mobile (`data.get("id_token", "")`, no `credential`
         # fallback). A `credential`-only body must be treated as missing, not
         # silently accepted the way GoogleMobileTest's alias case is.
-        res = self._post({'credential': 'bogus'})
+        res = self._post({"credential": "bogus"})
         self.assertEqual(res.status_code, 400)
 
     def test_invalid_token_returns_400(self):
-        with patch('sso.views.get_social_adapter') as mock_get_adapter:
+        with patch("sso.views.get_social_adapter") as mock_get_adapter:
             provider = MagicMock()
-            provider.verify_token.side_effect = Exception('bad token')
+            provider.verify_token.side_effect = Exception("bad token")
             mock_get_adapter.return_value.get_provider.return_value = provider
-            res = self._post({'id_token': 'bogus'})
+            res = self._post({"id_token": "bogus"})
         self.assertEqual(res.status_code, 400)
 
-    @patch('sso.views.complete_social_login')
+    @patch("sso.views.complete_social_login")
     def test_success_returns_jwt_for_password_less_sso_user(self, mock_complete):
-        user = _sso_only_user('am@test.com')
+        user = _sso_only_user("am@test.com")
         # See GoogleMobileTest's identical setup for why force_login is needed
         # here: complete_social_login is mocked and never touches
         # request.session, so without a real pre-existing session the
         # no-session assertions below would pass whether or not
         # request.session.flush() actually runs.
-        session_owner = User.objects.create_user(username='session-owner2@test.com', email='session-owner2@test.com')
+        session_owner = User.objects.create_user(
+            username="session-owner2@test.com", email="session-owner2@test.com"
+        )
         self.client.force_login(session_owner)
-        self.assertIn('_auth_user_id', self.client.session)
+        self.assertIn("_auth_user_id", self.client.session)
 
-        with patch('sso.views.get_social_adapter') as mock_get_adapter:
+        with patch("sso.views.get_social_adapter") as mock_get_adapter:
             sl = MagicMock()
-            sl.user.first_name = ''
-            sl.user.last_name = ''
+            sl.user.first_name = ""
+            sl.user.last_name = ""
             provider = MagicMock()
             provider.verify_token.return_value = sl
             mock_get_adapter.return_value.get_provider.return_value = provider
@@ -356,16 +394,18 @@ class AppleMobileTest(TestCase):
 
             mock_complete.side_effect = set_authenticated
 
-            res = self._post({'id_token': 'valid', 'first_name': 'Alice', 'last_name': 'Smith'})
+            res = self._post(
+                {"id_token": "valid", "first_name": "Alice", "last_name": "Smith"}
+            )
 
         self.assertEqual(res.status_code, 200)
         data = res.json()
-        self.assertIn('access', data)
-        self.assertIn('refresh', data)
-        self.assertEqual(sl.user.first_name, 'Alice')
-        self.assertEqual(sl.user.last_name, 'Smith')
-        self.assertNotIn('_auth_user_id', self.client.session)
-        self.assertEqual(res.cookies['sessionid'].value, '')
+        self.assertIn("access", data)
+        self.assertIn("refresh", data)
+        self.assertEqual(sl.user.first_name, "Alice")
+        self.assertEqual(sl.user.last_name, "Smith")
+        self.assertNotIn("_auth_user_id", self.client.session)
+        self.assertEqual(res.cookies["sessionid"].value, "")
         self.assertFalse(User.objects.get(pk=user.pk).has_usable_password())
 
 
@@ -377,106 +417,138 @@ class MobileLoginTest(TestCase):
 
     def setUp(self):
         self.client = Client()
-        self.url = '/api/login/'
+        self.url = "/api/login/"
 
     def _post(self, body):
         return self.client.post(
             self.url,
             data=json.dumps(body),
-            content_type='application/json',
+            content_type="application/json",
         )
 
     def test_valid_login_returns_tokens(self):
-        User.objects.create_user(username='ml-a@test.com', email='ml-a@test.com', password='pass123')
-        res = self._post({'username': 'ml-a@test.com', 'password': 'pass123'})
+        User.objects.create_user(
+            username="ml-a@test.com", email="ml-a@test.com", password="pass123"
+        )
+        res = self._post({"username": "ml-a@test.com", "password": "pass123"})
         self.assertEqual(res.status_code, 200)
         data = res.json()
-        self.assertIn('access', data)
-        self.assertIn('refresh', data)
+        self.assertIn("access", data)
+        self.assertIn("refresh", data)
 
     def test_wrong_password_returns_generic_error_unchanged(self):
-        User.objects.create_user(username='ml-b@test.com', email='ml-b@test.com', password='correct')
-        res = self._post({'username': 'ml-b@test.com', 'password': 'wrong'})
+        User.objects.create_user(
+            username="ml-b@test.com", email="ml-b@test.com", password="correct"
+        )
+        res = self._post({"username": "ml-b@test.com", "password": "wrong"})
         self.assertEqual(res.status_code, 401)
         data = res.json()
         # Ordinary failures must keep SimpleJWT's stock shape -- no '_auth' key.
-        self.assertIn('detail', data)
-        self.assertNotIn('_auth', data)
+        self.assertIn("detail", data)
+        self.assertNotIn("_auth", data)
+
+    def test_wrong_password_with_linked_social_account_is_not_sso_only(self):
+        # A user who has BOTH a password and a linked provider looks identical
+        # to an SSO-only user by socialaccount_set alone. Only the
+        # has_usable_password() check separates them; drop it and a single
+        # typo tells this user their account is Google-only.
+        user = User.objects.create_user(
+            username="ml-c@test.com", email="ml-c@test.com", password="correct"
+        )
+        SocialAccount.objects.create(user=user, provider="google", uid="mobile-67890")
+
+        res = self._post({"username": "ml-c@test.com", "password": "wrong"})
+        self.assertEqual(res.status_code, 401)
+        data = res.json()
+        self.assertIn("detail", data)
+        self.assertNotIn("_auth", data)
 
     def test_unknown_username_returns_generic_error_unchanged(self):
-        res = self._post({'username': 'ml-nobody@test.com', 'password': 'x'})
+        res = self._post({"username": "ml-nobody@test.com", "password": "x"})
         self.assertEqual(res.status_code, 401)
         data = res.json()
-        self.assertIn('detail', data)
-        self.assertNotIn('_auth', data)
+        self.assertIn("detail", data)
+        self.assertNotIn("_auth", data)
 
     def test_sso_only_account_returns_code_and_providers(self):
-        user = User.objects.create_user(username='ml-sso@test.com', email='ml-sso@test.com', password='x')
+        user = User.objects.create_user(
+            username="ml-sso@test.com", email="ml-sso@test.com", password="x"
+        )
         user.set_unusable_password()
         user.save()
-        SocialAccount.objects.create(user=user, provider='google', uid='mobile-12345')
+        SocialAccount.objects.create(user=user, provider="google", uid="mobile-12345")
 
-        res = self._post({'username': 'ml-sso@test.com', 'password': 'anything'})
+        res = self._post({"username": "ml-sso@test.com", "password": "anything"})
         self.assertEqual(res.status_code, 401)
         data = res.json()
-        self.assertEqual(data['error'], 'auth.generic_error')
-        self.assertEqual(data['_auth']['code'], 'sso_only_account')
-        self.assertIn('google', data['_auth']['providers'])
-        self.assertNotIn('access', data)
-        self.assertNotIn('refresh', data)
+        self.assertEqual(data["error"], "auth.generic_error")
+        self.assertEqual(data["_auth"]["code"], "sso_only_account")
+        self.assertIn("google", data["_auth"]["providers"])
+        self.assertNotIn("access", data)
+        self.assertNotIn("refresh", data)
 
 
 class PasswordResetApiTest(TestCase):
     def setUp(self):
         self.client = Client()
-        self.url = '/api/auth/password/reset'
+        self.url = "/api/auth/password/reset"
 
     def _post(self, body):
         return self.client.post(
             self.url,
             data=json.dumps(body),
-            content_type='application/json',
+            content_type="application/json",
         )
 
     def test_invalid_json(self):
-        res = self.client.post(self.url, data='not-json', content_type='application/json')
+        res = self.client.post(
+            self.url, data="not-json", content_type="application/json"
+        )
         self.assertEqual(res.status_code, 400)
 
     def test_invalid_email(self):
-        res = self._post({'email': 'not-an-email'})
+        res = self._post({"email": "not-an-email"})
         self.assertEqual(res.status_code, 400)
-        self.assertEqual(res.json()['error'], 'auth.invalid_email')
+        self.assertEqual(res.json()["error"], "auth.invalid_email")
 
     def test_valid_email_sends_reset_and_returns_200(self):
-        User.objects.create_user(username='reset@test.com', email='reset@test.com', password='x')
-        with patch('sso.views.SefariaPasswordResetForm.save') as mock_save:
-            res = self._post({'email': 'reset@test.com'})
+        User.objects.create_user(
+            username="reset@test.com", email="reset@test.com", password="x"
+        )
+        with patch("sso.views.SefariaPasswordResetForm.save") as mock_save:
+            res = self._post({"email": "reset@test.com"})
         self.assertEqual(res.status_code, 200)
         self.assertEqual(res.json(), {})
         mock_save.assert_called_once()
         _, kwargs = mock_save.call_args
-        self.assertEqual(kwargs['email_template_name'], 'registration/password_reset_email.txt')
-        self.assertEqual(kwargs['html_email_template_name'], 'registration/password_reset_email.html')
+        self.assertEqual(
+            kwargs["email_template_name"], "registration/password_reset_email.txt"
+        )
+        self.assertEqual(
+            kwargs["html_email_template_name"], "registration/password_reset_email.html"
+        )
 
     def test_unknown_email_still_returns_200(self):
         # Django's PasswordResetForm silently no-ops for unknown emails (prevents
         # account enumeration) — the API must not leak whether the address exists.
-        res = self._post({'email': 'nobody@test.com'})
+        res = self._post({"email": "nobody@test.com"})
         self.assertEqual(res.status_code, 200)
 
     def test_sso_only_account_does_not_send_reset_email(self):
-        user = User.objects.create_user(username='sso-reset@test.com', email='sso-reset@test.com', password='x')
+        user = User.objects.create_user(
+            username="sso-reset@test.com", email="sso-reset@test.com", password="x"
+        )
         user.set_unusable_password()
         user.save()
-        SocialAccount.objects.create(user=user, provider='google', uid='12345')
+        SocialAccount.objects.create(user=user, provider="google", uid="12345")
 
-        with patch('sso.views.SefariaPasswordResetForm.save') as mock_save:
-            res = self._post({'email': 'sso-reset@test.com'})
+        with patch("sso.views.SefariaPasswordResetForm.save") as mock_save:
+            res = self._post({"email": "sso-reset@test.com"})
 
         self.assertEqual(res.status_code, 401)
         data = res.json()
-        self.assertEqual(data['_auth']['code'], 'sso_only_account')
-        self.assertIn('google', data['_auth']['providers'])
+        self.assertEqual(data["_auth"]["code"], "sso_only_account")
+        self.assertIn("google", data["_auth"]["providers"])
         mock_save.assert_not_called()
 
     def test_reachable_without_csrf_token(self):

--- a/sso/tests/views_test.py
+++ b/sso/tests/views_test.py
@@ -448,10 +448,17 @@ class MobileLoginTest(TestCase):
         self.assertNotIn("_auth", data)
 
     def test_wrong_password_with_linked_social_account_is_not_sso_only(self):
-        # A user who has BOTH a password and a linked provider looks identical
-        # to an SSO-only user by socialaccount_set alone. Only the
-        # has_usable_password() check separates them; drop it and a single
-        # typo tells this user their account is Google-only.
+        # Defence-in-depth, not a reachable state today: no application path
+        # produces a user with both a usable password and a linked provider.
+        # Linking wipes the password (sso/adapters.py pre_social_login), the
+        # reset API rejects SSO-only accounts outright, and the web reset form
+        # inherits Django's get_users(), which skips unusable-password users.
+        #
+        # This constructs that state directly to pin the guard: if the
+        # "SSO always wins on an email collision" product decision in
+        # adapters.py is ever revisited, has_usable_password() is the only
+        # thing keeping a mistyped password from being reported as
+        # "your account is Google-only".
         user = User.objects.create_user(
             username="ml-c@test.com", email="ml-c@test.com", password="correct"
         )
@@ -556,12 +563,14 @@ class PasswordResetApiTest(TestCase):
         # that actually enforces CSRF (unlike the default test Client) must
         # still reach the view rather than being rejected by the middleware.
         csrf_client = Client(enforce_csrf_checks=True)
-        User.objects.create_user(username='csrf@test.com', email='csrf@test.com', password='x')
-        with patch('sso.views.SefariaPasswordResetForm.save') as mock_save:
+        User.objects.create_user(
+            username="csrf@test.com", email="csrf@test.com", password="x"
+        )
+        with patch("sso.views.SefariaPasswordResetForm.save") as mock_save:
             res = csrf_client.post(
                 self.url,
-                data=json.dumps({'email': 'csrf@test.com'}),
-                content_type='application/json',
+                data=json.dumps({"email": "csrf@test.com"}),
+                content_type="application/json",
             )
         self.assertEqual(res.status_code, 200)
         self.assertEqual(res.json(), {})

--- a/sso/tests/views_test.py
+++ b/sso/tests/views_test.py
@@ -369,6 +369,63 @@ class AppleMobileTest(TestCase):
         self.assertFalse(User.objects.get(pk=user.pk).has_usable_password())
 
 
+class MobileLoginTest(TestCase):
+    """api/login/ -- the SimpleJWT endpoint the mobile app posts to. Mobile
+    sends the email address in the 'username' field (see api.js's
+    Sefaria.api.login), matching this project's USERNAME_FIELD='username'
+    default-User-model setup."""
+
+    def setUp(self):
+        self.client = Client()
+        self.url = '/api/login/'
+
+    def _post(self, body):
+        return self.client.post(
+            self.url,
+            data=json.dumps(body),
+            content_type='application/json',
+        )
+
+    def test_valid_login_returns_tokens(self):
+        User.objects.create_user(username='ml-a@test.com', email='ml-a@test.com', password='pass123')
+        res = self._post({'username': 'ml-a@test.com', 'password': 'pass123'})
+        self.assertEqual(res.status_code, 200)
+        data = res.json()
+        self.assertIn('access', data)
+        self.assertIn('refresh', data)
+
+    def test_wrong_password_returns_generic_error_unchanged(self):
+        User.objects.create_user(username='ml-b@test.com', email='ml-b@test.com', password='correct')
+        res = self._post({'username': 'ml-b@test.com', 'password': 'wrong'})
+        self.assertEqual(res.status_code, 401)
+        data = res.json()
+        # Ordinary failures must keep SimpleJWT's stock shape -- no '_auth' key.
+        self.assertIn('detail', data)
+        self.assertNotIn('_auth', data)
+
+    def test_unknown_username_returns_generic_error_unchanged(self):
+        res = self._post({'username': 'ml-nobody@test.com', 'password': 'x'})
+        self.assertEqual(res.status_code, 401)
+        data = res.json()
+        self.assertIn('detail', data)
+        self.assertNotIn('_auth', data)
+
+    def test_sso_only_account_returns_code_and_providers(self):
+        user = User.objects.create_user(username='ml-sso@test.com', email='ml-sso@test.com', password='x')
+        user.set_unusable_password()
+        user.save()
+        SocialAccount.objects.create(user=user, provider='google', uid='mobile-12345')
+
+        res = self._post({'username': 'ml-sso@test.com', 'password': 'anything'})
+        self.assertEqual(res.status_code, 401)
+        data = res.json()
+        self.assertEqual(data['error'], 'auth.generic_error')
+        self.assertEqual(data['_auth']['code'], 'sso_only_account')
+        self.assertIn('google', data['_auth']['providers'])
+        self.assertNotIn('access', data)
+        self.assertNotIn('refresh', data)
+
+
 class PasswordResetApiTest(TestCase):
     def setUp(self):
         self.client = Client()

--- a/sso/tests/views_test.py
+++ b/sso/tests/views_test.py
@@ -478,3 +478,19 @@ class PasswordResetApiTest(TestCase):
         self.assertEqual(data['_auth']['code'], 'sso_only_account')
         self.assertIn('google', data['_auth']['providers'])
         mock_save.assert_not_called()
+
+    def test_reachable_without_csrf_token(self):
+        # Mobile holds no csrftoken cookie and sends no Referer, so a client
+        # that actually enforces CSRF (unlike the default test Client) must
+        # still reach the view rather than being rejected by the middleware.
+        csrf_client = Client(enforce_csrf_checks=True)
+        User.objects.create_user(username='csrf@test.com', email='csrf@test.com', password='x')
+        with patch('sso.views.SefariaPasswordResetForm.save') as mock_save:
+            res = csrf_client.post(
+                self.url,
+                data=json.dumps({'email': 'csrf@test.com'}),
+                content_type='application/json',
+            )
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.json(), {})
+        mock_save.assert_called_once()

--- a/sso/views.py
+++ b/sso/views.py
@@ -43,6 +43,14 @@ def sso_only_account_info(email):
     One user lookup plus one social-account fetch: has_usable_password()
     reads a field already on the fetched user, so it needs no query of
     its own.
+
+    That password check is defence-in-depth rather than a live branch: an
+    account with both a usable password and a linked provider is not
+    reachable today, since linking wipes the password (adapters.py's
+    "SSO always wins on an email collision"). It is kept because it is
+    free and because that is a product decision, not an invariant -- if it
+    is ever revisited, this check is what stops a mistyped password being
+    reported as "your account is Google-only".
     """
     try:
         user = get_user(email)

--- a/sso/views.py
+++ b/sso/views.py
@@ -10,12 +10,16 @@ from allauth.socialaccount.providers.google.views import (
     login_by_token as google_login_by_token,
 )
 from django.contrib.auth import authenticate, login as auth_login
+from django.contrib.auth.models import User
 from django.http import JsonResponse
 from django.views.decorators.csrf import csrf_exempt, ensure_csrf_cookie
 from django.views.decorators.http import require_POST
+from rest_framework import exceptions
+from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
 from rest_framework_simplejwt.tokens import RefreshToken
+from rest_framework_simplejwt.views import TokenObtainPairView
 
-from emailusernames.utils import user_exists, get_user
+from emailusernames.utils import get_user
 from sefaria.forms import SefariaPasswordResetForm
 
 logger = structlog.get_logger(__name__)
@@ -26,6 +30,65 @@ def _jwt_for_user(user):
     return {"access": str(refresh.access_token), "refresh": str(refresh)}
 
 
+def sso_only_account_info(email):
+    """
+    Return the list of SSO provider ids linked to `email`'s account if that
+    account is SSO-only (no usable password), or None if the account can
+    (also) sign in with a password, or doesn't exist.
+
+    Shared by email_login (web, session-based) and MobileTokenObtainPairView
+    (mobile, JWT-based) so both surface the same 'this account only has
+    Google/Apple sign-in' signal on a failed credential check.
+
+    One user lookup plus one social-account fetch: has_usable_password()
+    reads a field already on the fetched user, so it needs no query of
+    its own.
+    """
+    try:
+        user = get_user(email)
+    except User.DoesNotExist:
+        return None
+    if user.has_usable_password():
+        return None
+    providers = list(user.socialaccount_set.values_list("provider", flat=True))
+    return providers or None
+
+
+class SSOAwareTokenObtainPairSerializer(TokenObtainPairSerializer):
+    """
+    SimpleJWT's TokenObtainPairSerializer with SSO-only-account detection
+    layered onto the failure path. On success, behaves identically to the
+    stock serializer (returns {access, refresh}). On failure, if the account
+    turns out to be SSO-only, raises AuthenticationFailed with a structured
+    detail mirroring email_login's JSON shape instead of SimpleJWT's generic
+    'no active account' message. Any other failure is re-raised unchanged.
+    """
+
+    def validate(self, attrs):
+        try:
+            return super().validate(attrs)
+        except exceptions.AuthenticationFailed:
+            providers = sso_only_account_info(attrs.get(self.username_field, ""))
+            if providers:
+                raise exceptions.AuthenticationFailed(
+                    {
+                        "error": "auth.generic_error",
+                        "_auth": {"code": "sso_only_account", "providers": providers},
+                    }
+                )
+            raise
+
+
+class MobileTokenObtainPairView(TokenObtainPairView):
+    """
+    api/login/ -- the JWT login endpoint used by the mobile app. Identical to
+    SimpleJWT's stock TokenObtainPairView except for SSO-only-account
+    detection on the failure path; see SSOAwareTokenObtainPairSerializer.
+    """
+
+    serializer_class = SSOAwareTokenObtainPairSerializer
+
+
 def _clean_name(value):
     if not value:
         return ""
@@ -33,22 +96,14 @@ def _clean_name(value):
     return cleaned[:150]
 
 
-def _sso_only_account_error(email):
-    """If `email` belongs to an existing user who can only sign in via SSO
-    (no usable password, has a linked social account), return the shared
-    'sso_only_account' JsonResponse. Otherwise return None."""
-    if not user_exists(email):
-        return None
-    u = get_user(email)
-    if u.has_usable_password() or not u.socialaccount_set.exists():
-        return None
-    providers = list(u.socialaccount_set.values_list("provider", flat=True))
+def _sso_only_account_response(providers, status=401):
+    """Build the shared 'sso_only_account' JsonResponse from a provider list."""
     return JsonResponse(
         {
             "error": "auth.generic_error",
             "_auth": {"code": "sso_only_account", "providers": providers},
         },
-        status=401,
+        status=status,
     )
 
 
@@ -207,9 +262,9 @@ def password_reset_api(request):
     if not form.is_valid():
         return JsonResponse({"error": "auth.invalid_email"}, status=400)
 
-    err = _sso_only_account_error(email)
-    if err:
-        return err
+    providers = sso_only_account_info(email)
+    if providers:
+        return _sso_only_account_response(providers)
 
     form.save(
         request=request,
@@ -225,7 +280,9 @@ def password_reset_api(request):
 def email_login(request):
     """
     JSON email/password login for the SSO auth page. Session-based (not JWT).
-    The existing /login form view and /api/login JWT endpoint are unchanged.
+    The existing /login form view is unchanged; /api/login (mobile, JWT) uses
+    the same SSO-only-account detection via sso_only_account_info -- see
+    MobileTokenObtainPairView.
 
     Body (JSON): { email, password }
 
@@ -244,12 +301,10 @@ def email_login(request):
 
     user = authenticate(request, username=email, password=password)
     if user is None:
-        err = _sso_only_account_error(email)
-        if err:
-            return err
-        return JsonResponse(
-            {"error": "auth.invalid_credentials"}, status=401
-        )
+        providers = sso_only_account_info(email)
+        if providers:
+            return _sso_only_account_response(providers)
+        return JsonResponse({"error": "auth.invalid_credentials"}, status=401)
 
     auth_login(request, user)
     return JsonResponse({})

--- a/sso/views.py
+++ b/sso/views.py
@@ -249,8 +249,11 @@ def apple_mobile(request):
     return JsonResponse(tokens)
 
 
+@csrf_exempt
 @require_POST
 def password_reset_api(request):
+    # Target email comes from the body, not the session, so CSRF adds no
+    # protection here; the mobile client carries no cookie/Referer to supply it.
     try:
         data = json.loads(request.body)
     except (json.JSONDecodeError, ValueError):


### PR DESCRIPTION
Two backend fixes the Sefaria-Mobile app needs for its auth screens. Consumer: Sefaria-Mobile#217.

## What this does

- **`api/login/` can now say *why* a login failed.** It was stock SimpleJWT, so an account that only has Google/Apple linked returned the same generic "no active account" as a wrong password. The app had no way to tell the user to use the SSO buttons. It now returns the same `401 {error, _auth: {code: 'sso_only_account', providers}}` that `email_login` already gives web.
- **`password_reset_api` is now `@csrf_exempt`.** It wasn't, so the app's forgot-password screen got a 403 with an HTML body on every attempt. `google_mobile` and `apple_mobile` already carry the decorator; this one was missed.
- **One shared `sso_only_account_info(email)` helper**, called by `email_login`, `password_reset_api` and the new serializer — so web and mobile detection can't drift.
- **Four queries collapsed to two** in that helper (`user_exists` + `get_user` repeated the same lookup). Flagged on #3580's review, never addressed. Semantics unchanged.

## Verified

```
POST /api/auth/password/reset  ->  403 text/html "CSRF verification failed"   (before)
POST /api/auth/google/mobile   ->  400 {"error": "auth.social_signin_failed"} (exempt, reaches the view)
```

## Why a serializer, not a view override

Subclasses via `serializer_class` — SimpleJWT's documented extension point. #3612 did the same job by catching `AuthenticationFailed` in `post()` and returning a raw `JsonResponse`, which bypasses DRF's exception handler and content negotiation. That PR is closed in favour of this one.

## History

- Supersedes **#3580**, closed 2026-08-06 as "not currently needed — nothing in Sefaria-Mobile consumes `sso_only_account`". That condition is now met.
- Replaces **#3612**.
- Related: **#3609**.

## ⚠️ Needs a decision before merge

This extends **account enumeration** to `api/login/` — an unauthenticated caller can learn whether an email is registered and which providers it uses. `password_reset_api` already leaks the same. Neither endpoint is throttled; the project has no `DEFAULT_THROTTLE_CLASSES` anywhere. The exposure already ships on `email_login`, so this widens an existing surface rather than opening a new one — but it's a deliberate tradeoff, not an oversight. Throttling is worth its own story.

Separately: middleware-level rejections return **HTML**, so the app can only ever show a generic error for them. A JSON error handler for the mobile-facing auth endpoints is worth doing on its own.

## Tests

- `sso/tests/views_test.py` — 31 passing, including `MobileLoginTest` (valid login / wrong password / unknown user / SSO-only account)
- `password_reset_api` and `email_login` keep identical status codes and bodies after the refactor
