### PR TITLE
Check names, phone numbers and bare URLs in spam dashboards [sc-46591]

### DIFF
--- a/sefaria/spam.py
+++ b/sefaria/spam.py
@@ -1,0 +1,79 @@
+r"""
+Patterns for spotting spam in the text a user can write, wherever they can write it.
+
+Used by both spam dashboards (sefaria.views.sheet_spam_dashboard and
+profile_spam_dashboard). What reads as spam in a profile bio reads as spam in a sheet,
+so the free-text rule is defined once here as spam_text_clauses() and pointed at
+whichever field is being reviewed.
+
+The patterns run against two different stores: first and last name live on the Django
+User record in Postgres, while slugs, bios and sheet text live in Mongo. A pattern that
+runs against both has to stay inside the regex subset Postgres, Python and PCRE share --
+no \b, \d or lookarounds. Where a boundary is needed, ([^a-z]|$) stands in for the \y
+Postgres wants and the \b Python wants.
+"""
+
+SPAM_KEYWORDS = ["support", "coin", "helpline", "base"]
+
+# Matched against the profile slug in Mongo.
+SPAM_KEYWORDS_REGEX = r'(?i)' + "|".join(r'.*%s.*' % keyword for keyword in SPAM_KEYWORDS)
+
+# Markup links in user-written text. Deliberately ignores links back to Sefaria.
+SPAM_HREF_REGEX = r'.*(?!href=[\'"](\/|http(s)?:\/\/(www\.)?sefaria).+[\'"])(href).*'
+
+# User-written text can advertise a contact number with no spam keyword present. This wants
+# 9+ digits in a loose grouping, so that prose like a "2020-2024" date range doesn't read
+# as a phone number, and so that two years in one sentence can't chain into a single match.
+# The trade is that a bare 7 digit local number is missed -- it has the same shape as a
+# year range, and a number advertised as spam carries an area or country code anyway.
+SPAM_PHONE_REGEX = r'[0-9]([-. ()+]{0,2}[0-9]){8,}'
+
+SPAM_URL_TLDS = ["com", "net", "org", "info", "biz", "xyz", "top", "club", "online", "site",
+                 "shop", "live", "io", "co", "ru", "uk", "de", "me", "il"]
+
+# Matched against names in Postgres, so no lookaheads.
+SPAM_NAME_URL_REGEX = r'(https?://|www\.|[a-z0-9_-]+\.(%s)([^a-z]|$))' % "|".join(SPAM_URL_TLDS)
+
+# Matched against free text, and only ever in Mongo, so this one can use a lookahead to leave
+# links back to Sefaria alone the way SPAM_HREF_REGEX does. The leading boundary is what makes
+# that exclusion hold: without it the pattern would sidestep the lookahead by matching from
+# "efaria.org". Built from the same TLD list so the two can't drift apart.
+SPAM_URL_REGEX = r'(^|[^a-z0-9_.-])(https?://)?(www\.)?(?!sefaria\.)[a-z0-9_-]+\.(%s)([^a-z]|$)' % "|".join(SPAM_URL_TLDS)
+
+
+def spam_text_clauses(*fields):
+    """
+    Mongo $or branches flagging spammy free text in any of `fields`.
+
+    One rule for every place a user can write prose -- a profile bio, a sheet's outside
+    text -- so that the two dashboards can't drift apart on what counts as spam.
+    """
+    return [clause for field in fields for clause in (
+        {field: {"$regex": SPAM_HREF_REGEX}},
+        {field: {"$regex": SPAM_PHONE_REGEX}},
+        {field: {"$regex": SPAM_URL_REGEX, "$options": "i"}},
+    )]
+
+
+def spam_name_user_ids(min_user_id):
+    """
+    Ids of Users above `min_user_id` whose first or last name reads as spam.
+
+    Names aren't in the Mongo profile doc, so the dashboard's main query can't reach them.
+    This gets the ids from Postgres to fold back into that query. The two fields are matched
+    as one string so that a phone number split across them is still caught.
+    """
+    from django.contrib.auth.models import User
+    from django.db.models import Q, Value
+    from django.db.models.functions import Concat
+
+    name_query = Q()
+    for keyword in SPAM_KEYWORDS:
+        name_query |= Q(full_name__icontains=keyword)
+    for pattern in [SPAM_PHONE_REGEX, SPAM_NAME_URL_REGEX]:
+        name_query |= Q(full_name__iregex=pattern)
+
+    return list(User.objects
+                .annotate(full_name=Concat("first_name", Value(" "), "last_name"))
+                .filter(name_query, id__gt=min_user_id)
+                .values_list("id", flat=True))

--- a/sefaria/tests/spam_dashboard_test.py
+++ b/sefaria/tests/spam_dashboard_test.py
@@ -1,0 +1,135 @@
+"""
+Tests for sefaria/spam.py -- the patterns behind both spam dashboards.
+
+Two halves, because the dashboards read two stores. The name patterns run in Postgres
+and are exercised through the real ORM query in spam_name_user_ids(). The free-text and
+slug patterns run in Mongo as $regex, and are exercised here with Python's re as a
+stand-in for Mongo's PCRE -- close enough for the constructs these patterns use, and it
+keeps the suite off a live Mongo.
+
+The free-text cases are written as bios but the rule is field-agnostic: spam_text_clauses()
+is what both dashboards point at their own fields, so the same cases govern sheet text.
+
+The negative cases carry most of the weight. These dashboards feed a review queue whose
+only action is irreversible deletion, so a pattern that flags ordinary members is worse
+than one that misses a spammer: 'Miriam Cohen' must not read as the .co TLD, '2020-2024'
+must not read as a phone number, and text linking to sefaria.org must stay clear, which
+is the carve-out SPAM_HREF_REGEX already makes for markup links.
+"""
+import re
+
+import pytest
+from django.contrib.auth.models import User
+
+from sefaria.spam import (SPAM_PHONE_REGEX, SPAM_NAME_URL_REGEX, SPAM_KEYWORDS,
+                          spam_text_clauses, spam_name_user_ids)
+
+
+# (first_name, last_name, should_be_flagged, why)
+NAME_CASES = [
+    ("Coinbase", "Support 1-800-555-1234", True, "keyword and phone"),
+    ("Binance", "Helpline", True, "keyword alone"),
+    ("1-800", "555-1234", True, "phone split across the two fields"),
+    ("Call", "+1 (888) 555 0199", True, "bracket and space grouping"),
+    ("Wallet", "18885550199", True, "unpunctuated digit run"),
+    ("Tel", "972-2-123-4567", True, "israeli grouping"),
+    ("Visit", "spam.co.il", True, "bare url"),
+    ("Free", "visit-us.com", True, "bare url, hyphenated host"),
+    ("Click", "http://spam.ru", True, "url with scheme"),
+    ("Best", "www.example.org", True, "url with www"),
+
+    ("Miriam", "Cohen", False, "'Co' must not read as the .co TLD"),
+    ("Yaakov", "Levi", False, "ordinary name"),
+    ("Jean-Pierre", "St.Clair", False, "dot inside a surname"),
+    ("B.", "Cohen", False, "initial followed by a dot"),
+    ("Levi", "613", False, "digit run under the threshold"),
+    ("Rabbi", "2020-2024", False, "date range, 8 digits"),
+    ("Sarah", "Netanel", False, "contains 'net', not as a TLD"),
+    ("Dov", "Weinberg", False, "no keyword, number or url"),
+]
+
+# (text, should_be_flagged, why)
+TEXT_CASES = [
+    ('Call our helpline at 1-800-555-1234 now', True, "phone in prose"),
+    ('Visit spam.ru for free coins', True, "bare url, no markup"),
+    ('reach me at WWW.SPAM-SITE.COM', True, "uppercase bare url"),
+    ('crypto help: http://wallet-recovery.xyz', True, "url with scheme"),
+    ('My site <a href="http://spam.ru">here</a>', True, "external link in markup"),
+    ('support at 972 2 123 4567', True, "space separated number"),
+
+    ('Read <a href="https://www.sefaria.org/Genesis">Genesis</a>', False, "sefaria link in markup"),
+    ('I post my sheets at www.sefaria.org/profile/me', False, "bare sefaria url"),
+    ('See sefaria.org for my sheets', False, "bare sefaria url without www"),
+    ('Rabbi in Jerusalem, 2020-2024', False, "date range"),
+    ('Studied 2015-2019, ordained 2021', False, "two dates in one sentence"),
+    ('Born 1948. Teaching since 1975.', False, "years across two sentences"),
+    ('Author of a Mishnah Berurah commentary', False, "ordinary prose"),
+    ('Interested in Talmud, Halakhah and Tanakh', False, "ordinary prose with commas"),
+]
+
+
+def text_is_flagged(text):
+    """
+    Run the dashboards' actual Mongo clauses against `text` with re.
+
+    Reads the clauses out of spam_text_clauses() rather than restating the patterns, so
+    that a change to the rule -- a new pattern, a dropped one, a changed $options -- is
+    picked up here instead of quietly passing against a stale copy.
+    """
+    for clause in spam_text_clauses("field"):
+        spec = clause["field"]
+        flags = re.I if spec.get("$options") == "i" else 0
+        if re.search(spec["$regex"], text, flags):
+            return True
+    return False
+
+
+def name_is_flagged(first_name, last_name):
+    """Mirror of spam_name_user_ids()'s matching, without the database."""
+    full_name = "%s %s" % (first_name, last_name)
+    return bool(any(keyword in full_name.lower() for keyword in SPAM_KEYWORDS)
+                or re.search(SPAM_PHONE_REGEX, full_name)
+                or re.search(SPAM_NAME_URL_REGEX, full_name, re.I))
+
+
+@pytest.mark.parametrize("first_name,last_name,expected,why", NAME_CASES)
+def test_name_patterns(first_name, last_name, expected, why):
+    assert name_is_flagged(first_name, last_name) is expected, why
+
+
+@pytest.mark.parametrize("text,expected,why", TEXT_CASES)
+def test_text_patterns(text, expected, why):
+    assert text_is_flagged(text) is expected, why
+
+
+def test_spam_text_clauses_covers_every_field_it_is_given():
+    """Both dashboards get the identical rule, whatever field they point it at."""
+    bio_clauses = spam_text_clauses("bio")
+    sheet_clauses = spam_text_clauses("sources.outsideText", "sources.comment")
+
+    assert [list(clause)[0] for clause in bio_clauses] == ["bio"] * 3
+    assert len(sheet_clauses) == 6
+    assert ([clause["sources.outsideText"] for clause in sheet_clauses[:3]]
+            == [clause["bio"] for clause in bio_clauses]), "fields must share one rule"
+
+
+@pytest.mark.django_db
+def test_spam_name_user_ids_matches_the_name_patterns():
+    """The ORM query flags the same names the patterns do, via Postgres rather than re."""
+    for i, (first_name, last_name, _, _why) in enumerate(NAME_CASES):
+        User.objects.create(id=100 + i, username="spamtest%d" % i,
+                            first_name=first_name, last_name=last_name)
+
+    flagged = set(spam_name_user_ids(50))
+
+    for i, (first_name, last_name, expected, why) in enumerate(NAME_CASES):
+        assert ((100 + i) in flagged) is expected, "%s %s: %s" % (first_name, last_name, why)
+
+
+@pytest.mark.django_db
+def test_spam_name_user_ids_ignores_users_below_the_cutoff():
+    """An older account is out of scope even when its name matches."""
+    User.objects.create(id=1, username="spamtestold", first_name="Coinbase", last_name="Support")
+    User.objects.create(id=100, username="spamtestnew", first_name="Coinbase", last_name="Support")
+
+    assert spam_name_user_ids(50) == [100]

--- a/sefaria/views.py
+++ b/sefaria/views.py
@@ -1229,6 +1229,7 @@ def categorize_sheets(request):
 def sheet_spam_dashboard(request):
 
     from django.contrib.auth.models import User
+    from sefaria.spam import spam_text_clauses
 
     if request.method == 'POST':
         return jsonResponse({"error": "Unsupported Method: {}".format(request.method)})
@@ -1244,8 +1245,7 @@ def sheet_spam_dashboard(request):
 
         earliest_new_user_id = User.objects.filter(date_joined__gte=date).order_by('date_joined')[0].id
 
-        regex = r'.*(?!href=[\'"](\/|http(s)?:\/\/(www\.)?sefaria).+[\'"])(href).*'
-        sheets = db.sheets.find({"sources.ref": {"$exists": False}, "dateCreated": {"$gt": date.strftime("%Y-%m-%dT%H:%M:%S.%f")}, "owner": {"$gt": earliest_new_user_id}, "includedRefs": {"$size": 0}, "reviewed": {"$ne": True}, "$or": [{"sources.outsideText": {"$regex": regex}}, {"sources.comment": {"$regex": regex}}, {"sources.outsideBiText.en": {"$regex": regex}}, {"sources.outsideBiText.he": {"$regex": regex}}]})
+        sheets = db.sheets.find({"sources.ref": {"$exists": False}, "dateCreated": {"$gt": date.strftime("%Y-%m-%dT%H:%M:%S.%f")}, "owner": {"$gt": earliest_new_user_id}, "includedRefs": {"$size": 0}, "reviewed": {"$ne": True}, "$or": spam_text_clauses("sources.outsideText", "sources.comment", "sources.outsideBiText.en", "sources.outsideBiText.he")})
 
         sheets_list = []
 
@@ -1262,6 +1262,7 @@ def sheet_spam_dashboard(request):
 def profile_spam_dashboard(request):
 
     from django.contrib.auth.models import User
+    from sefaria.spam import SPAM_KEYWORDS_REGEX, spam_text_clauses, spam_name_user_ids
 
     if request.method == 'POST':
         return jsonResponse({"error": "Unsupported Method: {}".format(request.method)})
@@ -1277,10 +1278,6 @@ def profile_spam_dashboard(request):
 
         earliest_new_user_id = User.objects.filter(date_joined__gte=date).order_by('date_joined')[0].id
 
-        regex = r'.*(?!href=[\'"](\/|http(s)?:\/\/(www\.)?sefaria).+[\'"])(href).*'
-
-        spam_keywords_regex = r'(?i).*support.*|.*coin.*|.*helpline.*|.*base.*'
-
         users_to_check = db.profiles.find(
             {'$and': [
                 {"id": {"$gt": earliest_new_user_id}, "reviewed": {"$ne": True}, "settings.reading_history": {"$ne": False}},
@@ -1290,8 +1287,9 @@ def profile_spam_dashboard(request):
                     {'twitter': {"$ne": ""}},
                     {'youtube': {"$ne": ""}},
                     {'linkedin': {"$ne": ""}},
-                    {'bio': {"$regex": regex}},
-                    {'slug': {"$regex": spam_keywords_regex}}
+                    *spam_text_clauses('bio'),
+                    {'slug': {"$regex": SPAM_KEYWORDS_REGEX}},
+                    {'id': {"$in": spam_name_user_ids(earliest_new_user_id)}}
             ]
         }]})
 


### PR DESCRIPTION
Shortcut: https://app.shortcut.com/sefaria/story/46591

## The vector

Spammers moved to the first and last name fields, which neither spam dashboard checked.

Names live on the Django `User` record in Postgres, not in the Mongo profile doc, so `profile_spam_dashboard`'s query could not reach them. The `slug` *is* checked and is built from the name at signup — but `UserProfile.save()` pushes a name edit to the Django `User` without regenerating the slug. Sign up as "Miriam Cohen", then rename to "Coinbase Support", and the slug stays `miriam-cohen` forever. The check was evaded entirely.

## Changes

- New `sefaria/spam.py` holds the patterns as one source of truth.
- Names are matched in Postgres and folded into the Mongo query by user id. First and last are concatenated before matching, so a number split across the two fields (`1-800` / `555-1234`) is still caught.
- Free text is checked for phone numbers and bare URLs, not just `href` markup. That rule is `spam_text_clauses()`, and **both** dashboards point it at their own fields — so `sheet_spam_dashboard` picks up the same coverage, having previously matched `href` only.
- Links back to Sefaria stay excluded, matching the carve-out the existing href check already made.

## Trade-offs worth a reviewer's eye

- The phone pattern wants 9+ digits so that prose like a `2020-2024` date range is not read as a phone number. The cost is that a bare 7-digit local number is missed — it has the same shape as a year range, and spam numbers carry an area or country code anyway.
- The sheet dashboard's `$or` grows from 4 regex branches to 12, on a candidate set already narrowed by `dateCreated`, `owner`, `includedRefs` and `sources.ref`.
- Name matching uses `__iregex`, so those patterns stay inside the regex subset Postgres, Python and PCRE share — no `\b`, `\d` or lookarounds. The free-text URL variant runs only in Mongo and does use a lookahead.

## Tests

`sefaria/tests/spam_dashboard_test.py`. The negative cases carry the weight, since the only action this queue offers is irreversible deletion: `Miriam Cohen` must not read as the `.co` TLD, `Jean-Pierre St.Clair` and `B. Cohen` must survive the URL pattern, `2020-2024` and `Born 1948. Teaching since 1975.` must not read as phone numbers, and text linking to sefaria.org must stay clear.

Verified locally by driving the test functions against a real `auth_user` table in SQLite (35/35). The repo's pytest suite could not start in my environment — `sefaria/settings.py:404` raises `NameError: APPLE_SSO_IOS_BUNDLE_ID` without the SSO entries in local_settings, pre-existing and unrelated to this branch. **CI is the real gate**, both for pytest proper and for Postgres `iregex`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)