### PR TITLE
feat(sc-46669): let siddur instruction rubrics span both columns

### DIFF
--- a/e2e-tests/library/siddur-instruction-rubrics.spec.ts
+++ b/e2e-tests/library/siddur-instruction-rubrics.spec.ts
@@ -1,0 +1,113 @@
+import { test, expect, Page } from '@playwright/test';
+import { goToPageWithLang, hideAllModalsAndPopups } from '../utils';
+import { LANGUAGES, SOURCE_LANGUAGES, t } from '../globals';
+import { PageManager } from '../pages/pageManager';
+import { MODULE_URLS } from '../constants';
+
+/**
+ * SID-0NN — Siddur instruction rubrics (sc-46669).
+ *
+ * Siddur texts carry English rubrics in <i class="instruction"> tags ("Some say the following
+ * meditation before putting on the tefillin."). They live on the translation side, in segments
+ * that have no source text at all.
+ *
+ * Two behaviors are covered:
+ *   - side-by-side bilingual: a rubric spans both columns instead of wrapping inside half of one
+ *   - source-only: the rubric shows to an English-UI reader, stays hidden to a Hebrew-UI reader
+ *
+ * The trigger is "segment has no source text" (the `noPrimary` class), NOT "contains an
+ * instruction tag" — segments like Tefillin 11 carry a rubric inline alongside a real translation
+ * and a facing Hebrew source, and must keep the normal 50/50 split. SID-002 is that regression
+ * guard; without it a `:has(i.instruction)` implementation would look correct.
+ *
+ * Data verified against production via /api/v3/texts (CLAUDE.md §2A): the section has 16 segments,
+ * of which 1, 5, 7, 9, 12 and 14 are rubric-only and 11 is the mixed case.
+ */
+
+const SECTION_REF = 'The Koren Shalem Siddur; Ashkenaz, Weekdays, Tefillin';
+const SECTION_PATH = '/The_Koren_Shalem_Siddur%3B_Ashkenaz%2C_Weekdays%2C_Tefillin';
+
+const RUBRIC_ONLY_REF = `${SECTION_REF} 1`;   // rubric only, no Hebrew
+const MIXED_REF = `${SECTION_REF} 11`;        // "Some say:" rubric + real translation + Hebrew
+const PLAIN_REF = `${SECTION_REF} 13`;        // ordinary bilingual segment, no rubric
+
+test.describe('Library Reader — Siddur instruction rubrics — English', () => {
+  let page: Page;
+  let pm: PageManager;
+
+  test.beforeEach(async ({ context }) => {
+    page = await goToPageWithLang(context, `${MODULE_URLS.EN.LIBRARY}${SECTION_PATH}`, LANGUAGES.EN);
+    pm = new PageManager(page, LANGUAGES.EN);
+    await hideAllModalsAndPopups(page);
+    // Wait for a specific segment, not just the reader shell — the panel mounts before the
+    // text streams in (CLAUDE.md §2 rule 11).
+    await expect(page.locator(`.basetext .segment[data-ref="${PLAIN_REF}"]`))
+      .toBeVisible({ timeout: t(30000) });
+  });
+
+  test('SID-001: side-by-side — a source-less rubric spans both columns', async () => {
+    await pm.onSourceTextPage().setContentLanguage(SOURCE_LANGUAGES.BI);
+    await pm.onSourceTextPage().setBiLayout('heRight');
+
+    const rubric = await pm.onSourceTextPage().getSegmentSpanLayout(RUBRIC_ONLY_REF);
+    expect(rubric).not.toBeNull();
+    expect(rubric!.translation?.hasInstruction).toBe(true);
+
+    // The rubric fills the segment's whole width rather than a 50% column.
+    expect(rubric!.translation!.float).toBe('none');
+    expect(rubric!.translation!.width).toBeGreaterThan(rubric!.segmentWidth * 0.9);
+
+    // The empty source span must not reserve the facing half.
+    expect(rubric!.primary!.display).toBe('none');
+  });
+
+  test('SID-002: side-by-side — a rubric mixed with real translation keeps the 50/50 split', async () => {
+    await pm.onSourceTextPage().setContentLanguage(SOURCE_LANGUAGES.BI);
+    await pm.onSourceTextPage().setBiLayout('heRight');
+
+    const mixed = await pm.onSourceTextPage().getSegmentSpanLayout(MIXED_REF);
+    expect(mixed).not.toBeNull();
+
+    // Both columns still render and neither is full width.
+    expect(mixed!.primary!.display).not.toBe('none');
+    expect(mixed!.translation!.float).not.toBe('none');
+    expect(mixed!.translation!.width).toBeLessThan(mixed!.segmentWidth * 0.75);
+    expect(mixed!.primary!.width).toBeLessThan(mixed!.segmentWidth * 0.75);
+
+    // And an ordinary segment is untouched.
+    const plain = await pm.onSourceTextPage().getSegmentSpanLayout(PLAIN_REF);
+    expect(plain!.translation!.width).toBeLessThan(plain!.segmentWidth * 0.75);
+  });
+
+  test('SID-003: source-only with an English UI shows the rubric', async () => {
+    await pm.onSourceTextPage().setContentLanguage(SOURCE_LANGUAGES.HE);
+
+    const rubric = await pm.onSourceTextPage().isInstructionRendered(RUBRIC_ONLY_REF);
+    expect(rubric).not.toBeNull();
+    expect(rubric!.present).toBe(true);
+    expect(rubric!.rendered).toBe(true);
+    expect(rubric!.height).toBeGreaterThan(0);
+  });
+});
+
+test.describe('Library Reader — Siddur instruction rubrics — Hebrew', () => {
+  let page: Page;
+  let pm: PageManager;
+
+  test.beforeEach(async ({ context }) => {
+    page = await goToPageWithLang(context, `${MODULE_URLS.HE.LIBRARY}${SECTION_PATH}`, LANGUAGES.HE);
+    pm = new PageManager(page, LANGUAGES.HE);
+    await hideAllModalsAndPopups(page);
+    await expect(page.locator(`.basetext .segment[data-ref="${PLAIN_REF}"]`))
+      .toBeVisible({ timeout: t(30000) });
+  });
+
+  test('SID-004: source-only with a Hebrew UI keeps the English rubric hidden', async () => {
+    await pm.onSourceTextPage().setContentLanguage(SOURCE_LANGUAGES.HE);
+
+    const rubric = await pm.onSourceTextPage().isInstructionRendered(RUBRIC_ONLY_REF);
+    expect(rubric).not.toBeNull();
+    expect(rubric!.present).toBe(true);
+    expect(rubric!.rendered).toBe(false);
+  });
+});

--- a/e2e-tests/pages/sourceTextPage.ts
+++ b/e2e-tests/pages/sourceTextPage.ts
@@ -7,30 +7,74 @@ export class SourceTextPage extends HelperBase {
         super(page, language)
     }
 
-    async setContentLanguage(mode: RegExp) {
-        await this.page.getByRole('button', { name: 'Toggle Reader Menu Display Settings' }).click();
-        await this.page.getByRole('radio', { name: mode }).click();
+    /**
+     * The reader's display-settings ("Aa") toggle.
+     *
+     * Anchored on the class hardcoded in DisplaySettingsButton (Misc.jsx) rather than the
+     * accessible name: that name is `Sefaria._("common.text_display_options")`, which renders as
+     * "אפשרויות תצוגת טקסט" under a Hebrew interface. See CLAUDE.md §2 rule 15.
+     */
+    private get displaySettingsToggle() {
+        return this.page.locator('.readerOptionsTooltip').first()
     }
 
-    private get displaySettingsToggle() {
-        return this.page.getByRole('button', { name: 'Toggle Reader Menu Display Settings' })
+    private async openDisplaySettings() {
+        const menu = this.page.locator('.texts-properties-menu')
+        if (!(await menu.isVisible().catch(() => false))) {
+            await this.displaySettingsToggle.click()
+            await expect(menu).toBeVisible({ timeout: t(10000) })
+        }
+    }
+
+    private async closeDisplaySettings() {
+        const menu = this.page.locator('.texts-properties-menu')
+        if (await menu.isVisible().catch(() => false)) {
+            await this.displaySettingsToggle.click()
+            await expect(menu).toBeHidden({ timeout: t(10000) })
+        }
     }
 
     /**
-     * Choose the bilingual layout. The radios are labelled with the internal, interface-language
-     * invariant values ('stacked' | 'heLeft' | 'heRight'), so this is safe under a Hebrew UI.
-     * Only meaningful while the content language is "Source with Translation".
+     * Pick Source / Translation / Source with Translation, using the SOURCE_LANGUAGES constants.
+     *
+     * The radios' accessible names are translated, but their `value` attributes are always the
+     * English keys — and the SOURCE_LANGUAGES regexes list the English spelling as one branch, so
+     * matching on `value` works from either interface language.
+     */
+    async setContentLanguage(mode: RegExp) {
+        await this.openDisplaySettings()
+        const radios = this.page.locator('.texts-properties-menu input[type="radio"][name^="languageOptions"]')
+        await expect(radios.first()).toBeVisible({ timeout: t(10000) })
+
+        const values = await radios.evaluateAll(
+            (els) => els.map(el => (el as HTMLInputElement).value))
+        const index = values.findIndex(v => mode.test(v))
+        if (index === -1) {
+            throw new Error(`No content-language option matching ${mode} — found: ${values.join(', ')}`)
+        }
+
+        // The <input> sits behind its styled <label>, so click the label the user actually sees.
+        await radios.nth(index).locator('..').click()
+        await expect(radios.nth(index)).toBeChecked({ timeout: t(10000) })
+        await this.closeDisplaySettings()
+    }
+
+    /**
+     * Choose the bilingual layout. Only meaningful while the content language is
+     * "Source with Translation".
+     *
+     * Anchored on the input's `value` for the same reason as above: these radios take their
+     * accessible name from a visible <span class="int-en"> label ("Show RTL Text Right of LTR
+     * Text"), which changes under a Hebrew interface.
      */
     async setBiLayout(layout: 'stacked' | 'heLeft' | 'heRight') {
-        const radio = this.page.getByRole('radio', { name: layout, exact: true })
-        if (!(await radio.isVisible())) {
-            await this.displaySettingsToggle.click()
-        }
+        await this.openDisplaySettings()
+        const radio = this.page.locator(
+            `.texts-properties-menu .layout-options input[type="radio"][value="${layout}"]`).first()
         await expect(radio).toBeVisible({ timeout: t(10000) })
-        await radio.click()
-        // Close the settings dialog so it can't intercept later clicks or screenshots.
-        await this.displaySettingsToggle.click()
-        await expect(radio).toBeHidden({ timeout: t(10000) })
+        await radio.locator('..').click()
+        await expect(radio).toBeChecked({ timeout: t(10000) })
+        await this.closeDisplaySettings()
     }
 
     /**

--- a/e2e-tests/pages/sourceTextPage.ts
+++ b/e2e-tests/pages/sourceTextPage.ts
@@ -12,6 +12,79 @@ export class SourceTextPage extends HelperBase {
         await this.page.getByRole('radio', { name: mode }).click();
     }
 
+    private get displaySettingsToggle() {
+        return this.page.getByRole('button', { name: 'Toggle Reader Menu Display Settings' })
+    }
+
+    /**
+     * Choose the bilingual layout. The radios are labelled with the internal, interface-language
+     * invariant values ('stacked' | 'heLeft' | 'heRight'), so this is safe under a Hebrew UI.
+     * Only meaningful while the content language is "Source with Translation".
+     */
+    async setBiLayout(layout: 'stacked' | 'heLeft' | 'heRight') {
+        const radio = this.page.getByRole('radio', { name: layout, exact: true })
+        if (!(await radio.isVisible())) {
+            await this.displaySettingsToggle.click()
+        }
+        await expect(radio).toBeVisible({ timeout: t(10000) })
+        await radio.click()
+        // Close the settings dialog so it can't intercept later clicks or screenshots.
+        await this.displaySettingsToggle.click()
+        await expect(radio).toBeHidden({ timeout: t(10000) })
+    }
+
+    /**
+     * Read the resolved layout of one segment's source/translation spans in a single round trip.
+     * Returned widths are rounded CSS pixels; `segmentWidth` is the width of the segment's own
+     * text container, so callers can assert "spans the full column" without hardcoding a pixel
+     * value that varies with viewport.
+     *
+     * One atomic evaluate rather than a sequence of locator reads — see CLAUDE.md §2 rule 20(b).
+     */
+    async getSegmentSpanLayout(ref: string) {
+        return await this.page.evaluate((segRef: string) => {
+            const seg = document.querySelector(`.basetext .segment[data-ref="${segRef}"]`)
+            if (!seg) return null
+            const read = (sel: string) => {
+                const el = seg.querySelector(`:scope > p > .contentSpan.${sel}`)
+                if (!el) return null
+                const cs = window.getComputedStyle(el)
+                return {
+                    display: cs.display,
+                    float: cs.float,
+                    width: Math.round(parseFloat(cs.width)),
+                    direction: cs.direction,
+                    className: el.className,
+                    hasInstruction: !!el.querySelector(':scope > i.instruction'),
+                }
+            }
+            return {
+                segmentWidth: Math.round(seg.getBoundingClientRect().width),
+                primary: read('primary'),
+                translation: read('translation'),
+            }
+        }, ref)
+    }
+
+    /**
+     * Whether a segment's instruction rubric is actually rendered to the reader.
+     * Uses offsetParent + rect rather than :visible so a `display:none` ancestor counts as hidden.
+     */
+    async isInstructionRendered(ref: string) {
+        return await this.page.evaluate((segRef: string) => {
+            const seg = document.querySelector(`.basetext .segment[data-ref="${segRef}"]`)
+            if (!seg) return null
+            const instr = seg.querySelector('i.instruction')
+            if (!instr) return { present: false, rendered: false, height: 0 }
+            const rect = (instr as HTMLElement).getBoundingClientRect()
+            return {
+                present: true,
+                rendered: (instr as HTMLElement).offsetParent !== null && rect.height > 0,
+                height: Math.round(rect.height),
+            }
+        }, ref)
+    }
+
     // Refactored from utils.ts: changeLanguageOfText
     async changeTextLanguage(sourceLanguage: RegExp) {
         // Clicking on the Source Language toggle

--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -1306,6 +1306,13 @@ a.interfaceLinks-option.active, a.interfaceLinks-option.inactive {
 .readerPanel.hebrew .versionsTextList .translation {
   display: block;
 }
+/* Rubrics (<i class="instruction">) generally exist only on the translation side, in segments
+   that have no source text at all. In source-only mode those segments would otherwise render
+   empty, so show the instruction — but only to an English-speaking reader, since the rubric
+   itself is English. */
+.interface-english .readerPanel.hebrew .basetext .segment.noPrimary > p > .contentSpan.translation:has(> i.instruction) {
+  display: inline;
+}
 
 .readerPanel.english .he.heOnly{
   display: inline;
@@ -6261,6 +6268,21 @@ big {
 .heLeft.bilingual .SheetSource .sheetItem.segment > .he{
   float: left;
   padding-right: 20px;
+}
+/* A segment with no source text has nothing to sit beside in side-by-side mode, so let its
+   translation span both columns rather than wrap inside half the width. In practice these are
+   the instruction rubrics of siddurim and similar texts. */
+.heLeft.bilingual .basetext .segment.noPrimary > p > .contentSpan.translation,
+.heRight.bilingual .basetext .segment.noPrimary > p > .contentSpan.translation {
+  display: block;
+  width: 100%;
+  float: none;
+  padding-left: 0;
+  padding-right: 0;
+}
+.heLeft.bilingual .basetext .segment.noPrimary > p > .contentSpan.primary,
+.heRight.bilingual .basetext .segment.noPrimary > p > .contentSpan.primary {
+  display: none;
 }
 .segment > p > .he.translation {
   --hebrew-font: var(--hebrew-sans-serif-font-family);

--- a/static/js/TextRange.jsx
+++ b/static/js/TextRange.jsx
@@ -652,6 +652,7 @@ class TextSegment extends Component {
       invisibleHighlight: this.props.highlight,
       heOnly: heOnly,
       enOnly: enOnly,
+      noPrimary: hasNoPrimarry,
       showNamedEntityLinks: !!this.props.onNamedEntityClick,
     });
     if(hasNoTranslation && !this.props.he){


### PR DESCRIPTION
Closes [sc-46669](https://app.shortcut.com/sefaria/story/46669)

Siddur texts carry English rubrics in `<i class="instruction">` tags — *"Some say the following meditation before putting on the tefillin."* They live on the translation side, in segments that have **no source text at all**.

Example: https://www.sefaria.org/The_Koren_Shalem_Siddur%3B_Ashkenaz%2C_Weekdays%2C_Tefillin.1?lang=bi

## Before / after

| mode | before | after |
| --- | --- | --- |
| Bilingual side-by-side | rubric wraps inside the 50% translation column, empty column beside it | rubric spans both columns |
| Bilingual stacked | — | unchanged |
| Translation-only | — | unchanged |
| Source-only + **English** UI | segment renders empty (height 0) | rubric shown |
| Source-only + **Hebrew** UI | hidden | unchanged (hidden) |

## Why the trigger is "no source text", not "has an instruction tag"

Keying off `:has(> i.instruction)` alone **misfires**. Sampling 11 siddur sections via `/api/v3/texts` (498 segments, 174 containing instructions):

| pattern | count |
| --- | --- |
| EN instruction-only, tag at top level | 98 |
| **EN instruction mixed with real translation, tag at top level** | **32** |
| HE instruction (always mixed, never alone) | 58 |

Those 32 include `Tefillin 11` (*"Some say:"* + a full translation) and every `Leader:` / `Cong. then Leader:` line in Kaddish and Kedusha — all with facing Hebrew. Full-widthing them would break the parallel layout.

Of 102 segments with no Hebrew, 101 carry a rubric, and **zero** instruction-only translations have facing Hebrew. So this exposes the already-computed `hasNoPrimarry` as a `noPrimary` class and keys the CSS on that. The source-only rule additionally requires `:has(> i.instruction)` so missing-source segments library-wide don't start showing English in Hebrew-only mode.

`SID-002` is the regression guard for the mixed case — without it a `:has(i.instruction)` implementation would look correct.

## Notes for review

- Both rules are scoped to `.basetext`, so the connections panel is unaffected (`TextList`/`VersionsTextList` pass `basetext={false}`).
- Selectors key on `.primary`/`.translation` rather than `.he`/`.en`, because those language classes are currently unreliable on this text — see sc-46469, fixed in the follow-up PR stacked on this branch.
- `:has()` already appears 8× in these stylesheets.

## Tests

`e2e-tests/library/siddur-instruction-rubrics.spec.ts` — SID-001 … SID-004, plus new `SourceTextPage` methods (`setBiLayout`, `getSegmentSpanLayout`, `isInstructionRendered`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
