### PR TITLE
fix(sc-46469): don't promote a lone translation version to primary

### DIFF
--- a/e2e-tests/library/siddur-language-direction.spec.ts
+++ b/e2e-tests/library/siddur-language-direction.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect, Page } from '@playwright/test';
+import { goToPageWithLang, hideAllModalsAndPopups } from '../utils';
+import { LANGUAGES, t } from '../globals';
+import { PageManager } from '../pages/pageManager';
+import { MODULE_URLS } from '../constants';
+
+/**
+ * SID-01N — Language direction on refs whose source side is empty (sc-46469).
+ *
+ * Landing directly on a segment that has no source text made the WHOLE section render its
+ * Hebrew left-to-right. The segment-level API call returns only the translation version (there
+ * is no Hebrew for that segment), and `getPrimaryAndTranslationFromVersions` promoted that lone
+ * translation to `primary` — handing its `ltr` direction and `english` language to every segment
+ * in the section, including the ones that do have Hebrew.
+ *
+ * The commentary panel in the original report is incidental: clicking a segment to open
+ * commentary just moves the URL to that segment ref, which is what triggers the fetch. Loading
+ * the section ref, or a segment that has Hebrew, was always fine — SID-012 pins that control so
+ * a regression can't be mistaken for "the test never worked".
+ */
+
+const SECTION_REF = 'The Koren Shalem Siddur; Ashkenaz, Weekdays, Tefillin';
+const SECTION_SLUG = 'The_Koren_Shalem_Siddur%3B_Ashkenaz%2C_Weekdays%2C_Tefillin';
+
+const HEBREW_SEGMENT_REF = `${SECTION_REF} 2`;  // has Hebrew; renders correctly even on master
+const HEBREW_RANGE = /[֐-׿]/;
+
+test.describe('Library Reader — language direction with an empty source segment — English', () => {
+  let page: Page;
+  let pm: PageManager;
+
+  const loadAt = async (context, segment: string) => {
+    page = await goToPageWithLang(
+      context, `${MODULE_URLS.EN.LIBRARY}/${SECTION_SLUG}.${segment}?lang=bi`, LANGUAGES.EN);
+    pm = new PageManager(page, LANGUAGES.EN);
+    await hideAllModalsAndPopups(page);
+    await expect(page.locator(`.basetext .segment[data-ref="${HEBREW_SEGMENT_REF}"]`))
+      .toBeVisible({ timeout: t(30000) });
+  };
+
+  test('SID-011: landing on a source-less segment keeps the section Hebrew right-to-left', async ({ context }) => {
+    // Segment 1 is an instruction rubric with no Hebrew — the trigger for sc-46469.
+    await loadAt(context, '1');
+
+    const seg = await pm.onSourceTextPage().getSegmentSpanLayout(HEBREW_SEGMENT_REF);
+    expect(seg).not.toBeNull();
+
+    // Sanity: this segment really does carry Hebrew source text.
+    const sourceText = await page.locator(
+      `.basetext .segment[data-ref="${HEBREW_SEGMENT_REF}"] .contentSpan.primary`).innerText();
+    expect(sourceText).toMatch(HEBREW_RANGE);
+
+    // ...so its source span must be marked Hebrew and render rtl.
+    expect(seg!.primary!.className).toContain('he');
+    expect(seg!.primary!.className).not.toContain('contentSpan en');
+    expect(seg!.primary!.direction).toBe('rtl');
+  });
+
+  test('SID-012: landing on a segment that has Hebrew is unaffected (control)', async ({ context }) => {
+    await loadAt(context, '2');
+
+    const seg = await pm.onSourceTextPage().getSegmentSpanLayout(HEBREW_SEGMENT_REF);
+    expect(seg!.primary!.className).toContain('he');
+    expect(seg!.primary!.direction).toBe('rtl');
+  });
+});

--- a/static/js/sefaria/sefaria.js
+++ b/static/js/sefaria/sefaria.js
@@ -709,8 +709,18 @@ Sefaria = extend(Sefaria, {
   getPrimaryAndTranslationFromVersions: function(versions) {
     let primary, translation;
     if (versions.length === 1) {
-      primary = versions[0];
-      translation = {text: []};
+      // A single version is not necessarily the primary one. When a ref has no source text --
+      // e.g. a siddur segment holding only an English instruction rubric -- the API returns the
+      // translation alone. Promoting it to primary hands its `ltr` direction and `english`
+      // language to everything downstream, which is how landing on such a segment flipped a whole
+      // Hebrew section to left-to-right (sc-46469).
+      if (versions[0].isPrimary || versions[0].isSource) {
+        primary = versions[0];
+        translation = {text: []};
+      } else {
+        translation = versions[0];
+        primary = {text: []};
+      }
     } else if (versions[0].isPrimary && !versions[1].isSource) {
       [primary, translation] = versions;
     } else {


### PR DESCRIPTION
Closes [sc-46469](https://app.shortcut.com/sefaria/story/46469)

**Stacked on #3623** — base that first, or review only the last commit here.

> ⚠️ **Draft: the fix is reasoned and parses, but I have not yet run it.** Playwright browsers weren't installable in my environment and staging has no siddur data. See "Verification status" below. Marking ready once the local run is green.

## Symptom

Landing directly on a segment whose source side is empty makes the **whole section** render its Hebrew left-to-right — punctuation lands on the wrong side (`.בְּשֵׁם כָּל יִשְׂרָאֵל`).

Reproduces on production today:

| URL | source span | direction |
| --- | --- | --- |
| `…Tefillin.1?lang=bi&with=Rabbi Sacks on Siddur&lang2=en` (the report) | `contentSpan en primary` | ltr ❌ |
| `…Tefillin.1?lang=bi` (no commentary) | `contentSpan en primary` | ltr ❌ |
| `…Tefillin.2?lang=bi&with=…` | `contentSpan he primary` | rtl ✅ |
| `…Tefillin.2?lang=bi` | `contentSpan he primary` | rtl ✅ |

The commentary panel is **incidental** — clicking a segment to open commentary just moves the URL to that segment ref, which is what triggers the fetch. The variable is *which* segment: one with no source text.

## Cause

`getPrimaryAndTranslationFromVersions` ([sefaria.js:709](https://github.com/Sefaria/Sefaria-Project/blob/master/static/js/sefaria/sefaria.js#L709)):

```js
if (versions.length === 1) {
  primary = versions[0];
  translation = {text: []};
}
```

A lone version is assumed to be the source. But `Tefillin 1` holds only an English instruction rubric, so the API correctly returns just the translation — which then gets promoted to `primary`. `_adaptApiResponse` records `primaryDirection: 'ltr'`, `primaryLang: 'english'`, and `ContentText` renders the source span as `<span class="contentSpan en primary" lang="en">`.

Because the reader fetches with context, that one response carries the **entire section's** text, so all 16 segments inherit the wrong direction. Confirmed in the live cache on prod:

```
_texts['…tefillin 1']  →  primaryDirection: "ltr",  primaryLang: "english",
                          heVersionTitle: "English Edition…",  he: <16-segment array>
_texts['…tefillin 2']  →  primaryDirection: "rtl",  primaryLang: "hebrew"
```

## Fix

Decide from the version's own `isPrimary` / `isSource` flags rather than assuming.

Worth a reviewer's eye: the `else if (versions[0].isPrimary && !versions[1].isSource)` branch below happens to resolve correctly for both orderings the API currently returns, but by coincidence of ordering rather than by reading the flags. Left alone here to keep the diff tight.

## Verification status

- ✅ Root cause confirmed empirically on production (cache dump + the 4-URL repro/control matrix above).
- ✅ `sefaria.js` parses; both new specs typecheck.
- ❌ **Not yet executed.** `npx playwright install` was skipped (another agent was already installing), and `sefariastaging.org` returns 404 for the siddur, so production was the only "before" environment available.
- ⏳ Next: run `SID-011`/`SID-012` against production (expect red) and against a local instance on this branch (expect green).

## Tests

`e2e-tests/library/siddur-language-direction.spec.ts`

- `SID-011` — landing on a source-less segment keeps the section's Hebrew rtl *(the regression)*
- `SID-012` — landing on a segment that has Hebrew is unaffected *(control; passes on master, so a green SID-011 can't be a false positive from the page failing to load)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
