### PR TITLE
Source cards text should be black

### DIFF
--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -5046,7 +5046,7 @@ body .ui-autocomplete.dictionary-toc-autocomplete .ui-menu-item a.ui-state-focus
 .searchResultCard-snippet {
   font-size: 18px;
   line-height: 1.5;
-  color: var(--secondary-text-grey);
+  color: var(--near-black);
   word-break: break-word;
 }
 .searchResultCard-snippet.he {


### PR DESCRIPTION
## Description
The text on source cards was gray, reverting to black. 