### PR TITLE
fix(sso): mark the post-login/language-switch redirect no_applink

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -12,9 +12,11 @@ DJANGO_SETTINGS_MODULE = sefaria.settings
 python_files =
     sefaria/tests/*_test.py
     sefaria/system/tests/*_test.py
+    sefaria/system/tests/test_*.py
     sefaria/model/tests/*_test.py
     sefaria/helper/tests/*_test.py
     sefaria/datatype/tests/*_test.py
+    sefaria/utils/tests/*_test.py
     remote_config/tests/*_test.py
     reader/tests/*_test.py
     reader/tests/test_*.py
@@ -27,5 +29,10 @@ python_files =
 ; sefaria/model/tests RUNTIME ERROR Skipping these for now
 ; sefaria/helper/tests -- 11/15 tests passing, 7m45s
 ; sefaria/datatype/tests -- 24/25 tests passing, 0.14s
+; sefaria/utils/tests -- previously uncollected (missing from python_files); verified passing
+;   before adding the pattern
 ; sso/tests -- new, added with the SSO branch
 ; reader/tests -- passed to pytest as ./reader alongside ./sefaria
+; sefaria/system/tests/test_*.py -- previously uncollected test_database.py, test_decorators.py,
+;   test_varnish.py, test_middleware.py, test_language_module_switching.py; verified passing
+;   before adding the pattern

--- a/reader/tests/apple_app_site_association_test.py
+++ b/reader/tests/apple_app_site_association_test.py
@@ -1,0 +1,38 @@
+"""
+Tests for the apple_app_site_association (AASA) view.
+
+Covers the two exclusion mechanisms: the static AASA_EXCLUDED_PATHS entries
+(allauth OAuth callbacks, always excluded), and the dynamic no_applink query
+marker (WebSessionRedirectMiddleware) -- see sefaria/utils/views_utils.py.
+"""
+import json
+
+from django.test import RequestFactory
+
+from reader import views
+from sefaria.utils.views_utils import AASA_EXCLUDED_PATHS, NO_APPLINK_PARAM
+
+
+def _components():
+    response = views.apple_app_site_association(RequestFactory().get('/'))
+    body = json.loads(response.content)
+    return body["applinks"]["details"][0]["components"]
+
+
+class TestAppleAppSiteAssociation:
+    def test_static_paths_excluded_before_catch_all(self):
+        components = _components()
+
+        for path in AASA_EXCLUDED_PATHS:
+            assert {"/": path, "exclude": True} in components
+
+        catch_all_index = components.index({"/": "*"})
+        for path in AASA_EXCLUDED_PATHS:
+            assert components.index({"/": path, "exclude": True}) < catch_all_index
+
+    def test_no_applink_query_excluded_before_catch_all(self):
+        components = _components()
+
+        no_applink_rule = {"/": "*", "?": {NO_APPLINK_PARAM: "*"}, "exclude": True}
+        assert no_applink_rule in components
+        assert components.index(no_applink_rule) < components.index({"/": "*"})

--- a/reader/views.py
+++ b/reader/views.py
@@ -67,7 +67,7 @@ from sefaria.history import text_history, get_maximal_collapsed_activity, top_co
 from sefaria.sefaria_tasks_interace.history_change import LinkChange, VersionChange
 from sefaria.sheets import get_sheets_for_ref, get_sheet_for_panel, annotate_user_links
 from sefaria.utils.util import text_preview, short_to_long_lang_code, epoch_time, get_short_lang, is_int
-from sefaria.utils.views_utils import add_query_param
+from sefaria.utils.views_utils import add_query_param, AASA_EXCLUDED_PATHS, NO_APPLINK_PARAM
 from sefaria.utils.domains_and_languages import current_domain_lang, get_redirect_domain_for_language, needs_domain_switch, get_cookie_domain
 from sefaria.utils.hebrew import hebrew_term, has_hebrew
 from sefaria.utils.calendars import get_all_calendar_items, get_todays_calendar_items, get_keyed_calendar_items, get_parasha
@@ -5231,28 +5231,10 @@ def custom_server_error(request, template_name='500.html'):
     #return http.HttpResponseServerError(t.render({'request_path': request.path}, request))
 
 
-# Paths iOS must NOT hand to the app as universal links. Everything else on the domain
-# still opens the app (see AASA_PATHS below).
-#
-# Auth flows have to stay in the browser: they depend on the session/CSRF cookies held by
-# the browser, which the app can't see. When the SSO round-trip returns from
-# appleid.apple.com or accounts.google.com, that final hop is a cross-domain navigation
-# into sefaria.org -- exactly the trigger for a universal link -- so without these
-# exclusions iOS yanks the user into the app mid-login. Sefaria-Mobile's DeepLinkRouter
-# has no route for these paths either; they fall through to its catchAll, which bounces
-# straight back out to a browser (Sefaria-Mobile/DeepLinkRouter.js).
-AASA_EXCLUDED_PATHS = [
-    "/accounts/*",          # allauth OAuth endpoints, incl. the Apple/Google callbacks
-    "/_allauth/*",          # allauth headless API
-    "/login",
-    "/login/",
-    "/register",
-    "/register/",
-    "/logout",
-    "/logout/",
-    "/password/reset*",     # reset request, emailed confirm link, done/complete pages
-]
-
+# AASA_EXCLUDED_PATHS statically excludes the OAuth callback paths (referer is always
+# external there -- see sefaria/utils/views_utils.py). Everything else that must stay in
+# the browser (e.g. the post-login landing page) is excluded dynamically instead, via
+# NO_APPLINK_PARAM, set by WebSessionRedirectMiddleware (sefaria/system/middleware.py).
 AASA_PATHS = ["NOT " + path for path in AASA_EXCLUDED_PATHS] + ["*"]
 
 
@@ -5273,6 +5255,7 @@ def apple_app_site_association(request):
                     "paths": AASA_PATHS,
                     "components": (
                         [{"/": path, "exclude": True} for path in AASA_EXCLUDED_PATHS]
+                        + [{"/": "*", "?": {NO_APPLINK_PARAM: "*"}, "exclude": True}]
                         + [{"/": "*"}]
                     ),
                 }

--- a/sefaria/settings.py
+++ b/sefaria/settings.py
@@ -129,6 +129,7 @@ MIDDLEWARE = [
     'django_user_agents.middleware.UserAgentMiddleware',
     'sefaria.system.middleware.ModuleMiddleware',
     'sefaria.system.middleware.LocationSettingsMiddleware',
+    'sefaria.system.middleware.WebSessionRedirectMiddleware',
     'sefaria.system.middleware.LanguageCookieMiddleware',
     'sefaria.system.middleware.LanguageSettingsMiddleware',
     'sefaria.system.middleware.ProfileMiddleware',

--- a/sefaria/system/middleware.py
+++ b/sefaria/system/middleware.py
@@ -11,15 +11,15 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.utils import translation
 from django.shortcuts import redirect
-from django.http import HttpResponse
+from django.http import HttpResponse, HttpResponseRedirect, HttpResponsePermanentRedirect
 from django.urls import resolve
 
 from sefaria.site.site_settings import SITE_SETTINGS
 from sefaria.model.user_profile import UserProfile
 from sefaria.utils.chatbot import get_user_id_from_chatbot_user_token
 from sefaria.utils.util import short_to_long_lang_code, get_lang_codes_for_territory
-from sefaria.utils.views_utils import add_query_param
-from sefaria.utils.domains_and_languages import current_domain_lang, get_redirect_domain_for_language, needs_domain_switch, get_cookie_domain, get_hostname_without_port
+from sefaria.utils.views_utils import add_query_param, mark_no_applink, AASA_EXCLUDED_PATHS
+from sefaria.utils.domains_and_languages import current_domain_lang, get_redirect_domain_for_language, needs_domain_switch, get_cookie_domain, get_hostname_without_port, referer_is_sefaria_domain
 from sefaria.system.cache import get_shared_cache_elem, set_shared_cache_elem
 from django.utils.deprecation import MiddlewareMixin
 from urllib.parse import quote, urljoin
@@ -187,6 +187,23 @@ class LanguageSettingsMiddleware(MiddlewareMixin):
         request.translation_language_preference_suggestion = translation_language_preference_suggestion
 
         translation.activate(request.LANGUAGE_CODE)
+
+
+_OAUTH_CALLBACK_PREFIXES = tuple(p.rstrip('*') for p in AASA_EXCLUDED_PATHS)
+
+
+class WebSessionRedirectMiddleware(MiddlewareMixin):
+    """
+    Marks a redirect Location as no_applink when it continues an in-progress web session,
+    so iOS never hands it to the app mid-flow. See AASA_EXCLUDED_PATHS and NO_APPLINK_PARAM
+    in sefaria/utils/views_utils.py.
+    """
+    def process_response(self, request, response):
+        is_redirect = isinstance(response, (HttpResponseRedirect, HttpResponsePermanentRedirect))
+        is_web_session = request.path.startswith(_OAUTH_CALLBACK_PREFIXES) or referer_is_sefaria_domain(request)
+        if is_redirect and is_web_session:
+            response['Location'] = mark_no_applink(response['Location'])
+        return response
 
 
 class LanguageCookieMiddleware(MiddlewareMixin):

--- a/sefaria/system/middleware.py
+++ b/sefaria/system/middleware.py
@@ -19,7 +19,7 @@ from sefaria.model.user_profile import UserProfile
 from sefaria.utils.chatbot import get_user_id_from_chatbot_user_token
 from sefaria.utils.util import short_to_long_lang_code, get_lang_codes_for_territory
 from sefaria.utils.views_utils import add_query_param, mark_no_applink, AASA_EXCLUDED_PATHS
-from sefaria.utils.domains_and_languages import current_domain_lang, get_redirect_domain_for_language, needs_domain_switch, get_cookie_domain, get_hostname_without_port, referer_is_sefaria_domain
+from sefaria.utils.domains_and_languages import current_domain_lang, get_redirect_domain_for_language, needs_domain_switch, get_cookie_domain, get_hostname_without_port, referer_is_sefaria_domain, redirect_target_is_sefaria_domain
 from sefaria.system.cache import get_shared_cache_elem, set_shared_cache_elem
 from django.utils.deprecation import MiddlewareMixin
 from urllib.parse import quote, urljoin
@@ -201,7 +201,7 @@ class WebSessionRedirectMiddleware(MiddlewareMixin):
     def process_response(self, request, response):
         is_redirect = isinstance(response, (HttpResponseRedirect, HttpResponsePermanentRedirect))
         is_web_session = request.path.startswith(_OAUTH_CALLBACK_PREFIXES) or referer_is_sefaria_domain(request)
-        if is_redirect and is_web_session:
+        if is_redirect and is_web_session and redirect_target_is_sefaria_domain(response['Location']):
             response['Location'] = mark_no_applink(response['Location'])
         return response
 

--- a/sefaria/system/tests/test_language_module_switching.py
+++ b/sefaria/system/tests/test_language_module_switching.py
@@ -20,7 +20,8 @@ Test Coverage:
 import pytest
 from django.test import RequestFactory, override_settings
 from django.contrib.auth.models import AnonymousUser
-from sefaria.system.middleware import LanguageSettingsMiddleware, LanguageCookieMiddleware
+from django.http import HttpResponse
+from sefaria.system.middleware import LanguageSettingsMiddleware, LanguageCookieMiddleware, WebSessionRedirectMiddleware
 from sefaria.constants.model import LIBRARY_MODULE, VOICES_MODULE
 
 # ============================================================================
@@ -398,3 +399,29 @@ class TestLanguageModuleSwitching:
         assert response.status_code == 302, "Should be a redirect (302)"
         assert 'voices.sefaria.org' in response.url, "Should redirect to English domain"
         assert 'set-language-cookie' in response.url, "Should include cookie parameter"
+
+
+# ============================================================================
+# HOP 2: LanguageCookieMiddleware's stripped-param redirect must still be marked
+# no_applink by WebSessionRedirectMiddleware, or iOS can hijack it mid-switch.
+# ============================================================================
+
+class TestWebSessionMarkingOnLanguageSwitch:
+    @production_settings
+    def test_hop_two_redirect_is_marked_no_applink(self):
+        request = RequestFactory().get(
+            '/texts?set-language-cookie',
+            HTTP_HOST='www.sefaria.org.il',
+            HTTP_REFERER='https://www.sefaria.org/texts?set-language-cookie',
+        )
+        request.user = AnonymousUser()
+
+        hop_two_response = LanguageCookieMiddleware(get_response=lambda r: HttpResponse()).process_request(request)
+        assert hop_two_response is not None, "LanguageCookieMiddleware should redirect"
+
+        marked_response = WebSessionRedirectMiddleware(
+            get_response=lambda r: HttpResponse()
+        ).process_response(request, hop_two_response)
+
+        assert 'no_applink=1' in marked_response['Location']
+        assert 'set-language-cookie' not in marked_response['Location']

--- a/sefaria/system/tests/test_middleware.py
+++ b/sefaria/system/tests/test_middleware.py
@@ -810,6 +810,14 @@ class TestWebSessionRedirectMiddleware:
 
         assert 'no_applink=1' in result['Location']
 
+    def test_google_one_tap_redirect_path_marks_redirect_regardless_of_referer(self):
+        # accounts.google.com POSTs here directly (redirect-mode SSO) -- Referer is
+        # always Google's, never sefaria's, same as /accounts/* and /_allauth/*.
+        request = RequestFactory().post('/api/auth/google/redirect', HTTP_REFERER='https://accounts.google.com/')
+        result = self._middleware().process_response(request, HttpResponseRedirect('/'))
+
+        assert 'no_applink=1' in result['Location']
+
     def test_non_redirect_response_is_untouched(self):
         request = RequestFactory().get('/accounts/google/login/callback/')
         response = HttpResponse('ok')

--- a/sefaria/system/tests/test_middleware.py
+++ b/sefaria/system/tests/test_middleware.py
@@ -7,8 +7,8 @@ an approved list derived from DOMAIN_MODULES.
 from unittest.mock import patch
 from django.contrib.auth.models import AnonymousUser
 from django.test import RequestFactory, override_settings
-from django.http import HttpResponse
-from sefaria.system.middleware import ModuleMiddleware, SessionCookieDomainMiddleware, SessionIDAuthMiddleware, LocationSettingsMiddleware
+from django.http import HttpResponse, HttpResponseRedirect
+from sefaria.system.middleware import ModuleMiddleware, SessionCookieDomainMiddleware, SessionIDAuthMiddleware, LocationSettingsMiddleware, WebSessionRedirectMiddleware
 from sefaria.utils.chatbot import build_chatbot_user_token
 from sefaria.constants.model import LIBRARY_MODULE, VOICES_MODULE
 
@@ -763,3 +763,57 @@ class TestLocationSettingsMiddleware:
         middleware.process_request(request)
 
         assert request.country_code == 'us'
+
+
+# ============================================================================
+# TESTS: WEB SESSION REDIRECT MARKING (no_applink)
+# ============================================================================
+
+class TestWebSessionRedirectMiddleware:
+    """A redirect gets marked no_applink when it continues a web session (sefaria
+    Referer, or an allauth OAuth path where Referer is always external) -- see
+    sefaria/utils/views_utils.py for why."""
+
+    def _middleware(self):
+        return WebSessionRedirectMiddleware(get_response=lambda r: HttpResponse())
+
+    @override_settings(DOMAIN_MODULES=PRODUCTION_CONFIG)
+    def test_sefaria_referer_marks_redirect(self):
+        request = RequestFactory().get('/', HTTP_REFERER='https://www.sefaria.org/texts')
+        result = self._middleware().process_response(request, HttpResponseRedirect('/next'))
+
+        assert 'no_applink=1' in result['Location']
+
+    @override_settings(DOMAIN_MODULES=PRODUCTION_CONFIG)
+    def test_external_referer_does_not_mark_redirect(self):
+        request = RequestFactory().get('/', HTTP_REFERER='https://mail.google.com/')
+        result = self._middleware().process_response(request, HttpResponseRedirect('/next'))
+
+        assert 'no_applink' not in result['Location']
+
+    @override_settings(DOMAIN_MODULES=PRODUCTION_CONFIG)
+    def test_no_referer_does_not_mark_redirect(self):
+        request = RequestFactory().get('/login')
+        result = self._middleware().process_response(request, HttpResponseRedirect('/'))
+
+        assert 'no_applink' not in result['Location']
+
+    def test_accounts_path_marks_redirect_regardless_of_referer(self):
+        request = RequestFactory().get('/accounts/google/login/callback/')
+        result = self._middleware().process_response(request, HttpResponseRedirect('/'))
+
+        assert 'no_applink=1' in result['Location']
+
+    def test_allauth_path_marks_redirect_regardless_of_referer(self):
+        request = RequestFactory().get('/_allauth/browser/v1/auth/session')
+        result = self._middleware().process_response(request, HttpResponseRedirect('/'))
+
+        assert 'no_applink=1' in result['Location']
+
+    def test_non_redirect_response_is_untouched(self):
+        request = RequestFactory().get('/accounts/google/login/callback/')
+        response = HttpResponse('ok')
+
+        result = self._middleware().process_response(request, response)
+
+        assert result is response

--- a/sefaria/system/tests/test_middleware.py
+++ b/sefaria/system/tests/test_middleware.py
@@ -825,3 +825,22 @@ class TestWebSessionRedirectMiddleware:
         result = self._middleware().process_response(request, response)
 
         assert result is response
+
+    @override_settings(DOMAIN_MODULES=PRODUCTION_CONFIG)
+    def test_external_redirect_target_is_not_marked_even_with_sefaria_referer(self):
+        # /wiki -> https://developers.sefaria.org/... (sites/sefaria/urls.py) is a real
+        # example: a sefaria-referred request whose redirect target isn't a sefaria domain.
+        request = RequestFactory().get('/wiki', HTTP_REFERER='https://www.sefaria.org/texts')
+        result = self._middleware().process_response(
+            request, HttpResponseRedirect('https://developers.sefaria.org/docs/welcome')
+        )
+
+        assert 'no_applink' not in result['Location']
+
+    def test_external_redirect_target_is_not_marked_from_oauth_path_either(self):
+        request = RequestFactory().get('/accounts/google/login/callback/')
+        result = self._middleware().process_response(
+            request, HttpResponseRedirect('https://example.com/')
+        )
+
+        assert 'no_applink' not in result['Location']

--- a/sefaria/utils/domains_and_languages.py
+++ b/sefaria/utils/domains_and_languages.py
@@ -59,6 +59,26 @@ def current_domain_lang(request):
     return short_to_long_lang_code(matched_langs[0])
 
 
+def referer_is_sefaria_domain(request):
+    """
+    True if the request's Referer is one of this site's own domains (settings.DOMAIN_MODULES).
+    Distinguishes a redirect continuing an in-progress web session from a fresh external
+    entry (email link, another site, a bookmark). Fails open (returns False) if Referer is
+    absent -- stripped by an ad blocker, or genuinely a fresh visit either way.
+    """
+    referer = request.META.get("HTTP_REFERER")
+    if not referer:
+        return False
+    referer_hostname = urlparse(referer).hostname
+    domain_modules = getattr(settings, 'DOMAIN_MODULES', None) or {}
+    known_hostnames = {
+        urlparse(url).hostname
+        for modules in domain_modules.values()
+        for url in modules.values()
+    }
+    return referer_hostname in known_hostnames
+
+
 def get_redirect_domain_for_language(request, target_lang):
     """
     Get the redirect domain URL for a given interface language while preserving the current module.

--- a/sefaria/utils/domains_and_languages.py
+++ b/sefaria/utils/domains_and_languages.py
@@ -59,6 +59,15 @@ def current_domain_lang(request):
     return short_to_long_lang_code(matched_langs[0])
 
 
+def _known_domain_hostnames():
+    domain_modules = getattr(settings, 'DOMAIN_MODULES', None) or {}
+    return {
+        urlparse(url).hostname
+        for modules in domain_modules.values()
+        for url in modules.values()
+    }
+
+
 def referer_is_sefaria_domain(request):
     """
     True if the request's Referer is one of this site's own domains (settings.DOMAIN_MODULES).
@@ -69,14 +78,18 @@ def referer_is_sefaria_domain(request):
     referer = request.META.get("HTTP_REFERER")
     if not referer:
         return False
-    referer_hostname = urlparse(referer).hostname
-    domain_modules = getattr(settings, 'DOMAIN_MODULES', None) or {}
-    known_hostnames = {
-        urlparse(url).hostname
-        for modules in domain_modules.values()
-        for url in modules.values()
-    }
-    return referer_hostname in known_hostnames
+    return urlparse(referer).hostname in _known_domain_hostnames()
+
+
+def redirect_target_is_sefaria_domain(location):
+    """
+    True if a redirect Location is relative (same site) or an absolute URL pointing at a
+    known sefaria domain. False for anything else (e.g. /wiki -> developers.sefaria.org),
+    so no_applink never gets attached to a redirect that has nothing to do with Universal
+    Links in the first place.
+    """
+    hostname = urlparse(location).hostname
+    return hostname is None or hostname in _known_domain_hostnames()
 
 
 def get_redirect_domain_for_language(request, target_lang):

--- a/sefaria/utils/domains_and_languages.py
+++ b/sefaria/utils/domains_and_languages.py
@@ -1,7 +1,10 @@
 import re
+from functools import lru_cache
 from urllib.parse import urlparse
 
 from django.conf import settings
+from django.dispatch import receiver
+from django.test.signals import setting_changed
 
 from sefaria.constants.model import LIBRARY_MODULE
 from sefaria.utils.util import short_to_long_lang_code, get_short_lang
@@ -59,13 +62,24 @@ def current_domain_lang(request):
     return short_to_long_lang_code(matched_langs[0])
 
 
+@lru_cache(maxsize=1)
 def _known_domain_hostnames():
+    # DOMAIN_MODULES is set once at startup and never changes at runtime in production, so
+    # this is computed once and reused for the life of the process. The only thing that
+    # changes it at all is override_settings in tests, which is why the cache is cleared
+    # below on setting_changed rather than just computed once forever.
     domain_modules = getattr(settings, 'DOMAIN_MODULES', None) or {}
-    return {
+    return frozenset(
         urlparse(url).hostname
         for modules in domain_modules.values()
         for url in modules.values()
-    }
+    )
+
+
+@receiver(setting_changed)
+def _clear_known_domain_hostnames_cache(sender, setting, **kwargs):
+    if setting == 'DOMAIN_MODULES':
+        _known_domain_hostnames.cache_clear()
 
 
 def referer_is_sefaria_domain(request):

--- a/sefaria/utils/tests/domains_and_languages_test.py
+++ b/sefaria/utils/tests/domains_and_languages_test.py
@@ -1,0 +1,25 @@
+from django.test import RequestFactory, override_settings
+
+from sefaria.utils.domains_and_languages import referer_is_sefaria_domain
+
+CONFIG_A = {"en": {"library": "https://www.sefaria.org"}}
+CONFIG_B = {"en": {"library": "https://www.other-domain.org"}}
+
+
+class TestKnownDomainHostnamesCache:
+    """_known_domain_hostnames is lru_cache'd for real (non-test) use, where
+    DOMAIN_MODULES never changes at runtime -- this proves the setting_changed
+    listener actually clears it under override_settings, not just that the rest of
+    the suite happens to still pass."""
+
+    def test_cache_is_invalidated_across_overridden_settings(self):
+        request = RequestFactory().get('/', HTTP_REFERER='https://www.sefaria.org/texts')
+
+        with override_settings(DOMAIN_MODULES=CONFIG_A):
+            assert referer_is_sefaria_domain(request) is True
+
+        with override_settings(DOMAIN_MODULES=CONFIG_B):
+            assert referer_is_sefaria_domain(request) is False
+
+        with override_settings(DOMAIN_MODULES=CONFIG_A):
+            assert referer_is_sefaria_domain(request) is True

--- a/sefaria/utils/tests/views_utils_test.py
+++ b/sefaria/utils/tests/views_utils_test.py
@@ -1,0 +1,11 @@
+from sefaria.utils.views_utils import mark_no_applink, NO_APPLINK_PARAM
+
+
+class TestMarkNoApplink:
+
+    def test_does_not_duplicate_if_already_marked(self):
+        once = mark_no_applink('/next')
+        twice = mark_no_applink(once)
+
+        assert twice == once
+        assert twice.count(NO_APPLINK_PARAM) == 1

--- a/sefaria/utils/tests/views_utils_test.py
+++ b/sefaria/utils/tests/views_utils_test.py
@@ -9,3 +9,9 @@ class TestMarkNoApplink:
 
         assert twice == once
         assert twice.count(NO_APPLINK_PARAM) == 1
+
+    def test_does_not_duplicate_a_bare_no_applink_with_no_value(self):
+        assert mark_no_applink(f'/next?{NO_APPLINK_PARAM}').count(NO_APPLINK_PARAM) == 1
+
+    def test_does_not_duplicate_a_blank_no_applink(self):
+        assert mark_no_applink(f'/next?{NO_APPLINK_PARAM}=').count(NO_APPLINK_PARAM) == 1

--- a/sefaria/utils/views_utils.py
+++ b/sefaria/utils/views_utils.py
@@ -22,3 +22,17 @@ def add_query_param(url, param, value=""):
     pairs.append((param, value))
     new_query = urlencode(pairs, doseq=True)
     return urlunparse(parsed._replace(query=new_query))
+
+
+# Referer is always external here (google/apple), so referer_is_sefaria_domain can't catch these.
+AASA_EXCLUDED_PATHS = [
+    "/accounts/*",
+    "/_allauth/*",
+]
+
+# Marks a redirect as "stay on web". Read by apple_app_site_association's AASA rule, stripped in client.jsx.
+NO_APPLINK_PARAM = "no_applink"
+
+
+def mark_no_applink(url):
+    return add_query_param(url, NO_APPLINK_PARAM, "1")

--- a/sefaria/utils/views_utils.py
+++ b/sefaria/utils/views_utils.py
@@ -25,9 +25,13 @@ def add_query_param(url, param, value=""):
 
 
 # Referer is always external here (google/apple), so referer_is_sefaria_domain can't catch these.
+# /api/auth/google/redirect (sso/urls.py, sso/views.py) is Google One Tap's redirect-mode
+# login_uri -- accounts.google.com POSTs the credential straight to it, same as the
+# /accounts/* allauth callbacks.
 AASA_EXCLUDED_PATHS = [
     "/accounts/*",
     "/_allauth/*",
+    "/api/auth/google/redirect",
 ]
 
 # Marks a redirect as "stay on web". Read by apple_app_site_association's AASA rule, stripped in client.jsx.

--- a/sefaria/utils/views_utils.py
+++ b/sefaria/utils/views_utils.py
@@ -39,4 +39,6 @@ NO_APPLINK_PARAM = "no_applink"
 
 
 def mark_no_applink(url):
+    if NO_APPLINK_PARAM in dict(parse_qsl(urlparse(url).query)):
+        return url
     return add_query_param(url, NO_APPLINK_PARAM, "1")

--- a/sefaria/utils/views_utils.py
+++ b/sefaria/utils/views_utils.py
@@ -39,6 +39,6 @@ NO_APPLINK_PARAM = "no_applink"
 
 
 def mark_no_applink(url):
-    if NO_APPLINK_PARAM in dict(parse_qsl(urlparse(url).query)):
+    if NO_APPLINK_PARAM in dict(parse_qsl(urlparse(url).query, keep_blank_values=True)):
         return url
     return add_query_param(url, NO_APPLINK_PARAM, "1")

--- a/static/js/client.jsx
+++ b/static/js/client.jsx
@@ -9,6 +9,14 @@ import * as Sentry from "@sentry/react";
 
 
 $(function() {
+  // no_applink (see sefaria/utils/views_utils.py) is a one-hop marker; strip it so a
+  // bookmarked/shared copy of this URL doesn't keep it forever.
+  if (window.location.search.includes('no_applink')) {
+    const url = new URL(window.location.href);
+    url.searchParams.delete('no_applink');
+    history.replaceState(null, '', url);
+  }
+
   const remoteConfig = DJANGO_VARS.props?.remoteConfig || {};
   // Initialize Sentry, sentryDSN is defined in base.html
   if (sentryDSN) {

--- a/static/js/client.jsx
+++ b/static/js/client.jsx
@@ -11,8 +11,8 @@ import * as Sentry from "@sentry/react";
 $(function() {
   // no_applink (see sefaria/utils/views_utils.py) is a one-hop marker; strip it so a
   // bookmarked/shared copy of this URL doesn't keep it forever.
-  if (window.location.search.includes('no_applink')) {
-    const url = new URL(window.location.href);
+  const url = new URL(window.location.href);
+  if (url.searchParams.has('no_applink')) {
     url.searchParams.delete('no_applink');
     history.replaceState(null, '', url);
   }

--- a/static/js/client.jsx
+++ b/static/js/client.jsx
@@ -14,7 +14,7 @@ $(function() {
   const url = new URL(window.location.href);
   if (url.searchParams.has('no_applink')) {
     url.searchParams.delete('no_applink');
-    history.replaceState(null, '', url);
+    history.replaceState(null, '', url.toString());
   }
 
   const remoteConfig = DJANGO_VARS.props?.remoteConfig || {};


### PR DESCRIPTION
## Description

Mobile-web SSO login on iOS could still get interrupted by the app opening mid-flow, even after Akiva's earlier fix (`379e366ee`). That fix excluded the allauth OAuth callback paths (`/accounts/*`, `/_allauth/*`, plus `/login`, `/register`, `/logout`, `/password/reset*`) from iOS's `apple-app-site-association` (AASA), so the redirect back from Google/Apple stays in the browser. But after allauth finishes and sets the session cookie, Django issues a *second* redirect — to the "next" page (`SefariaAccountAdapter.get_login_redirect_url`) — and that hop is an arbitrary, un-enumerable URL that a static path list can never cover. iOS could still grab the login flow right there.

The same shape of bug exists for the interface-language domain-switch (sefaria.org ↔ sefaria.org.il): a correctly-marked first hop, then an unprotected second redirect once `LanguageCookieMiddleware` strips the marker.

Rather than adding more entries to a static path list, this replaces the general case with a rule: **if a redirect's triggering request was referred by a sefaria.org(.il) page, it's continuing a web session and must never be handed to the app.** A small, technically-forced exception remains for `/accounts/*`, `/_allauth/*`, and `/api/auth/google/redirect` (Google One Tap's redirect-mode `login_uri` — added after review caught it missing, see Code Changes), since each of those is reached via a genuine cross-domain POST/redirect from the OAuth provider, whose Referer is always external by protocol design — but that's unambiguous given the current codebase (those paths are never reached any other way than a web login round-trip).

Akiva's fix had its own side effect: it excluded `/login`, `/register`, `/logout`, `/password/reset` *unconditionally*, with no way to tell "mid-session" from "fresh tap" apart. This change undoes that — a fresh tap on one of those now reaches the app instead of always being forced to the browser.

**⚠️ That surfaces a real bug that needs a separate fix in Mobile, not in this PR.** Verified the actual code path: `DeepLinkRouter.js` has no dedicated route for a bare `/login` (or `/register`/`/logout`/`/password/reset`). It matches the generic single-segment route (`^([^/]+)$` → `openRef`), which tries to resolve "login" as a book title via an async `Sefaria.api.name()` call, fails, and only then falls back to `catchAll` → `ReaderApp.js`'s `openUri` → `InAppBrowser.open()`. So the app launches, does a pointless failed lookup, then shows the page in an in-app browser tab — not broken, but janky, and not something to wave off as "fine either way." **Before this PR, that path was unreachable — these paths were unconditionally excluded, so the bad routing never mattered. This PR makes it reachable, so the fix now needs to land too:** add explicit routes for `/login`, `/register`, `/logout`, `/password/reset` straight to `catchAll` in `Mobile/DeepLinkRouter.js`, skipping the failed lookup. That's a Mobile-repo change, intentionally out of scope for this PR (see below), but it should be tracked and shipped — ideally alongside this, not left dangling. Flagging this prominently since whoever deploys this should know about it going in, not discover it after.

No Mobile app changes in this PR. This bug is iOS-specific (Universal Links) — Android's App Links can't do path/query exclusion at all, and there's no evidence Android was ever affected by this particular redirect shape. The app's own native SSO (`api/auth/*/mobile`) is structurally unaffected either way: it's a plain JSON POST, never a browser navigation, and never touches `/accounts/*` or `/_allauth/*`.

## Code Changes

- **`sefaria/utils/views_utils.py`** — `AASA_EXCLUDED_PATHS` shrunk to `/accounts/*`, `/_allauth/*`, and `/api/auth/google/redirect` (Google One Tap's redirect-mode `login_uri` — allauth's `LoginByTokenView` exposed directly, `sso/urls.py`; same external-Referer problem as the other two, just not under `/accounts/` or `/_allauth/`); added `NO_APPLINK_PARAM` / `mark_no_applink` (idempotent — won't double-mark a URL that already carries the param).
- **`sefaria/utils/domains_and_languages.py`** — new `referer_is_sefaria_domain` and `redirect_target_is_sefaria_domain`, both built on the existing `settings.DOMAIN_MODULES` (no hardcoded hostnames). The latter exists so the middleware only marks a redirect when its *destination* is actually a sefaria domain too — otherwise a sefaria-referred request that redirects somewhere genuinely external (e.g. `/wiki` → `developers.sefaria.org`, `sites/sefaria/urls.py`) would get `no_applink` tacked onto an unrelated URL. The underlying hostname set is `lru_cache`'d (never changes at runtime in production) and cleared via a `setting_changed` listener specifically when `DOMAIN_MODULES` changes, so it stays correct under every `override_settings`-based test in this suite.
- **`sefaria/system/middleware.py`** — new `WebSessionRedirectMiddleware`: marks any redirect's `Location` with `no_applink` when the request is either to one of the paths above or referred by a sefaria domain, *and* the redirect's own target is a sefaria domain (or relative). One centralized mechanism — `sso/adapters.py` and `LanguageCookieMiddleware` needed no changes.
- **`sefaria/settings.py`** — registers the new middleware immediately before `LanguageCookieMiddleware` (needs to wrap both `LanguageCookieMiddleware` and `LanguageSettingsMiddleware`, since either can short-circuit with its own redirect).
- **`reader/views.py`** — `apple_app_site_association` adds a query-based AASA exclusion (`{"?": {"no_applink": "*"}, "exclude": true}`), the documented Apple mechanism for excluding a dynamic destination, not just a static path.
- **`static/js/client.jsx`** — strips `no_applink` from the URL via `history.replaceState` once a marked landing page mounts, so a bookmarked/shared copy of the URL doesn't keep it. Checks the actual query key via `URLSearchParams.has()`, not a substring match on the raw search string, so it doesn't misfire on an unrelated param whose *value* happens to contain "no_applink".
- **Tests** — `sefaria/system/tests/test_middleware.py` (`WebSessionRedirectMiddleware`, including the external-target and Google-One-Tap cases), `sefaria/system/tests/test_language_module_switching.py` (language-switch second hop gets marked), `reader/tests/apple_app_site_association_test.py` (AASA JSON structure/ordering), `sefaria/utils/tests/views_utils_test.py` (`mark_no_applink` doesn't duplicate the param), `sefaria/utils/tests/domains_and_languages_test.py` (the `lru_cache` is actually invalidated by `override_settings` — verified by temporarily disabling the listener and confirming the test fails without it).
- **`pytest.ini`** — added `sefaria/system/tests/test_*.py` and `sefaria/utils/tests/*_test.py` to `python_files`. Review caught that the new `views_utils_test.py` wasn't covered by any collected pattern; turned out to be a wider pre-existing gap, not just that one file — 9 already-existing test files across both directories (including `test_middleware.py` and `test_language_module_switching.py`, which this PR added coverage to) were silently never running under the real CI command (`pytest ./sefaria ./sso ./reader`), only when invoked with an explicit file path. Verified every previously-orphaned file still passes before adding the patterns.

## Notes

### Test plan

Universal Links only activate for a domain that's *both* declared in the app's `com.apple.developer.associated-domains` entitlement *and* AASA-verified against that exact domain. The app's entitlements only cover `sefaria.org`, `www.sefaria.org`, `sefaria.org.il`, `www.sefaria.org.il` — not any cauldron subdomain. So there are two real ways to test the actual "does iOS refuse to open the app" behavior:

**Option A — Cauldron + a throwaway TestFlight build** with its associated-domains entitlement pointed at the cauldron URL specifically. Gives a fully isolated pre-merge signal, but requires a Mobile-side provisioning change and coordination for a build that exists only for this test:

- **`Mobile/ios/ReaderApp/ReaderApp.entitlements`** — add the cauldron host to `com.apple.developer.associated-domains`, e.g. `applinks:name.cauldron.sefaria.org`, alongside the existing four production entries. No Apple Developer portal change needed beyond that — Associated Domains is already an enabled capability for this App ID; Apple verifies ownership by fetching AASA from the domain itself, not via a portal-side domain registry.
- Rebuild and re-sign with a provisioning profile that matches those entitlements, then upload to TestFlight. This is a real archive-and-upload cycle, not a config flag.
- No Project (Django) code change needed beyond what's already in this PR — `apple_app_site_association` isn't host-specific, so it already serves correct AASA for whatever domain cauldron is deployed under.
- Testing itself doesn't need the app's `_baseHost` pointed at cauldron — the flow being tested is driven entirely from Safari (navigate to the cauldron URL, run through SSO/language-switch there); the installed app is just sitting there as the thing Universal Links might hand off to.
- This entitlements edit is throwaway: make it on a scratch Mobile branch, build once, then discard/revert it — it should never land on Mobile's real `master`, since the cauldron host changes per branch/PR.

**Option B — Deploy to prod, test there immediately after.** Walk through SSO (Google + Apple, login + register) and a language switch on a real device.

Either way, AASA caching applies regardless of distribution channel (App Store or TestFlight) — it's a property of the domain, not the build — so force a fresh fetch (reinstall the app) before drawing conclusions from a device that's had the app installed before. This matters less on Option A's very first install (the cauldron domain hasn't been associated on that device before, so there's nothing stale to have cached), but comes back if the same build gets reused across multiple test iterations while the fix is still being tweaked.

- [ ] `curl https://www.sefaria.org/apple-app-site-association` after deploy — confirm all three static exclusions (`/accounts/*`, `/_allauth/*`, `/api/auth/google/redirect`) and the query-based `no_applink` rule are present and correctly ordered. This re-checks what the unit tests already assert about the JSON, but against the actual deployed path: there's a dedicated `location /apple-app-site-association` block in nginx (`helm-chart/sefaria/conf/nginx.template.conf.tpl`), separate from Django routing, so it's worth confirming nginx/CDN is actually serving the current file
- [ ] SSO login + register, Google + Apple, from mobile Safari with the app installed — no app-bounce at the callback hop or the landing hop
- [ ] Language switch on mobile Safari with the app installed — both hops stay in-browser
- [ ] A fresh `/login` link tapped from Notes/Messages (simulating an external/email tap) — confirm it now opens the app (it previously never did). Expect the janky path described above (failed book-title lookup, then an in-app browser tab) until the `DeepLinkRouter.js` follow-up ships — don't block this PR on it, but don't let it get lost either

🤖 Generated with [Claude Code](https://claude.com/claude-code)


