### PR TITLE
fix(backup): make pg_dump verification actually compare row counts

### DIFF
--- a/helm-chart/sefaria/templates/configmap/create-pg-dumps.yaml
+++ b/helm-chart/sefaria/templates/configmap/create-pg-dumps.yaml
@@ -140,15 +140,25 @@ data:
         continue
       fi
 
-      # Get DB count (live query)
+      # Get DB count (live query). Note: "set -e" is in effect and these are bare
+      # command substitutions, so the "|| VAR=$?" form is required -- without it a
+      # failing psql/pg_restore aborts the script before the error branch below is
+      # ever reached. stderr goes to a file so it cannot be counted as dump rows.
+      DB_COUNT_STATUS=0
       DB_COUNT_OUTPUT=$(psql -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USER" -d "$PG_DB" -t -c \
-        "SELECT COUNT(*) FROM \"$TABLE\";" 2>&1)
-      DB_COUNT_STATUS=$?
+        "SELECT COUNT(*) FROM \"$TABLE\";" 2>"$DATADIR/verify_db_err.txt") || DB_COUNT_STATUS=$?
+      if [[ $DB_COUNT_STATUS -ne 0 ]]; then
+        DB_COUNT_OUTPUT=$(cat "$DATADIR/verify_db_err.txt")
+      fi
       DB_COUNT=$(echo "$DB_COUNT_OUTPUT" | xargs)
 
       # Get dump count by extracting and counting rows
-      DUMP_COUNT_OUTPUT=$(pg_restore --data-only --table="$TABLE" "$DUMP_FILE" 2>&1)
-      DUMP_COUNT_STATUS=$?
+      DUMP_COUNT_STATUS=0
+      DUMP_COUNT_OUTPUT=$(pg_restore --data-only --table="$TABLE" "$DUMP_FILE" \
+        2>"$DATADIR/verify_dump_err.txt") || DUMP_COUNT_STATUS=$?
+      if [[ $DUMP_COUNT_STATUS -ne 0 ]]; then
+        DUMP_COUNT_OUTPUT=$(cat "$DATADIR/verify_dump_err.txt")
+      fi
       DUMP_COUNT=$(echo "$DUMP_COUNT_OUTPUT" | \
         grep -v "^SET " | grep -v "^SELECT " | grep -v "^--" | grep -v "^$" | \
         grep -v "^COPY " | grep -v "^\\\." | wc -l | xargs)

--- a/helm-chart/sefaria/templates/configmap/create-pg-dumps.yaml
+++ b/helm-chart/sefaria/templates/configmap/create-pg-dumps.yaml
@@ -120,8 +120,13 @@ data:
     echo "=== Verifying Dump Contents ==="
     
     # Get tables from dump
-    DUMP_TABLES=$(pg_restore --list "$DUMP_FILE" 2>/dev/null | grep "TABLE DATA" | awk '{print $6}')
-    
+    DUMP_TABLES=$(pg_restore --list "$DUMP_FILE" 2>/dev/null | grep "TABLE DATA" | awk '{print $7}')
+
+    if [[ -z "$DUMP_TABLES" ]]; then
+      echo "ERROR: no TABLE DATA entries found in dump; pg_restore --list returned nothing to verify."
+      exit 1
+    fi
+
     echo ""
     printf "%-35s | %12s | %12s | %12s | %s\n" "Table" "DB Rows" "Dump Rows" "Diff" "Status"
     printf "%-35s-|-%12s-|-%12s-|-%12s-|-%s\n" "-----------------------------------" "------------" "------------" "------------" "--------"
@@ -136,44 +141,53 @@ data:
       fi
 
       # Get DB count (live query)
-      DB_COUNT=$(psql -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USER" -d "$PG_DB" -t -c \
-        "SELECT COUNT(*) FROM \"$TABLE\";" 2>/dev/null | xargs)
-      
-      if [[ -z "$DB_COUNT" ]]; then
-        DB_COUNT=0
-      fi
+      DB_COUNT_OUTPUT=$(psql -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USER" -d "$PG_DB" -t -c \
+        "SELECT COUNT(*) FROM \"$TABLE\";" 2>&1)
+      DB_COUNT_STATUS=$?
+      DB_COUNT=$(echo "$DB_COUNT_OUTPUT" | xargs)
 
       # Get dump count by extracting and counting rows
-      DUMP_COUNT=$(pg_restore --data-only --table="$TABLE" "$DUMP_FILE" 2>/dev/null | \
+      DUMP_COUNT_OUTPUT=$(pg_restore --data-only --table="$TABLE" "$DUMP_FILE" 2>&1)
+      DUMP_COUNT_STATUS=$?
+      DUMP_COUNT=$(echo "$DUMP_COUNT_OUTPUT" | \
         grep -v "^SET " | grep -v "^SELECT " | grep -v "^--" | grep -v "^$" | \
         grep -v "^COPY " | grep -v "^\\\." | wc -l | xargs)
-      
-      if [[ -z "$DUMP_COUNT" ]]; then
-        DUMP_COUNT=0
-      fi
 
-      # Calculate difference and percentage
-      DIFF=$((DB_COUNT - DUMP_COUNT))
-      
-      # Calculate percentage difference (allow 1% tolerance for changes during backup)
-      if [[ $DB_COUNT -gt 0 ]]; then
-        DIFF_PCT=$(awk "BEGIN {printf \"%.2f\", ($DIFF / $DB_COUNT) * 100}")
-        ABS_DIFF_PCT=$(awk "BEGIN {printf \"%.2f\", sqrt(($DIFF_PCT)^2)}")
-      else
-        ABS_DIFF_PCT=0
-      fi
-      
-      # Status logic: OK if exact match or within 1% tolerance
-      if [[ $DIFF -eq 0 ]]; then
-        STATUS="OK"
-      elif (( $(awk "BEGIN {print ($ABS_DIFF_PCT <= 1.0)}") )); then
-        STATUS="OK (±1%)"
-      elif [[ $DIFF -gt 0 ]]; then
-        STATUS="MISSING"
+      if [[ $DB_COUNT_STATUS -ne 0 || ! "$DB_COUNT" =~ ^[0-9]+$ ]]; then
+        echo "ERROR: failed to get live row count for \"$TABLE\": $DB_COUNT_OUTPUT"
+        DB_COUNT=0
+        DIFF=0
+        STATUS="DB QUERY FAILED"
+        MISMATCH=$((MISMATCH + 1))
+      elif [[ $DUMP_COUNT_STATUS -ne 0 ]]; then
+        echo "ERROR: failed to read dump contents for \"$TABLE\": $DUMP_COUNT_OUTPUT"
+        DIFF=0
+        STATUS="DUMP READ FAILED"
         MISMATCH=$((MISMATCH + 1))
       else
-        STATUS="EXTRA"
-        MISMATCH=$((MISMATCH + 1))
+        # Calculate difference and percentage
+        DIFF=$((DB_COUNT - DUMP_COUNT))
+
+        # Calculate percentage difference (allow 1% tolerance for changes during backup)
+        if [[ $DB_COUNT -gt 0 ]]; then
+          DIFF_PCT=$(awk "BEGIN {printf \"%.2f\", ($DIFF / $DB_COUNT) * 100}")
+          ABS_DIFF_PCT=$(awk "BEGIN {printf \"%.2f\", sqrt(($DIFF_PCT)^2)}")
+        else
+          ABS_DIFF_PCT=0
+        fi
+
+        # Status logic: OK if exact match or within 1% tolerance
+        if [[ $DIFF -eq 0 ]]; then
+          STATUS="OK"
+        elif (( $(awk "BEGIN {print ($ABS_DIFF_PCT <= 1.0)}") )); then
+          STATUS="OK (±1%)"
+        elif [[ $DIFF -gt 0 ]]; then
+          STATUS="MISSING"
+          MISMATCH=$((MISMATCH + 1))
+        else
+          STATUS="EXTRA"
+          MISMATCH=$((MISMATCH + 1))
+        fi
       fi
 
       printf "%-35s | %12s | %12s | %12s | %s\n" "$TABLE" "$DB_COUNT" "$DUMP_COUNT" "$DIFF" "$STATUS"
@@ -185,6 +199,13 @@ data:
     echo ""
     printf "%-35s | %12s | %12s | %12s |\n" "TOTAL" "$TOTAL_DB" "$TOTAL_DUMP" "$((TOTAL_DB - TOTAL_DUMP))"
     echo ""
+
+    # Guard against a tautological pass: if every count came back zero, the
+    # comparison above verified nothing, even if MISMATCH is 0.
+    if [[ $TOTAL_DUMP -eq 0 || $TOTAL_DB -eq 0 ]]; then
+      echo "ERROR: verification totals are zero (TOTAL_DB=$TOTAL_DB, TOTAL_DUMP=$TOTAL_DUMP); the check compared nothing and cannot be trusted."
+      MISMATCH=$((MISMATCH + 1))
+    fi
 
     # Final summary
     echo "=== Summary ==="
@@ -206,10 +227,10 @@ data:
     echo "Dump file: $DUMP_FILE"
     echo "Row counts saved to: $COUNTS_FILE"
 
-    # Exit with error if mismatches found (optional - comment out if you want to allow mismatches)
-    # if [[ $MISMATCH -gt 0 ]]; then
-    #   exit 1
-    # fi
+    # Exit with error if mismatches found, so a real mismatch fails the Job.
+    if [[ $MISMATCH -gt 0 ]]; then
+      exit 1
+    fi
 
     exit $DUMP_EXIT_CODE
 {{- end }}


### PR DESCRIPTION
## Summary

The `=== Verifying Dump Contents ===` block in `helm-chart/sefaria/templates/configmap/create-pg-dumps.yaml` was tautologically green: it printed `SUCCESS: All row counts match within tolerance!` while comparing nothing.

**Root cause**: `pg_restore --list` output lines look like:

```
218; 1259 16485 TABLE DATA public auth_user sefaria
```

The script extracted `$6` (`public`, the schema) instead of `$7` (`auth_user`, the table). Every loop iteration then queried a nonexistent relation named `public`. The psql/pg_restore errors were swallowed by `2>/dev/null`, so `DB_COUNT` and `DUMP_COUNT` both collapsed to `0`, `DIFF` was always `0`, `STATUS` was always `OK`, `MISMATCH` stayed `0` across all 30 tables, and the script declared success.

**Evidence**: production run `production-postgresbackup-manual-1787039791888` logged 30 identical rows reading `public | 0 | 0 | 0 | OK` and a final `TOTAL | 0 | 0 | 0` — yet still printed SUCCESS. The dump itself was fine (a correct 37,486,432-byte file was produced); only the verification check was blind. This check exists specifically to catch silent backup regressions, and as written it could not have caught any.

## Changes (all inside the `create-dumps.sh` script body; connection/templating and pg_dump flags untouched)

1. `awk '{print $6}'` → `awk '{print $7}'` to pull the actual table name from `pg_restore --list`.
2. The DB_COUNT (`psql`) and DUMP_COUNT (`pg_restore --data-only`) calls no longer silently coerce a failure into `0`. A failed count is captured, echoed, and marked as a verification failure (`DB QUERY FAILED` / `DUMP READ FAILED`), incrementing `MISMATCH`.
3. Added a guard right after `DUMP_TABLES` is computed: if it's empty, the script prints an error and exits `1` instead of falling through to a false "SUCCESS".
4. Added a tautology guard before the final summary: if `TOTAL_DUMP` or `TOTAL_DB` is `0`, the verification is meaningless — the script prints an explicit error and counts it as a mismatch. This is the check that would have caught the present bug.
5. The previously commented-out
   ```bash
   # if [[ $MISMATCH -gt 0 ]]; then
   #   exit 1
   # fi
   ```
   is now live, so a real mismatch fails the Job instead of printing a warning under a green checkmark. The existing propagation of a nonzero `pg_dump` exit code (`exit $DUMP_EXIT_CODE`) is preserved.

`PG_HOST`/`PG_DB` and the `{{ if .Values.postgres.host }}...{{ else }}${DATABASES_HOST}{{ end }}` templating, and all `pg_dump` flags, are unchanged.

## Test plan

- [x] Extracted the rendered `create-dumps.sh` body and ran `bash -n` — parses cleanly.
- [x] Verified the awk field fix: `echo '218; 1259 16485 TABLE DATA public auth_user sefaria' | awk '{print $7}'` → `auth_user` (table name), vs `awk '{print $6}'` → `public` (schema, the bug).
- [x] `helm template sefaria helm-chart/sefaria -f <prod values extracted from envs/prod/helmrelease.yaml> -s templates/configmap/create-pg-dumps.yaml` renders successfully with the new logic intact.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

https://claude.ai/code/session_01TfZU5AMmB6D9gtNos3jnQn