### PR TITLE
Bug/sc 46799/why does citation menachot 3b match menachot

### DIFF
--- a/sefaria/helper/linker/tasks.py
+++ b/sefaria/helper/linker/tasks.py
@@ -588,10 +588,10 @@ def _extract_resolved_spans(resolved_refs):
     for resolved_ref in resolved_refs:
         if resolved_ref.is_ambiguous or resolved_ref.resolution_failed:
             continue
-        entity = resolved_ref.raw_entity
+        pretty_span = resolved_ref.pretty_span
         spans.append({
-            "charRange": entity.char_indices,
-            "text": entity.text,
+            "charRange": pretty_span.range,
+            "text": pretty_span.text,
             "type": MUTCSpanType.CITATION.value,
             "ref": resolved_ref.ref.normal(),
         })

--- a/sefaria/helper/linker/tests/task_test.py
+++ b/sefaria/helper/linker/tests/task_test.py
@@ -1,8 +1,13 @@
 """
 Tests for sefaria.helper.linker.tasks
 """
+from types import SimpleNamespace
+
 import pytest
-from sefaria.helper.linker.tasks import _get_link_trefs_to_add_and_delete
+from ne_span import NEDoc
+from sefaria.model.linker.ref_part import RawRef
+from sefaria.model.linker.ref_resolver import ResolvedRef
+from sefaria.helper.linker.tasks import _get_link_trefs_to_add_and_delete, _extract_resolved_spans
 
 
 @pytest.mark.parametrize("trefs_found,existing_linked_trefs,all_linked_trefs,expected_add,expected_delete,test_id", [
@@ -59,3 +64,37 @@ def test_link_trefs_operations(trefs_found, existing_linked_trefs, all_linked_tr
     
     assert to_add == expected_add, f"Failed for test: {test_id}"
     assert to_delete == expected_delete, f"Failed for test: {test_id}"
+
+
+def _make_resolved_ref(doc_text, span_text, tref):
+    doc = NEDoc(doc_text)
+    start = doc_text.index(span_text)
+    end = start + len(span_text)
+    raw_ref = RawRef(doc.subspan(slice(start, end)), 'he', [])
+    # _extract_resolved_spans only ever calls .normal() on `ref`, so a stand-in avoids needing a real Ref/DB
+    fake_ref = SimpleNamespace(normal=lambda: tref)
+    return ResolvedRef(raw_ref, [], fake_ref)
+
+
+@pytest.mark.parametrize(('doc_text', 'span_text', 'tref'), [
+    # Rashba on Berakhot 17b:1: "אסקה רב אשי בגמרא (לקמן ברכות יח, א) דמוטל...". Confirmed against the real
+    # LinkerOutput debug span (GET /api/v3/texts/Rashba_on_Berakhot.17b.1?debug_mode=linker) that the raw
+    # entity span is 'בגמרא (לקמן ברכות יח, א' -- the trailing ")" is just outside the matched span.
+    ['אסקה רב אשי בגמרא (לקמן ברכות יח, א) דמוטל עליו לקוברו', 'בגמרא (לקמן ברכות יח, א', 'Berakhot 18a'],
+])
+def test_extract_resolved_spans_end_paren(doc_text, span_text, tref):
+    """
+    `_extract_resolved_spans` builds the citation spans that end up on the live MarkedUpTextChunk (i.e. the
+    text that actually gets highlighted/linked for readers), and it reads straight off
+    `resolved_ref.raw_entity.char_indices`/`.text` rather than `resolved_ref.pretty_text`. `pretty_text`
+    already knows how to extend the span to include a trailing ")" just outside the raw entity (see
+    test_pretty_text_end_paren in sefaria/model/linker/tests/linker_test.py) -- this function just never
+    consults it, so the closing paren silently gets dropped from what's actually shown to readers.
+    """
+    resolved_ref = _make_resolved_ref(doc_text, span_text, tref)
+    spans = _extract_resolved_spans([resolved_ref])
+
+    assert len(spans) == 1
+    assert spans[0]['text'] == resolved_ref.pretty_text
+    start, end = spans[0]['charRange']
+    assert doc_text[start:end] == resolved_ref.pretty_text

--- a/sefaria/model/linker/ref_resolver.py
+++ b/sefaria/model/linker/ref_resolver.py
@@ -117,9 +117,9 @@ class ResolvedRef(AbstractResolvedEntity, abst.Cloneable):
         return [span]
 
     @property
-    def pretty_text(self) -> str:
+    def pretty_span(self) -> NESpan:
         """
-        Return text of underlying RawRef with modifications to make it nicer
+        Return span of underlying RawRef with modifications to make it nicer
         Currently
         - adds ending parentheses if just outside span
         - adds extra DH words that were matched but aren't in span
@@ -127,7 +127,15 @@ class ResolvedRef(AbstractResolvedEntity, abst.Cloneable):
         """
         new_raw_ref_span = self._get_pretty_dh_span(self.raw_entity.span)
         new_raw_ref_span = self._get_pretty_end_paren_span(new_raw_ref_span)
-        return new_raw_ref_span.text
+        return new_raw_ref_span
+
+    @property
+    def pretty_text(self) -> str:
+        """
+        Return text of underlying RawRef with modifications to make it nicer. See `pretty_span`.
+        @return:
+        """
+        return self.pretty_span.text
 
     def _get_pretty_dh_span(self, curr_span: NESpan) -> NESpan:
         curr_start, curr_end = curr_span.range
@@ -878,6 +886,13 @@ class ResolvedRefPruner:
                 if part is None:
                     break  # no more
                 to_match_explicit.remove(part)
+        elif RefPartType.RELATIVE in {part.type for part in to_match_explicit}:
+            # A RELATIVE part (e.g. "לקמן"/"להלן") only signals that context *may* help disambiguate; it doesn't
+            # correspond to a resolvable section itself. When a match doesn't use context at all -- e.g. the book
+            # and all sections were stated explicitly -- the marker is redundant and shouldn't block the match
+            # from counting as complete (see sc-46799: this used to force an explicit "<Book Daf Amud" citation
+            # through context-based resolution, which could compute the wrong daf/amud).
+            to_match_explicit = {part for part in to_match_explicit if part.type != RefPartType.RELATIVE}
         return resolved_explicit == to_match_explicit
 
     @staticmethod
@@ -978,7 +993,12 @@ class ResolvedRefPruner:
     @staticmethod
     def get_context_free_matches(resolved_refs: List[ResolvedRef]) -> List[ResolvedRef]:
         def match_is_context_free(match: ResolvedRef) -> bool:
-            return match.context_ref is None and set(match.get_resolved_parts()) == set(match.raw_entity.parts_to_match)
+            if match.context_ref is not None:
+                return False
+            # See matched_all_explicit_sections: a RELATIVE part is just a signal, not a resolvable section, so
+            # it shouldn't be required for a match to count as "using all input parts".
+            required_parts = {part for part in match.raw_entity.parts_to_match if part.type != RefPartType.RELATIVE}
+            return set(match.get_resolved_parts()) == required_parts
         return list(filter(match_is_context_free, resolved_refs))
 
     @staticmethod

--- a/sefaria/model/linker/ref_resolver.py
+++ b/sefaria/model/linker/ref_resolver.py
@@ -890,8 +890,7 @@ class ResolvedRefPruner:
             # A RELATIVE part (e.g. "לקמן"/"להלן") only signals that context *may* help disambiguate; it doesn't
             # correspond to a resolvable section itself. When a match doesn't use context at all -- e.g. the book
             # and all sections were stated explicitly -- the marker is redundant and shouldn't block the match
-            # from counting as complete (see sc-46799: this used to force an explicit "<Book Daf Amud" citation
-            # through context-based resolution, which could compute the wrong daf/amud).
+            # from counting as complete .
             to_match_explicit = {part for part in to_match_explicit if part.type != RefPartType.RELATIVE}
         return resolved_explicit == to_match_explicit
 

--- a/sefaria/model/linker/ref_resolver.py
+++ b/sefaria/model/linker/ref_resolver.py
@@ -603,7 +603,7 @@ class RefResolver:
                 # BUT did get refined more when considering context
                 context_free_matches = list(filter(lambda x: not (x.num_resolved(include={ContextPart}) > 0 and x.ref.normal() in refs_matched), context_free_matches))
             temp_matches += context_free_matches + context_full_matches
-        return ResolvedRefPruner.prune_refined_ref_part_matches(self._thoroughness, temp_matches)
+        return ResolvedRefPruner.prune_refined_ref_part_matches(self._thoroughness, temp_matches, book_context_ref)
 
     @staticmethod
     def _get_section_contexts(context_ref: text.Ref, match_index: text.Index, common_index: text.Index) -> List[SectionContext]:
@@ -991,6 +991,33 @@ class ResolvedRefPruner:
         return temp_resolved_refs
 
     @staticmethod
+    def _get_index_title_context(index: text.Index) -> Set[str]:
+        return {index.title} | set(getattr(index, 'base_text_titles', []))
+
+    @staticmethod
+    def _has_relative_part(match: ResolvedRef) -> bool:
+        return any(part.type == RefPartType.RELATIVE for part in match.raw_entity.parts_to_match)
+
+    @staticmethod
+    def _matches_current_book_context(match: ResolvedRef, book_context_ref: Optional[text.Ref]) -> bool:
+        if not match.ref or not book_context_ref:
+            return False
+        context_titles = ResolvedRefPruner._get_index_title_context(book_context_ref.index)
+        match_titles = ResolvedRefPruner._get_index_title_context(match.ref.index)
+        return len(context_titles & match_titles) > 0
+
+    @staticmethod
+    def prune_relative_ref_matches(resolved_refs: List[ResolvedRef], book_context_ref: Optional[text.Ref]) -> List[ResolvedRef]:
+        if not book_context_ref or not any(ResolvedRefPruner._has_relative_part(match) for match in resolved_refs):
+            return resolved_refs
+        temp_resolved_refs = [
+            match for match in resolved_refs
+            if not ResolvedRefPruner._has_relative_part(match)
+            or ResolvedRefPruner._matches_current_book_context(match, book_context_ref)
+        ]
+        return temp_resolved_refs if len(temp_resolved_refs) > 0 else resolved_refs
+
+    @staticmethod
     def get_context_free_matches(resolved_refs: List[ResolvedRef]) -> List[ResolvedRef]:
         def match_is_context_free(match: ResolvedRef) -> bool:
             if match.context_ref is not None:
@@ -1012,13 +1039,14 @@ class ResolvedRefPruner:
         return top_resolved_refs
 
     @staticmethod
-    def prune_refined_ref_part_matches(thoroughness, resolved_refs: List[ResolvedRef]) -> List[ResolvedRef]:
+    def prune_refined_ref_part_matches(thoroughness, resolved_refs: List[ResolvedRef], book_context_ref: Optional[text.Ref] = None) -> List[ResolvedRef]:
         """
         Applies some heuristics to remove false positives
         """
         resolved_refs = ResolvedRefPruner.remove_incorrect_matches(resolved_refs)
         if len(resolved_refs) == 0:
             return resolved_refs
+        resolved_refs = ResolvedRefPruner.prune_relative_ref_matches(resolved_refs, book_context_ref)
 
         # if any context-free match uses all input parts, dont need to try context
         context_free_matches = ResolvedRefPruner.get_context_free_matches(resolved_refs)

--- a/sefaria/model/linker/referenceable_book_node.py
+++ b/sefaria/model/linker/referenceable_book_node.py
@@ -28,13 +28,8 @@ def subref(ref: text.Ref, section: int, is_amud: bool = False):
 
 def _talmud_subref(ref: text.Ref, section: int):
     """
-    Refine `ref` (whose Daf is already set) by amud. Unlike a normal subref, this merges into the ref's existing
-    (last) section instead of appending a new one, since Daf+Amud are stored as a single combined address.
-    `section` must be 1 (amud aleph) or 2 (amud bet) -- the only values AddressAmud can ever produce -- and must
-    only be called once per ref: calling it a second time (e.g. on a ref whose amud has already been merged in,
-    or with an out-of-range value like a daf number) silently produces a bogus daf/amud instead of failing to
-    match. Callers are expected to only reach this via the dedicated Amud referenceable node (see
-    NumberedReferenceableBookNode.possible_subrefs), which structurally can only be matched once per ref chain.
+    Refine a Talmud daf ref by amud, merging `section` into the existing daf address.
+    `section` must be 1 (amud aleph) or 2 (amud bet).
     """
     if section not in (1, 2):
         raise InputError(f"Talmud amud value must be 1 (aleph) or 2 (bet), got {section}")

--- a/sefaria/model/linker/referenceable_book_node.py
+++ b/sefaria/model/linker/referenceable_book_node.py
@@ -17,8 +17,8 @@ from sefaria.utils.hebrew import hebrew_term
 logger = structlog.get_logger(__name__)
 
 
-def subref(ref: text.Ref, section: int):
-    if ref.index_node.addressTypes[len(ref.sections)-1] == "Talmud":
+def subref(ref: text.Ref, section: int, is_amud: bool = False):
+    if is_amud:
         return _talmud_subref(ref, section)
     elif ref.index.categories == ['Tanakh', 'Torah']:
         return _parsha_subref(ref, section)
@@ -27,6 +27,19 @@ def subref(ref: text.Ref, section: int):
 
 
 def _talmud_subref(ref: text.Ref, section: int):
+    """
+    Refine `ref` (whose Daf is already set) by amud. Unlike a normal subref, this merges into the ref's existing
+    (last) section instead of appending a new one, since Daf+Amud are stored as a single combined address.
+    `section` must be 1 (amud aleph) or 2 (amud bet) -- the only values AddressAmud can ever produce -- and must
+    only be called once per ref: calling it a second time (e.g. on a ref whose amud has already been merged in,
+    or with an out-of-range value like a daf number) silently produces a bogus daf/amud instead of failing to
+    match. Callers are expected to only reach this via the dedicated Amud referenceable node (see
+    NumberedReferenceableBookNode.possible_subrefs), which structurally can only be matched once per ref chain.
+    """
+    if section not in (1, 2):
+        raise InputError(f"Talmud amud value must be 1 (aleph) or 2 (bet), got {section}")
+    if len(ref.sections) == 0 or ref.index_node.addressTypes[len(ref.sections)-1] != "Talmud":
+        raise InputError(f"Can't apply amud to a ref that doesn't already have a Talmud daf set: {ref}")
     d = ref._core_dict()
     d['sections'][-1] += (section-1)
     d['toSections'] = d['sections'][:]
@@ -263,10 +276,14 @@ class NumberedReferenceableBookNode(IndexNodeReferenceableBookNode):
         possible_subrefs = []
         can_match_out_of_order_list = []
         for sec, toSec, addr_class in zip(possible_sections, possible_to_sections, addr_classes):
+            # Only the dedicated Amud node (inserted once per Talmud Daf, see insert_amud_node_values) may merge
+            # into the ref's existing section via _talmud_subref; every other address type appends a new section.
+            # This is what makes it structurally impossible to apply an amud merge more than once per ref chain.
+            is_amud = issubclass(addr_class, schema.AddressAmud)
             try:
-                refined_ref = subref(initial_ref, sec)
+                refined_ref = subref(initial_ref, sec, is_amud)
                 if toSec != sec:
-                    to_ref = subref(initial_ref, toSec)
+                    to_ref = subref(initial_ref, toSec, is_amud)
                     refined_ref = refined_ref.to(to_ref)
                 possible_subrefs += [refined_ref]
                 can_match_out_of_order_list += [addr_class.can_match_out_of_order(lang, section_str)]

--- a/sefaria/model/linker/tests/linker_test.py
+++ b/sefaria/model/linker/tests/linker_test.py
@@ -453,11 +453,6 @@ def test_full_pipeline_ref_resolver(monkeypatch, context_tref, input_str, lang, 
 
 
 @pytest.mark.parametrize(('doc_text', 'span_text', 'expected_pretty_text'), [
-    # Rashba on Berakhot 17b:1: "אסקה רב אשי בגמרא (לקמן ברכות יח, א) דמוטל...". Confirmed against the real
-    # LinkerOutput debug span (GET /api/v3/texts/Rashba_on_Berakhot.17b.1?debug_mode=linker) that the raw
-    # entity span is 'בגמרא (לקמן ברכות יח, א' (open paren included, closing paren just outside the span).
-    # ResolvedRef.pretty_text handles this correctly on its own -- see test_extract_resolved_spans_end_paren
-    # in sefaria/helper/linker/tests/task_test.py for where the trailing paren actually gets lost.
     ['אסקה רב אשי בגמרא (לקמן ברכות יח, א) דמוטל עליו לקוברו', 'בגמרא (לקמן ברכות יח, א', 'בגמרא (לקמן ברכות יח, א)'],
     # Same shape, with a trailing ":)" instead of just ")"
     ['גמ\' שמזונותן עליך. עיין ביצה (דף טו ע"ב רש"י ד"ה שמא יפשע:) עוד', 'ביצה (דף טו ע"ב רש"י ד"ה שמא יפשע', 'ביצה (דף טו ע"ב רש"י ד"ה שמא יפשע:)'],

--- a/sefaria/model/linker/tests/linker_test.py
+++ b/sefaria/model/linker/tests/linker_test.py
@@ -234,6 +234,7 @@ def test_multiple_ambiguities():
     # Relative (e.g. Lekaman)
     [crrd(["@תוס'", "<לקמן", "#ד ע\"ב", "*ד\"ה דאר\"י"], "Gilyon HaShas on Berakhot 2a:2"), ("Tosafot on Berakhot 4b:6:1",)],  # likaman + abbrev in DH
     [crrd(['<לקמן', '#משנה א'], "Mishnah Berakhot 1", prev_trefs=['Mishnah Shabbat 1']), ("Mishnah Berakhot 1:1",)],  # competing relative and sham
+    [crrd(["<להלן", "@מנחות", "#ג", "#ב"], "Steinsaltz on Menachot 2b:5"), ("Menachot 3b", "Mishnah Menachot 3:2")],  # sc-46799: explicit book+daf+amud shouldn't be forced through context (used to wrongly match Menachot 4a); ambiguous with Mishnah Menachot same as the same citation without the relative marker
     
     # Section name matching instead of address type
     [crrd(["@Teshuvot", "@HaRosh", "#Klal 1"], lang='en'), ("Teshuvot HaRosh 1",)],
@@ -449,6 +450,27 @@ def test_full_pipeline_ref_resolver(monkeypatch, context_tref, input_str, lang, 
         assert match.pretty_text == expected_pretty_text
         for part, expected_part_str in zip(match.raw_entity.raw_ref_parts, expected_part_strs):
             assert part.text == expected_part_str
+
+
+@pytest.mark.parametrize(('doc_text', 'span_text', 'expected_pretty_text'), [
+    # Rashba on Berakhot 17b:1: "אסקה רב אשי בגמרא (לקמן ברכות יח, א) דמוטל...". Confirmed against the real
+    # LinkerOutput debug span (GET /api/v3/texts/Rashba_on_Berakhot.17b.1?debug_mode=linker) that the raw
+    # entity span is 'בגמרא (לקמן ברכות יח, א' (open paren included, closing paren just outside the span).
+    # ResolvedRef.pretty_text handles this correctly on its own -- see test_extract_resolved_spans_end_paren
+    # in sefaria/helper/linker/tests/task_test.py for where the trailing paren actually gets lost.
+    ['אסקה רב אשי בגמרא (לקמן ברכות יח, א) דמוטל עליו לקוברו', 'בגמרא (לקמן ברכות יח, א', 'בגמרא (לקמן ברכות יח, א)'],
+    # Same shape, with a trailing ":)" instead of just ")"
+    ['גמ\' שמזונותן עליך. עיין ביצה (דף טו ע"ב רש"י ד"ה שמא יפשע:) עוד', 'ביצה (דף טו ע"ב רש"י ד"ה שמא יפשע', 'ביצה (דף טו ע"ב רש"י ד"ה שמא יפשע:)'],
+    # No delimiter nearby -> span is left untouched
+    ['זה טקסט רגיל בלי סוגריים בסוף', 'טקסט רגיל', 'טקסט רגיל'],
+])
+def test_pretty_text_end_paren(doc_text, span_text, expected_pretty_text):
+    doc = NEDoc(doc_text)
+    start = doc_text.index(span_text)
+    end = start + len(span_text)
+    raw_ref = RawRef(doc.subspan(slice(start, end)), 'he', [])
+    resolved_ref = ResolvedRef(raw_ref, [], None)
+    assert resolved_ref.pretty_text == expected_pretty_text
 
 
 @pytest.fixture

--- a/sefaria/model/linker/tests/linker_test.py
+++ b/sefaria/model/linker/tests/linker_test.py
@@ -234,7 +234,7 @@ def test_multiple_ambiguities():
     # Relative (e.g. Lekaman)
     [crrd(["@תוס'", "<לקמן", "#ד ע\"ב", "*ד\"ה דאר\"י"], "Gilyon HaShas on Berakhot 2a:2"), ("Tosafot on Berakhot 4b:6:1",)],  # likaman + abbrev in DH
     [crrd(['<לקמן', '#משנה א'], "Mishnah Berakhot 1", prev_trefs=['Mishnah Shabbat 1']), ("Mishnah Berakhot 1:1",)],  # competing relative and sham
-    [crrd(["<להלן", "@מנחות", "#ג", "#ב"], "Steinsaltz on Menachot 2b:5"), ("Menachot 3b", "Mishnah Menachot 3:2")],  # sc-46799: explicit book+daf+amud shouldn't be forced through context (used to wrongly match Menachot 4a); ambiguous with Mishnah Menachot same as the same citation without the relative marker
+    [crrd(["<להלן", "@מנחות", "#ג", "#ב"], "Steinsaltz on Menachot 2b:5"), ("Menachot 3b",)],  # sc-46799: relative refs stay in the current book/base-text context, so Mishnah Menachot is pruned
     
     # Section name matching instead of address type
     [crrd(["@Teshuvot", "@HaRosh", "#Klal 1"], lang='en'), ("Teshuvot HaRosh 1",)],


### PR DESCRIPTION
This pull request introduces several improvements and fixes related to reference resolution, citation span extraction, and Talmud amud handling in the linker pipeline. The main changes clarify how citation spans are extracted and displayed, ensure that relative reference markers do not block explicit matches, and add robust validation and documentation for Talmud amud processing. Test coverage is expanded to confirm these behaviors.

**Citation span extraction and display:**
- Changed `_extract_resolved_spans` in `tasks.py` to use `resolved_ref.pretty_span` instead of `raw_entity`, ensuring that citation spans include any trailing delimiters (like a closing parenthesis) that should be highlighted for readers.
- Updated `ResolvedRef` to expose both `pretty_span` (returns the full, display-ready span object) and `pretty_text` (returns just the text), and adjusted internal logic to build these spans correctly.

**Reference resolution logic:**
- Modified logic in `matched_all_explicit_sections` and `get_context_free_matches` to treat RELATIVE ref parts (like "לקמן") as signals rather than required, resolvable sections. This prevents explicit citations from being incorrectly forced through context-based resolution, fixing previous ambiguity errors. [[1]](diffhunk://#diff-e07e11947d0d7f8e7b716ded7ba41035741176a877683e53c428ed583f41272cR889-R895) [[2]](diffhunk://#diff-e07e11947d0d7f8e7b716ded7ba41035741176a877683e53c428ed583f41272cL981-R1001)

**Talmud amud handling:**
- Refactored `subref` and `_talmud_subref` to explicitly handle amud merging, add parameterization, and validate correct usage, preventing subtle bugs in ref construction. Added docstrings to clarify correct usage patterns. [[1]](diffhunk://#diff-7fa7962d424602e0b880f0f9202dcf51d93e7e9569bcc196689b16be9f56625aL20-R21) [[2]](diffhunk://#diff-7fa7962d424602e0b880f0f9202dcf51d93e7e9569bcc196689b16be9f56625aR30-R42)
- Updated `possible_subrefs` to correctly distinguish amud merges from other section appends, ensuring structural correctness in reference resolution.

**Test coverage:**
- Added new tests in both `linker_test.py` and `task_test.py` to confirm correct highlighting of citation spans (including trailing delimiters), proper handling of RELATIVE markers, and correct amud processing. [[1]](diffhunk://#diff-723e4a67602c52234a57b09077a2a52c309ac83f4f3594c0c64d97aa792de172R67-R100) [[2]](diffhunk://#diff-5451a242992e95ae2562ee9874d6984060222bcda58611f15489b7023063b7f9R237) [[3]](diffhunk://#diff-5451a242992e95ae2562ee9874d6984060222bcda58611f15489b7023063b7f9R455-R475)

**Test and import updates:**
- Updated test imports to support new test cases and helper functions.

These changes collectively improve the accuracy, clarity, and maintainability of the reference resolution and citation highlighting pipeline.