### PR TITLE
hotfix(helm): stop the kubelet killing slow-but-alive web pods

### DIFF
--- a/helm-chart/sefaria/templates/rollout/web.yaml
+++ b/helm-chart/sefaria/templates/rollout/web.yaml
@@ -205,8 +205,10 @@ spec:
           # shifts its traffic onto the remaining pods, which then slow down and fail their
           # own probes. Readiness (below) is deliberately left at the default so a slow pod is
           # still pulled out of the Service — liveness should only fire for a genuinely dead
-          # process, not a busy one.
-          failureThreshold: 6
+          # process, not a busy one. 60s x 7 = 420s, which matches the --timeout 420 this
+          # container already passes to gunicorn: the kubelet should not kill a worker before
+          # gunicorn's own timeout would have recycled it.
+          failureThreshold: 7
         readinessProbe:
           httpGet:
             path: /healthz

--- a/helm-chart/sefaria/templates/rollout/web.yaml
+++ b/helm-chart/sefaria/templates/rollout/web.yaml
@@ -198,6 +198,15 @@ spec:
           # initialDelaySeconds: 120
           periodSeconds: 60
           timeoutSeconds: 60
+          # /healthz is served by the same gunicorn workers as real traffic, so it queues
+          # behind them. Without an explicit threshold this defaults to 3, meaning ~3 minutes
+          # of a slow-but-alive app is enough for the kubelet to kill the container. Killing a
+          # slow pod makes things worse: the restart re-imports the whole application and
+          # shifts its traffic onto the remaining pods, which then slow down and fail their
+          # own probes. Readiness (below) is deliberately left at the default so a slow pod is
+          # still pulled out of the Service — liveness should only fire for a genuinely dead
+          # process, not a busy one.
+          failureThreshold: 6
         readinessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
`/healthz` is served by the same gunicorn workers as real traffic, so it queues behind them. With no explicit `failureThreshold` it defaults to 3 — about 3 minutes of a slow-but-alive app is enough for the kubelet to kill the container.

Since the 2026-08-23 deploy: **17–20 liveness-probe kills per pod** (vs 1–2 before), **zero OOMKills**. Each kill re-imports the whole app and shifts its traffic onto the remaining pods, which then fail their own probes — kills arrive in waves.

`60s × 7 = 420s`, matching the `--timeout 420` this container already passes to gunicorn. The probe was stricter than the app's own timeout.

**Readiness deliberately unchanged** — a slow pod should leave the Service, not be restarted.

Temporary. Revert once the ~2× per-request regression is fixed, or once liveness points at an endpoint outside the request queue. The tradeoff is that a genuinely hung worker now takes ~7 min to be restarted instead of ~3.

**Testing on preprod:** preprod does not currently reproduce this (0 restarts, 2 replicas, no APM traces), so it can confirm the change is safe but not that it works.
```
kubectl -n preprod get rollout preprod-web \
  -o jsonpath='{.spec.template.spec.containers[?(@.name=="web")].livenessProbe}'
# expect: ...,"timeoutSeconds":60,"failureThreshold":7}
```
Confirm readiness has no `failureThreshold`, pods stay at 0 restarts, and no `Killing`/`Unhealthy` events appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbbDpzvvxiRi2U9J9wssxi
