### PR TITLE
perf(deps): defer sefaria.helper.search import to first use

### DIFF
--- a/sefaria/model/dependencies.py
+++ b/sefaria/model/dependencies.py
@@ -6,18 +6,57 @@ from . import abstract, link, note, history, schema, text, layer, version_state,
 
 from .abstract import subscribe, cascade, cascade_to_list, cascade_delete, cascade_delete_to_list
 # ES cascade handlers that keep the search indices in sync with model changes.
-# sefaria.helper.search deliberately avoids importing sefaria.model at module level,
-# so importing it here (while sefaria.model's __init__ is still running) is safe.
-from sefaria.helper.search import (
-    process_index_title_change_in_search,
-    process_index_title_change_in_book_search,
-    process_index_save_in_book_search,
-    process_index_delete_in_book_search,
-    process_topic_save_in_topic_search,
-    process_topic_delete_in_topic_search,
-    process_category_path_change_in_book_search,
-    process_category_change_in_category_search,
-)
+#
+# These are wrapped in thunks rather than imported at module level. `dependencies` is
+# imported while sefaria.model's __init__ is still running, so a module-level import of
+# sefaria.helper.search pulls that module -- and transitively sefaria.search and the
+# Elasticsearch client -- into *every* worker boot, whether or not anything is ever
+# indexed. The handlers already defer their own imports (`from sefaria.search import
+# index_topic_doc` inside the function body), so deferring this one makes the module
+# consistent with them.
+#
+# Behaviour is unchanged. The only difference is *when* the import happens: on the first
+# save/delete that actually needs it, rather than during startup. Subscription order is
+# unchanged and still matters -- see the ordering comments further down.
+
+def _es_index_title_change_in_search(*args, **kwargs):
+    from sefaria.helper.search import process_index_title_change_in_search
+    return process_index_title_change_in_search(*args, **kwargs)
+
+
+def _es_index_title_change_in_book_search(*args, **kwargs):
+    from sefaria.helper.search import process_index_title_change_in_book_search
+    return process_index_title_change_in_book_search(*args, **kwargs)
+
+
+def _es_index_save_in_book_search(*args, **kwargs):
+    from sefaria.helper.search import process_index_save_in_book_search
+    return process_index_save_in_book_search(*args, **kwargs)
+
+
+def _es_index_delete_in_book_search(*args, **kwargs):
+    from sefaria.helper.search import process_index_delete_in_book_search
+    return process_index_delete_in_book_search(*args, **kwargs)
+
+
+def _es_topic_save_in_topic_search(*args, **kwargs):
+    from sefaria.helper.search import process_topic_save_in_topic_search
+    return process_topic_save_in_topic_search(*args, **kwargs)
+
+
+def _es_topic_delete_in_topic_search(*args, **kwargs):
+    from sefaria.helper.search import process_topic_delete_in_topic_search
+    return process_topic_delete_in_topic_search(*args, **kwargs)
+
+
+def _es_category_path_change_in_book_search(*args, **kwargs):
+    from sefaria.helper.search import process_category_path_change_in_book_search
+    return process_category_path_change_in_book_search(*args, **kwargs)
+
+
+def _es_category_change_in_category_search(*args, **kwargs):
+    from sefaria.helper.search import process_category_change_in_category_search
+    return process_category_change_in_category_search(*args, **kwargs)
 import sefaria.system.cache as scache
 import structlog
 
@@ -30,7 +69,7 @@ subscribe(text.process_index_change_in_toc,                             text.Ind
 subscribe(place.process_index_place_change, text.Index, 'attributeChange', 'compPlace')
 subscribe(place.process_index_place_change, text.Index, 'attributeChange', 'pubPlace')
 # Entity search: keep the `book` index in sync with Index saves
-subscribe(process_index_save_in_book_search,                            text.Index, "save")
+subscribe(_es_index_save_in_book_search,                            text.Index, "save")
 
 # Index Name Change
 subscribe(text.process_index_title_change_in_core_cache,                text.Index, "attributeChange", "title")
@@ -50,8 +89,8 @@ subscribe(marked_up_text_chunk.process_index_title_change,              text.Ind
 # ES: listeners fire in subscription order, so these must stay last in this block —
 # in particular after process_index_title_change_in_versions has renamed the book's
 # versions in Mongo, which process_index_title_change_in_search re-reads.
-subscribe(process_index_title_change_in_search,                         text.Index, "attributeChange", "title")
-subscribe(process_index_title_change_in_book_search,                    text.Index, "attributeChange", "title")
+subscribe(_es_index_title_change_in_search,                         text.Index, "attributeChange", "title")
+subscribe(_es_index_title_change_in_book_search,                    text.Index, "attributeChange", "title")
 
 # Taken care of on save
 # subscribe(text.process_index_change_in_toc,                             text.Index, "attributeChange", "title")
@@ -69,7 +108,7 @@ subscribe(cascade_delete(notification.GlobalNotificationSet, "content.index", "t
 subscribe(ref_data.process_index_delete_in_ref_data,                    text.Index, "delete")
 subscribe(marked_up_text_chunk.process_index_delete,                    text.Index, "delete")
 # Entity search: keep the `book` index in sync with Index deletes
-subscribe(process_index_delete_in_book_search,                          text.Index, "delete")
+subscribe(_es_index_delete_in_book_search,                          text.Index, "delete")
 
 # Process in ES
 def process_version_title_change_in_search(ver, **kwargs):
@@ -145,8 +184,8 @@ subscribe(layer.process_note_deletion_in_layer,                         note.Not
 # notify() dispatches on the exact instance type, and topics load as their subclass
 # (Topic.subclass_map), so each concrete class needs its own subscription.
 for topic_klass in (topic.Topic, topic.PersonTopic, topic.AuthorTopic):
-    subscribe(process_topic_save_in_topic_search,                       topic_klass, "save")
-    subscribe(process_topic_delete_in_topic_search,                     topic_klass, "delete")
+    subscribe(_es_topic_save_in_topic_search,                       topic_klass, "save")
+    subscribe(_es_topic_delete_in_topic_search,                     topic_klass, "delete")
 subscribe(topic.process_topic_delete,                                 topic.Topic, "delete")
 subscribe(topic.process_topic_description_change,                       topic.Topic, "attributeChange", "description")
 subscribe(topic.process_topic_delete,                                 topic.AuthorTopic, "delete")
@@ -192,12 +231,12 @@ subscribe(marked_up_text_chunk.process_category_path_change,  category.Category,
 subscribe(text.rebuild_library_after_category_change,                   category.Category, "save")
 # Entity search: must stay subscribed after category.process_category_path_change,
 # which cascades the new path into the Mongo Index records this hook re-reads.
-subscribe(process_category_path_change_in_book_search,  category.Category, "attributeChange", "path")
+subscribe(_es_category_path_change_in_book_search,  category.Category, "attributeChange", "path")
 # Category search: must stay subscribed after text.rebuild_library_after_category_change,
 # because the re-sync reads the (rebuilt) TOC tree. Save and delete both re-sync the whole
 # `category` index -- see sefaria.search.resync_category_docs.
-subscribe(process_category_change_in_category_search,  category.Category, "save")
-subscribe(process_category_change_in_category_search,  category.Category, "delete")
+subscribe(_es_category_change_in_category_search,  category.Category, "save")
+subscribe(_es_category_change_in_category_search,  category.Category, "delete")
 
 # Manuscripts
 subscribe(manuscript.process_slug_change_in_manuscript,  manuscript.Manuscript, "attributeChange", "slug")


### PR DESCRIPTION
## Why

`sefaria/model/dependencies.py` is imported while `sefaria.model.__init__` is still running. Its module-level import:

```python
from sefaria.helper.search import (process_index_save_in_book_search, ...)
```

pulls `sefaria/helper/search.py` — and transitively `sefaria/search.py` and the Elasticsearch client — into **every worker boot**, whether or not anything is ever indexed.

Datadog's Continuous Profiler shows worker startup is already dominated by module-import work (`marshal.loads`, `compile`, `__build_class__`, `stat`) under `Arbiter.spawn_worker → post_fork`, and CPU roughly doubles (108 → 218 ms/min) during periods when pods are cycling. Every avoidable import at boot is paid again on every restart.

Note the inconsistency this fixes: **the handlers already defer their own imports** — e.g. `process_topic_save_in_topic_search` does `from sefaria.search import index_topic_doc` *inside* the function body. Only the top-level import in `dependencies.py` was eager.

## What changed

Each of the eight ES cascade handlers is wrapped in a thunk that imports on first call. One file, no behaviour change — only *when* the import happens.

**Subscription order is unchanged**, which matters: the file carries explicit ordering comments (`must stay last in this block`, `must stay subscribed after process_index_title_change_in_versions`, `must stay subscribed after text.rebuild_library_after_category_change`). All nine `subscribe()` calls keep their exact positions.

## How to test on preprod

**The measurement is independent of any incident hypothesis** — it either reduces boot cost or it doesn't:

```bash
# inside a preprod web pod, or any container built from this branch
time python -c "import sefaria.model"
```

Run it on `preprod` before merge and on this branch after. Expect the ES/search import chain to drop out of the boot path.

To see it directly in the profiler: **APM → Profiles → Explorer**, `service:web`, metric **CPU**, and **turn off "My Code"** (library frames are hidden by default and that is where the import work lives). Compare a window containing worker starts before and after.

Functional check — the subscriptions must still fire:

1. Save a Topic on preprod and confirm the corresponding `PUT /topic-a/_doc/<slug>` still reaches Elasticsearch (visible in APM as an `elasticsearch` span on `service:web`).
2. Rename an Index title and confirm the search-index sync still runs.
3. Confirm no import errors at boot: `kubectl -n preprod logs <pod> -c web | head -50`.

**Rollback:** revert the commit. Single file, no schema or config impact.

## Scope

This is a **boot-cost** improvement, not a fix for the ~2× per-request regression seen since `v6.111.0-prod.2`. It matters most while pods are cycling frequently — which is itself addressed by #3661 (liveness probe). Worth landing on its own merits regardless of what caused the 2×.

Related: #3661 (liveness `failureThreshold`), and the investigation artifact for full context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbbDpzvvxiRi2U9J9wssxi
