### PR TITLE
hotfix(deps): defer sefaria.helper.search import to first use

### DIFF
--- a/sefaria/model/dependencies.py
+++ b/sefaria/model/dependencies.py
@@ -6,18 +6,57 @@ from . import abstract, link, note, history, schema, text, layer, version_state,
 
 from .abstract import subscribe, cascade, cascade_to_list, cascade_delete, cascade_delete_to_list
 # ES cascade handlers that keep the search indices in sync with model changes.
-# sefaria.helper.search deliberately avoids importing sefaria.model at module level,
-# so importing it here (while sefaria.model's __init__ is still running) is safe.
-from sefaria.helper.search import (
-    process_index_title_change_in_search,
-    process_index_title_change_in_book_search,
-    process_index_save_in_book_search,
-    process_index_delete_in_book_search,
-    process_topic_save_in_topic_search,
-    process_topic_delete_in_topic_search,
-    process_category_path_change_in_book_search,
-    process_category_change_in_category_search,
-)
+#
+# These are wrapped in thunks rather than imported at module level. `dependencies` is
+# imported while sefaria.model's __init__ is still running, so a module-level import of
+# sefaria.helper.search pulls that module -- and transitively sefaria.search and the
+# Elasticsearch client -- into *every* worker boot, whether or not anything is ever
+# indexed. The handlers already defer their own imports (`from sefaria.search import
+# index_topic_doc` inside the function body), so deferring this one makes the module
+# consistent with them.
+#
+# Behaviour is unchanged. The only difference is *when* the import happens: on the first
+# save/delete that actually needs it, rather than during startup. Subscription order is
+# unchanged and still matters -- see the ordering comments further down.
+
+def _es_index_title_change_in_search(*args, **kwargs):
+    from sefaria.helper.search import process_index_title_change_in_search
+    return process_index_title_change_in_search(*args, **kwargs)
+
+
+def _es_index_title_change_in_book_search(*args, **kwargs):
+    from sefaria.helper.search import process_index_title_change_in_book_search
+    return process_index_title_change_in_book_search(*args, **kwargs)
+
+
+def _es_index_save_in_book_search(*args, **kwargs):
+    from sefaria.helper.search import process_index_save_in_book_search
+    return process_index_save_in_book_search(*args, **kwargs)
+
+
+def _es_index_delete_in_book_search(*args, **kwargs):
+    from sefaria.helper.search import process_index_delete_in_book_search
+    return process_index_delete_in_book_search(*args, **kwargs)
+
+
+def _es_topic_save_in_topic_search(*args, **kwargs):
+    from sefaria.helper.search import process_topic_save_in_topic_search
+    return process_topic_save_in_topic_search(*args, **kwargs)
+
+
+def _es_topic_delete_in_topic_search(*args, **kwargs):
+    from sefaria.helper.search import process_topic_delete_in_topic_search
+    return process_topic_delete_in_topic_search(*args, **kwargs)
+
+
+def _es_category_path_change_in_book_search(*args, **kwargs):
+    from sefaria.helper.search import process_category_path_change_in_book_search
+    return process_category_path_change_in_book_search(*args, **kwargs)
+
+
+def _es_category_change_in_category_search(*args, **kwargs):
+    from sefaria.helper.search import process_category_change_in_category_search
+    return process_category_change_in_category_search(*args, **kwargs)
 import sefaria.system.cache as scache
 import structlog
 
@@ -30,7 +69,7 @@ subscribe(text.process_index_change_in_toc,                             text.Ind
 subscribe(place.process_index_place_change, text.Index, 'attributeChange', 'compPlace')
 subscribe(place.process_index_place_change, text.Index, 'attributeChange', 'pubPlace')
 # Entity search: keep the `book` index in sync with Index saves
-subscribe(process_index_save_in_book_search,                            text.Index, "save")
+subscribe(_es_index_save_in_book_search,                            text.Index, "save")
 
 # Index Name Change
 subscribe(text.process_index_title_change_in_core_cache,                text.Index, "attributeChange", "title")
@@ -50,8 +89,8 @@ subscribe(marked_up_text_chunk.process_index_title_change,              text.Ind
 # ES: listeners fire in subscription order, so these must stay last in this block —
 # in particular after process_index_title_change_in_versions has renamed the book's
 # versions in Mongo, which process_index_title_change_in_search re-reads.
-subscribe(process_index_title_change_in_search,                         text.Index, "attributeChange", "title")
-subscribe(process_index_title_change_in_book_search,                    text.Index, "attributeChange", "title")
+subscribe(_es_index_title_change_in_search,                         text.Index, "attributeChange", "title")
+subscribe(_es_index_title_change_in_book_search,                    text.Index, "attributeChange", "title")
 
 # Taken care of on save
 # subscribe(text.process_index_change_in_toc,                             text.Index, "attributeChange", "title")
@@ -69,7 +108,7 @@ subscribe(cascade_delete(notification.GlobalNotificationSet, "content.index", "t
 subscribe(ref_data.process_index_delete_in_ref_data,                    text.Index, "delete")
 subscribe(marked_up_text_chunk.process_index_delete,                    text.Index, "delete")
 # Entity search: keep the `book` index in sync with Index deletes
-subscribe(process_index_delete_in_book_search,                          text.Index, "delete")
+subscribe(_es_index_delete_in_book_search,                          text.Index, "delete")
 
 # Process in ES
 def process_version_title_change_in_search(ver, **kwargs):
@@ -145,8 +184,8 @@ subscribe(layer.process_note_deletion_in_layer,                         note.Not
 # notify() dispatches on the exact instance type, and topics load as their subclass
 # (Topic.subclass_map), so each concrete class needs its own subscription.
 for topic_klass in (topic.Topic, topic.PersonTopic, topic.AuthorTopic):
-    subscribe(process_topic_save_in_topic_search,                       topic_klass, "save")
-    subscribe(process_topic_delete_in_topic_search,                     topic_klass, "delete")
+    subscribe(_es_topic_save_in_topic_search,                       topic_klass, "save")
+    subscribe(_es_topic_delete_in_topic_search,                     topic_klass, "delete")
 subscribe(topic.process_topic_delete,                                 topic.Topic, "delete")
 subscribe(topic.process_topic_description_change,                       topic.Topic, "attributeChange", "description")
 subscribe(topic.process_topic_delete,                                 topic.AuthorTopic, "delete")
@@ -192,12 +231,12 @@ subscribe(marked_up_text_chunk.process_category_path_change,  category.Category,
 subscribe(text.rebuild_library_after_category_change,                   category.Category, "save")
 # Entity search: must stay subscribed after category.process_category_path_change,
 # which cascades the new path into the Mongo Index records this hook re-reads.
-subscribe(process_category_path_change_in_book_search,  category.Category, "attributeChange", "path")
+subscribe(_es_category_path_change_in_book_search,  category.Category, "attributeChange", "path")
 # Category search: must stay subscribed after text.rebuild_library_after_category_change,
 # because the re-sync reads the (rebuilt) TOC tree. Save and delete both re-sync the whole
 # `category` index -- see sefaria.search.resync_category_docs.
-subscribe(process_category_change_in_category_search,  category.Category, "save")
-subscribe(process_category_change_in_category_search,  category.Category, "delete")
+subscribe(_es_category_change_in_category_search,  category.Category, "save")
+subscribe(_es_category_change_in_category_search,  category.Category, "delete")
 
 # Manuscripts
 subscribe(manuscript.process_slug_change_in_manuscript,  manuscript.Manuscript, "attributeChange", "slug")


### PR DESCRIPTION
`sefaria/model/dependencies.py` is imported while `sefaria.model.__init__` is still running, so its module-level `from sefaria.helper.search import (...)` pulls that module — and transitively `sefaria/search.py` and the Elasticsearch client — into **every worker boot**, whether or not anything is ever indexed.

That matters right now because web pods are restarting far more often than usual since the 2026-08-23 deploy, so the boot path is being paid repeatedly. The profiler shows worker startup dominated by module-import work (`marshal.loads`, `compile`, `__build_class__`) under `Arbiter.spawn_worker → post_fork`.

Each of the eight ES cascade handlers is wrapped in a thunk that imports on first call. **Subscription order is unchanged** — the file carries explicit ordering comments (`must stay last in this block`, `must stay subscribed after …`) and all nine `subscribe()` calls keep their positions. The handlers already defer their own imports (`from sefaria.search import index_topic_doc` inside the function body), so this makes the module consistent with them.

Behaviour is identical; only the timing of the import changes.

**Testing on preprod:**
```
time python -c "import sefaria.model"     # before vs after
```
Then confirm the subscriptions still fire: save a Topic and check the `PUT /topic-a/_doc/<slug>` still reaches Elasticsearch, and that the pod boots without import errors.

**Rollback:** revert the commit. Single file, no schema or config impact.

Replaces #3662 (same commit, re-cut onto `preprod` under `hotfix/*` to satisfy the promotion gate). Related: #3661.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbbDpzvvxiRi2U9J9wssxi
