### PR TITLE
Feature/sc 46882/updates to linker editor

### DIFF
--- a/scripts/linker_editor_history/export_linker_editor_history.py
+++ b/scripts/linker_editor_history/export_linker_editor_history.py
@@ -1,0 +1,42 @@
+"""
+Export linker_editor_history entries to a JSON file, for replay against another environment
+via replay_linker_editor_history.py.
+"""
+import argparse
+import json
+
+import django
+django.setup()
+
+from tqdm import tqdm
+
+from sefaria.system.database import db
+
+
+def _serialize(doc):
+    doc = dict(doc)
+    doc["_id"] = str(doc["_id"])
+    return doc
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Export linker_editor_history to a JSON file")
+    parser.add_argument("--output", "-o", required=True, help="Output JSON file path")
+    args = parser.parse_args()
+
+    # Sort by _id (not `created`, which is only second-resolution and can tie within a
+    # replay/import burst) -- ObjectIds are monotonic at millisecond+counter resolution, so
+    # this is the reliable original write order to preserve for replay.
+    cursor = db.linker_editor_history.find().sort("_id", 1)
+    total = db.linker_editor_history.count_documents({})
+
+    entries = [_serialize(doc) for doc in tqdm(cursor, total=total, desc="Exporting", unit="doc")]
+
+    with open(args.output, "w", encoding="utf-8") as f:
+        json.dump(entries, f, ensure_ascii=False, indent=2)
+
+    print(f"Exported {len(entries):,} linker_editor_history entries to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/linker_editor_history/replay_linker_editor_history.py
+++ b/scripts/linker_editor_history/replay_linker_editor_history.py
@@ -1,0 +1,175 @@
+"""
+Replay linker_editor_history entries (as exported by export_linker_editor_history.py) against
+this environment, by calling the same sefaria.helper.linker_editor functions the live
+/linker-editor UI calls -- so every replayed edit goes through the same validation, cache
+invalidation, and (re-)logging a live admin action would.
+
+This does NOT protect against cross-environment drift the source history can't see: a schema
+that has diverged between environments, match_templates edited directly against Mongo outside
+the linker editor, or a NonUniqueTerm that pre-existed in one environment's seed data but not
+the other's. Any of those surface as an InputError on the affected entry, which this script
+pauses on and asks the operator to ignore or abort -- it does not guess.
+"""
+import argparse
+import json
+import os
+import sys
+
+import django
+django.setup()
+
+from sefaria.helper import linker_editor
+from sefaria.model.linker_editor_history import log_linker_editor_action
+from sefaria.system.exceptions import InputError
+
+# Actions whose logged params match the target function's keyword arguments exactly.
+DIRECT_ACTIONS = {
+    "add_match_template": linker_editor.add_match_template,
+    "remove_match_template": linker_editor.remove_match_template,
+    "replace_match_template": linker_editor.replace_match_template,
+    "set_address_types": linker_editor.set_address_types,
+    "set_node_properties": linker_editor.set_node_properties,
+    "add_non_unique_term_titles": linker_editor.add_non_unique_term_titles,
+    "delete_non_unique_term": linker_editor.delete_non_unique_term,
+}
+
+
+def _remap(value, slug_remap):
+    """Recursively substitute any string found in slug_remap: an original NonUniqueTerm slug ->
+    the slug this environment actually assigned when the term's create_non_unique_term entry was
+    replayed. Slug generation includes a live collision-avoidance suffix against whatever terms
+    already exist in this DB, so it isn't guaranteed to match the source environment's slug."""
+    if isinstance(value, str):
+        return slug_remap.get(value, value)
+    if isinstance(value, list):
+        return [_remap(v, slug_remap) for v in value]
+    if isinstance(value, dict):
+        return {k: _remap(v, slug_remap) for k, v in value.items()}
+    return value
+
+
+def _apply_create_non_unique_term(params, uid, slug_remap):
+    # Logged params include the server-assigned `slug` from the source environment, which isn't
+    # a parameter of create_non_unique_term(titles, uid) -- drop it, then remap future references
+    # to it onto whatever slug this environment actually assigns.
+    result = linker_editor.create_non_unique_term(titles=params["titles"], uid=uid)
+    original_slug = params.get("slug")
+    if original_slug:
+        slug_remap[original_slug] = result["slug"]
+    return result
+
+
+def _apply_swap_non_unique_term_usages(params, uid):
+    # Logged params are {old_slug, new_slug, affected_usages}, but the function signature is
+    # (slug, new_slug, uid) -- affected_usages is a derived audit trail recomputed live from the
+    # usage index, not an input.
+    return linker_editor.swap_non_unique_term_usages(slug=params["old_slug"], new_slug=params["new_slug"], uid=uid)
+
+
+def _apply_rebuild_dibur_hamatchils_sync(params, uid):
+    # Celery Task instances remain plain callables: calling one directly (instead of
+    # .apply_async) runs its body synchronously in-process, no broker/worker required.
+    from sefaria.helper.linker.tasks import rebuild_dibur_hamatchils_task
+    title = params["title"]
+    rebuild_dibur_hamatchils_task(title)
+    # The synchronous path bypasses enqueue_rebuild_dibur_hamatchils, which normally logs this
+    # action -- log it manually so this environment's own audit trail stays consistent.
+    log_linker_editor_action(uid, "rebuild_dibur_hamatchils", {"title": title}, index_title=title)
+
+
+def _apply_entry(entry, uid, slug_remap, sync_dibur_hamatchil):
+    action = entry["action"]
+    params = _remap(entry["params"], slug_remap)
+
+    if action == "create_non_unique_term":
+        return _apply_create_non_unique_term(params, uid, slug_remap)
+    if action == "swap_non_unique_term_usages":
+        return _apply_swap_non_unique_term_usages(params, uid)
+    if action == "rebuild_dibur_hamatchils":
+        if sync_dibur_hamatchil:
+            return _apply_rebuild_dibur_hamatchils_sync(params, uid)
+        return linker_editor.enqueue_rebuild_dibur_hamatchils(title=params["title"], uid=uid)
+    if action in DIRECT_ACTIONS:
+        return DIRECT_ACTIONS[action](**params, uid=uid)
+    raise InputError("Unknown linker_editor_history action '{}'.".format(action))
+
+
+def _load_progress(progress_path):
+    if not os.path.exists(progress_path):
+        return set()
+    with open(progress_path, encoding="utf-8") as f:
+        return set(json.load(f))
+
+
+def _save_progress(progress_path, applied_ids):
+    with open(progress_path, "w", encoding="utf-8") as f:
+        json.dump(sorted(applied_ids), f)
+
+
+def _prompt_ignore_or_abort(entry, error):
+    print("\nFAILED to replay entry:", file=sys.stderr)
+    print(f"  _id: {entry.get('_id')}", file=sys.stderr)
+    print(f"  action: {entry.get('action')}", file=sys.stderr)
+    print(f"  params: {entry.get('params')}", file=sys.stderr)
+    print(f"  error: {error}", file=sys.stderr)
+    while True:
+        choice = input("[i]gnore and continue, or [a]bort? ").strip().lower()
+        if choice in ("i", "ignore"):
+            return True
+        if choice in ("a", "abort"):
+            return False
+        print("Please answer 'i' or 'a'.")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Replay linker_editor_history entries (from export_linker_editor_history.py) against this environment."
+    )
+    parser.add_argument("--input", required=True, help="Path to the JSON file produced by export_linker_editor_history.py")
+    parser.add_argument("--uid", required=True, type=int,
+                         help="Destination-environment user id to attribute every replayed action to "
+                              "(the recorded source-environment uid is never reused)")
+    parser.add_argument("--sync-dibur-hamatchil", action="store_true",
+                         help="Run dibur_hamatchil rebuilds synchronously in-process instead of enqueueing a Celery "
+                              "task -- use this if the destination has no worker consuming that queue")
+    parser.add_argument("--progress-file", default=None,
+                         help="Resume/progress sidecar file path (default: <input>.progress.json)")
+    args = parser.parse_args()
+
+    progress_path = args.progress_file or (args.input + ".progress.json")
+
+    with open(args.input, encoding="utf-8") as f:
+        entries = json.load(f)
+    entries.sort(key=lambda e: e["_id"])  # ObjectId hex strings sort lexically == chronologically
+
+    applied_ids = _load_progress(progress_path)
+    slug_remap = {}
+    applied = ignored = already_done = 0
+
+    for entry in entries:
+        entry_id = entry["_id"]
+        if entry_id in applied_ids:
+            already_done += 1
+            continue
+        try:
+            _apply_entry(entry, args.uid, slug_remap, args.sync_dibur_hamatchil)
+        except InputError as e:
+            if _prompt_ignore_or_abort(entry, e):
+                ignored += 1
+                continue
+            print(f"\nAborted. {applied} entries applied, {ignored} ignored before this point.", file=sys.stderr)
+            print("Resume by re-running with the same --input; already-applied entries will be skipped.", file=sys.stderr)
+            sys.exit(1)
+        applied_ids.add(entry_id)
+        _save_progress(progress_path, applied_ids)
+        applied += 1
+
+    print(f"\nDone. {applied} entries applied, {ignored} ignored, {already_done} already applied in a prior run.")
+    if slug_remap:
+        print("NonUniqueTerm slug remapping (source slug -> destination slug):")
+        for old, new in slug_remap.items():
+            print(f"  {old} -> {new}")
+
+
+if __name__ == "__main__":
+    main()

--- a/sefaria/helper/linker_editor.py
+++ b/sefaria/helper/linker_editor.py
@@ -475,15 +475,41 @@ def enqueue_rebuild_linker_resolvers(langs) -> str:
 # NonUniqueTerm read / search
 # ---------------------------------------------------------------------------
 
+def _term_match_rank(term: NonUniqueTerm, q_lower: str) -> int:
+    """
+    Best (lowest) match quality of `q_lower` against any of the term's titles or its slug:
+    0 = exact match, 1 = prefix match, 2 = match anywhere else (substring). The query that
+    produced `term` already guarantees at least a substring match, so 2 is the fallback.
+    """
+    strings = [term.slug] + [t.get("text", "") for t in (term.titles or [])]
+    best = 2
+    for s in strings:
+        s_lower = (s or "").lower()
+        if s_lower == q_lower:
+            return 0
+        if best > 1 and s_lower.startswith(q_lower):
+            best = 1
+    return best
+
+
 def search_non_unique_terms(q: str, limit: int = 20) -> List[dict]:
-    """Search NonUniqueTerms by title text or slug (case-insensitive) for autocomplete."""
+    """
+    Search NonUniqueTerms by title text or slug (case-insensitive) for autocomplete.
+    Mongo's $regex carries no relevance signal, so ranking exact/prefix matches first is
+    done here in Python: pull a candidate pool a bit larger than `limit` in whatever
+    (~natural) order Mongo returns, rank each by match quality, then truncate.
+    """
     q = get_linker_normalizer("he").normalize(q or "").strip()
     if not q:
         return []
+    q_lower = q.lower()
     regex = {"$regex": re.escape(q), "$options": "i"}
     query = {"$or": [{"titles.text": regex}, {"slug": regex}]}
+    candidate_pool = max(limit * 5, 100)
+    candidates = list(NonUniqueTermSet(query, limit=candidate_pool))
+    candidates.sort(key=lambda term: _term_match_rank(term, q_lower))
     results = []
-    for term in NonUniqueTermSet(query, limit=limit):
+    for term in candidates[:limit]:
         results.append({
             "slug": term.slug,
             "primary_en": term.get_primary_title("en"),

--- a/sefaria/helper/linker_editor.py
+++ b/sefaria/helper/linker_editor.py
@@ -477,19 +477,31 @@ def enqueue_rebuild_linker_resolvers(langs) -> str:
 
 def _term_match_rank(term: NonUniqueTerm, q_lower: str) -> int:
     """
-    Best (lowest) match quality of `q_lower` against any of the term's titles or its slug:
-    0 = exact match, 1 = prefix match, 2 = match anywhere else (substring). The query that
-    produced `term` already guarantees at least a substring match, so 2 is the fallback.
+    Best (lowest) match quality of `q_lower` against this term, weighted toward what the
+    autosuggest actually displays (the primary en/he titles and the slug) rather than every
+    title indiscriminately. Otherwise a term whose *primary* title is merely a substring
+    match (e.g. "קרבן פסח") can outrank a different term whose primary title is the true
+    exact match (e.g. "פסח"), just because the first term also happens to carry some
+    unrelated alt title ("פסח" as shorthand) that's an exact match on its own.
+
+    0 = exact match on a primary title or the slug
+    1 = prefix match on a primary title or the slug
+    2 = exact or prefix match on an alt (non-primary) title
+    3 = substring match anywhere (the fallback; the query that produced `term` already
+        guarantees at least this much)
     """
-    strings = [term.slug] + [t.get("text", "") for t in (term.titles or [])]
-    best = 2
-    for s in strings:
+    primary_strings = [term.slug, term.get_primary_title("en"), term.get_primary_title("he")]
+    primary_lower = [(s or "").lower() for s in primary_strings]
+    if q_lower in primary_lower:
+        return 0
+    if any(s.startswith(q_lower) for s in primary_lower):
+        return 1
+    alt_strings = [t.get("text", "") for t in (term.titles or []) if not t.get("primary")]
+    for s in alt_strings:
         s_lower = (s or "").lower()
-        if s_lower == q_lower:
-            return 0
-        if best > 1 and s_lower.startswith(q_lower):
-            best = 1
-    return best
+        if s_lower == q_lower or s_lower.startswith(q_lower):
+            return 2
+    return 3
 
 
 def search_non_unique_terms(q: str, limit: int = 20) -> List[dict]:

--- a/sefaria/helper/tests/linker_editor_test.py
+++ b/sefaria/helper/tests/linker_editor_test.py
@@ -711,6 +711,46 @@ def test_search_non_unique_terms_ranks_exact_and_prefix_matches_first(monkeypatc
     assert [r["slug"] for r in results] == ["bavli", "bavli-extra", "unrelated-slug"]
 
 
+def test_search_non_unique_terms_ranks_primary_title_over_unrelated_alt_title_match(monkeypatch):
+    # Regression for a real-world case: searching "פסח" put "קרבן פסח" (Korban Pesach)
+    # above the "פסח" (Pesach) term itself, because Korban Pesach also carries an
+    # unrelated alt title that's an exact-match shorthand ("פסח"). A term's own alt
+    # title being an exact match shouldn't outrank a different term whose *primary*
+    # title is the true exact match.
+    class FakeTerm:
+        def __init__(self, slug, en, he, titles):
+            self.slug = slug
+            self._en = en
+            self._he = he
+            self.titles = titles
+
+        def get_primary_title(self, lang):
+            return self._en if lang == "en" else self._he
+
+    pesach = FakeTerm("pesach", "Pesach", "פסח", [
+        {"lang": "en", "text": "Pesach", "primary": True},
+        {"lang": "he", "text": "פסח", "primary": True},
+    ])
+    paschal_offering = FakeTerm("paschal-offering", "Paschal Offering", "קרבן פסח", [
+        {"lang": "en", "text": "Paschal Offering", "primary": True},
+        {"lang": "he", "text": "קרבן פסח", "primary": True},
+        {"lang": "he", "text": "פסח", "primary": False},
+    ])
+
+    class FakeNonUniqueTermSet:
+        def __init__(self, query, limit=None):
+            pass
+
+        def __iter__(self):
+            # Natural order puts the alt-title collision first, as observed in prod.
+            return iter([paschal_offering, pesach])
+
+    monkeypatch.setattr(le, "NonUniqueTermSet", FakeNonUniqueTermSet)
+
+    results = le.search_non_unique_terms("פסח", 5)
+    assert [r["slug"] for r in results] == ["pesach", "paschal-offering"]
+
+
 def test_create_non_unique_term():
     from sefaria.model.schema import NonUniqueTerm
     detail = None

--- a/sefaria/helper/tests/linker_editor_test.py
+++ b/sefaria/helper/tests/linker_editor_test.py
@@ -647,6 +647,7 @@ def test_search_non_unique_terms_normalizes_query(monkeypatch):
 
     class FakeTerm:
         slug = "__le_test_term__"
+        titles = [{"lang": "en", "text": "Hagigah ha Something"}]
 
         def get_primary_title(self, lang):
             return "Primary" if lang == "en" else "עיקרי"
@@ -666,17 +667,48 @@ def test_search_non_unique_terms_normalizes_query(monkeypatch):
         "primary_he": "עיקרי",
     }]
     regex = {"$regex": le.re.escape("Hagigah ha"), "$options": "i"}
+    # The candidate pool fetched from Mongo is wider than `limit` — ranking happens in
+    # Python afterward, over this larger pool, before truncating back down to `limit`.
     assert captured[0] == (
         {"$or": [{"titles.text": regex}, {"slug": regex}]},
-        7,
+        max(7 * 5, 100),
     )
 
     le.search_non_unique_terms("בְּרֵאשִׁ֑ית", 5)
     regex = {"$regex": le.re.escape("בראשית"), "$options": "i"}
     assert captured[1] == (
         {"$or": [{"titles.text": regex}, {"slug": regex}]},
-        5,
+        max(5 * 5, 100),
     )
+
+
+def test_search_non_unique_terms_ranks_exact_and_prefix_matches_first(monkeypatch):
+    # Substring hit buried in an unrelated title, plus a slug that's an exact match
+    # and a title that's a prefix match — Mongo's natural order returns them in the
+    # "wrong" order here (substring hit first) to confirm the ranking step reorders them.
+    class FakeTerm:
+        def __init__(self, slug, titles):
+            self.slug = slug
+            self.titles = titles
+
+        def get_primary_title(self, lang):
+            return self.slug
+
+    substring_hit = FakeTerm("unrelated-slug", [{"lang": "en", "text": "Some Bavli Reference"}])
+    prefix_hit = FakeTerm("bavli-extra", [{"lang": "en", "text": "Bavli Extra"}])
+    exact_hit = FakeTerm("bavli", [{"lang": "en", "text": "Bavli"}])
+
+    class FakeNonUniqueTermSet:
+        def __init__(self, query, limit=None):
+            pass
+
+        def __iter__(self):
+            return iter([substring_hit, prefix_hit, exact_hit])
+
+    monkeypatch.setattr(le, "NonUniqueTermSet", FakeNonUniqueTermSet)
+
+    results = le.search_non_unique_terms("bavli", 5)
+    assert [r["slug"] for r in results] == ["bavli", "bavli-extra", "unrelated-slug"]
 
 
 def test_create_non_unique_term():

--- a/static/css/linker-editor.css
+++ b/static/css/linker-editor.css
@@ -100,6 +100,8 @@
 .linkerEditorSuggestion.highlighted { background: #eef2fb; }
 .linkerEditorSuggestion .termSlug { font-weight: 600; font-size: 13px; }
 .linkerEditorSuggestion .termTitles { font-size: 12px; color: #777; }
+/* "Add as a new term" fallback suggestion, offered when a search comes back empty. */
+.termCreateSuggestion { font-size: 13px; font-style: italic; color: #1a5c9e; }
 
 /* Tree */
 .linkerEditorIndexTitleRow { display: flex; align-items: baseline; flex-wrap: wrap; gap: 12px; margin: 0 0 16px; }
@@ -132,7 +134,10 @@
 }
 .expandToggle { cursor: pointer; width: 14px; color: #888; user-select: none; }
 .expandToggle.placeholder { cursor: default; }
+.schemaNodeTitleGroup { display: inline-flex; flex-direction: column; line-height: 1.25; }
 .schemaNodeTitle { font-weight: 600; }
+/* Hebrew title, shown smaller directly under the primary (English) title. */
+.schemaNodeTitleHe { font-size: 11px; font-weight: normal; color: #777; }
 .schemaNodeKey { font-size: 12px; color: #999; }
 .schemaNodeStructName {
   font-size: 11px;

--- a/static/js/LinkerEditorPage.jsx
+++ b/static/js/LinkerEditorPage.jsx
@@ -27,6 +27,17 @@ const nodePrimaryTitle = (node) => {
   return node.title || node.sharedTitle || node.key || node.wholeRef || '(untitled)';
 };
 
+// Companion Hebrew title, shown smaller underneath the primary (English) title.
+// A default node has no titles of its own, so there's nothing to show here.
+const nodePrimaryHebrewTitle = (node) => {
+  if (node.default) { return null; }
+  const titles = node.titles || [];
+  const primaryHe = titles.find(t => t.lang === 'he' && t.primary);
+  if (primaryHe) { return primaryHe.text; }
+  const anyHe = titles.find(t => t.lang === 'he');
+  return anyHe ? anyHe.text : null;
+};
+
 const pathString = (keyPath) => keyPath.join('.');
 
 // A NonUniqueTerm badge shows its primary English title (falling back to primary
@@ -133,18 +144,30 @@ const DIBUR_HAMATCHIL_PROPS = new Set(['isSegmentLevelDiburHamatchil', 'diburHam
 // NonUniqueTerm autocomplete (used by the MatchTemplate editor)
 // ---------------------------------------------------------------------------
 
-const TermAutocomplete = ({ onSelect, placeholder, clearOnSelect=false, autoFocus=false }) => {
+// A sentinel suggestion offered whenever a search comes back empty, letting the user
+// jump straight to creating the typed text as a new NonUniqueTerm.
+const CREATE_TERM_ITEM = (text) => ({ __create__: true, name: text, slug: text });
+
+const TermAutocomplete = ({ onSelect, placeholder, clearOnSelect=false, autoFocus=false, onCreateTerm }) => {
   let clearInput = null;
   const selectTerm = (term) => {
     if (!term) { return; }
+    if (term.__create__) {
+      if (onCreateTerm) { onCreateTerm(term.name); }
+      if (clearOnSelect && clearInput) { clearInput(); }
+      return;
+    }
     onSelect(term);
     if (clearOnSelect && clearInput) { clearInput(); }
   };
   const getSuggestions = async (inputValue) => {
-    if (!inputValue || inputValue.trim().length < 1) { return []; }
+    const trimmed = (inputValue || '').trim();
+    if (!trimmed) { return []; }
     try {
-      const d = await editorApi.searchTerms(inputValue.trim());
-      return (d.terms || []).map(t => ({ ...t, name: t.slug }));
+      const d = await editorApi.searchTerms(trimmed);
+      const terms = (d.terms || []).map(t => ({ ...t, name: t.slug }));
+      if (!terms.length && onCreateTerm) { return [CREATE_TERM_ITEM(trimmed)]; }
+      return terms;
     } catch (e) { return []; }
   };
   const renderInput = (highlightedIndex, highlightedSuggestion, getInputProps, setInputValue) => {
@@ -155,14 +178,24 @@ const TermAutocomplete = ({ onSelect, placeholder, clearOnSelect=false, autoFocu
   };
   const renderItems = (suggestions, highlightedIndex, getItemProps) => (
     suggestions.map((item, index) => (
-      <div
-        key={item.slug}
-        {...getItemProps({ item, index })}
-        className={'linkerEditorSuggestion' + (highlightedIndex === index ? ' highlighted' : '')}
-      >
-        <span className="termSlug">{item.slug}</span>
-        <span className="termTitles">{item.primary_en}{item.primary_he ? ` · ${item.primary_he}` : ''}</span>
-      </div>
+      item.__create__ ? (
+        <div
+          key="__create__"
+          {...getItemProps({ item, index })}
+          className={'linkerEditorSuggestion linkerEditorSuggestionCreate' + (highlightedIndex === index ? ' highlighted' : '')}
+        >
+          <span className="termCreateSuggestion">+ {Sefaria._('Add')} “{item.slug}” {Sefaria._('as a new term')}</span>
+        </div>
+      ) : (
+        <div
+          key={item.slug}
+          {...getItemProps({ item, index })}
+          className={'linkerEditorSuggestion' + (highlightedIndex === index ? ' highlighted' : '')}
+        >
+          <span className="termSlug">{item.slug}</span>
+          <span className="termTitles">{item.primary_en}{item.primary_he ? ` · ${item.primary_he}` : ''}</span>
+        </div>
+      )
     ))
   );
   return (
@@ -188,7 +221,7 @@ const TermAutocomplete = ({ onSelect, placeholder, clearOnSelect=false, autoFocu
 // MatchTemplate editor within a node card
 // ---------------------------------------------------------------------------
 
-const MatchTemplateRow = ({ template, title, keyPath, termTitles, onTermClick, onChanged }) => {
+const MatchTemplateRow = ({ template, title, keyPath, termTitles, onTermClick, onChanged, onCreateTerm }) => {
   const [addingTerm, setAddingTerm] = useState(false);
   const [busy, setBusy] = useState(false);
   const path = pathString(keyPath);
@@ -229,7 +262,7 @@ const MatchTemplateRow = ({ template, title, keyPath, termTitles, onTermClick, o
       </div>
       <div className="matchTemplateActions">
         {addingTerm
-          ? <TermAutocomplete onSelect={addTermToTemplate} placeholder={Sefaria._('Add term…')} />
+          ? <TermAutocomplete onSelect={addTermToTemplate} placeholder={Sefaria._('Add term…')} autoFocus={true} onCreateTerm={onCreateTerm} />
           : <button className="linkerEditorBtn small" onClick={() => setAddingTerm(true)}>+ {Sefaria._('term')}</button>}
         <button className="linkerEditorBtn small danger" onClick={removeTemplate} title={Sefaria._('Delete')}>×</button>
       </div>
@@ -237,7 +270,7 @@ const MatchTemplateRow = ({ template, title, keyPath, termTitles, onTermClick, o
   );
 };
 
-const AddMatchTemplateForm = ({ title, keyPath, termTitles, onChanged }) => {
+const AddMatchTemplateForm = ({ title, keyPath, termTitles, onChanged, onCreateTerm }) => {
   const [open, setOpen] = useState(false);
   const [slugs, setSlugs] = useState([]);
   // Titles for slugs picked here that aren't yet in the index-wide termTitles map.
@@ -277,7 +310,7 @@ const AddMatchTemplateForm = ({ title, keyPath, termTitles, onChanged }) => {
           </TermBadge>
         ))}
       </div>
-      <TermAutocomplete autoFocus={true} clearOnSelect={true} onSelect={addSlug} />
+      <TermAutocomplete autoFocus={true} clearOnSelect={true} onSelect={addSlug} onCreateTerm={onCreateTerm} />
       <label className="scopeSelect">
         {Sefaria._('scope')}:
         <select value={scope} onChange={e => setScope(e.target.value)}>
@@ -650,6 +683,7 @@ const SchemaNodeCard = ({
   addressTypeOptions,
   termTitles,
   onTermClick,
+  onCreateTerm,
   onChanged,
   onDhChanged,
   altStructRootEntries=[],
@@ -676,7 +710,10 @@ const SchemaNodeCard = ({
         {hasChildren && !forceExpanded
           ? <span className="expandToggle" onClick={() => toggleExpand(path)}>{expanded ? '▾' : '▸'}</span>
           : <span className="expandToggle placeholder" />}
-        <span className="schemaNodeTitle">{nodePrimaryTitle(node)}</span>
+        <span className="schemaNodeTitleGroup">
+          <span className="schemaNodeTitle">{nodePrimaryTitle(node)}</span>
+          {nodePrimaryHebrewTitle(node) && <span className="schemaNodeTitleHe" dir="rtl">{nodePrimaryHebrewTitle(node)}</span>}
+        </span>
         {ancestorCrumbs.length > 0 && (
           <span className="schemaNodePath">
             (
@@ -706,9 +743,10 @@ const SchemaNodeCard = ({
                 termTitles={termTitles}
                 onTermClick={onTermClick}
                 onChanged={onChanged}
+                onCreateTerm={onCreateTerm}
               />
             ))}
-            {!isDefault && <AddMatchTemplateForm title={title} keyPath={keyPath} termTitles={termTitles} onChanged={onChanged} />}
+            {!isDefault && <AddMatchTemplateForm title={title} keyPath={keyPath} termTitles={termTitles} onChanged={onChanged} onCreateTerm={onCreateTerm} />}
           </div>
         )}
 
@@ -744,6 +782,7 @@ const SchemaNodeCard = ({
               addressTypeOptions={addressTypeOptions}
               termTitles={termTitles}
               onTermClick={onTermClick}
+              onCreateTerm={onCreateTerm}
               onChanged={onChanged}
               onDhChanged={onDhChanged}
               collapseBranchBodyWhenCollapsed={collapseBranchBodyWhenCollapsed}
@@ -768,6 +807,7 @@ const SchemaNodeCard = ({
               addressTypeOptions={addressTypeOptions}
               termTitles={termTitles}
               onTermClick={onTermClick}
+              onCreateTerm={onCreateTerm}
               onChanged={onChanged}
               onDhChanged={onDhChanged}
               jumpToPath={jumpToPath}
@@ -779,7 +819,7 @@ const SchemaNodeCard = ({
   );
 };
 
-const AltStructGroup = ({ structName, nodes, title, expandedPaths, toggleExpand, addressTypeOptions, termTitles, onTermClick, onChanged, onDhChanged, jumpToPath }) => {
+const AltStructGroup = ({ structName, nodes, title, expandedPaths, toggleExpand, addressTypeOptions, termTitles, onTermClick, onCreateTerm, onChanged, onDhChanged, jumpToPath }) => {
   const path = pathString(['__alt__', structName]);
   const expanded = expandedPaths.has(path);
 
@@ -806,6 +846,7 @@ const AltStructGroup = ({ structName, nodes, title, expandedPaths, toggleExpand,
               addressTypeOptions={addressTypeOptions}
               termTitles={termTitles}
               onTermClick={onTermClick}
+              onCreateTerm={onCreateTerm}
               onChanged={onChanged}
               onDhChanged={onDhChanged}
               collapseBranchBodyWhenCollapsed={true}
@@ -825,7 +866,7 @@ const AltStructGroup = ({ structName, nodes, title, expandedPaths, toggleExpand,
 // NonUniqueTerm detail panel (bottom slide-up)
 // ---------------------------------------------------------------------------
 
-const TermDetailPanel = ({ slug, createMode, refreshToken, onClose, onCreated, onJump, onChanged }) => {
+const TermDetailPanel = ({ slug, createMode, initialTitle, onCreateTerm, refreshToken, onClose, onCreated, onJump, onChanged }) => {
   const [detail, setDetail] = useState(null);
   const [error, setError] = useState(null);
   const [newTitle, setNewTitle] = useState('');
@@ -845,6 +886,14 @@ const TermDetailPanel = ({ slug, createMode, refreshToken, onClose, onCreated, o
     editorApi.termDetail(slug).then(setDetail, e => setError(e.message || String(e)));
   }, [slug, createMode, refreshToken]);
 
+  // Entering create mode (including re-entering it from an "Add as new term" autosuggest
+  // elsewhere on the page) seeds whichever language field matches what was already typed.
+  useEffect(() => {
+    if (!createMode) { return; }
+    setNewEn(initialTitle && initialTitle.lang === 'en' ? initialTitle.text : '');
+    setNewHe(initialTitle && initialTitle.lang === 'he' ? initialTitle.text : '');
+  }, [createMode, initialTitle]);
+
   const handlePanelKeyDown = (e) => {
     if (e.key === 'Escape') { e.stopPropagation(); onClose(); }
   };
@@ -862,6 +911,13 @@ const TermDetailPanel = ({ slug, createMode, refreshToken, onClose, onCreated, o
       setError(e.message || String(e));
     }
     setCreating(false);
+  };
+
+  const handleCreateKeyDown = (e) => {
+    if (e.key === 'Enter' && !creating && (newEn.trim() || newHe.trim())) {
+      e.preventDefault();
+      createTerm();
+    }
   };
 
   const addTitles = async () => {
@@ -925,6 +981,7 @@ const TermDetailPanel = ({ slug, createMode, refreshToken, onClose, onCreated, o
               className="linkerEditorTermInput"
               value={newEn}
               onChange={e => setNewEn(e.target.value)}
+              onKeyDown={handleCreateKeyDown}
               placeholder={Sefaria._('Primary English title')}
               autoFocus
             />
@@ -932,6 +989,7 @@ const TermDetailPanel = ({ slug, createMode, refreshToken, onClose, onCreated, o
               className="linkerEditorTermInput"
               value={newHe}
               onChange={e => setNewHe(e.target.value)}
+              onKeyDown={handleCreateKeyDown}
               placeholder={Sefaria._('Primary Hebrew title')}
               dir="rtl"
             />
@@ -979,6 +1037,7 @@ const TermDetailPanel = ({ slug, createMode, refreshToken, onClose, onCreated, o
                   onSelect={setSwapTarget}
                   placeholder={Sefaria._('Swap to term…')}
                   autoFocus={true}
+                  onCreateTerm={onCreateTerm}
                 />
                 {swapTarget && <span className="termSwapTarget">{swapTarget.slug}</span>}
                 <button
@@ -1101,6 +1160,9 @@ const LinkerEditorPage = ({ initialBook, onBookChange }) => {
   const [addressTypeOptions, setAddressTypeOptions] = useState([]);
   const [termSlug, setTermSlug] = useState(null);
   const [addingTerm, setAddingTerm] = useState(false);
+  // Prefilled title (language + typed text) for the next time the Add New Term drawer
+  // opens, set when it's opened from a "no matches — add as new term" autosuggest.
+  const [createPrefill, setCreatePrefill] = useState(null);
   const [searchingTerm, setSearchingTerm] = useState(false);
   const [termTitles, setTermTitles] = useState({});
   const [refreshToken, setRefreshToken] = useState(0);
@@ -1113,9 +1175,16 @@ const LinkerEditorPage = ({ initialBook, onBookChange }) => {
 
   const markDhDirty = useCallback(() => { setDhDirty(true); setDhMsg(null); }, []);
 
-  const openTerm = useCallback((slug) => { setAddingTerm(false); setSearchingTerm(false); setTermSlug(slug); }, []);
-  const closeTermDrawer = useCallback(() => { setTermSlug(null); setAddingTerm(false); }, []);
+  const openTerm = useCallback((slug) => { setAddingTerm(false); setSearchingTerm(false); setCreatePrefill(null); setTermSlug(slug); }, []);
+  const closeTermDrawer = useCallback(() => { setTermSlug(null); setAddingTerm(false); setCreatePrefill(null); }, []);
   const openSearchedTerm = useCallback((term) => { openTerm(term.slug); }, [openTerm]);
+  // Opened from a term autosuggest box with no matches — jumps straight to the Add New
+  // Term drawer with whatever was typed pre-filled into the matching language field.
+  const openCreateTerm = useCallback((text) => {
+    setTermSlug(null); setSearchingTerm(false);
+    setCreatePrefill({ lang: detectTitleLang(text), text });
+    setAddingTerm(true);
+  }, []);
 
   useEffect(() => {
     editorApi.addressTypes().then(d => setAddressTypeOptions(d.address_types || []));
@@ -1268,7 +1337,7 @@ const LinkerEditorPage = ({ initialBook, onBookChange }) => {
             <h1><InterfaceText>Linker Editor</InterfaceText></h1>
             <div className="linkerEditorTopActions">
               {title && <button className="linkerEditorBtn" onClick={leaveIndex}>{Sefaria._('New search')}</button>}
-              <button className="linkerEditorBtn" onClick={() => { setTermSlug(null); setAddingTerm(true); }}>{Sefaria._('Add New Term')}</button>
+              <button className="linkerEditorBtn" onClick={() => { setTermSlug(null); setCreatePrefill(null); setAddingTerm(true); }}>{Sefaria._('Add New Term')}</button>
               <button className="linkerEditorBtn" onClick={() => setSearchingTerm(!searchingTerm)}>{Sefaria._('Search Term')}</button>
               {searchingTerm && (
                 <div className="linkerEditorHeaderTermSearch">
@@ -1276,6 +1345,7 @@ const LinkerEditorPage = ({ initialBook, onBookChange }) => {
                     onSelect={openSearchedTerm}
                     placeholder={Sefaria._('Search terms…')}
                     autoFocus={true}
+                    onCreateTerm={openCreateTerm}
                   />
                 </div>
               )}
@@ -1343,6 +1413,7 @@ const LinkerEditorPage = ({ initialBook, onBookChange }) => {
                   addressTypeOptions={addressTypeOptions}
                   termTitles={termTitles}
                   onTermClick={openTerm}
+                  onCreateTerm={openCreateTerm}
                   onChanged={reload}
                   onDhChanged={markDhDirty}
                   altStructRootEntries={altStructRootEntries}
@@ -1357,6 +1428,8 @@ const LinkerEditorPage = ({ initialBook, onBookChange }) => {
             <TermDetailPanel
               slug={termSlug}
               createMode={addingTerm}
+              initialTitle={createPrefill}
+              onCreateTerm={openCreateTerm}
               refreshToken={refreshToken}
               onClose={closeTermDrawer}
               onCreated={openTerm}


### PR DESCRIPTION
This pull request introduces several improvements and new features to the linker editor system, focusing on NonUniqueTerm autocomplete, search ranking, and usability enhancements in both backend and frontend code. It also adds scripts for exporting and replaying linker editor history, which will help with environment migrations or audits. The most important changes are summarized below.

---

**Backend: NonUniqueTerm Search Improvements**
* Improved NonUniqueTerm search ranking: The `search_non_unique_terms` function now ranks exact matches first, then prefix matches, then substring matches, ensuring more relevant autocomplete results. The candidate pool fetched from Mongo is now larger and sorted in Python for relevance.
* Added tests for ranking logic: New tests verify that exact and prefix matches are prioritized over substring matches. [[1]](diffhunk://#diff-c6af93640ea227dd0da3c673398ff6b4862f22d2e243b9a2224c8f3a6bc2a001R650) [[2]](diffhunk://#diff-c6af93640ea227dd0da3c673398ff6b4862f22d2e243b9a2224c8f3a6bc2a001R670-R713)

**Backend: Export/Replay Linker Editor History**
* Added `export_linker_editor_history.py`: Exports all `linker_editor_history` entries to a JSON file for migration or replay in another environment.
* Added `replay_linker_editor_history.py`: Replays exported history entries in a target environment, with robust error handling and progress tracking.

**Frontend: Autocomplete and UI Enhancements**
* Autocomplete fallback for creating new terms: When a search returns no results, the autocomplete now offers a suggestion to "Add as a new term," streamlining the creation of new NonUniqueTerms directly from the UI. [[1]](diffhunk://#diff-f3a8ab81683e6227ba81400c7b4ad7449a3c7b100be738d88d3ad08dd2b082ebL136-R170) [[2]](diffhunk://#diff-f3a8ab81683e6227ba81400c7b4ad7449a3c7b100be738d88d3ad08dd2b082ebR181-R189) [[3]](diffhunk://#diff-f3a8ab81683e6227ba81400c7b4ad7449a3c7b100be738d88d3ad08dd2b082ebR198) [[4]](diffhunk://#diff-f3a8ab81683e6227ba81400c7b4ad7449a3c7b100be738d88d3ad08dd2b082ebL232-R273) [[5]](diffhunk://#diff-f3a8ab81683e6227ba81400c7b4ad7449a3c7b100be738d88d3ad08dd2b082ebL280-R313)
* Added Hebrew title display: Schema nodes now show their primary Hebrew title (if available) under the English title, both in the UI and with supporting CSS. [[1]](diffhunk://#diff-f3a8ab81683e6227ba81400c7b4ad7449a3c7b100be738d88d3ad08dd2b082ebR30-R40) [[2]](diffhunk://#diff-f3a8ab81683e6227ba81400c7b4ad7449a3c7b100be738d88d3ad08dd2b082ebR713-R716) [[3]](diffhunk://#diff-3f65bfbcac523e01ab38f84e2330583e154fcc64490813491cba4d0f4881aa98R137-R140)

**Frontend: Styling**
* Added styles for new term creation suggestions and Hebrew titles, improving clarity and visual distinction in the UI. [[1]](diffhunk://#diff-3f65bfbcac523e01ab38f84e2330583e154fcc64490813491cba4d0f4881aa98R103-R104) [[2]](diffhunk://#diff-3f65bfbcac523e01ab38f84e2330583e154fcc64490813491cba4d0f4881aa98R137-R140)

---

These changes collectively improve the accuracy and usability of the linker editor, enhance migration support, and make the interface more informative and user-friendly.