### PR TITLE
fix(preprod): point helmrelease at chart 0.87.5-preprod.2

### DIFF
--- a/envs/preprod/helmrelease.yaml
+++ b/envs/preprod/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: sefaria
-      version: "0.87.5-preprod.1"
+      version: "0.87.5-preprod.2"
       sourceRef:
         kind: HelmRepository
         name: sefaria-project


### PR DESCRIPTION
#3661 merged but never reached the cluster. Its deploy job built and tagged chart **`0.87.5-preprod.2`**, then failed on the last step:

```
[preprod c917e8738] deploy(preprod): app=6.111.0-preprod.4 chart=0.87.5-preprod.2
 * [new tag]   preprod/6.111.0-preprod.4+chart.0.87.5-preprod.2
 ! [rejected]  preprod -> preprod (non-fast-forward)
```

#3663 merged three minutes later and moved `preprod`, so the version-bump commit was rejected — **the tag was pushed, its commit was not**. The next deploy run reported `release-chart: skipped`, so the chart stayed pinned at `0.87.5-preprod.1` and #3661's `livenessProbe.failureThreshold: 7` never reached the cluster.

Confirmed on the live cluster: `livenessProbe` is still `{"httpGet":…,"periodSeconds":60,"timeoutSeconds":60}` with no `failureThreshold`.

**This changes the reference only.** The chart is already built — nothing rebuilds.

## Verify after merge

```
kubectl -n preprod get rollout preprod-web \
  -o jsonpath='{.spec.template.spec.containers[?(@.name=="web")].livenessProbe}'
# expect: ...,"timeoutSeconds":60,"failureThreshold":7}
```

Readiness should remain **without** `failureThreshold` — that split is the point of #3661. Pods should roll cleanly and stay at 0 restarts.

## Note for future merges

Two PRs merged to the same static-env branch within a few minutes will make the earlier deploy fail this way. Worth spacing merges to `preprod` until the deploy run finishes.

Fixes the delivery of #3661. Related: #3663 (already live as `v6.111.0-preprod.5`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbbDpzvvxiRi2U9J9wssxi
