### PR TITLE
hotfix: revert #3661/#3663, raise Varnish memory headroom, add backend health probe

### DIFF
--- a/helm-chart/sefaria/templates/configmap/varnish-config.yaml
+++ b/helm-chart/sefaria/templates/configmap/varnish-config.yaml
@@ -13,10 +13,19 @@ data:
   sefaria.vcl: |-
     vcl 4.0;
 
+    probe web_probe {
+        .url = "/healthz";
+        .timeout = 30s;
+        .interval = 10s;
+        .window = 5;
+        .threshold = 2;
+    }
+
     backend default {
         .host = "web-{{ $.Values.deployEnv }}-{{ $v }}";
         .port = "80";
-        .first_byte_timeout = 900s;
+        .first_byte_timeout = {{ $.Values.varnish.tuning.first_byte_timeout }}s;
+        .probe = web_probe;
     }
 
     sub vcl_recv {

--- a/helm-chart/sefaria/templates/rollout/web.yaml
+++ b/helm-chart/sefaria/templates/rollout/web.yaml
@@ -198,17 +198,6 @@ spec:
           # initialDelaySeconds: 120
           periodSeconds: 60
           timeoutSeconds: 60
-          # /healthz is served by the same gunicorn workers as real traffic, so it queues
-          # behind them. Without an explicit threshold this defaults to 3, meaning ~3 minutes
-          # of a slow-but-alive app is enough for the kubelet to kill the container. Killing a
-          # slow pod makes things worse: the restart re-imports the whole application and
-          # shifts its traffic onto the remaining pods, which then slow down and fail their
-          # own probes. Readiness (below) is deliberately left at the default so a slow pod is
-          # still pulled out of the Service — liveness should only fire for a genuinely dead
-          # process, not a busy one. 60s x 7 = 420s, which matches the --timeout 420 this
-          # container already passes to gunicorn: the kubelet should not kill a worker before
-          # gunicorn's own timeout would have recycled it.
-          failureThreshold: 7
         readinessProbe:
           httpGet:
             path: /healthz

--- a/helm-chart/sefaria/values.yaml
+++ b/helm-chart/sefaria/values.yaml
@@ -195,14 +195,21 @@ varnish:
   resources:
     requests:
       # must be in megabibytes, because we pass it into the malloc definition
-      memory: "25Mi"
+      memory: "700Mi"
       cpu: "10m"
     limits:
-      memory: "300Mi"
+      memory: "1024Mi"
       cpu: "100m"
   tuning:
-    # malloc should be ~75% of the memory request.
-    malloc: "250m"
+    # malloc should be ~75% of the memory request. Previously 250m against a 300Mi limit
+    # (~50-64Mi headroom) is the likely reason varnish's own pod kept OOM-restarting under
+    # load, flushing its in-memory cache each time. 512m against 1024Mi limit keeps the
+    # ~75% convention and leaves ~500Mi of real headroom for connection state, thread
+    # stacks, and the ban list. NOTE: prod and preprod already override these three keys
+    # (envs/prod/helmrelease.yaml, envs/preprod/helmrelease.yaml -> 17Gi/18Gi/14440m) and
+    # are unaffected by this default; this change only takes effect for staging/dev/
+    # cauldrons/local, which inherit the chart default.
+    malloc: "512m"
     nuke_limit: "400"
     # Threading
     # http://book.varnish-software.com/4.0/chapters/Tuning.html#details-of-threading-parameters

--- a/sefaria/model/dependencies.py
+++ b/sefaria/model/dependencies.py
@@ -6,57 +6,18 @@ from . import abstract, link, note, history, schema, text, layer, version_state,
 
 from .abstract import subscribe, cascade, cascade_to_list, cascade_delete, cascade_delete_to_list
 # ES cascade handlers that keep the search indices in sync with model changes.
-#
-# These are wrapped in thunks rather than imported at module level. `dependencies` is
-# imported while sefaria.model's __init__ is still running, so a module-level import of
-# sefaria.helper.search pulls that module -- and transitively sefaria.search and the
-# Elasticsearch client -- into *every* worker boot, whether or not anything is ever
-# indexed. The handlers already defer their own imports (`from sefaria.search import
-# index_topic_doc` inside the function body), so deferring this one makes the module
-# consistent with them.
-#
-# Behaviour is unchanged. The only difference is *when* the import happens: on the first
-# save/delete that actually needs it, rather than during startup. Subscription order is
-# unchanged and still matters -- see the ordering comments further down.
-
-def _es_index_title_change_in_search(*args, **kwargs):
-    from sefaria.helper.search import process_index_title_change_in_search
-    return process_index_title_change_in_search(*args, **kwargs)
-
-
-def _es_index_title_change_in_book_search(*args, **kwargs):
-    from sefaria.helper.search import process_index_title_change_in_book_search
-    return process_index_title_change_in_book_search(*args, **kwargs)
-
-
-def _es_index_save_in_book_search(*args, **kwargs):
-    from sefaria.helper.search import process_index_save_in_book_search
-    return process_index_save_in_book_search(*args, **kwargs)
-
-
-def _es_index_delete_in_book_search(*args, **kwargs):
-    from sefaria.helper.search import process_index_delete_in_book_search
-    return process_index_delete_in_book_search(*args, **kwargs)
-
-
-def _es_topic_save_in_topic_search(*args, **kwargs):
-    from sefaria.helper.search import process_topic_save_in_topic_search
-    return process_topic_save_in_topic_search(*args, **kwargs)
-
-
-def _es_topic_delete_in_topic_search(*args, **kwargs):
-    from sefaria.helper.search import process_topic_delete_in_topic_search
-    return process_topic_delete_in_topic_search(*args, **kwargs)
-
-
-def _es_category_path_change_in_book_search(*args, **kwargs):
-    from sefaria.helper.search import process_category_path_change_in_book_search
-    return process_category_path_change_in_book_search(*args, **kwargs)
-
-
-def _es_category_change_in_category_search(*args, **kwargs):
-    from sefaria.helper.search import process_category_change_in_category_search
-    return process_category_change_in_category_search(*args, **kwargs)
+# sefaria.helper.search deliberately avoids importing sefaria.model at module level,
+# so importing it here (while sefaria.model's __init__ is still running) is safe.
+from sefaria.helper.search import (
+    process_index_title_change_in_search,
+    process_index_title_change_in_book_search,
+    process_index_save_in_book_search,
+    process_index_delete_in_book_search,
+    process_topic_save_in_topic_search,
+    process_topic_delete_in_topic_search,
+    process_category_path_change_in_book_search,
+    process_category_change_in_category_search,
+)
 import sefaria.system.cache as scache
 import structlog
 
@@ -69,7 +30,7 @@ subscribe(text.process_index_change_in_toc,                             text.Ind
 subscribe(place.process_index_place_change, text.Index, 'attributeChange', 'compPlace')
 subscribe(place.process_index_place_change, text.Index, 'attributeChange', 'pubPlace')
 # Entity search: keep the `book` index in sync with Index saves
-subscribe(_es_index_save_in_book_search,                            text.Index, "save")
+subscribe(process_index_save_in_book_search,                            text.Index, "save")
 
 # Index Name Change
 subscribe(text.process_index_title_change_in_core_cache,                text.Index, "attributeChange", "title")
@@ -89,8 +50,8 @@ subscribe(marked_up_text_chunk.process_index_title_change,              text.Ind
 # ES: listeners fire in subscription order, so these must stay last in this block —
 # in particular after process_index_title_change_in_versions has renamed the book's
 # versions in Mongo, which process_index_title_change_in_search re-reads.
-subscribe(_es_index_title_change_in_search,                         text.Index, "attributeChange", "title")
-subscribe(_es_index_title_change_in_book_search,                    text.Index, "attributeChange", "title")
+subscribe(process_index_title_change_in_search,                         text.Index, "attributeChange", "title")
+subscribe(process_index_title_change_in_book_search,                    text.Index, "attributeChange", "title")
 
 # Taken care of on save
 # subscribe(text.process_index_change_in_toc,                             text.Index, "attributeChange", "title")
@@ -108,7 +69,7 @@ subscribe(cascade_delete(notification.GlobalNotificationSet, "content.index", "t
 subscribe(ref_data.process_index_delete_in_ref_data,                    text.Index, "delete")
 subscribe(marked_up_text_chunk.process_index_delete,                    text.Index, "delete")
 # Entity search: keep the `book` index in sync with Index deletes
-subscribe(_es_index_delete_in_book_search,                          text.Index, "delete")
+subscribe(process_index_delete_in_book_search,                          text.Index, "delete")
 
 # Process in ES
 def process_version_title_change_in_search(ver, **kwargs):
@@ -184,8 +145,8 @@ subscribe(layer.process_note_deletion_in_layer,                         note.Not
 # notify() dispatches on the exact instance type, and topics load as their subclass
 # (Topic.subclass_map), so each concrete class needs its own subscription.
 for topic_klass in (topic.Topic, topic.PersonTopic, topic.AuthorTopic):
-    subscribe(_es_topic_save_in_topic_search,                       topic_klass, "save")
-    subscribe(_es_topic_delete_in_topic_search,                     topic_klass, "delete")
+    subscribe(process_topic_save_in_topic_search,                       topic_klass, "save")
+    subscribe(process_topic_delete_in_topic_search,                     topic_klass, "delete")
 subscribe(topic.process_topic_delete,                                 topic.Topic, "delete")
 subscribe(topic.process_topic_description_change,                       topic.Topic, "attributeChange", "description")
 subscribe(topic.process_topic_delete,                                 topic.AuthorTopic, "delete")
@@ -231,12 +192,12 @@ subscribe(marked_up_text_chunk.process_category_path_change,  category.Category,
 subscribe(text.rebuild_library_after_category_change,                   category.Category, "save")
 # Entity search: must stay subscribed after category.process_category_path_change,
 # which cascades the new path into the Mongo Index records this hook re-reads.
-subscribe(_es_category_path_change_in_book_search,  category.Category, "attributeChange", "path")
+subscribe(process_category_path_change_in_book_search,  category.Category, "attributeChange", "path")
 # Category search: must stay subscribed after text.rebuild_library_after_category_change,
 # because the re-sync reads the (rebuilt) TOC tree. Save and delete both re-sync the whole
 # `category` index -- see sefaria.search.resync_category_docs.
-subscribe(_es_category_change_in_category_search,  category.Category, "save")
-subscribe(_es_category_change_in_category_search,  category.Category, "delete")
+subscribe(process_category_change_in_category_search,  category.Category, "save")
+subscribe(process_category_change_in_category_search,  category.Category, "delete")
 
 # Manuscripts
 subscribe(manuscript.process_slug_change_in_manuscript,  manuscript.Manuscript, "attributeChange", "slug")


### PR DESCRIPTION
## Root cause

Per `wiki/incidents/prod-oomkill-cascade-2026-08-26.md` (§ "Update 2026-08-27"): a spoofed-UA bot campaign hammering `api/related` and `api/strapi/graphql-cache` at 10–25× baseline, plus Varnish's own pod restarting 9 times during the incident (confirmed via `kubernetes.containers.restarts` + raw kubelet events), flushing its cache each time. Neither #3661 nor #3663 touches either mechanism.

## Reverts

- **#3661** (liveness `failureThreshold: 7`): only changed which failure mode fires (liveness-kill → slower cgroup-OOMKill). Doesn't fix anything by itself — reverted to reduce moving parts now that real fixes are in flight.
- **#3663** (defer search import): a real optimization, but never implicated in any finding. Reverted for the same reason.

Both via `git revert -m 1` against `origin/preprod` (neither commit is on `master` — they shipped as direct hotfixes). Clean, no conflicts.

## Helm changes

- **Varnish backend health probe** — was missing entirely. Varnish now stops routing to a backend already failing `/healthz` instead of waiting out `first_byte_timeout` on every connection.
- **Fixed `first_byte_timeout`**: hardcoded to `900s` directly in the VCL, ignoring the Helm value entirely. Now templated. ⚠️ **Risk**: once live, this drops the effective prod timeout from 900s to prod's real tuning value (60s) — watch closely through preprod before promoting.
- **Varnish memory bump** (25Mi/300Mi/250m → 700Mi/1024Mi/512m) — **chart default only**. Correction: prod/preprod already override this to 17Gi/18Gi/14.4GB malloc (unchanged since March) — ~3.5Gi of real headroom, not ~50Mi. **This has no effect on prod/preprod**; it only helps staging/dev/cauldrons, which inherit the thin default. The Varnish restart cause is still unresolved for prod.

## Follow-up — not in this PR

A Cloudflare WAF rule on the bot campaign's actual fingerprint (paths + near-zero static-asset ratio) is the real fix on the traffic side — existing rules are IP/country-based and aren't catching 60K+ distinct IPs. Tracked separately; see `wiki/concepts/Cloudflare Edge and WAF.md`.

Full evidence: `wiki/incidents/prod-oomkill-cascade-2026-08-26.md`.
