### PR TITLE
chore: pass props down

### DIFF
--- a/static/js/auth/AuthPage.jsx
+++ b/static/js/auth/AuthPage.jsx
@@ -109,6 +109,8 @@ const AuthPage = ({
       <ForgotView
         emailValue={fields.email} setField={setField} csrf={csrf}
         onSuccess={() => setView('forgot-sent')} onBack={() => setView('email')}
+        registerGoogleTarget={registerGoogleTarget} triggerApple={triggerApple}
+        setActiveErrorHandler={setActiveErrorHandler}
       />
     );
   } else if (view === 'forgot-sent') {

--- a/static/js/auth/ForgotView.jsx
+++ b/static/js/auth/ForgotView.jsx
@@ -6,7 +6,13 @@ import EmailInput from './EmailInput.jsx';
 import Button from '../common/Button.jsx';
 import { authError, postJson } from './utils.js';
 
-const ForgotView = ({ emailValue, setField, csrf, onSuccess, onBack }) => {
+// The reset endpoint answers an SSO-only address with the same `sso_only_account` error
+// LoginView gets, so this view's banner renders the same "Continue with Google/Apple" links
+// and needs the same provider wiring to make them live (see ErrorBanner.jsx).
+const ForgotView = ({
+  emailValue, setField, csrf, onSuccess, onBack,
+  registerGoogleTarget, triggerApple, setActiveErrorHandler,
+}) => {
   const onSubmit = async () => {
     const { ok, data } = await postJson('/api/auth/password/reset', { email: emailValue }, csrf);
     if (ok) { onSuccess(); return; }
@@ -16,6 +22,8 @@ const ForgotView = ({ emailValue, setField, csrf, onSuccess, onBack }) => {
   return (
     <FormView onBack={onBack} heading={<InterfaceText>auth.forgot_password</InterfaceText>}
       formId="forgot-form" onSubmit={onSubmit}
+      registerGoogleTarget={registerGoogleTarget} triggerApple={triggerApple}
+      setActiveErrorHandler={setActiveErrorHandler}
     >
       {({ submitting }) => (
         <>
@@ -35,6 +43,9 @@ ForgotView.propTypes = {
   csrf: PropTypes.string.isRequired,
   onSuccess: PropTypes.func.isRequired,
   onBack: PropTypes.func.isRequired,
+  registerGoogleTarget: PropTypes.func,
+  triggerApple: PropTypes.func,
+  setActiveErrorHandler: PropTypes.func,
 };
 
 export default ForgotView;

--- a/static/js/auth/tests/ForgotView.test.js
+++ b/static/js/auth/tests/ForgotView.test.js
@@ -1,0 +1,112 @@
+/* Testing done using Jest */
+// No React Testing Library in this repo — react-dom directly, same pattern as the
+// other hook/component tests in this directory.
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { act } from 'react-dom/test-utils';
+
+// Misc.jsx transitively imports a .css file, which this repo's Jest setup has no
+// transform for. Only InterfaceText is reached from this tree, and it just renders text.
+jest.mock('../../Misc.jsx', () => ({
+  InterfaceText: ({ children }) => children,
+}));
+
+// Button.jsx imports sefaria/util, which boots the whole Sefaria singleton on import.
+// Nothing in this test depends on the submit button's markup — the form is submitted directly.
+jest.mock('../../common/Button.jsx', () => ({ children, ...rest }) => (
+  require('react').createElement('button', { type: 'submit', ...rest }, children)
+));
+
+// eslint-disable-next-line import/first
+import ForgotView from '../ForgotView.jsx';
+
+let container = null;
+
+const realSefaria = global.Sefaria;
+const realFetch = global.fetch;
+beforeAll(() => { global.Sefaria = { _: (key) => key, interfaceLang: 'english' }; });
+afterAll(() => { global.Sefaria = realSefaria; global.fetch = realFetch; });
+
+function mount(props) {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  act(() => {
+    ReactDOM.render(React.createElement(ForgotView, {
+      emailValue: 'sso-user@example.com',
+      setField: () => () => {},
+      csrf: 'csrf',
+      onSuccess: () => {},
+      onBack: () => {},
+      ...props,
+    }), container);
+  });
+}
+
+afterEach(() => {
+  if (container) {
+    act(() => { ReactDOM.unmountComponentAtNode(container); });
+    document.body.removeChild(container);
+    container = null;
+  }
+});
+
+// Replies to /api/auth/password/reset the way sso/views.py does for an address that
+// only ever signed in through a provider.
+function mockSsoOnlyReset(providers) {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: false,
+    json: () => Promise.resolve({
+      error: 'auth.sso_only_account',
+      _auth: { code: 'sso_only_account', providers },
+    }),
+  });
+}
+
+async function submit() {
+  const form = container.querySelector('#forgot-form');
+  await act(async () => {
+    form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+  });
+}
+
+// The forgot-password banner's "Continue with Google/Apple" links were inert because
+// AuthPage rendered ForgotView without the provider props every other view gets: Google's
+// portaled button had no element to mount into, and Apple's onClick called an undefined
+// trigger. Both links are the only way forward from this screen for an SSO-only account.
+describe('ForgotView sso_only_account banner', () => {
+  it('registers the banner Google link as the portal target for the real Google button', async () => {
+    mockSsoOnlyReset(['google']);
+    const registerGoogleTarget = jest.fn();
+    mount({ registerGoogleTarget });
+    await submit();
+
+    const target = container.querySelector('.sefaria-auth-provider-action--google-target');
+    expect(target).not.toBeNull();
+    expect(registerGoogleTarget).toHaveBeenCalledWith(target);
+  });
+
+  it('fires triggerApple when the banner Apple link is clicked', async () => {
+    mockSsoOnlyReset(['apple']);
+    const triggerApple = jest.fn();
+    mount({ triggerApple });
+    await submit();
+
+    const link = container.querySelector('a.sefaria-auth-provider-action');
+    expect(link).not.toBeNull();
+    act(() => { link.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true })); });
+    expect(triggerApple).toHaveBeenCalled();
+  });
+
+  // An SSO popup can fail after the click that started it, so the failure has to surface
+  // in whichever view is mounted — here, this one — rather than back on ChooseView.
+  it('registers its own error handler while mounted, and clears it on unmount', () => {
+    const setActiveErrorHandler = jest.fn();
+    mount({ setActiveErrorHandler });
+    expect(setActiveErrorHandler).toHaveBeenCalledWith(expect.any(Function));
+
+    act(() => { ReactDOM.unmountComponentAtNode(container); });
+    expect(setActiveErrorHandler).toHaveBeenLastCalledWith(null);
+    document.body.removeChild(container);
+    container = null;
+  });
+});


### PR DESCRIPTION
## Description

On the **Forgot password** screen, entering an email that belongs to a Google-only or Apple-only account shows an error banner with "Continue with Google" / "Continue with Apple" links — but those links did nothing.

Every other view in the auth flow receives three helper props from `AuthPage` that make those provider links work. `ForgotView` was the only view that wasn't given them, so the banner rendered but had nothing wired behind it. The Google link had no element for the real Google button to mount into, and the Apple link's `onClick` called an undefined function.  This PR passes those three props down to `ForgotView`. 

## Code Changes

**`static/js/auth/AuthPage.jsx`** — Pass `registerGoogleTarget`, `triggerApple`, and `setActiveErrorHandler` into `<ForgotView>`, matching what the other views already receive.

**`static/js/auth/ForgotView.jsx`** — Accept the three props, forward them to `FormView`, and add them to `propTypes`. `FormView` already knows what to do with them (`static/js/auth/FormView.jsx` lines 28–37); it just never got them from this view.

| Prop | What it does |
|---|---|
| `registerGoogleTarget` | Tells the real Google sign-in button which DOM element to render into |
| `triggerApple` | The function the Apple link calls when clicked |
| `setActiveErrorHandler` | Routes errors that arrive *after* the sign-in popup opens back to this view, instead of a different screen |

**`static/js/auth/tests/ForgotView.test.js`** — New file, 3 tests, one per prop:

- the banner's Google link is registered as the portal target for the real Google button
- clicking the banner's Apple link fires `triggerApple`
- the view registers its error handler on mount and clears it on unmount
