### PR TITLE
Feature/sc 46895/linker bulk corrector

### DIFF
--- a/api/linker_bulk_corrector_views.py
+++ b/api/linker_bulk_corrector_views.py
@@ -1,0 +1,46 @@
+from django.views import View
+
+from sefaria.client.util import jsonResponse
+from sefaria.helper import linker_bulk_corrector
+from sefaria.system.exceptions import InputError
+from .views import _load_json_body, StaffRequiredMixin
+
+
+class LinkerBulkCorrectorAPIView(StaffRequiredMixin, View):
+
+    def _handle(self, request, handler, status=200):
+        body, err = _load_json_body(request, empty_as_object=True)
+        if err:
+            return err
+        try:
+            return jsonResponse(handler(body), status=status)
+        except InputError as e:
+            return jsonResponse({"error": str(e)}, status=400)
+
+
+class LinkerBulkCorrectorSearchView(LinkerBulkCorrectorAPIView):
+
+    def post(self, request):
+        return self._handle(request, linker_bulk_corrector.search_citations)
+
+
+class LinkerBulkCorrectorNavigateView(LinkerBulkCorrectorAPIView):
+
+    def post(self, request):
+        return self._handle(request, linker_bulk_corrector.navigate_dataset)
+
+
+class LinkerBulkCorrectorReparseCitationView(LinkerBulkCorrectorAPIView):
+
+    def post(self, request):
+        return self._handle(request, linker_bulk_corrector.reparse_citation)
+
+
+class LinkerBulkCorrectorReparseDatasetView(LinkerBulkCorrectorAPIView):
+
+    def post(self, request):
+        return self._handle(
+            request,
+            lambda body: linker_bulk_corrector.enqueue_bulk_reparse_dataset(body, request.user.id),
+            status=202,
+        )

--- a/reader/views.py
+++ b/reader/views.py
@@ -1407,6 +1407,13 @@ def linker_editor(request):
     return menu_page(request, props, page="linkerEditor", title=title)
 
 
+@ensure_csrf_cookie
+@staff_member_required
+def linker_bulk_corrector(request):
+    title = _("Linker Bulk Corrector")
+    return menu_page(request, page="linkerBulkCorrector", title=title)
+
+
 def canonical_url(request):
     if not SITE_SETTINGS["TORAH_SPECIFIC"]:
         return None

--- a/sefaria/helper/linker/tasks.py
+++ b/sefaria/helper/linker/tasks.py
@@ -1077,6 +1077,19 @@ def parse_linker_citation_task(self, payload: dict) -> dict:
     return linker_resource_panel_admin.parse_linker_citation(payload)
 
 
+@app.task(name="linker.parse_citations_batch", bind=True)
+def parse_linker_citations_batch_task(self, payloads: list[dict]) -> list[dict]:
+    from sefaria.helper import linker_resource_panel_admin
+    logger.info("parse_linker_citations_batch:start", task_id=self.request.id, count=len(payloads or []))
+    return linker_resource_panel_admin.parse_linker_citations_batch(payloads)
+
+
+@app.task(name="linker.bulk_reparse_dataset", bind=True)
+def bulk_reparse_dataset_task(self, dataset: dict, user_id: Optional[int] = None) -> dict:
+    from sefaria.helper import linker_bulk_corrector
+    return linker_bulk_corrector.bulk_reparse_dataset(dataset, user_id=user_id, task=self)
+
+
 @app.task(name="linker.rebuild_nonuniqueterm_index", bind=True)
 def rebuild_nonuniqueterm_index_task(self) -> dict:
     """

--- a/sefaria/helper/linker_bulk_corrector.py
+++ b/sefaria/helper/linker_bulk_corrector.py
@@ -1,0 +1,549 @@
+import copy
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+from sefaria import tracker
+from sefaria.helper import linker_resource_panel_admin
+from sefaria.helper.linker import tasks as linker_tasks
+from sefaria.model import Link, LinkSet, Ref, library, log_linker_editor_action
+from sefaria.model.marked_up_text_chunk import LinkerOutput, LinkerOutputSet, MarkedUpTextChunk, MarkedUpTextChunkSet, MUTCSpanType
+from sefaria.model.text import TextChunk, prepare_index_regex_for_dependency_process
+from sefaria.system.exceptions import InputError
+
+
+VALID_STATUSES = {"parsed", "unparsed", "ambiguous"}
+VALID_LANGS = {"he", "en"}
+NAVIGATION_SCAN_LIMIT = 200
+SNIPPET_RADIUS = 300
+
+
+@dataclass(frozen=True)
+class CitationItem:
+    ref: str
+    versionTitle: str
+    language: str
+    charRange: tuple[int, int]
+    spans: list[dict]
+    order: str
+    status: str
+
+
+def parse_dataset_definition(raw: dict) -> dict:
+    if not isinstance(raw, dict):
+        raise InputError("dataset must be an object")
+    dataset_type = raw.get("type")
+    if dataset_type != "book":
+        raise InputError("Only book datasets are supported")
+    book_title = raw.get("bookTitle")
+    if isinstance(book_title, str):
+        book_title = book_title.strip()
+    if not isinstance(book_title, str) or not book_title:
+        raise InputError("Missing required field: dataset.bookTitle")
+    index = library.get_index(book_title)
+    version_title = raw.get("versionTitle")
+    if version_title == "":
+        version_title = None
+    lang = raw.get("lang")
+    if lang == "":
+        lang = None
+    if lang is not None and lang not in VALID_LANGS:
+        raise InputError("dataset.lang must be 'he', 'en', or null")
+    statuses = raw.get("status") or ["unparsed"]
+    if not isinstance(statuses, list) or not statuses:
+        raise InputError("dataset.status must be a non-empty list")
+    statuses = list(dict.fromkeys(statuses))
+    invalid = [status for status in statuses if status not in VALID_STATUSES]
+    if invalid:
+        raise InputError(f"Unknown citation status: {', '.join(invalid)}")
+    return {
+        "type": "book",
+        "bookTitle": index.title,
+        "versionTitle": version_title,
+        "lang": lang,
+        "status": statuses,
+    }
+
+
+def _book_query(dataset: dict) -> dict:
+    index = library.get_index(dataset["bookTitle"])
+    query = {"ref": {"$regex": prepare_index_regex_for_dependency_process(index)}}
+    if dataset.get("versionTitle"):
+        query["versionTitle"] = dataset["versionTitle"]
+    if dataset.get("lang"):
+        query["language"] = dataset["lang"]
+    return query
+
+
+def resolve_book_dataset_docs(dataset: dict) -> list[LinkerOutput]:
+    return list(LinkerOutputSet(_book_query(dataset)))
+
+
+def _citation_status(spans: list[dict]) -> str:
+    if any(span.get("failed") for span in spans):
+        return "unparsed"
+    if any(span.get("ambiguous") for span in spans):
+        return "ambiguous"
+    return "parsed"
+
+
+def group_citation_spans(docs: list[LinkerOutput]) -> list[CitationItem]:
+    grouped: dict[tuple[str, str, str, tuple[int, int]], list[dict]] = {}
+    for doc in docs:
+        for span in doc.spans:
+            if span.get("type") != MUTCSpanType.CITATION.value or span.get("deleted"):
+                continue
+            char_range = span.get("charRange")
+            if not isinstance(char_range, list) or len(char_range) != 2:
+                continue
+            key = (doc.ref, doc.versionTitle, doc.language, tuple(char_range))
+            grouped.setdefault(key, []).append(span)
+
+    items = []
+    for (ref, version_title, language, char_range), spans in grouped.items():
+        try:
+            order = Ref(ref).order_id()
+        except Exception:
+            order = ref
+        items.append(CitationItem(
+            ref=ref,
+            versionTitle=version_title,
+            language=language,
+            charRange=char_range,
+            spans=spans,
+            order=order,
+            status=_citation_status(spans),
+        ))
+    return sorted(items, key=lambda item: (item.order, item.ref, item.versionTitle, item.language, item.charRange[0]))
+
+
+def _full_grouped_items(dataset: dict) -> list[CitationItem]:
+    return group_citation_spans(resolve_book_dataset_docs(dataset))
+
+
+def _stats(items: list[CitationItem]) -> dict:
+    return {
+        "totalCitations": len(items),
+        "parsedCitations": sum(1 for item in items if item.status == "parsed"),
+    }
+
+
+def _filtered_items(items: list[CitationItem], dataset: dict) -> list[CitationItem]:
+    statuses = set(dataset["status"])
+    return [item for item in items if item.status in statuses]
+
+
+def _normalize_page(raw_page) -> int:
+    try:
+        page = int(raw_page or 0)
+    except (TypeError, ValueError):
+        raise InputError("page must be an integer")
+    if page < 0:
+        raise InputError("page must be non-negative")
+    return page
+
+
+def _normalize_page_size(raw_page_size) -> int:
+    try:
+        page_size = int(raw_page_size or 1)
+    except (TypeError, ValueError):
+        raise InputError("pageSize must be an integer")
+    if page_size < 1 or page_size > 100:
+        raise InputError("pageSize must be between 1 and 100")
+    return page_size
+
+
+def search_citations(payload: dict) -> dict:
+    dataset = parse_dataset_definition(payload.get("dataset"))
+    page = _normalize_page(payload.get("page"))
+    page_size = _normalize_page_size(payload.get("pageSize"))
+    all_items = _full_grouped_items(dataset)
+    filtered = _filtered_items(all_items, dataset)
+    start = page * page_size
+    page_items = filtered[start:start + page_size]
+    parse_results = linker_resource_panel_admin.parse_linker_citations_batch_sync([
+        _parts_payload_from_item(item) for item in page_items
+    ]) if page_items else []
+    return {
+        "dataset": dataset,
+        "page": page,
+        "pageSize": page_size,
+        "total": len(filtered),
+        "stats": _stats(all_items),
+        "results": [
+            serialize_citation_result(item, parse_result)
+            for item, parse_result in zip(page_items, parse_results)
+        ],
+    }
+
+
+def render_citation_snippet(item: CitationItem) -> dict:
+    tc = TextChunk(Ref(item.ref), lang=item.language, vtitle=item.versionTitle)
+    text = tc.text or ""
+    start, end = item.charRange
+    window_start = max(0, start - SNIPPET_RADIUS)
+    window_end = min(len(text), end + SNIPPET_RADIUS)
+    snippet_text = text[window_start:window_end]
+
+    linker_output = LinkerOutput().load({
+        "ref": item.ref,
+        "versionTitle": item.versionTitle,
+        "language": item.language,
+    })
+    source_spans = linker_output.spans if linker_output else item.spans
+    spans_by_range = {}
+    for span in source_spans:
+        if span.get("type") != MUTCSpanType.CITATION.value or span.get("deleted"):
+            continue
+        span_start, span_end = span.get("charRange") or [None, None]
+        if span_start is None or span_end is None or span_end <= window_start or span_start >= window_end:
+            continue
+        key = tuple(span["charRange"])
+        spans_by_range.setdefault(key, span)
+
+    # Ensure the focused citation's own span representation wins when the same charRange has
+    # several ambiguous candidates.
+    for span in item.spans:
+        spans_by_range[tuple(span["charRange"])] = span
+
+    spans = []
+    for span in spans_by_range.values():
+        rebased = copy.deepcopy(span)
+        rebased["charRange"] = [span["charRange"][0] - window_start, span["charRange"][1] - window_start]
+        spans.append(rebased)
+    debug_chunk = LinkerOutput({
+        "ref": item.ref,
+        "versionTitle": item.versionTitle,
+        "language": item.language,
+        "spans": spans,
+    })
+    focused_range = f"{start - window_start}-{end - window_start}"
+    return {"html": _mark_snippet_anchors(debug_chunk.apply_spans_to_text(snippet_text), focused_range)}
+
+
+def _mark_snippet_anchors(html: str, focused_range: str) -> str:
+    def repl(match):
+        classes = match.group("classes")
+        range_value = match.group("range")
+        marker = "lbcFocusedCitation" if range_value == focused_range else "lbcContextCitation"
+        return f'<a class="refLink {marker} {classes}"{match.group("attrs")}>'
+
+    return re.sub(
+        r'<a class="refLink (?P<classes>[^"]+)"(?P<attrs>[^>]*data-range=(?P<range>\d+-\d+)[^>]*)>',
+        repl,
+        html,
+    )
+
+
+def _parts_payload_from_span(span: dict, language: str) -> dict:
+    parts = []
+    input_parts = span.get("inputRefParts") or []
+    input_types = span.get("inputRefPartTypes") or []
+    for i, text in enumerate(input_parts):
+        part_type = input_types[i] if i < len(input_types) else None
+        if part_type == "RANGE":
+            sections = span.get("inputRangeSections") or []
+            to_sections = span.get("inputRangeToSections") or []
+            parts.extend({"text": section, "type": "NUMBERED"} for section in sections)
+            parts.append({"text": "-", "type": "RANGE_SYMBOL"})
+            parts.extend({"text": section, "type": "NUMBERED"} for section in to_sections)
+            continue
+        parts.append({"text": text, "type": part_type})
+    parts = [part for part in parts if part.get("text") and part.get("type")]
+    if not parts:
+        raise InputError("Stored citation is missing input ref parts")
+    return {
+        "parts": parts,
+        "lang": language,
+        "contextRef": span.get("contextRef"),
+        "prevRefs": [],
+    }
+
+
+def _parts_payload_from_item(item: CitationItem) -> dict:
+    return _parts_payload_from_span(item.spans[0], item.language)
+
+
+def _status_from_parse_result(parse_result: dict) -> str:
+    parsings = parse_result.get("parsings") or []
+    valid = [parsing for parsing in parsings if parsing.get("valid") and parsing.get("ref")]
+    if not valid:
+        return "unparsed"
+    if len(valid) > 1:
+        return "ambiguous"
+    return "parsed"
+
+
+def _ref_parts(parse_result: dict) -> list[dict]:
+    return parse_result.get("input", {}).get("parts") or []
+
+
+def serialize_citation_result(item: CitationItem, parse_result: Optional[dict] = None) -> dict:
+    parse_result = parse_result or {"input": {"parts": []}, "parsings": []}
+    return {
+        "ref": item.ref,
+        "versionTitle": item.versionTitle,
+        "language": item.language,
+        "charRange": list(item.charRange),
+        "status": item.status,
+        "snippet": render_citation_snippet(item),
+        "refParts": _ref_parts(parse_result),
+        "parsings": parse_result.get("parsings") or [],
+    }
+
+
+def _cursor_key(cursor: dict) -> Optional[tuple[str, tuple[int, int]]]:
+    if not cursor:
+        return None
+    ref = cursor.get("ref")
+    char_range = cursor.get("charRange")
+    if isinstance(char_range, str):
+        char_range = char_range.split("-")
+    if not ref or not isinstance(char_range, list) or len(char_range) != 2:
+        raise InputError("cursor must include ref and charRange")
+    try:
+        return ref, (int(char_range[0]), int(char_range[1]))
+    except (TypeError, ValueError):
+        raise InputError("cursor.charRange values must be integers")
+
+
+def _cursor_for_item(item: CitationItem) -> dict:
+    return {"ref": item.ref, "charRange": list(item.charRange)}
+
+
+def _cursor_matches(item: CitationItem, key: tuple[str, tuple[int, int]]) -> bool:
+    return item.ref == key[0] and item.charRange == key[1]
+
+
+def navigate_dataset(payload: dict) -> dict:
+    dataset = parse_dataset_definition(payload.get("dataset"))
+    direction = payload.get("direction")
+    if direction not in {"forward", "backward"}:
+        raise InputError("direction must be 'forward' or 'backward'")
+    items = _full_grouped_items(dataset)
+    if not items:
+        return {"found": False, "continuationCursor": None, "checked": 0}
+    cursor = _cursor_key(payload.get("cursor") or {})
+    if cursor is None:
+        idx = -1 if direction == "forward" else len(items)
+    else:
+        matching_indices = [i for i, item in enumerate(items) if _cursor_matches(item, cursor)]
+        idx = matching_indices[0] if matching_indices else (-1 if direction == "forward" else len(items))
+
+    step = 1 if direction == "forward" else -1
+    current = idx + step
+    checked = 0
+    last_scanned = None
+    while 0 <= current < len(items) and checked < NAVIGATION_SCAN_LIMIT:
+        item = items[current]
+        parse_result = linker_resource_panel_admin.parse_linker_citation_sync(_parts_payload_from_item(item))
+        fresh_status = _status_from_parse_result(parse_result)
+        fresh_item = CitationItem(
+            ref=item.ref,
+            versionTitle=item.versionTitle,
+            language=item.language,
+            charRange=item.charRange,
+            spans=item.spans,
+            order=item.order,
+            status=fresh_status,
+        )
+        persist_citation_resolution(item.ref, item.versionTitle, item.language, list(item.charRange), parse_result)
+        checked += 1
+        last_scanned = item
+        if fresh_status in set(dataset["status"]):
+            return {
+                "found": True,
+                "item": serialize_citation_result(fresh_item, parse_result),
+                "position": current,
+                "checked": checked,
+            }
+        current += step
+    return {
+        "found": False,
+        "continuationCursor": _cursor_for_item(last_scanned) if last_scanned else None,
+        "checked": checked,
+    }
+
+
+def _load_item(ref: str, version_title: str, language: str, char_range: list[int]) -> CitationItem:
+    linker_output = LinkerOutput().load({"ref": ref, "versionTitle": version_title, "language": language})
+    if not linker_output:
+        raise InputError(f"No stored linker output found for {ref}, {language}, {version_title}")
+    spans = [
+        span for span in linker_output.spans
+        if span.get("type") == MUTCSpanType.CITATION.value
+        and span.get("charRange") == char_range
+        and not span.get("deleted")
+    ]
+    if not spans:
+        raise InputError(f"No stored citation found for {ref} at {char_range}")
+    try:
+        order = Ref(ref).order_id()
+    except Exception:
+        order = ref
+    return CitationItem(ref, version_title, language, tuple(char_range), spans, order, _citation_status(spans))
+
+
+def reparse_citation(payload: dict) -> dict:
+    ref = Ref(linker_resource_panel_admin._required(payload, "ref")).normal()
+    version_title = linker_resource_panel_admin._required(payload, "versionTitle")
+    language = linker_resource_panel_admin._required(payload, "language" if "language" in payload else "lang")
+    char_range = linker_resource_panel_admin._normalize_char_range(linker_resource_panel_admin._required(payload, "charRange"))
+    item = _load_item(ref, version_title, language, char_range)
+    parse_result = linker_resource_panel_admin.parse_linker_citation_sync(_parts_payload_from_item(item))
+    return persist_citation_resolution(ref, version_title, language, char_range, parse_result)
+
+
+def _debug_spans_from_parse_result(item: CitationItem, parse_result: dict) -> list[dict]:
+    parts = parse_result.get("input", {}).get("parts") or []
+    parsings = parse_result.get("parsings") or []
+    valid = [parsing for parsing in parsings if parsing.get("valid") and parsing.get("ref")]
+    status = _status_from_parse_result(parse_result)
+    span_text = item.spans[0].get("text")
+    base = {
+        "charRange": list(item.charRange),
+        "text": span_text,
+        "type": MUTCSpanType.CITATION.value,
+        "failed": status == "unparsed",
+        "ambiguous": status == "ambiguous",
+        "inputRefParts": [part.get("text") for part in parts],
+        "inputRefPartTypes": [part.get("type") for part in parts],
+        "inputRefPartClasses": [part.get("class") for part in parts],
+        "contextRef": parse_result.get("input", {}).get("contextRef"),
+        "contextType": None,
+    }
+    new_spans = []
+    source_parsings = valid if valid else (parsings[:1] or [{}])
+    for parsing in source_parsings:
+        span = copy.deepcopy(base)
+        span["ref"] = parsing.get("ref")
+        if parsing.get("disqualificationReason"):
+            span["disqualificationReason"] = parsing.get("disqualificationReason")
+        pairings = parsing.get("pairings") or []
+        matched_parts = [part for pairing in pairings for part in (pairing.get("parts") or [])]
+        if matched_parts:
+            span["resolvedRefParts"] = [part.get("text") for part in matched_parts]
+            span["resolvedRefPartTypes"] = [part.get("type") for part in matched_parts]
+            span["resolvedRefPartClasses"] = [part.get("class") for part in matched_parts]
+        new_spans.append(span)
+    return new_spans
+
+
+def _parsed_ref_from_parse_result(parse_result: dict) -> Optional[str]:
+    valid = [parsing for parsing in (parse_result.get("parsings") or []) if parsing.get("valid") and parsing.get("ref")]
+    if len(valid) == 1:
+        return valid[0]["ref"]
+    return None
+
+
+def _replace_spans_at_char_range(chunk, char_range: list[int], new_spans: list[dict]) -> bool:
+    original = chunk.spans
+    kept = [
+        span for span in original
+        if not (span.get("type") == MUTCSpanType.CITATION.value and span.get("charRange") == char_range)
+    ]
+    if kept == original and not new_spans:
+        return False
+    chunk.spans = kept + new_spans
+    if chunk.spans:
+        chunk.save()
+    else:
+        chunk.delete()
+    return True
+
+
+def _other_backing_spans_exist(citing_ref: str, version_title: str, language: str, char_range: list[int], target_ref: str) -> bool:
+    for mutc in MarkedUpTextChunkSet({"ref": citing_ref}):
+        for span in mutc.spans:
+            if span.get("type") != MUTCSpanType.CITATION.value or span.get("deleted"):
+                continue
+            if mutc.versionTitle == version_title and mutc.language == language and span.get("charRange") == char_range:
+                continue
+            if span.get("ref") == target_ref:
+                return True
+    return False
+
+
+def _update_generated_link(citing_ref: str, old_refs: set[str], new_ref: Optional[str], version_title: str, language: str, char_range: list[int]) -> None:
+    old_refs.discard(None)
+    if new_ref:
+        existing_new = Link().load({"refs": {"$all": [citing_ref, new_ref]}, "generated_by": "add_links_from_text"})
+        if not existing_new:
+            reusable = None
+            for old_ref in old_refs:
+                reusable = Link().load({"refs": {"$all": [citing_ref, old_ref]}, "generated_by": "add_links_from_text"})
+                if reusable:
+                    break
+            if reusable:
+                reusable.refs = sorted([citing_ref, new_ref])
+                reusable.save()
+            else:
+                linker_tasks._create_link_for_resolution(citing_ref, new_ref)
+    for old_ref in old_refs:
+        if old_ref == new_ref or _other_backing_spans_exist(citing_ref, version_title, language, char_range, old_ref):
+            continue
+        for link in LinkSet({"refs": {"$all": [citing_ref, old_ref]}, "generated_by": "add_links_from_text"}):
+            tracker.delete(None, Link, link._id)
+
+
+def persist_citation_resolution(ref: str, versionTitle: str, language: str, charRange: list[int], parse_result: dict) -> dict:
+    item = _load_item(ref, versionTitle, language, charRange)
+    new_debug_spans = _debug_spans_from_parse_result(item, parse_result)
+    parsed_ref = _parsed_ref_from_parse_result(parse_result)
+    old_refs = {span.get("ref") for span in item.spans if span.get("ref")}
+
+    query = {"ref": ref, "versionTitle": versionTitle, "language": language}
+    linker_output = LinkerOutput().load(query)
+    _replace_spans_at_char_range(linker_output, charRange, new_debug_spans)
+
+    mutc = MarkedUpTextChunk().load(query)
+    if mutc:
+        mutc_span = []
+        if parsed_ref:
+            mutc_span = [{
+                "charRange": charRange,
+                "text": item.spans[0].get("text"),
+                "type": MUTCSpanType.CITATION.value,
+                "ref": parsed_ref,
+            }]
+        _replace_spans_at_char_range(mutc, charRange, mutc_span)
+    elif parsed_ref:
+        MarkedUpTextChunk({
+            "ref": ref,
+            "versionTitle": versionTitle,
+            "language": language,
+            "spans": [{
+                "charRange": charRange,
+                "text": item.spans[0].get("text"),
+                "type": MUTCSpanType.CITATION.value,
+                "ref": parsed_ref,
+            }],
+        }).save()
+
+    _update_generated_link(ref, old_refs, parsed_ref, versionTitle, language, charRange)
+    fresh_item = _load_item(ref, versionTitle, language, charRange)
+    return serialize_citation_result(fresh_item, parse_result)
+
+
+def enqueue_bulk_reparse_dataset(payload: dict, user_id: Optional[int]) -> dict:
+    dataset = parse_dataset_definition(payload.get("dataset"))
+    from sefaria.celery_setup.config import CeleryQueue
+    async_result = linker_tasks.bulk_reparse_dataset_task.apply_async(args=(dataset, user_id), queue=CeleryQueue.TASKS.value)
+    return {"task_id": async_result.id}
+
+
+def bulk_reparse_dataset(dataset: dict, user_id: Optional[int] = None, task=None) -> dict:
+    dataset = parse_dataset_definition(dataset)
+    items = _filtered_items(_full_grouped_items(dataset), dataset)
+    total = len(items)
+    if task:
+        task.update_state(state="PROGRESS", meta={"current": 0, "total": total})
+
+    for i, item in enumerate(items, start=1):
+        parse_result = linker_resource_panel_admin.parse_linker_citation(_parts_payload_from_item(item))
+        persist_citation_resolution(item.ref, item.versionTitle, item.language, list(item.charRange), parse_result)
+        if task:
+            task.update_state(state="PROGRESS", meta={"current": i, "total": total})
+
+    log_linker_editor_action(user_id, "bulk_reparse_dataset", {"dataset": dataset, "total": total}, index_title=dataset["bookTitle"])
+    return {"ok": True, "current": total, "total": total, "dataset": dataset}

--- a/sefaria/helper/linker_bulk_corrector.py
+++ b/sefaria/helper/linker_bulk_corrector.py
@@ -536,14 +536,41 @@ def bulk_reparse_dataset(dataset: dict, user_id: Optional[int] = None, task=None
     dataset = parse_dataset_definition(dataset)
     items = _filtered_items(_full_grouped_items(dataset), dataset)
     total = len(items)
+    skipped = []
     if task:
-        task.update_state(state="PROGRESS", meta={"current": 0, "total": total})
+        task.update_state(state="PROGRESS", meta={"current": 0, "total": total, "skipped": 0})
 
     for i, item in enumerate(items, start=1):
-        parse_result = linker_resource_panel_admin.parse_linker_citation(_parts_payload_from_item(item))
-        persist_citation_resolution(item.ref, item.versionTitle, item.language, list(item.charRange), parse_result)
+        try:
+            parse_result = linker_resource_panel_admin.parse_linker_citation(_parts_payload_from_item(item))
+            persist_citation_resolution(item.ref, item.versionTitle, item.language, list(item.charRange), parse_result)
+        except InputError as e:
+            skipped.append({
+                "ref": item.ref,
+                "versionTitle": item.versionTitle,
+                "language": item.language,
+                "charRange": list(item.charRange),
+                "error": str(e),
+            })
         if task:
-            task.update_state(state="PROGRESS", meta={"current": i, "total": total})
+            task.update_state(state="PROGRESS", meta={
+                "current": i,
+                "total": total,
+                "skipped": len(skipped),
+                "skippedSample": skipped[:10],
+            })
 
-    log_linker_editor_action(user_id, "bulk_reparse_dataset", {"dataset": dataset, "total": total}, index_title=dataset["bookTitle"])
-    return {"ok": True, "current": total, "total": total, "dataset": dataset}
+    log_linker_editor_action(
+        user_id,
+        "bulk_reparse_dataset",
+        {"dataset": dataset, "total": total, "skipped": len(skipped), "skippedSample": skipped[:10]},
+        index_title=dataset["bookTitle"],
+    )
+    return {
+        "ok": True,
+        "current": total,
+        "total": total,
+        "skipped": len(skipped),
+        "skippedSample": skipped[:10],
+        "dataset": dataset,
+    }

--- a/sefaria/helper/linker_resource_panel_admin.py
+++ b/sefaria/helper/linker_resource_panel_admin.py
@@ -321,6 +321,19 @@ def parse_linker_citation_sync(payload: dict, timeout: int = 20) -> dict:
         raise InputError("Linker parse timed out; the task queue may be busy. Try again in a moment.")
 
 
+def parse_linker_citations_batch_sync(payloads: list[dict], timeout: int = 60) -> list[dict]:
+    if not isinstance(payloads, list):
+        raise InputError("payloads must be a list")
+    from celery.exceptions import TimeoutError as CeleryTimeoutError
+    from sefaria.helper.linker.tasks import parse_linker_citations_batch_task
+    from sefaria.celery_setup.config import CeleryQueue
+    async_result = parse_linker_citations_batch_task.apply_async(args=(payloads,), queue=CeleryQueue.TASKS.value)
+    try:
+        return async_result.get(timeout=timeout)
+    except CeleryTimeoutError:
+        raise InputError("Linker parse timed out; the task queue may be busy. Try again in a moment.")
+
+
 def parse_linker_citation(payload: dict) -> dict:
     """
     Runs on a Celery worker (see parse_linker_citation_task in helper.linker.tasks) — never
@@ -358,6 +371,12 @@ def parse_linker_citation(payload: dict) -> dict:
         },
         "parsings": [_serialize_resolved_ref(resolved_ref) for resolved_ref in resolved_refs],
     }
+
+
+def parse_linker_citations_batch(payloads: list[dict]) -> list[dict]:
+    if not isinstance(payloads, list):
+        raise InputError("payloads must be a list")
+    return [parse_linker_citation(payload) for payload in payloads]
 
 
 # ---------------------------------------------------------------------------

--- a/sefaria/helper/linker_resource_panel_admin.py
+++ b/sefaria/helper/linker_resource_panel_admin.py
@@ -384,7 +384,7 @@ def parse_linker_citations_batch(payloads: list[dict]) -> list[dict]:
 # ---------------------------------------------------------------------------
 
 def _upsert_dataset_example(example_type: str, text: str, entities: list, ref: str, lang: str,
-                            version_title: str, user_id: Optional[int]) -> dict:
+                            version_title: str, user_id: Optional[int], reason: Optional[str] = None) -> dict:
     """
     Store (or overwrite) one gold training example. Uniqueness is (type, ref, text) so
     re-clicking a button refreshes the labels rather than creating duplicates.
@@ -399,6 +399,11 @@ def _upsert_dataset_example(example_type: str, text: str, entities: list, ref: s
     example.labels = {"entities": entities}
     example.added_by = user_id
     example.added_at = int(time.time())
+    reason = reason.strip() if isinstance(reason, str) else None
+    if reason:
+        example.reason = reason
+    elif hasattr(example, "reason"):
+        delattr(example, "reason")
     example.save()
     return {
         "ok": True,
@@ -450,7 +455,7 @@ def add_ref_dataset_example(payload: dict, user_id: Optional[int]) -> dict:
         entities.append([norm_start, norm_end, label])
 
     entities.sort(key=lambda e: (e[0], e[1]))
-    return _upsert_dataset_example("ref", normalized_text, entities, ref, lang, version_title, user_id)
+    return _upsert_dataset_example("ref", normalized_text, entities, ref, lang, version_title, user_id, payload.get("reason"))
 
 
 def _expand_ref_parts(span: dict) -> list:
@@ -568,4 +573,4 @@ def add_ref_part_dataset_example(payload: dict, user_id: Optional[int]) -> dict:
     normalizer = get_linker_normalizer(lang)
     normalized_citation = normalizer.normalize(span["text"])
     entities = _locate_ref_part_entities(normalized_citation, span, normalizer, lang)
-    return _upsert_dataset_example("ref part", normalized_citation, entities, ref, lang, version_title, user_id)
+    return _upsert_dataset_example("ref part", normalized_citation, entities, ref, lang, version_title, user_id, payload.get("reason"))

--- a/sefaria/model/linker_dataset_example.py
+++ b/sefaria/model/linker_dataset_example.py
@@ -30,6 +30,7 @@ class LinkerDatasetExample(AbstractMongoRecord):
         "versionTitle",
         "added_by",
         "added_at",
+        "reason",
     ]
 
     attr_schemas = {
@@ -40,6 +41,7 @@ class LinkerDatasetExample(AbstractMongoRecord):
         "versionTitle": {"type": "string", "required": False},
         "added_by": {"type": "integer", "required": False, "nullable": True},
         "added_at": {"type": "integer", "required": False},
+        "reason": {"type": "string", "required": False},
         "labels": {
             "type": "dict",
             "required": True,

--- a/sefaria/model/linker_editor_history.py
+++ b/sefaria/model/linker_editor_history.py
@@ -28,6 +28,7 @@ ACTIONS = (
     "add_non_unique_term_titles",
     "delete_non_unique_term",
     "swap_non_unique_term_usages",
+    "bulk_reparse_dataset",
 )
 
 

--- a/sefaria/model/marked_up_text_chunk.py
+++ b/sefaria/model/marked_up_text_chunk.py
@@ -248,6 +248,7 @@ class LinkerOutput(MarkedUpTextChunk):
                     "llm_resolved_phrase_non_segment": {"type": "string", "required": False, "nullable": True},
                     "llm_ambiguous_option_valid": {"type": "boolean", "required": False, "nullable": True},
                     "llm_resolved_ref_but_rejected": {"type": "string", "required": False, "nullable": True},
+                    "disqualificationReason": {"type": "string", "required": False, "nullable": True},
                     "failed": {"type": "boolean", "required": True},
                     "ambiguous": {"type": "boolean", "required": True},
                     "deleted": {"type": "boolean", "required": False},

--- a/sefaria/system/database.py
+++ b/sefaria/system/database.py
@@ -166,6 +166,8 @@ def ensure_indices(active_db=None):
         ('sheets', [[("views", pymongo.DESCENDING)]],{}),
         ('sheets', ["categories"], {}),
         ('links', [[("owner", pymongo.ASCENDING), ("date_modified", pymongo.DESCENDING)]], {}),
+        ('marked_up_text_chunks', [[("ref", pymongo.ASCENDING), ("versionTitle", pymongo.ASCENDING), ("language", pymongo.ASCENDING)]], {}),
+        ('linker_output', [[("ref", pymongo.ASCENDING), ("versionTitle", pymongo.ASCENDING), ("language", pymongo.ASCENDING)]], {}),
         ('texts', ["title"],{}),
         ('texts', [[("priority", pymongo.DESCENDING), ("_id", pymongo.ASCENDING)]],{}),
         ('texts', [[("versionTitle", pymongo.ASCENDING), ("language", pymongo.ASCENDING)]],{}),

--- a/sefaria/urls_library.py
+++ b/sefaria/urls_library.py
@@ -24,6 +24,7 @@ urlpatterns = [
     re_path(r'^translations/(?P<slug>[^.]+)$', reader_views.translations_page),
     re_path(r'^modtools/?$', reader_views.modtools),
     re_path(r'^linker-editor/?$', reader_views.linker_editor),
+    re_path(r'^linker-bulk-corrector/?$', reader_views.linker_bulk_corrector),
     path('modtools/upload_text', sefaria_views.modtools_upload_workflowy),
     path('modtools/links', sefaria_views.links_upload_api),
     path('modtools/links/<path:tref1>/<path:tref2>', sefaria_views.get_csv_links_by_refs_api),

--- a/sefaria/urls_shared.py
+++ b/sefaria/urls_shared.py
@@ -7,6 +7,7 @@ import sourcesheets.views as sheets_views
 import remote_config.views as remote_config_views
 import api.views as api_views
 import api.linker_admin_views as linker_api_views
+import api.linker_bulk_corrector_views as linker_bulk_corrector_views
 import sefaria.views as sefaria_views
 import sefaria.gauth.views as gauth_views
 import guides.views as guides_views
@@ -131,6 +132,12 @@ shared_patterns = [
     path('_api/linker-admin/segment/rerun', linker_api_views.LinkerAdminRerunSegmentView.as_view()),
     path('_api/linker-admin/dataset/ref', linker_api_views.LinkerAdminAddRefDatasetView.as_view()),
     path('_api/linker-admin/dataset/ref-part', linker_api_views.LinkerAdminAddRefPartDatasetView.as_view()),
+
+    # Linker bulk corrector (staff-only): search/navigate/re-parse stored linker citation spans.
+    path('_api/linker-bulk-corrector/search', linker_bulk_corrector_views.LinkerBulkCorrectorSearchView.as_view()),
+    path('_api/linker-bulk-corrector/navigate', linker_bulk_corrector_views.LinkerBulkCorrectorNavigateView.as_view()),
+    path('_api/linker-bulk-corrector/citation/reparse', linker_bulk_corrector_views.LinkerBulkCorrectorReparseCitationView.as_view()),
+    path('_api/linker-bulk-corrector/reparse-dataset', linker_bulk_corrector_views.LinkerBulkCorrectorReparseDatasetView.as_view()),
 
     path('api/ref/<str:tref>', api_views.RefView.as_view()),
     re_path(r'^api/category/?(?P<path>.+)?$', reader_views.category_api),

--- a/static/css/linker-bulk-corrector.css
+++ b/static/css/linker-bulk-corrector.css
@@ -1,0 +1,337 @@
+.linkerBulkCorrector {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  min-height: calc(100vh - 60px);
+  background: #f7f7f4;
+  color: #222;
+}
+
+.lbcSidebar {
+  border-right: 1px solid #ddd8cf;
+  background: #fff;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+}
+
+.lbcSidebar h2,
+.lbcColumns h3 {
+  margin: 0 0 10px;
+  font-size: 15px;
+  font-weight: 600;
+}
+
+.lbcStatNumber {
+  font-size: 24px;
+  margin-bottom: 8px;
+}
+
+.lbcProgress {
+  height: 8px;
+  background: #e6e2da;
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.lbcProgress span {
+  display: block;
+  height: 100%;
+  background: #3d6f68;
+}
+
+.lbcHistory {
+  flex: 1;
+  overflow: auto;
+}
+
+.lbcHistory button {
+  display: block;
+  width: 100%;
+  text-align: left;
+  border: 0;
+  border-bottom: 1px solid #eee9e1;
+  background: transparent;
+  padding: 10px 0;
+  cursor: pointer;
+}
+
+.lbcMeta {
+  color: #777;
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.lbcShortcuts {
+  color: #555;
+  font-size: 13px;
+  line-height: 1.9;
+}
+
+.lbcShortcuts kbd {
+  border: 1px solid #ccc6bb;
+  border-radius: 4px;
+  padding: 1px 5px;
+  background: #f8f6f1;
+}
+
+.lbcMain {
+  padding: 24px 32px 90px;
+  min-width: 0;
+}
+
+.lbcSearch {
+  display: grid;
+  grid-template-columns: minmax(160px, 1.4fr) minmax(160px, 1.4fr) 110px auto auto auto;
+  gap: 10px;
+  align-items: center;
+  margin-bottom: 20px;
+}
+
+.lbcSearch input,
+.lbcSearch select {
+  min-height: 36px;
+  border: 1px solid #cfc8bc;
+  border-radius: 4px;
+  padding: 0 10px;
+  background: #fff;
+}
+
+.lbcAutocomplete {
+  position: relative;
+  min-width: 0;
+}
+
+.lbcSearchInput {
+  width: 100%;
+}
+
+.lbcDropdown {
+  position: absolute;
+  z-index: 20;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  max-height: 280px;
+  overflow: auto;
+  background: #fff;
+  border: 1px solid #cfc8bc;
+  border-radius: 4px;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.12);
+}
+
+.lbcSuggestion {
+  padding: 9px 10px;
+  cursor: pointer;
+}
+
+.lbcSuggestion.highlighted {
+  background: #e7f0ef;
+}
+
+.lbcSegmented {
+  display: flex;
+  border: 1px solid #cfc8bc;
+  border-radius: 4px;
+  overflow: hidden;
+  background: #fff;
+}
+
+.lbcSegmentButton {
+  border: 0;
+  border-right: 1px solid #cfc8bc;
+  background: #fff;
+  min-height: 34px;
+  padding: 0 10px;
+  cursor: pointer;
+}
+
+.lbcSegmentButton:last-child {
+  border-right: 0;
+}
+
+.lbcSegmentButton.active {
+  background: #3d6f68;
+  color: #fff;
+}
+
+.lbcError,
+.lbcTask {
+  margin-bottom: 12px;
+  padding: 10px 12px;
+  border-radius: 4px;
+}
+
+.lbcError {
+  background: #f7dedb;
+  color: #8a2b20;
+}
+
+.lbcTask {
+  background: #e7f0ef;
+  color: #254f4a;
+}
+
+.lbcEmpty {
+  padding: 80px 20px;
+  text-align: center;
+  color: #777;
+}
+
+.lbcResult {
+  max-width: 1100px;
+}
+
+.lbcResultHeader {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 14px;
+  align-items: center;
+  margin-bottom: 18px;
+}
+
+.lbcResultHeader h2 {
+  margin: 0;
+  font-size: 24px;
+}
+
+.lbcStatus {
+  border-radius: 4px;
+  padding: 5px 9px;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0;
+}
+
+.lbcStatus.parsed {
+  background: #dcebe4;
+  color: #24513d;
+}
+
+.lbcStatus.unparsed {
+  background: #f4dfdc;
+  color: #7a2a24;
+}
+
+.lbcStatus.ambiguous {
+  background: #f3ead4;
+  color: #6b4c10;
+}
+
+.lbcSnippet {
+  background: #fff;
+  border: 1px solid #ddd8cf;
+  border-radius: 6px;
+  padding: 18px;
+  line-height: 1.8;
+  margin-bottom: 20px;
+}
+
+.lbcSnippet .mutc.spanFailed {
+  background: #f8c9c2;
+}
+
+.lbcSnippet .mutc.spanAmbiguous {
+  background: #f7e4a8;
+}
+
+.lbcSnippet .mutc.spanSucceeded,
+.lbcSnippet .mutc.spanDisambiguated {
+  background: #bfe3d1;
+}
+
+.lbcSnippet .lbcContextCitation.mutc.spanFailed {
+  background: rgba(248, 201, 194, 0.35);
+}
+
+.lbcSnippet .lbcContextCitation.mutc.spanAmbiguous {
+  background: rgba(247, 228, 168, 0.38);
+}
+
+.lbcSnippet .lbcContextCitation.mutc.spanSucceeded,
+.lbcSnippet .lbcContextCitation.mutc.spanDisambiguated {
+  background: rgba(191, 227, 209, 0.35);
+}
+
+.lbcSnippet .lbcFocusedCitation {
+  box-shadow: 0 0 0 2px #234f49;
+  border-radius: 2px;
+}
+
+.lbcColumns {
+  display: grid;
+  grid-template-columns: minmax(220px, 0.8fr) minmax(360px, 1.4fr);
+  gap: 18px;
+}
+
+.lbcColumns section {
+  background: #fff;
+  border: 1px solid #ddd8cf;
+  border-radius: 6px;
+  padding: 16px;
+}
+
+.lbcPart,
+.lbcParsingTop {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  border-bottom: 1px solid #eee9e1;
+  padding: 7px 0;
+}
+
+.lbcPart span:last-child,
+.lbcParsingTop span {
+  color: #666;
+  font-size: 12px;
+}
+
+.lbcParsing {
+  border-bottom: 1px solid #eee9e1;
+  padding-bottom: 10px;
+  margin-bottom: 10px;
+}
+
+.lbcParsing.invalid {
+  opacity: 0.72;
+}
+
+.lbcPairing {
+  padding: 7px 0 0 12px;
+}
+
+.lbcNavOverlay {
+  position: fixed;
+  left: 50%;
+  bottom: 22px;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 10px 12px;
+  background: rgba(255, 255, 255, 0.96);
+  border: 1px solid #d8d1c6;
+  border-radius: 6px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+}
+
+.lbcNavOverlay button {
+  min-width: 84px;
+}
+
+@media (max-width: 900px) {
+  .linkerBulkCorrector {
+    grid-template-columns: 1fr;
+  }
+
+  .lbcSidebar {
+    border-right: 0;
+    border-bottom: 1px solid #ddd8cf;
+  }
+
+  .lbcSearch,
+  .lbcColumns,
+  .lbcResultHeader {
+    grid-template-columns: 1fr;
+  }
+}

--- a/static/css/linker-bulk-corrector.css
+++ b/static/css/linker-bulk-corrector.css
@@ -185,9 +185,9 @@
 
 .lbcResultHeader {
   display: grid;
-  grid-template-columns: 1fr auto auto;
+  grid-template-columns: 1fr auto minmax(360px, auto);
   gap: 14px;
-  align-items: center;
+  align-items: start;
   margin-bottom: 18px;
 }
 
@@ -217,6 +217,28 @@
 .lbcStatus.ambiguous {
   background: #f3ead4;
   color: #6b4c10;
+}
+
+.lbcResultActions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.lbcDatasetReason {
+  display: flex;
+  gap: 8px;
+  flex-basis: 100%;
+  justify-content: flex-end;
+}
+
+.lbcDatasetReason input {
+  min-height: 30px;
+  min-width: 220px;
+  border: 1px solid #cfc8bc;
+  border-radius: 4px;
+  padding: 0 9px;
 }
 
 .lbcSnippet {

--- a/static/css/linker-bulk-corrector.css
+++ b/static/css/linker-bulk-corrector.css
@@ -271,35 +271,6 @@
   padding: 16px;
 }
 
-.lbcPart,
-.lbcParsingTop {
-  display: flex;
-  justify-content: space-between;
-  gap: 12px;
-  border-bottom: 1px solid #eee9e1;
-  padding: 7px 0;
-}
-
-.lbcPart span:last-child,
-.lbcParsingTop span {
-  color: #666;
-  font-size: 12px;
-}
-
-.lbcParsing {
-  border-bottom: 1px solid #eee9e1;
-  padding-bottom: 10px;
-  margin-bottom: 10px;
-}
-
-.lbcParsing.invalid {
-  opacity: 0.72;
-}
-
-.lbcPairing {
-  padding: 7px 0 0 12px;
-}
-
 .lbcNavOverlay {
   position: fixed;
   left: 50%;

--- a/static/css/linker-bulk-corrector.css
+++ b/static/css/linker-bulk-corrector.css
@@ -83,7 +83,8 @@
 .lbcSearch {
   display: grid;
   grid-template-columns: minmax(160px, 1.4fr) minmax(160px, 1.4fr) 110px auto auto auto;
-  gap: 10px;
+  column-gap: 18px;
+  row-gap: 10px;
   align-items: center;
   margin-bottom: 20px;
 }

--- a/static/js/LinkerBulkCorrectorPage.jsx
+++ b/static/js/LinkerBulkCorrectorPage.jsx
@@ -6,6 +6,21 @@ import { GeneralAutocomplete } from './GeneralAutocomplete';
 const STORAGE_KEY = 'linkerBulkCorrectorState';
 const HISTORY_KEY = 'linkerBulkCorrectorHistory';
 const STATUS_OPTIONS = ['unparsed', 'ambiguous', 'parsed'];
+const LINKER_PART_COLORS = {
+  NAMED: "#dbeafe",
+  NUMBERED: "#dcfce7",
+  DH: "#fef3c7",
+  RANGE: "#fce7f3",
+  RANGE_SYMBOL: "#ede9fe",
+  IBID: "#e0f2fe",
+  RELATIVE: "#ffedd5",
+  NON_CTS: "#f3f4f6",
+};
+const CONTEXT_PART_CLASSES = ["ContextPart", "TermContext", "SectionContext"];
+const CONTEXT_TYPE_LABELS = {
+  CURRENT_BOOK: "curr. book",
+  IBID: "ibid",
+};
 
 const defaultDataset = {
   type: 'book',
@@ -107,16 +122,50 @@ const IndexTitleAutocomplete = ({value, onChange}) => {
   );
 };
 
-const Pairings = ({pairings}) => (
-  <div className="lbcPairings">
-    {(pairings || []).map((pairing, i) => (
-      <div className="lbcPairing" key={i}>
-        <div>{pairing.ref || pairing.node?.ref || 'No ref'}</div>
-        <div className="lbcMeta">{(pairing.parts || []).map(part => `${part.text}:${part.type}`).join(', ')}</div>
-      </div>
-    ))}
-  </div>
-);
+const matchedPartCount = (parsing) => (parsing.pairings || []).reduce((n, pairing) => n + (pairing.parts?.length || 0), 0);
+
+const LinkerPartChip = ({part, contextType}) => {
+  const contextLabel = contextType && CONTEXT_PART_CLASSES.includes(part.class)
+    ? (CONTEXT_TYPE_LABELS[contextType] || contextType)
+    : null;
+  return (
+    <span className="linkerAdminPartChip" style={{backgroundColor: LINKER_PART_COLORS[part.type] || "#f3f4f6"}}>
+      <span className="linkerAdminPartText">{part.text}</span>
+      <span className="linkerAdminPartType">{part.type}</span>
+      {contextLabel ? <span className="linkerAdminPartContext">from {contextLabel}</span> : null}
+    </span>
+  );
+};
+
+const LinkerPairings = ({pairings, contextType}) => {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="linkerAdminPairings">
+      <button className="linkerAdminDisclosure" onClick={() => setOpen(!open)} aria-expanded={open}>
+        <img
+          src="/static/icons/chevron-down.svg"
+          className={classNames("linkerAdminDisclosureChevron", {open})}
+          alt=""
+          aria-hidden={true}
+        />
+        Ref Part / Node Pairings
+      </button>
+      {open ? (pairings || []).map((pairing, i) => {
+        const pairingRef = pairing.ref || pairing.node?.ref;
+        return (
+          <div className="linkerAdminPairing" key={i}>
+            <div>{(pairing.parts || []).map((part, j) => <LinkerPartChip key={j} part={part} contextType={contextType} />)}</div>
+            <div className="linkerAdminNode">
+              {pairingRef
+                ? <a className="linkerAdminRefValue" href={`/${Sefaria.normRef(pairingRef)}`} target="_blank">{pairingRef}</a>
+                : (pairing.node?.key || "No node")}
+            </div>
+          </div>
+        );
+      }) : null}
+    </div>
+  );
+};
 
 const ResultDetails = ({item, onReparse, reparsing}) => {
   if (!item) {
@@ -138,24 +187,26 @@ const ResultDetails = ({item, onReparse, reparsing}) => {
       <div className="lbcColumns">
         <section>
           <h3>Ref Parts</h3>
-          {(item.refParts || []).map((part, i) => (
-            <div className="lbcPart" key={i}>
-              <span>{part.text}</span>
-              <span>{part.type}</span>
-            </div>
-          ))}
+          <div className="linkerAdminParts">
+            {(item.refParts || []).map((part, i) => <LinkerPartChip key={i} part={part} />)}
+          </div>
         </section>
         <section>
           <h3>Options Considered</h3>
-          {(item.parsings || []).map((parsing, i) => (
-            <div className={classNames('lbcParsing', {invalid: !parsing.valid})} key={i}>
-              <div className="lbcParsingTop">
-                <strong>{parsing.ref || 'No ref'}</strong>
-                <span>{parsing.valid ? 'valid' : parsing.disqualificationReason || 'invalid'}</span>
-              </div>
-              <Pairings pairings={parsing.pairings} />
-            </div>
-          ))}
+          <div className="linkerAdminParsingList">
+            {(item.parsings || [])
+              .map((parsing, i) => ({parsing, i}))
+              .sort((a, b) => (a.parsing.valid === b.parsing.valid)
+                ? (matchedPartCount(b.parsing) - matchedPartCount(a.parsing))
+                : (a.parsing.valid ? -1 : 1))
+              .map(({parsing, i}) => (
+                <div className={classNames("linkerAdminParsing", {valid: parsing.valid, invalid: !parsing.valid})} key={`${resultKey(item)}-${i}`}>
+                  <div className="linkerAdminParsingRef">{parsing.ref || "No Ref"}</div>
+                  {!parsing.valid ? <div className="linkerAdminInvalidReason">{parsing.disqualificationReason}</div> : null}
+                  <LinkerPairings pairings={parsing.pairings || []} contextType={parsing.contextType} />
+                </div>
+              ))}
+          </div>
         </section>
       </div>
     </div>

--- a/static/js/LinkerBulkCorrectorPage.jsx
+++ b/static/js/LinkerBulkCorrectorPage.jsx
@@ -1,0 +1,383 @@
+import React, {useCallback, useEffect, useMemo, useState} from 'react';
+import classNames from 'classnames';
+import Sefaria from './sefaria/sefaria';
+import { GeneralAutocomplete } from './GeneralAutocomplete';
+
+const STORAGE_KEY = 'linkerBulkCorrectorState';
+const HISTORY_KEY = 'linkerBulkCorrectorHistory';
+const STATUS_OPTIONS = ['unparsed', 'ambiguous', 'parsed'];
+
+const defaultDataset = {
+  type: 'book',
+  bookTitle: '',
+  versionTitle: null,
+  lang: null,
+  status: ['unparsed'],
+};
+
+const apiPost = (path, payload) => Sefaria.apiRequestWithBody(path, {}, payload, 'POST');
+
+const loadStored = (key, fallback) => {
+  if (typeof localStorage === 'undefined') {
+    return fallback;
+  }
+  try {
+    return JSON.parse(localStorage.getItem(key)) || fallback;
+  } catch {
+    return fallback;
+  }
+};
+
+const resultKey = (item) => item ? `${item.ref}|${item.versionTitle}|${item.language}|${item.charRange?.join('-')}` : '';
+
+const SmallMeta = ({item}) => (
+  <div className="lbcMeta">{item.versionTitle} ({item.language})</div>
+);
+
+const StatusToggle = ({status, selected, onClick}) => (
+  <button
+    type="button"
+    className={classNames('lbcSegmentButton', {active: selected})}
+    onClick={onClick}>
+    {status}
+  </button>
+);
+
+const IndexTitleAutocomplete = ({value, onChange}) => {
+  const getSuggestions = async (inputValue) => {
+    if (!inputValue || inputValue.trim().length < 2) { return []; }
+    try {
+      const d = await Sefaria.getName(inputValue.trim(), 10, ['ref']);
+      return (d.completion_objects || []).map(co => ({name: co.title, key: co.key || co.title}));
+    } catch (e) {
+      return [];
+    }
+  };
+  const select = async (item) => {
+    try {
+      const d = await Sefaria.getName(item.name);
+      onChange((d.index || d.book || item.name || '').trim());
+    } catch (e) {
+      onChange((item.name || '').trim());
+    }
+  };
+  const renderInput = (highlightedIndex, highlightedSuggestion, getInputProps) => {
+    const inputProps = getInputProps({
+      className: 'lbcSearchInput',
+      placeholder: 'Book title',
+      defaultValue: value || '',
+    });
+    const originalOnChange = inputProps.onChange;
+    return (
+      <input
+        {...inputProps}
+        onChange={(event) => {
+          if (originalOnChange) { originalOnChange(event); }
+          onChange(event.target.value);
+        }}
+      />
+    );
+  };
+  const renderItems = (suggestions, highlightedIndex, getItemProps) => (
+    suggestions.map((item, index) => (
+      <div
+        key={item.key + index}
+        {...getItemProps({item, index})}
+        className={classNames('lbcSuggestion', {highlighted: highlightedIndex === index})}>
+        {item.name}
+      </div>
+    ))
+  );
+  return (
+    <GeneralAutocomplete
+      containerClassString="lbcAutocomplete"
+      dropdownMenuClassString="lbcDropdown"
+      getSuggestions={getSuggestions}
+      renderInput={renderInput}
+      renderItems={renderItems}
+      onSelectedItemChange={({selectedItem}) => { if (selectedItem) { select(selectedItem); } }}
+      onEnter={({event, highlightedSuggestion, suggestions}) => {
+        const item = highlightedSuggestion || suggestions[0];
+        if (!item) { return false; }
+        event.preventDefault();
+        select(item);
+        return true;
+      }}
+    />
+  );
+};
+
+const Pairings = ({pairings}) => (
+  <div className="lbcPairings">
+    {(pairings || []).map((pairing, i) => (
+      <div className="lbcPairing" key={i}>
+        <div>{pairing.ref || pairing.node?.ref || 'No ref'}</div>
+        <div className="lbcMeta">{(pairing.parts || []).map(part => `${part.text}:${part.type}`).join(', ')}</div>
+      </div>
+    ))}
+  </div>
+);
+
+const ResultDetails = ({item, onReparse, reparsing}) => {
+  if (!item) {
+    return <div className="lbcEmpty">Search for a book to load citations.</div>;
+  }
+  return (
+    <div className="lbcResult">
+      <div className="lbcResultHeader">
+        <div>
+          <h2>{item.ref}</h2>
+          <SmallMeta item={item} />
+        </div>
+        <div className={`lbcStatus ${item.status}`}>{item.status}</div>
+        <button type="button" className="button small" onClick={onReparse} disabled={reparsing}>
+          {reparsing ? 'Re-parsing' : 'Re-parse'}
+        </button>
+      </div>
+      <div className="lbcSnippet" dangerouslySetInnerHTML={{__html: item.snippet?.html || ''}} />
+      <div className="lbcColumns">
+        <section>
+          <h3>Ref Parts</h3>
+          {(item.refParts || []).map((part, i) => (
+            <div className="lbcPart" key={i}>
+              <span>{part.text}</span>
+              <span>{part.type}</span>
+            </div>
+          ))}
+        </section>
+        <section>
+          <h3>Options Considered</h3>
+          {(item.parsings || []).map((parsing, i) => (
+            <div className={classNames('lbcParsing', {invalid: !parsing.valid})} key={i}>
+              <div className="lbcParsingTop">
+                <strong>{parsing.ref || 'No ref'}</strong>
+                <span>{parsing.valid ? 'valid' : parsing.disqualificationReason || 'invalid'}</span>
+              </div>
+              <Pairings pairings={parsing.pairings} />
+            </div>
+          ))}
+        </section>
+      </div>
+    </div>
+  );
+};
+
+const LinkerBulkCorrectorPage = () => {
+  const stored = loadStored(STORAGE_KEY, {});
+  const [dataset, setDataset] = useState(stored.dataset || defaultDataset);
+  const [page, setPage] = useState(stored.page || 0);
+  const [item, setItem] = useState(stored.item || null);
+  const [total, setTotal] = useState(stored.total || 0);
+  const [stats, setStats] = useState(stored.stats || {totalCitations: 0, parsedCitations: 0});
+  const [history, setHistory] = useState(loadStored(HISTORY_KEY, []));
+  const [loading, setLoading] = useState(false);
+  const [reparsing, setReparsing] = useState(false);
+  const [bulkTask, setBulkTask] = useState(null);
+  const [error, setError] = useState(null);
+
+  const normalizedDataset = useMemo(() => ({
+    ...dataset,
+    bookTitle: (dataset.bookTitle || '').trim(),
+    versionTitle: dataset.versionTitle || null,
+    lang: dataset.lang || null,
+  }), [dataset]);
+
+  const persistState = useCallback((next = {}) => {
+    if (typeof localStorage === 'undefined') { return; }
+    const state = {dataset: normalizedDataset, page, item, total, stats, ...next};
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  }, [normalizedDataset, page, item, total, stats]);
+
+  useEffect(() => {
+    persistState();
+  }, [persistState]);
+
+  const rememberItem = useCallback((nextItem) => {
+    if (!nextItem) { return; }
+    setHistory(prev => {
+      const filtered = prev.filter(entry => resultKey(entry) !== resultKey(nextItem));
+      const next = [nextItem, ...filtered].slice(0, 10);
+      if (typeof localStorage !== 'undefined') {
+        localStorage.setItem(HISTORY_KEY, JSON.stringify(next));
+      }
+      return next;
+    });
+  }, []);
+
+  const applySearchResponse = useCallback((data, nextPage) => {
+    const nextItem = data.results?.[0] || null;
+    setPage(nextPage);
+    setTotal(data.total || 0);
+    setStats(data.stats || {totalCitations: 0, parsedCitations: 0});
+    setItem(nextItem);
+    rememberItem(nextItem);
+  }, [rememberItem]);
+
+  const search = useCallback(async (nextPage = 0) => {
+    if (!normalizedDataset.bookTitle) { return; }
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await apiPost('/_api/linker-bulk-corrector/search', {dataset: normalizedDataset, page: nextPage, pageSize: 1});
+      applySearchResponse(data, nextPage);
+    } catch (e) {
+      setError(e.message || String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, [normalizedDataset, applySearchResponse]);
+
+  const navigate = useCallback(async (direction) => {
+    if (!item) {
+      search(0);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      let cursor = {ref: item.ref, charRange: item.charRange};
+      for (let i = 0; i < 20; i += 1) {
+        const data = await apiPost('/_api/linker-bulk-corrector/navigate', {dataset: normalizedDataset, direction, cursor});
+        if (data.found) {
+          setItem(data.item);
+          rememberItem(data.item);
+          setPage(data.position || 0);
+          return;
+        }
+        if (!data.continuationCursor) { return; }
+        cursor = data.continuationCursor;
+      }
+    } catch (e) {
+      setError(e.message || String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, [item, normalizedDataset, rememberItem, search]);
+
+  const reparseCurrent = useCallback(async () => {
+    if (!item) { return; }
+    setReparsing(true);
+    setError(null);
+    try {
+      const data = await apiPost('/_api/linker-bulk-corrector/citation/reparse', {
+        ref: item.ref,
+        versionTitle: item.versionTitle,
+        language: item.language,
+        charRange: item.charRange,
+      });
+      setItem(data);
+      rememberItem(data);
+    } catch (e) {
+      setError(e.message || String(e));
+    } finally {
+      setReparsing(false);
+    }
+  }, [item, rememberItem]);
+
+  const reparseDataset = useCallback(async () => {
+    if (!normalizedDataset.bookTitle) { return; }
+    setError(null);
+    const data = await apiPost('/_api/linker-bulk-corrector/reparse-dataset', {dataset: normalizedDataset});
+    setBulkTask({task_id: data.task_id, current: 0, total: null, state: 'PENDING'});
+  }, [normalizedDataset]);
+
+  useEffect(() => {
+    if (!bulkTask?.task_id || bulkTask.state === 'SUCCESS' || bulkTask.state === 'FAILURE') { return undefined; }
+    const timer = setInterval(async () => {
+      const data = await Sefaria._ApiPromise(`${Sefaria.apiHost}/api/async/${bulkTask.task_id}`);
+      setBulkTask({
+        ...bulkTask,
+        state: data.status || data.state,
+        current: data.meta?.current ?? data.current ?? bulkTask.current,
+        total: data.meta?.total ?? data.total ?? bulkTask.total,
+      });
+    }, 1500);
+    return () => clearInterval(timer);
+  }, [bulkTask]);
+
+  useEffect(() => {
+    const onKeyDown = (event) => {
+      if (event.target instanceof HTMLInputElement || event.target instanceof HTMLTextAreaElement) { return; }
+      if (event.key === 'ArrowRight' || event.key === 'l') { navigate('forward'); }
+      if (event.key === 'ArrowLeft' || event.key === 'h') { navigate('backward'); }
+      if (event.key === 'r') { reparseCurrent(); }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [navigate, reparseCurrent]);
+
+  const toggleStatus = (status) => {
+    const current = new Set(dataset.status || []);
+    if (current.has(status)) {
+      current.delete(status);
+    } else {
+      current.add(status);
+    }
+    setDataset({...dataset, status: Array.from(current)});
+  };
+
+  const parsedPct = stats.totalCitations ? Math.round((stats.parsedCitations / stats.totalCitations) * 100) : 0;
+
+  return (
+    <div className="linkerBulkCorrector sans-serif">
+      <aside className="lbcSidebar">
+        <section>
+          <h2>Stats</h2>
+          <div className="lbcStatNumber">{stats.parsedCitations} / {stats.totalCitations}</div>
+          <div className="lbcProgress"><span style={{width: `${parsedPct}%`}} /></div>
+        </section>
+        <section className="lbcHistory">
+          <h2>Previous 10</h2>
+          {history.map(entry => (
+            <button type="button" key={resultKey(entry)} onClick={() => setItem(entry)}>
+              <span>{entry.ref}</span>
+              <SmallMeta item={entry} />
+            </button>
+          ))}
+        </section>
+        <section className="lbcShortcuts">
+          <h2>Shortcuts</h2>
+          <div><kbd>right</kbd> / <kbd>l</kbd> Forward</div>
+          <div><kbd>left</kbd> / <kbd>h</kbd> Back</div>
+          <div><kbd>r</kbd> Re-parse</div>
+        </section>
+      </aside>
+      <main className="lbcMain">
+        <div className="lbcSearch">
+          <IndexTitleAutocomplete
+            value={dataset.bookTitle}
+            onChange={bookTitle => setDataset({...dataset, bookTitle})}
+          />
+          <input
+            type="text"
+            placeholder="Version title"
+            value={dataset.versionTitle || ''}
+            onChange={e => setDataset({...dataset, versionTitle: e.target.value})}
+          />
+          <select value={dataset.lang || ''} onChange={e => setDataset({...dataset, lang: e.target.value || null})}>
+            <option value="">he + en</option>
+            <option value="he">he</option>
+            <option value="en">en</option>
+          </select>
+          <div className="lbcSegmented">
+            {STATUS_OPTIONS.map(status => (
+              <StatusToggle key={status} status={status} selected={(dataset.status || []).includes(status)} onClick={() => toggleStatus(status)} />
+            ))}
+          </div>
+          <button type="button" className="button" onClick={() => search(0)} disabled={loading}>Search</button>
+          <button type="button" className="button" onClick={reparseDataset} disabled={loading}>Re-parse Results</button>
+        </div>
+        {error ? <div className="lbcError">{error}</div> : null}
+        {bulkTask ? <div className="lbcTask">Re-parse: {bulkTask.current || 0} / {bulkTask.total || '?'} ({bulkTask.state})</div> : null}
+        <ResultDetails item={item} onReparse={reparseCurrent} reparsing={reparsing} />
+      </main>
+      <nav className="lbcNavOverlay">
+        <button type="button" onClick={() => navigate('backward')} disabled={loading}>Back</button>
+        <span>{item ? `${page + 1} / ${total || '?'}` : 'No item'}</span>
+        <button type="button" onClick={() => navigate('forward')} disabled={loading}>Forward</button>
+      </nav>
+    </div>
+  );
+};
+
+export default LinkerBulkCorrectorPage;

--- a/static/js/LinkerBulkCorrectorPage.jsx
+++ b/static/js/LinkerBulkCorrectorPage.jsx
@@ -420,6 +420,7 @@ const LinkerBulkCorrectorPage = () => {
         state: data.status || data.state,
         current: data.meta?.current ?? data.current ?? bulkTask.current,
         total: data.meta?.total ?? data.total ?? bulkTask.total,
+        skipped: data.meta?.skipped ?? data.result?.skipped ?? bulkTask.skipped,
       });
     }, 1500);
     return () => clearInterval(timer);
@@ -498,7 +499,7 @@ const LinkerBulkCorrectorPage = () => {
           <button type="button" className="button" onClick={reparseDataset} disabled={loading}>Re-parse Results</button>
         </div>
         {error ? <div className="lbcError">{error}</div> : null}
-        {bulkTask ? <div className="lbcTask">Re-parse: {bulkTask.current || 0} / {bulkTask.total || '?'} ({bulkTask.state})</div> : null}
+        {bulkTask ? <div className="lbcTask">Re-parse: {bulkTask.current || 0} / {bulkTask.total || '?'} ({bulkTask.state}){bulkTask.skipped ? `, skipped ${bulkTask.skipped}` : ''}</div> : null}
         <ResultDetails item={item} onReparse={reparseCurrent} reparsing={reparsing} />
       </main>
       <nav className="lbcNavOverlay">

--- a/static/js/LinkerBulkCorrectorPage.jsx
+++ b/static/js/LinkerBulkCorrectorPage.jsx
@@ -76,11 +76,19 @@ const IndexTitleAutocomplete = ({value, onChange}) => {
       onChange((item.name || '').trim());
     }
   };
-  const renderInput = (highlightedIndex, highlightedSuggestion, getInputProps) => {
+  const renderInput = (highlightedIndex, highlightedSuggestion, getInputProps, setInputValue, suggestions) => {
     const inputProps = getInputProps({
       className: 'lbcSearchInput',
       placeholder: 'Book title',
       defaultValue: value || '',
+      onKeyDown: (event) => {
+        if (event.key !== 'Enter') { return; }
+        const item = highlightedSuggestion || suggestions[0];
+        if (!item) { return; }
+        event.preventDefault();
+        setInputValue(item.name);
+        select(item);
+      },
     });
     const originalOnChange = inputProps.onChange;
     return (
@@ -111,13 +119,6 @@ const IndexTitleAutocomplete = ({value, onChange}) => {
       renderInput={renderInput}
       renderItems={renderItems}
       onSelectedItemChange={({selectedItem}) => { if (selectedItem) { select(selectedItem); } }}
-      onEnter={({event, highlightedSuggestion, suggestions}) => {
-        const item = highlightedSuggestion || suggestions[0];
-        if (!item) { return false; }
-        event.preventDefault();
-        select(item);
-        return true;
-      }}
     />
   );
 };

--- a/static/js/LinkerBulkCorrectorPage.jsx
+++ b/static/js/LinkerBulkCorrectorPage.jsx
@@ -169,9 +169,58 @@ const LinkerPairings = ({pairings, contextType}) => {
 };
 
 const ResultDetails = ({item, onReparse, reparsing}) => {
+  const [datasetAction, setDatasetAction] = useState(null);
+  const [datasetReason, setDatasetReason] = useState('');
+  const [datasetBusy, setDatasetBusy] = useState(false);
+  const [datasetMessage, setDatasetMessage] = useState(null);
+  const [datasetError, setDatasetError] = useState(null);
+
+  useEffect(() => {
+    setDatasetAction(null);
+    setDatasetReason('');
+    setDatasetMessage(null);
+    setDatasetError(null);
+  }, [resultKey(item)]);
+
   if (!item) {
     return <div className="lbcEmpty">Search for a book to load citations.</div>;
   }
+
+  const openDatasetAction = (action) => {
+    setDatasetAction(action);
+    setDatasetReason('');
+    setDatasetMessage(null);
+    setDatasetError(null);
+  };
+
+  const submitDatasetExample = async () => {
+    const reason = datasetReason.trim();
+    if (!datasetAction || !reason) { return; }
+    setDatasetBusy(true);
+    setDatasetMessage(null);
+    setDatasetError(null);
+    try {
+      const isRefPart = datasetAction === 'ref-part';
+      const result = await apiPost(
+        isRefPart ? '/_api/linker-admin/dataset/ref-part' : '/_api/linker-admin/dataset/ref',
+        {
+          ref: item.ref,
+          lang: item.language,
+          versionTitle: item.versionTitle,
+          reason,
+          ...(isRefPart ? {charRange: item.charRange} : {}),
+        },
+      );
+      setDatasetMessage(`Saved ${isRefPart ? 'Ref Part' : 'Ref'} dataset example (${result.numEntities} labels)`);
+      setDatasetAction(null);
+      setDatasetReason('');
+    } catch (e) {
+      setDatasetError(e.message || String(e));
+    } finally {
+      setDatasetBusy(false);
+    }
+  };
+
   return (
     <div className="lbcResult">
       <div className="lbcResultHeader">
@@ -180,10 +229,39 @@ const ResultDetails = ({item, onReparse, reparsing}) => {
           <SmallMeta item={item} />
         </div>
         <div className={`lbcStatus ${item.status}`}>{item.status}</div>
-        <button type="button" className="button small" onClick={onReparse} disabled={reparsing}>
-          {reparsing ? 'Re-parsing' : 'Re-parse'}
-        </button>
+        <div className="lbcResultActions">
+          <button type="button" className="button small" onClick={onReparse} disabled={reparsing}>
+            {reparsing ? 'Re-parsing' : 'Re-parse'}
+          </button>
+          <button type="button" className="button small" onClick={() => openDatasetAction('ref')} disabled={datasetBusy}>
+            + Ref Dataset
+          </button>
+          <button type="button" className="button small" onClick={() => openDatasetAction('ref-part')} disabled={datasetBusy}>
+            + Ref Part Dataset
+          </button>
+          {datasetAction ? (
+            <div className="lbcDatasetReason">
+              <input
+                type="text"
+                placeholder="Reason"
+                value={datasetReason}
+                onChange={event => setDatasetReason(event.target.value)}
+                onKeyDown={event => {
+                  if (event.key === 'Enter' && datasetReason.trim()) {
+                    submitDatasetExample();
+                  }
+                }}
+                autoFocus
+              />
+              <button type="button" className="button small" onClick={submitDatasetExample} disabled={datasetBusy || !datasetReason.trim()}>
+                Save
+              </button>
+            </div>
+          ) : null}
+        </div>
       </div>
+      {datasetMessage ? <div className="linkerAdminMessage">{datasetMessage}</div> : null}
+      {datasetError ? <div className="lbcError">{datasetError}</div> : null}
       <div className="lbcSnippet" dangerouslySetInnerHTML={{__html: item.snippet?.html || ''}} />
       <div className="lbcColumns">
         <section>

--- a/static/js/ReaderApp.jsx
+++ b/static/js/ReaderApp.jsx
@@ -646,6 +646,11 @@ class ReaderApp extends Component {
               hist.url += "&book=" + encodeURIComponent(state.linkerEditorBook);
             }
             break;
+          case "linkerBulkCorrector":
+            hist.title = Sefaria._("Linker Bulk Corrector");
+            hist.url = "linker-bulk-corrector";
+            hist.mode = "linkerBulkCorrector";
+            break;
           case "user_stats":
             hist.title = Sefaria.getPageTitle("user_stats.torah_tracker");
             hist.url = "torahtracker";
@@ -1415,6 +1420,9 @@ toggleSignUpModal(modalContentKind = SignUpModalKind.Default) {
     } else if (path === "/linker-editor") {
       this.showLinkerEditor(params.get("book"));
 
+    } else if (path === "/linker-bulk-corrector") {
+      this.showLinkerBulkCorrector();
+
     } else if (path.match(/^\/sheets\/\d+/)) {
       openPanel("Sheet " + path.replace(/^\/sheets\//, ''));
 
@@ -2068,6 +2076,9 @@ toggleSignUpModal(modalContentKind = SignUpModalKind.Default) {
   }
   showLinkerEditor(book) {
     this.setSinglePanelState({menuOpen: "linkerEditor", linkerEditorBook: book || null});
+  }
+  showLinkerBulkCorrector() {
+    this.setSinglePanelState({menuOpen: "linkerBulkCorrector"});
   }
   showCollections() {
     this.setSinglePanelState({menuOpen: "collectionsPublic"});

--- a/static/js/ReaderPanel.jsx
+++ b/static/js/ReaderPanel.jsx
@@ -26,6 +26,7 @@ import CalendarsPage from './CalendarsPage'
 import UserStats  from './UserStats';
 import ModeratorToolsPanel  from './ModeratorToolsPanel';
 import LinkerEditorPage from './LinkerEditorPage';
+import LinkerBulkCorrectorPage from './LinkerBulkCorrectorPage';
 import PublicCollectionsPage from './PublicCollectionsPage';
 import TranslationsPage from './TranslationsPage';
 import { TextColumnBannerChooser } from './TextColumnBanner';
@@ -1107,6 +1108,13 @@ class ReaderPanel extends Component {
           interfaceLang={this.props.interfaceLang}
           initialBook={this.state.linkerEditorBook}
           onBookChange={this.setLinkerEditorBook.bind(this)}
+        />
+      );
+
+    } else if (this.state.menuOpen === "linkerBulkCorrector") {
+      menu = (
+        <LinkerBulkCorrectorPage
+          interfaceLang={this.props.interfaceLang}
         />
       );
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -125,6 +125,9 @@
     {% if page == 'linkerEditor' %}
     <link rel="stylesheet" href="{% static 'css/linker-editor.css' %}">
     {% endif %}
+    {% if page == 'linkerBulkCorrector' %}
+    <link rel="stylesheet" href="{% static 'css/linker-bulk-corrector.css' %}">
+    {% endif %}
     <!-- Specific styling to correct behavior of Unbounce banners -->
     <link rel="stylesheet" href="{% static 'css/unbounce-banner.css' %}">
 


### PR DESCRIPTION
This pull request introduces a new "Linker Bulk Corrector" feature for staff users, providing a UI and backend API for searching, navigating, and bulk re-parsing stored linker citation spans. It also adds support for tracking reasons when adding dataset examples and includes several related backend enhancements and optimizations.

**New Feature: Linker Bulk Corrector**

* Adds a staff-only "Linker Bulk Corrector" page and route to the frontend (`ReaderApp.jsx`, `ReaderPanel.jsx`, `reader/views.py`, `sefaria/urls_library.py`, `static/css/linker-bulk-corrector.css`). [[1]](diffhunk://#diff-b38056fa7d04452f7f5054642161d20aeed30be42a240458a534c4782875d9d9R649-R653) [[2]](diffhunk://#diff-b38056fa7d04452f7f5054642161d20aeed30be42a240458a534c4782875d9d9R1423-R1425) [[3]](diffhunk://#diff-b38056fa7d04452f7f5054642161d20aeed30be42a240458a534c4782875d9d9R2080-R2082) [[4]](diffhunk://#diff-59069556be1ae431638b9e58ae13b0c63dad47273356b0728af8542f7ce9568dR29) [[5]](diffhunk://#diff-59069556be1ae431638b9e58ae13b0c63dad47273356b0728af8542f7ce9568dR1114-R1120) [[6]](diffhunk://#diff-26c40bdd3eeaef442340754126fdbcb1ed9e451eb3bb31c02cb78053f5702eaaR1410-R1416) [[7]](diffhunk://#diff-ea5b33e971bd697a8723084472b6d9ab09957982d08af5a5429ecc10e3c8cbf5R27) [[8]](diffhunk://#diff-a4c6ea9e3631e799d47129580f665c4bc803548d9498b0de4e0fed42b8e113a0R1-R331)
* Implements corresponding API endpoints for search, navigation, and (re-)parsing citations and datasets (`api/linker_bulk_corrector_views.py`, `sefaria/urls_shared.py`). [[1]](diffhunk://#diff-4a65b715bd9d610fb529f102246ebee48cb05f03b9937117ccb881cd99fc8a05R1-R46) [[2]](diffhunk://#diff-8f355aa80bd3ead68ed63deaf8856b8ae9f3d71a6234d67dfe6cbcdb984e19e0R10) [[3]](diffhunk://#diff-8f355aa80bd3ead68ed63deaf8856b8ae9f3d71a6234d67dfe6cbcdb984e19e0R136-R141)

**Backend Enhancements for Linker Tasks**

* Adds batch parsing and bulk dataset re-parsing Celery tasks, and synchronous helpers for batch operations (`sefaria/helper/linker/tasks.py`, `sefaria/helper/linker_resource_panel_admin.py`). [[1]](diffhunk://#diff-6ca2bd7b035940a24296b5c125b8855f08f70f9a87712b2e9dd9eb666f64e23aR1080-R1092) [[2]](diffhunk://#diff-481bfa07ed8f6b370480e59655fad51fd993f7602c2138d0537a87ba81892665R324-R336) [[3]](diffhunk://#diff-481bfa07ed8f6b370480e59655fad51fd993f7602c2138d0537a87ba81892665R376-R387)
* Registers the new "bulk_reparse_dataset" action in the linker editor history (`sefaria/model/linker_editor_history.py`).

**Dataset Example Improvements**

* Adds support for an optional `reason` field when adding or updating linker dataset examples, including backend, model, and schema updates (`sefaria/helper/linker_resource_panel_admin.py`, `sefaria/model/linker_dataset_example.py`). [[1]](diffhunk://#diff-481bfa07ed8f6b370480e59655fad51fd993f7602c2138d0537a87ba81892665R402-R406) [[2]](diffhunk://#diff-481bfa07ed8f6b370480e59655fad51fd993f7602c2138d0537a87ba81892665L434-R458) [[3]](diffhunk://#diff-481bfa07ed8f6b370480e59655fad51fd993f7602c2138d0537a87ba81892665L552-R576) [[4]](diffhunk://#diff-2f5dc94d5fca436b8a11bcc499266ef57e69fae4ba7268fb3d7eea6ca7394686R33) [[5]](diffhunk://#diff-2f5dc94d5fca436b8a11bcc499266ef57e69fae4ba7268fb3d7eea6ca7394686R44)

**Database and Model Optimizations**

* Adds new database indices for `marked_up_text_chunks` and `linker_output` collections to optimize queries by ref, versionTitle, and language (`sefaria/system/database.py`).
* Adds a `disqualificationReason` field to the `LinkerOutput` model schema to track why a citation span might be disqualified (`sefaria/model/marked_up_text_chunk.py`).

These changes collectively provide staff with powerful tools for managing and correcting linker citations at scale, while improving tracking and performance for related data operations.