### PR TITLE
Fix limited number of Strapi entries for banners, modals, and sidebar ads

### DIFF
--- a/static/js/context.js
+++ b/static/js/context.js
@@ -123,6 +123,7 @@ const buildLocalizedQueryBlock = (contentType, filtersExpression, fieldsSelectio
           ${locale}_${contentType}: ${contentType}(
             locale: "${locale}"
             filters: ${filtersExpression}
+            pagination: { limit: -1 }
           ) {
             ${fieldsSelection}
           }


### PR DESCRIPTION
### Description

Banners, modals, and sidebar ads are all fetched from Strapi in a single GraphQL query. Editors can publish more than 10 of any one of these at the same time, but only the first 10 entries Strapi happened to return would appear on the website. Any remaining entries were silently dropped.

**Why:** GraphQL queries for a collection (a list of documents, such as all banners) are paginated. When a query doesn't specify how many results it needs, Strapi's GraphQL plugin uses its built-in default limit of **10**. This query was missing the pagination limit already used by other queries on the website, so it only received Strapi's default 10 entries.

**The fix:** Add `pagination: { limit: -1 }` to the query. In Strapi's GraphQL API, `-1` turns off pagination for that field. The same pattern is already used elsewhere in the codebase, so this PR makes the banners, modals, and sidebar ads query consistent with the existing convention instead of introducing a new one.

### How this was confirmed

I checked three separate places to confirm that `pagination: { limit: -1 }` would work:

1.  **The official Strapi documentation** (`https://docs.strapi.io/cms/api/graphql`) states that `pagination: { limit: -1 }` is the way to request every entry in a single request.

2.  **The Strapi plugin source**, checked in `@strapi/plugin-graphql` and `@strapi/utils`:

    -   `default-config.js` shows that the plugin's `maxLimit`, which controls the hard ceiling on the number of results, defaults to `-1`. This means there is no hard ceiling.

    -   `pagination.js` shows that the fallback limit is hard-coded to `10` when a query doesn't include a `pagination` argument (`STRAPI_DEFAULTS.offset.limit = 10`). This is Strapi's internal default, not something set in our configuration.

3.  **Our Strapi configuration** in `config/plugins.js` doesn't override either value. There is nothing in our CMS configuration preventing `limit: -1` from working, so the change only needs to be made in the query, not on the CMS side.

Strapi already allowed an unlimited number of results, but the query wasn't asking for more than the default 10. This change makes the frontend explicitly request every matching entry.

### Code Change

| File | Purpose |
| --- | --- |
| `static/js/context.js` | `buildLocalizedQueryBlock`, which generates the query for banners, modals, and sidebar ads once per supported locale, now adds `pagination: { limit: -1 }` to every generated query field. |