### PR TITLE
fix(search): load more results when scrolling on mobile web

### DIFF
--- a/static/js/Hooks.jsx
+++ b/static/js/Hooks.jsx
@@ -58,13 +58,26 @@ function useDebounce(value, delay) {
  * scroller: on singlePanel the document scrolls instead, though not for every
  * container, so it is decided per element rather than per breakpoint. */
 
-// Overflow alone is not enough: `overflow-y: visible` beside `overflow-x: hidden` computes to
-// `auto` (.noOverflowX does this to TopicPage), so real overflow has to be checked too.
+// `scroll` always scrolls, `auto` and `overlay` only when the content does not fit, and
+// `visible` never does.
+const OVERFLOW_VALUES_THAT_CAN_SCROLL = ['scroll', 'auto', 'overlay'];
+
+// Both halves are needed, because `auto` is a condition rather than a promise: it means "scroll
+// only if the content does not fit". A container can report `auto` and still never scroll.
 const isScrollingElement = (el) => {
   if (!el) { return false; }
+
+  // Does the CSS permit a scrollbar? Not enough on its own -- `overflow-y: visible` beside an
+  // `overflow-x` that is not visible computes to `auto`, which is what .noOverflowX does to the
+  // topic and profile containers.
   const {overflowY} = window.getComputedStyle(el);
-  if (!['scroll', 'auto', 'overlay'].includes(overflowY)) { return false; }
-  return el.scrollHeight > el.clientHeight;
+  const overflowAllowsScrolling = OVERFLOW_VALUES_THAT_CAN_SCROLL.includes(overflowY);
+
+  // Is the box actually hiding anything? On singlePanel these containers grow to their full
+  // content height, so nothing is hidden, no scrollbar appears, and no scroll event ever fires.
+  const contentIsTallerThanBox = el.scrollHeight > el.clientHeight;
+
+  return overflowAllowsScrolling && contentIsTallerThanBox;
 };
 
 // A null scroller means the document scrolls.

--- a/static/js/Hooks.jsx
+++ b/static/js/Hooks.jsx
@@ -51,6 +51,59 @@ function useDebounce(value, delay) {
   return debouncedValue;
 }
 
+
+/* Shared infinite-scroll trigger. Everything that loads on scroll binds through
+ * here, because getting the scroller wrong fails silently -- a listener on a non-scrolling
+ * element simply never fires. The container a component renders into is not always the
+ * scroller: on singlePanel the document scrolls instead, though not for every
+ * container, so it is decided per element rather than per breakpoint. */
+
+// Overflow alone is not enough: `overflow-y: visible` beside `overflow-x: hidden` computes to
+// `auto` (.noOverflowX does this to TopicPage), so real overflow has to be checked too.
+const isScrollingElement = (el) => {
+  if (!el) { return false; }
+  const {overflowY} = window.getComputedStyle(el);
+  if (!['scroll', 'auto', 'overlay'].includes(overflowY)) { return false; }
+  return el.scrollHeight > el.clientHeight;
+};
+
+// A null scroller means the document scrolls.
+const pixelsToBottom = (scroller) => (
+  scroller
+    ? scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight
+    : document.documentElement.scrollHeight - window.scrollY - window.innerHeight
+);
+
+// Returns an unsubscribe function.
+const observeNearBottom = (candidate, margin, onNearBottom) => {
+  const handler = () => {
+    // Re-checked per event: a container too short to scroll on page 1 can become the scroller.
+    const scroller = isScrollingElement(candidate) ? candidate : null;
+    if (pixelsToBottom(scroller) <= margin) { onNearBottom(); }
+  };
+  // Only one can fire: element scroll events don't bubble, document scroll is window-only.
+  const targets = candidate ? [candidate, window] : [window];
+  targets.forEach(t => t.addEventListener('scroll', handler, {passive: true}));
+  return () => targets.forEach(t => t.removeEventListener('scroll', handler));
+};
+
+/**
+ * Fires `onNearBottom` within `margin` px of the bottom of `getScrollCandidate()`, or of the
+ * document when that element is not the scroller. `onNearBottom` is read fresh on every event,
+ * so it need not be stable; callers do their own "already loading" / "nothing left" guarding.
+ * `enabled: false` skips binding; `deps` re-bind (normally the resolved element).
+ */
+function useScrollNearBottom({getScrollCandidate, margin, onNearBottom, enabled = true, deps = []}) {
+  const latestOnNearBottom = useRef(onNearBottom);
+  latestOnNearBottom.current = onNearBottom;
+
+  useEffect(() => {
+    if (!enabled) { return; }
+    return observeNearBottom(getScrollCandidate(), margin, () => latestOnNearBottom.current());
+  }, [enabled, margin, ...deps]);
+}
+
+
 /**
  * Hook for paginated data loading triggered by scroll position.
  *
@@ -97,25 +150,13 @@ function useScrollToLoad({scrollableRef, url, setter, itemsPreLoaded = 0, pageSi
     }
   }, []);
 
-  // Scroll listener for infinite loading
-  useEffect(() => {
-    const scrollable = scrollableRef.current;
-    if (!scrollable) return;
-
-    const scrollMargin = 600;  // Pixels from bottom to trigger load
-
-    const handleScroll = () => {
-      const scrollPosition = scrollable.scrollTop + scrollable.clientHeight;
-      const scrollThreshold = scrollable.scrollHeight - scrollMargin;
-
-      if (scrollPosition >= scrollThreshold) {
-        loadMore();
-      }
-    };
-
-    scrollable.addEventListener('scroll', handleScroll);
-    return () => scrollable.removeEventListener('scroll', handleScroll);
-  }, [loadMore]);
+  // `loadMore` guards itself against overlapping and past-the-end calls.
+  useScrollNearBottom({
+    getScrollCandidate: () => scrollableRef.current,
+    margin: 600,
+    onNearBottom: loadMore,
+    deps: [scrollableRef.current],
+  });
 }
 
 
@@ -142,20 +183,15 @@ function usePaginatedDisplay(scrollable_element_ref, input, pageSize, bottomMarg
     setLoadedToEnd(false);
   }, [scrollable_element_ref && scrollable_element_ref.current, input]);
   const numPages = useMemo(() => Math.ceil(input.length/pageSize), [input, pageSize]);
-  useEffect(() => {
-    if (!scrollable_element_ref) { return; }
-    const scrollable_element = $(scrollable_element_ref.current);
-    const handleScroll = () => {
-      if (loadedToEnd) { return; }
-      if (scrollable_element.scrollTop() + scrollable_element.innerHeight() + bottomMargin >= scrollable_element[0].scrollHeight) {
-        setPage(prevPage => prevPage + 1);
-      }
-    };
-    scrollable_element.on("scroll", handleScroll);
-    return () => {
-      scrollable_element.off("scroll", handleScroll);
-    }
-  }, [scrollable_element_ref && scrollable_element_ref.current, loadedToEnd]);
+  // No ref at all means the caller opts out of scroll pagination entirely -- not the same as
+  // passing a ref to a container that turns out not to be the scroller.
+  useScrollNearBottom({
+    getScrollCandidate: () => scrollable_element_ref.current,
+    margin: bottomMargin,
+    onNearBottom: () => { if (!loadedToEnd) { setPage(prevPage => prevPage + 1); } },
+    enabled: !!scrollable_element_ref,
+    deps: [scrollable_element_ref && scrollable_element_ref.current],
+  });
   useEffect(() => {
     setInputUpToPage(prev => {
       // decide whether or not inputUpToPage has changed. if it's the same element-by-element to `prev`, return `prev`
@@ -248,6 +284,7 @@ function usePaginatedLoad(fetchDataByPage, setter, identityElement, numPages, re
 }
 
 export {
+  useScrollNearBottom,
   useScrollToLoad,
   usePaginatedDisplay,
   useDebounce,

--- a/static/js/InfiniteScroll.jsx
+++ b/static/js/InfiniteScroll.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef } from 'react';
 import $ from './sefaria/sefariaJquery';
 import Sefaria from './sefaria/sefaria';
+import { useScrollNearBottom } from './Hooks';
 import { LoadingMessage } from './Misc';
 
 // How close (px) to the bottom of the scroll container before we ask for the next page.
@@ -17,8 +18,9 @@ const LOADING_MORE_STRING_ID = "search_page.loading_more_results";
  * Books / Authors / Topics entity tabs.
  *
  * - `hasMore` / `isLoading` gate the trigger (never load past the end, never overlap a
- *   running query). They're read through a ref so the scroll handler binds once and always
- *   sees current values without re-attaching on every render.
+ *   running query).
+ * - `scrollableSelector` is only a *candidate* container -- `useScrollNearBottom` decides
+ *   whether it or the document is the actual scroller.
  * - `isLoadingMore` controls the bottom "Loading more results..." message — the caller sets
  *   it only when appending to an existing list, so an *initial* load (skeleton / "Searching...")
  *   is left to the parent.
@@ -26,9 +28,7 @@ const LOADING_MORE_STRING_ID = "search_page.loading_more_results";
 const InfiniteScroll = ({ className, hasMore, isLoading, isLoadingMore, loadMore,
                           scrollableSelector = '.content', children }) => {
   const ref = useRef(null);
-  const latest = useRef({});
   const pending = useRef(false);
-  latest.current = { hasMore, isLoading, loadMore };
 
   // Clear the pending guard once the parent acknowledges the request by flipping isLoading on,
   // then back off. Without this, rapid scroll events between the loadMore() call and the next
@@ -37,20 +37,16 @@ const InfiniteScroll = ({ className, hasMore, isLoading, isLoadingMore, loadMore
     if (!isLoading) { pending.current = false; }
   }, [isLoading]);
 
-  useEffect(() => {
-    const $scrollable = $(ref.current).closest(scrollableSelector);
-    if (!$scrollable.length) { return; }
-    const onScroll = () => {
-      const { hasMore, isLoading, loadMore } = latest.current;
+  useScrollNearBottom({
+    getScrollCandidate: () => $(ref.current).closest(scrollableSelector)[0],
+    margin: SCROLL_MARGIN,
+    onNearBottom: () => {
       if (!hasMore || isLoading || pending.current) { return; }
-      if ($scrollable.scrollTop() + $scrollable.innerHeight() + SCROLL_MARGIN >= $scrollable[0].scrollHeight) {
-        pending.current = true;
-        loadMore();
-      }
-    };
-    $scrollable.on('scroll.infiniteScroll', onScroll);
-    return () => $scrollable.off('scroll.infiniteScroll', onScroll);
-  }, [scrollableSelector]);
+      pending.current = true;
+      loadMore();
+    },
+    deps: [scrollableSelector],
+  });
 
   return (
     <div className={className} ref={ref}>

--- a/static/js/tests/useScrollNearBottom.test.js
+++ b/static/js/tests/useScrollNearBottom.test.js
@@ -1,0 +1,166 @@
+/**
+ * useScrollNearBottom: picking the element that actually scrolls (sc-46995).
+ *
+ * The bug is silent -- a `scroll` listener on a non-scrolling div never fires -- and the
+ * scroller cannot be inferred from the breakpoint, so these pin down all four real cases.
+ *
+ * No React Testing Library in this repo -- react-dom directly, same pattern as
+ * static/js/tests/searchResultCardAuxClick.test.js.
+ */
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { act } from 'react-dom/test-utils';
+import { useScrollNearBottom } from '../Hooks';
+
+// jsdom does no layout, so scroll geometry is always 0. Stamp it on by hand.
+const withGeometry = (el, {scrollHeight, clientHeight, scrollTop = 0}) => {
+  Object.defineProperty(el, 'scrollHeight', {value: scrollHeight, configurable: true});
+  Object.defineProperty(el, 'clientHeight', {value: clientHeight, configurable: true});
+  Object.defineProperty(el, 'scrollTop', {value: scrollTop, writable: true, configurable: true});
+  return el;
+};
+
+const setDocumentGeometry = ({scrollHeight, innerHeight, scrollY}) => {
+  Object.defineProperty(document.documentElement, 'scrollHeight', {value: scrollHeight, configurable: true});
+  Object.defineProperty(window, 'innerHeight', {value: innerHeight, writable: true, configurable: true});
+  Object.defineProperty(window, 'scrollY', {value: scrollY, writable: true, configurable: true});
+};
+
+const Probe = ({candidate, onNearBottom, margin = 300}) => {
+  useScrollNearBottom({getScrollCandidate: () => candidate, margin, onNearBottom});
+  return null;
+};
+
+const renderProbe = (props) => {
+  const host = document.createElement('div');
+  document.body.appendChild(host);
+  act(() => { ReactDOM.render(<Probe {...props} />, host); });
+  return () => act(() => { ReactDOM.unmountComponentAtNode(host); });
+};
+
+describe('useScrollNearBottom', () => {
+  let candidate;
+
+  beforeEach(() => {
+    candidate = document.createElement('div');
+    document.body.appendChild(candidate);
+    // A document far from its bottom, so any fire must have come from the element.
+    setDocumentGeometry({scrollHeight: 10000, innerHeight: 800, scrollY: 0});
+  });
+
+  afterEach(() => { document.body.innerHTML = ''; });
+
+  test('desktop: fires on the container that scrolls', () => {
+    // .readerNavMenu .content on desktop -- fixed height, own scrollbar, overflowing.
+    candidate.style.overflowY = 'scroll';
+    withGeometry(candidate, {scrollHeight: 5000, clientHeight: 800, scrollTop: 4000});
+    const onNearBottom = jest.fn();
+    renderProbe({candidate, onNearBottom});
+
+    act(() => { candidate.dispatchEvent(new Event('scroll')); });
+
+    // 5000 - 4000 - 800 = 200px left, inside the 300px margin.
+    expect(onNearBottom).toHaveBeenCalled();
+  });
+
+  test('desktop: stays quiet while the container is far from its bottom', () => {
+    candidate.style.overflowY = 'scroll';
+    withGeometry(candidate, {scrollHeight: 5000, clientHeight: 800, scrollTop: 0});
+    const onNearBottom = jest.fn();
+    renderProbe({candidate, onNearBottom});
+
+    act(() => { candidate.dispatchEvent(new Event('scroll')); });
+
+    expect(onNearBottom).not.toHaveBeenCalled();
+  });
+
+  test('mobile: falls back to the document when the container stops scrolling', () => {
+    // .readerNavMenu .content on singlePanel: overflow-y: visible, height: auto.
+    candidate.style.overflowY = 'visible';
+    withGeometry(candidate, {scrollHeight: 5000, clientHeight: 5000});
+    setDocumentGeometry({scrollHeight: 5000, innerHeight: 800, scrollY: 4000});
+    const onNearBottom = jest.fn();
+    renderProbe({candidate, onNearBottom});
+
+    act(() => { window.dispatchEvent(new Event('scroll')); });
+
+    expect(onNearBottom).toHaveBeenCalled();
+  });
+
+  test('mobile: a container whose overflow-y COMPUTES to auto but never scrolls is not the scroller', () => {
+    // The .noOverflowX trap (s2.css:464): `overflow-y: visible` next to `overflow-x: hidden`
+    // computes to `auto`, which is what TopicPage and UserProfile get on mobile. jsdom does
+    // not implement that part of the cascade, so the computed result is set directly here.
+    // Geometry is what disambiguates: the div grew to fit its content, so it cannot scroll.
+    candidate.style.overflowY = 'auto';
+    withGeometry(candidate, {scrollHeight: 5000, clientHeight: 5000});
+    setDocumentGeometry({scrollHeight: 5000, innerHeight: 800, scrollY: 4000});
+    const onNearBottom = jest.fn();
+    renderProbe({candidate, onNearBottom});
+
+    act(() => { window.dispatchEvent(new Event('scroll')); });
+
+    expect(onNearBottom).toHaveBeenCalled();
+  });
+
+  test('mobile: a drawer that keeps its own scrollbar is still the scroller', () => {
+    // .textList .texts.content -- the connections-panel "Search in this Text" drawer. The
+    // singlePanel override never reaches it, so watching the document here would be wrong.
+    candidate.style.overflowY = 'scroll';
+    withGeometry(candidate, {scrollHeight: 5000, clientHeight: 400, scrollTop: 0});
+    // Document sitting right at its bottom: if the hook watched it, this would fire.
+    setDocumentGeometry({scrollHeight: 800, innerHeight: 800, scrollY: 0});
+    const onNearBottom = jest.fn();
+    renderProbe({candidate, onNearBottom});
+
+    act(() => { window.dispatchEvent(new Event('scroll')); });
+
+    expect(onNearBottom).not.toHaveBeenCalled();
+
+    candidate.scrollTop = 4400;
+    act(() => { candidate.dispatchEvent(new Event('scroll')); });
+
+    expect(onNearBottom).toHaveBeenCalled();
+  });
+
+  test('watches the document when there is no container at all', () => {
+    setDocumentGeometry({scrollHeight: 5000, innerHeight: 800, scrollY: 4000});
+    const onNearBottom = jest.fn();
+    renderProbe({candidate: null, onNearBottom});
+
+    act(() => { window.dispatchEvent(new Event('scroll')); });
+
+    expect(onNearBottom).toHaveBeenCalled();
+  });
+
+  test('unbinds on unmount', () => {
+    candidate.style.overflowY = 'scroll';
+    withGeometry(candidate, {scrollHeight: 5000, clientHeight: 800, scrollTop: 4000});
+    const onNearBottom = jest.fn();
+    const unmount = renderProbe({candidate, onNearBottom});
+
+    unmount();
+    act(() => { candidate.dispatchEvent(new Event('scroll')); });
+
+    expect(onNearBottom).not.toHaveBeenCalled();
+  });
+
+  test('calls the latest callback without re-binding', () => {
+    // Callers gate on state that changes every render (isLoading, loadedToEnd). The hook
+    // must see the current one, or infinite scroll would act on a stale snapshot.
+    candidate.style.overflowY = 'scroll';
+    withGeometry(candidate, {scrollHeight: 5000, clientHeight: 800, scrollTop: 4000});
+    const first = jest.fn();
+    const second = jest.fn();
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+
+    act(() => { ReactDOM.render(<Probe candidate={candidate} onNearBottom={first} />, host); });
+    act(() => { ReactDOM.render(<Probe candidate={candidate} onNearBottom={second} />, host); });
+    act(() => { candidate.dispatchEvent(new Event('scroll')); });
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalled();
+  });
+});

--- a/static/js/tests/useScrollNearBottom.test.js
+++ b/static/js/tests/useScrollNearBottom.test.js
@@ -1,5 +1,5 @@
 /**
- * useScrollNearBottom: picking the element that actually scrolls (sc-46995).
+ * useScrollNearBottom: picking the element that actually scrolls.
  *
  * The bug is silent -- a `scroll` listener on a non-scrolling div never fires -- and the
  * scroller cannot be inferred from the breakpoint, so these pin down all four real cases.


### PR DESCRIPTION
## What's broken

On mobile web, scrolling to the bottom of search results does nothing. No "Loading more
results..." message appears and no additional results load. On desktop the same search loads
more results correctly.

The same thing is broken on Topics, Collections, Profiles, and reading history in mobile web.

## Why

A `scroll` event only fires on an element that actually has its own scrollbar. If you attach a
scroll listener to a plain `<div>` that grows to fit its content, that listener is never called —
no error, no warning.  That is what happens on mobile. PR #3285 made the **whole page** scroll on mobile so
phone browsers can hide their address bar, which means the inner `.content` panel stopped
scrolling:

```css
/* static/css/s2.css */
.readerApp.singlePanel .readerNavMenu .content,
.readerApp.singlePanel .homeFeedWrapper .content { overflow-y: visible; }
```

Search, Topics, Collections and Profiles all render inside `.readerNavMenu .content`. Every one
of them had a scroll listener bound to that div, and every one of those listeners went dead on
mobile.

There were **three** separate hand-written copies of this listener, so the bug existed in three
places at once:

| File | Used by |
|---|---|
| `InfiniteScroll.jsx` | Search: Sources tab + Books / Authors / Topics tabs |
| `Hooks.jsx` → `useScrollToLoad` | Reading history |
| `Hooks.jsx` → `usePaginatedDisplay` | `FilterableList`: Topics, Collections, Profiles |

## The fix

All three now call one shared hook, `useScrollNearBottom` in `static/js/Hooks.jsx`. It works out
which element is really scrolling and listens to that — the container if it scrolls, otherwise
the page itself.

### Why not just check `Sefaria.multiPanel`?

The obvious one-line fix — *"if mobile, watch the page instead"* — is wrong, and would have
broken a feature that currently works.

The CSS rule above only applies to two selectors. It does **not** apply to the connections-panel
component that holds **"Search in this Text"**. On mobile that component is a fixed-height panel with
its very own scrollbar:

```css
.readerApp.singlePanel .textList { position: fixed; height: 54vh; }
.textList .texts            { height: 100%; overflow-y: scroll; }
```

So on mobile, one search list scrolls the page and another scrolls its own container.  Therefore, **whether
something scrolls is a property of the element, not of the screen size**, so checking `multiPanel` would have broken **"Search in this Text"**.

### The check that determines whether the hook should fire

We check both its CSS values that mean that scrolling is possible and we check the size of the container to make sure that it actually contains overflowing elements.
```
// `scroll` always scrolls, `auto` and `overlay` only when the content does not fit, and
// `visible` never does.
const OVERFLOW_VALUES_THAT_CAN_SCROLL = ['scroll', 'auto', 'overlay'];

// Both halves are needed, because `auto` is a condition rather than a promise: it means "scroll
// only if the content does not fit". A container can report `auto` and still never scroll.
const isScrollingElement = (el) => {
  if (!el) { return false; }

  // Does the CSS permit a scrollbar? Not enough on its own -- `overflow-y: visible` beside an
  // `overflow-x` that is not visible computes to `auto`, which is what .noOverflowX does to the
  // topic and profile containers.
  const {overflowY} = window.getComputedStyle(el);
  const overflowAllowsScrolling = OVERFLOW_VALUES_THAT_CAN_SCROLL.includes(overflowY);

  // Is the box actually hiding anything? On singlePanel these containers grow to their full
  // content height, so nothing is hidden, no scrollbar appears, and no scroll event ever fires.
  const contentIsTallerThanBox = el.scrollHeight > el.clientHeight;

  return overflowAllowsScrolling && contentIsTallerThanBox;
};
```