### PR TITLE
chore: allow topic, book, and category

### DIFF
--- a/helm-chart/sefaria/conf/nginx.template.conf.tpl
+++ b/helm-chart/sefaria/conf/nginx.template.conf.tpl
@@ -87,7 +87,7 @@ http {
     }
 
     # protect all non-allowed elasticsearch paths
-    location ~ ^/api/search/(?!(text|sheet|merged|merged-c)(/_search|/_analyze)/?) {
+    location ~ ^/api/search/(?!(text|sheet|merged|merged-c|topic|book|category)(/_search|/_analyze)/?) {
       return 403;
     }
 
@@ -191,7 +191,7 @@ http {
     }
 
     # protect all non-allowed elasticsearch paths
-    location ~ ^/api/search/(?!(text|sheet|merged|merged-c)(/_search|/_analyze)/?) {
+    location ~ ^/api/search/(?!(text|sheet|merged|merged-c|topic|book|category)(/_search|/_analyze)/?) {
       return 403;
     }
 


### PR DESCRIPTION
## Description
Our new search page includes an API call to retrieve books, topics and categories via /api/entity-search .  This currently fails if run locally and in your local_settings.py you set SEARCH_URL = "https://www.sefaria.org/api/search/".  The error is a 403 elasticsearch.AuthorizationException.  This is because nginx's `/api/search/` allowlist predates entity search and permits only `text|sheet|merged|merged-c`, while entity search queries `topic`, `book` and `category` (the last from `_resolve_categories`, so all three are needed).

Production is unaffected either way — in-cluster Django talks straight to Elasticsearch and never uses this proxy, which exists for callers outside the cluster.

## Code Changes

**`helm-chart/sefaria/conf/nginx.template.conf.tpl`** — added the three indices to the allowlist:

```diff
-location ~ ^/api/search/(?!(text|sheet|merged|merged-c)(/_search|/_analyze)/?) {
+location ~ ^/api/search/(?!(text|sheet|merged|merged-c|topic|book|category)(/_search|/_analyze)/?) {
```
