### PR TITLE
chore: reset margin top in navsidebar under 700 pixels

### DIFF
--- a/static/css/s2.css
+++ b/static/css/s2.css
@@ -4390,6 +4390,16 @@ body .ui-autocomplete.dictionary-toc-autocomplete .ui-menu-item a.ui-state-focus
 .searchContent .navSidebar {
   min-height: 100vh;
 }
+@media (max-width: 700px) {
+  .sidebarLayout {
+    flex-direction: column;
+  }
+  .navSidebar {
+    width: 100%;
+    margin-top: 0;
+    border-top: none;
+  }
+}
 .searchContent .navSidebar .searchFilters {
   /* Align the sidebar heading underline with the tab group underline:
      search bar (45px) + its margin (20px) + tab row height above the shared line */


### PR DESCRIPTION
## Description
On the search page below 700px wide, the "no results" message was partially hidden behind a gray block — the call-to-action button and the "report a bug / contact us" caption were cut off or invisible.  Turns out that this was a problem on many pages in the site so the fix here is global.

The cause is a background hack on .navSidebar in s2.css:1510-1517:
```
border-top: 80px solid #FBFBFA;
margin: -80px 0 0 0;
```

## Code Changes
margin-top: 0 — stops the sidebar being pulled up into the content. This alone removes the overlap.
border-top: none — removes the gray band itself, so no stray stripe is left behind.
width: 100% — the stacked sidebar was staying a fixed 420px, leaving dead space beside it.
