### PR TITLE
chore: hide the sign up modal

### DIFF
--- a/static/js/ReaderApp.jsx
+++ b/static/js/ReaderApp.jsx
@@ -142,7 +142,7 @@ class ReaderApp extends Component {
     this.setState({ editorSaveState: nextState });
     };
   handleAuthNavigate = (path, source = null) => {
-    // Hide the sign up modal and show the auth page, with the given path and source for analytics.
+    // Hide the sign up modal and show the auth page, with the given path and source.
     this.setState({ showAuth: true, authPath: path, authSource: source, showSignUpModal: false });
   }
   makePanelState(state) {

--- a/static/js/ReaderApp.jsx
+++ b/static/js/ReaderApp.jsx
@@ -142,7 +142,8 @@ class ReaderApp extends Component {
     this.setState({ editorSaveState: nextState });
     };
   handleAuthNavigate = (path, source = null) => {
-    this.setState({ showAuth: true, authPath: path, authSource: source });
+    // Hide the sign up modal and show the auth page, with the given path and source for analytics.
+    this.setState({ showAuth: true, authPath: path, authSource: source, showSignUpModal: false });
   }
   makePanelState(state) {
     // Return a full representation of a single panel's state, given a partial representation in `state`


### PR DESCRIPTION
## Description
When the user tried to do anything requiring they be logged in, we would show them a modal asking them to register or login.  However, clicking login or register would take them to the authentication page (AuthPage) but would not hide the modal.  

## Code Changes
Hide the modal when showing AuthPage.