### PR TITLE
Update documentation for parasha topic calendar endpoint

### DIFF
--- a/.github/workflows/readme-openapi-docs-sync.yml
+++ b/.github/workflows/readme-openapi-docs-sync.yml
@@ -5,7 +5,7 @@ name: Publish API Docs
 on:
   push:
     branches:
-      # This workflow will run every time you push code to the following branch: `master`
+      # This workflow will run every time you push code to the following branch: `prod`
       # Check out GitHub's docs for more info on configuring this:
       # https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
       - prod

--- a/docs/openAPI.json
+++ b/docs/openAPI.json
@@ -12937,6 +12937,19 @@
           "Calendars"
         ],
         "description": "Returns topic metadata for the current week's parasha — title, ref, category ordering, and bilingual display values.",
+        "parameters": [
+          {
+            "name": "diaspora",
+            "description": "Whether to return the diaspora parasha reading (`1`) or the Israel reading (`0`). Defaults to `1` (diaspora). In weeks where Israel and the diaspora read different portions, passing `0` returns the Israel reading.",
+            "schema": {
+              "type": "integer",
+              "enum": [0, 1],
+              "default": 1
+            },
+            "in": "query",
+            "required": false
+          }
+        ],
         "responses": {
           "200": {
             "content": {

--- a/docs/openAPI.json
+++ b/docs/openAPI.json
@@ -12942,9 +12942,9 @@
             "name": "diaspora",
             "description": "Whether to return the diaspora parasha reading (`1`) or the Israel reading (`0`). Defaults to `1` (diaspora). In weeks where Israel and the diaspora read different portions, passing `0` returns the Israel reading.",
             "schema": {
-              "type": "integer",
-              "enum": [0, 1],
-              "default": 1
+              "type": "string",
+              "enum": ["0", "1"],
+              "default": "1"
             },
             "in": "query",
             "required": false


### PR DESCRIPTION
## Description
The `calendars/topics/parasha` endpoint has a diaspora parameter that was not documented. This PR adds it to the OpenAPI.json file so it will populate on the interactive API reference. 

## Code Changes
- Adding documentation to the right place in the OpenAPI.json file
- Fixing an outdated comment in the push pipeline

## Notes
- Current docs (missing the diaspora param) - https://developers.sefaria.org/reference/get-calendar-parasha-topic
- Code confirming the diaspora param - https://github.com/Sefaria/Sefaria-Project/blob/ce3aaab9e5898d59e1770ee566d9e60ee2f97f72/reader/views.py#L2898