### PR TITLE
fix(helm): unshadow AASA so Django serves the association file

### DIFF
--- a/helm-chart/sefaria/conf/nginx.template.conf.tpl
+++ b/helm-chart/sefaria/conf/nginx.template.conf.tpl
@@ -70,7 +70,30 @@ http {
     listen 80;
     listen [::]:80;
     server_name {{ $rootDomain }};
-    return 301 https://{{ $wwwDomain }}$request_uri;
+
+    location /apple-app-site-association {
+      proxy_set_header Host {{ $wwwDomain }};
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto https;
+      proxy_set_header X-Forwarded-Port 443;
+      proxy_set_header X-Internal-Proxy 1;
+      proxy_pass http://varnishupstream;
+    }
+
+    location /.well-known/apple-app-site-association {
+      proxy_set_header Host {{ $wwwDomain }};
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto https;
+      proxy_set_header X-Forwarded-Port 443;
+      proxy_set_header X-Internal-Proxy 1;
+      proxy_pass http://varnishupstream;
+    }
+
+    location / {
+      return 301 https://{{ $wwwDomain }}$request_uri;
+    }
   }
 
   server {
@@ -108,20 +131,6 @@ http {
       access_log off;
       autoindex on;
       alias /app/robots.txt;
-    }
-
-    location /apple-app-site-association {
-      access_log off;
-      autoindex on;
-      default_type application/json;
-      return 200 '{"applinks": {"apps": [], "details": [{"appID": "2626EW4BML.org.sefaria.sefariaApp", "paths": ["*"]}]}}';
-    }
-
-    location /.well-known/apple-app-site-association {
-      access_log off;
-      autoindex on;
-      default_type application/json;
-      return 200 '{"applinks": {"apps": [], "details": [{"appID": "2626EW4BML.org.sefaria.sefariaApp", "paths": ["*"]}]}}';
     }
 
     location / {
@@ -212,20 +221,6 @@ http {
       access_log off;
       autoindex on;
       alias /app/robots.txt;
-    }
-
-    location /apple-app-site-association {
-      access_log off;
-      autoindex on;
-      default_type application/json;
-      return 200 '{"applinks": {"apps": [], "details": [{"appID": "2626EW4BML.org.sefaria.sefariaApp", "paths": ["*"]}]}}';
-    }
-
-    location /.well-known/apple-app-site-association {
-      access_log off;
-      autoindex on;
-      default_type application/json;
-      return 200 '{"applinks": {"apps": [], "details": [{"appID": "2626EW4BML.org.sefaria.sefariaApp", "paths": ["*"]}]}}';
     }
 
     location ~ ^/data\.\d+\.js$ {


### PR DESCRIPTION
## Description

Nginx has been `return 200`ing a hardcoded pre-exclusion AASA body on both `/apple-app-site-association` and `/.well-known/apple-app-site-association`, so Django's `apple_app_site_association` view is never reached in production. The 2026-08-12 path exclusions (PR #3609) have never been live; Apple still sees `paths: ["*"]`.

This PR deletes those four hardcoded `location` blocks (www + module servers) so the paths fall through to Varnish → Django, matching `/.well-known/assetlinks.json`. It also serves AASA on the apex 301 server: the www redirect moves into `location /`, and the two AASA paths proxy to Varnish with `Host` set to the www domain (Apple does not follow redirects, and the app entitlements claim the apex hosts).

Independent of PR #3631. After this ships, production AASA is the **master** #3609 body (nine static path exclusions). #3631 then adds the `no_applink` component on top.

## Code Changes

- `helm-chart/sefaria/conf/nginx.template.conf.tpl`
  - Apex server: proxy both AASA paths to `varnishupstream` with `Host: {{ $wwwDomain }}`; move the www 301 into `location /`
  - www and module servers: delete the four `return 200` AASA location blocks

## Notes

- VCL already `pass`es non-API GETs, so AASA gains a hop, not a cache. No purge needed.
- `LanguageSettingsMiddleware` already excludes `/apple-app-site-association` and `/.well-known/` — that exclusion becomes load-bearing after this ships. Do not remove it.
- Related Mobile follow-up: Sefaria-Mobile `fix/aasa-android-no-applink` (query-key bailout for `no_applink`).
- Related: https://github.com/Sefaria/Sefaria-Project/pull/3631, https://app.shortcut.com/sefaria/story/46559

## Test plan

- [ ] `helm template` (or a staging deploy) still renders balanced nginx config; zero remaining `return 200 '{"applinks"...'` lines
- [ ] After deploy, `curl -sD- https://www.sefaria.org/.well-known/apple-app-site-association` shows `via: 1.1 varnish` and a body with `components`, `appIDs`, and the nine static exclusions — **not** the 103-byte `paths: ["*"]` body
- [ ] Repeat for `/apple-app-site-association`, `www.sefaria.org.il`, and `voices.sefaria.org`
- [ ] Apex: `curl -sD- https://sefaria.org/.well-known/apple-app-site-association` returns **200**, not 301. Repeat for `sefaria.org.il`
- [ ] Do **not** expect a `no_applink` component until #3631 deploys
- [ ] Device testing: reinstall the app between iterations (AASA is cached per-domain per-device)


Made with [Cursor](https://cursor.com)