### PR TITLE
fix(tasks): raise prod memory and replica count

### DIFF
--- a/envs/prod/helmrelease.yaml
+++ b/envs/prod/helmrelease.yaml
@@ -129,12 +129,12 @@ spec:
       enabled: true
       resources:
         requests:
-          memory: "3Gi"
+          memory: "6Gi"
           cpu: "200m"
         limits:
-          memory: "6Gi"
+          memory: "8Gi"
           cpu: "1000m"
-      replicaCount: 5
+      replicaCount: 7
       redis:
         url: ""
         port: "26379"

--- a/helm-chart/sefaria/values.yaml
+++ b/helm-chart/sefaria/values.yaml
@@ -262,7 +262,6 @@ varnish:
 tasks:
   localsettings: {}
   enabled: false
-  # Chart defaults only. Prod/preprod size these in envs/*/helmrelease.yaml.
   resources:
     requests:
       memory: "2Gi"

--- a/helm-chart/sefaria/values.yaml
+++ b/helm-chart/sefaria/values.yaml
@@ -262,6 +262,7 @@ varnish:
 tasks:
   localsettings: {}
   enabled: false
+  # Chart defaults only. Prod/preprod size these in envs/*/helmrelease.yaml.
   resources:
     requests:
       memory: "2Gi"


### PR DESCRIPTION
## Summary

Break-glass hotfix for production celery workers. After the 12→5 replica cut (#3693), tasks pods run at **~99% of the 6Gi memory limit**, OOM-restart, and the queue backs up (Redis Sentinel RAM climbing; linker latency as a proxy).

Slack consensus (Lev / Noah / Yotam, 2026-09-09): raise memory request **and** limit, and go to ~7 replicas.

| | before | after |
|---|---|---|
| memory request | `3Gi` | **`6Gi`** |
| memory limit | `6Gi` | **`8Gi`** |
| CPU request/limit | `200m` / `1000m` | unchanged |
| replicas | `5` | **`7`** |

Datadog last 2 days on `production-tasks`: average usage ~5.8–6.0 GiB, max ~5.95 GiB (**99.1% of limit**). Monitor [22391016](https://us5.datadoghq.com/monitors/22391016) (`[Tasks] Memory Usage Near 6Gi Limit`) is in **Alert**; [22391011](https://us5.datadoghq.com/monitors/22391011) (`[Tasks] Container Restarts Climbing`) is in **Warn**. Dashboard: https://us5.datadoghq.com/dashboard/hir-n7r-wb8

Request is set to observed usage so the scheduler stops treating 6Gi of RSS as burst. Limit adds ~2Gi of headroom above the current ceiling. CPU stays at the post-#3693 `200m` — that cut was the capacity win; this restores memory without putting 6 cores back on the cluster.

Reserved memory: `5×3Gi = 15Gi` → `7×6Gi = 42Gi` (pre-#3693 was `12×3Gi = 36Gi`). Reserved CPU: `7×200m = 1.4` cores vs the old `12×500m = 6`.

`envs/prod/helmrelease.yaml` only.

## Test plan

- [ ] Promotion Gate warns (hotfix → prod is break-glass) but is green
- [ ] Merge; `Deploy Static Environment` updates prod and Flux reconciles (~5 min, or `flux reconcile source git sefaria-project-prod -n default`)
- [ ] `kubectl -n default get rollout production-tasks` shows `replicas: 7` and new RS
- [ ] Pods request `6Gi` / limit `8Gi`: `kubectl -n default get pods -l app=tasks-production -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.spec.containers[0].resources}{"\n"}{end}'`
- [ ] Memory % of limit drops off the 95%+ cliff; restart counter stops climbing
- [ ] After merge, back-merge: `gh workflow run manual-promotion.yaml -f source=prod -f target=preprod` so prod/preprod/master do not diverge
- [ ] Follow-up: retune monitors 22391011 / 22391016 — they still alert against the old 6Gi thresholds

Blue-green overlap: preview RS is 7×6Gi while the old 5×3Gi RS is still up (~57Gi requested until cutover). Cluster previously held 12 tasks pods, but watch for `Pending` during the rollout.

## Rollback

Revert this PR (or `git revert` on `prod`) and re-run the static deploy so Flux gets a new tag. Do **not** only `kubectl argo rollouts undo` — Flux will re-apply the tagged HelmRelease.