### PR TITLE
helm(tasks): bump chart so prod can pick up memory resize

### DIFF
--- a/helm-chart/sefaria/templates/rollout/task.yaml
+++ b/helm-chart/sefaria/templates/rollout/task.yaml
@@ -154,6 +154,7 @@ spec:
           - secretRef:
               name: local-settings-tasks-secrets-{{ .Values.deployEnv }}
               optional: true
+        # Prod sizes these in envs/prod/helmrelease.yaml; chart defaults are not what prod runs.
         resources: {{ toYaml .Values.tasks.resources | nindent 10 }}
         livenessProbe:
           exec:


### PR DESCRIPTION
## Summary

#3716 merged the tasks memory/replica values onto `prod`, but `Deploy Static Environment` failed in `update-deployment-state` with `nothing to commit, working tree clean` ([run 34471842190](https://github.com/Sefaria/Sefaria-Project/actions/runs/34471842190)).

`release-chart` was skipped (no `helm-chart/` path change), so the job reused `7.1.3-prod.1` + `0.88.2-prod.1`, could not create a new tag, and `trigger-deploy` never ran. Flux is still on `prod/7.1.3-prod.1+chart.0.88.2-prod.1`. Live pods are still **3Gi / 6Gi / 5 replicas**.

This PR only touches `helm-chart/sefaria/templates/rollout/task.yaml` (a comment) so `release-chart` runs and cuts **`0.88.2-prod.2`**. The HelmRelease values from #3716 (6Gi request / 8Gi limit / 7 replicas) are already on `prod` and will be tagged with that new chart version.

## Test plan

- [ ] Promotion Gate warns (hotfix → prod is break-glass) but is green
- [ ] Merge; `Deploy Static Environment` succeeds and tags `prod/7.1.3-prod.1+chart.0.88.2-prod.2`
- [ ] Flux GitRepository `sefaria-project-prod` moves to that tag (~5 min)
- [ ] `production-tasks` rollout shows 7 replicas, request `6Gi`, limit `8Gi`
- [ ] Close or let auto-update [#3717](https://github.com/Sefaria/Sefaria-Project/pull/3717) (prod → preprod) — it is blocked on the failed #3716 SHA; a new prod SHA with a passing deploy will unblock the back-merge

## Rollback

Revert this PR on `prod` and let the pipeline cut the next chart tag. Do not `kubectl argo rollouts undo` — Flux will re-apply the tagged HelmRelease.

Made with [Cursor](https://cursor.com)